### PR TITLE
Bug in making GAE http DELETE method request

### DIFF
--- a/src/main/java/com/stripe/net/APIResource.java
+++ b/src/main/java/com/stripe/net/APIResource.java
@@ -282,7 +282,7 @@ public abstract class APIResource extends StripeObject {
 		String unknownErrorMessage = "Sorry, an unknown error occurred while trying to use the " +
 				"Google App Engine runtime. Please contact support@stripe.com for assistance.";
 		try {
-			if (method == RequestMethod.GET) { url = String.format("%s?%s", url, query); }
+			if (method == RequestMethod.GET || method == RequestMethod.DELETE) { url = String.format("%s?%s", url, query); }
 			URL fetchURL = new URL(url);
 			
 			Class<?> requestMethodClass = Class.forName("com.google.appengine.api.urlfetch.HTTPMethod");


### PR DESCRIPTION
Fix for appending query parameters to the url while making GAE http DELETE method request (Used in cancel subscription api call to pass "at_period_end" parameter).
