### PR TITLE
Update the docs to use 1.0.13 instead of RELEASE for POM version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add this dependency to your project's POM:
     <dependency>
       <groupId>com.stripe</groupId>
       <artifactId>stripe-java</artifactId>
-      <version>RELEASE</version>
+      <version>1.0.13</version>
     </dependency>
 
 ### Others


### PR DESCRIPTION
In Maven-land, it's better to have a specific version number than a shifting pointer. Part of this is that it makes the build more repeatable when a build targets a known version, and the point at which that library changed can be known by the point at which the pom file changed its dependency.

So I'd say just keep the version you specify in the docs up to date, and expect people to use older versions unless changelogs/errata note a critical bug that should force an upgrade, or something. I haven't taken a close enough look at the source to determine if it reports the client library version to the server, but it would be reasonable for the server to reject the client and throw the client an error when the library is obsolete, so any periodic CI test that ran against old library versions would bother the crap out of whatever dev let it get so old.
