### PR TITLE
Pull request

### DIFF
--- a/src/main/java/com/stripe/model/BankAccount.java
+++ b/src/main/java/com/stripe/model/BankAccount.java
@@ -4,8 +4,8 @@ package com.stripe.model;
 public class BankAccount extends StripeObject {
 	String country;
 	String last4;
-  String bankName;
-  Boolean valid;
+        String bankName;
+        Boolean valid;
 
 	public String getLast4() {
 		return last4;

--- a/src/main/java/com/stripe/model/EventDataDeserializer.java
+++ b/src/main/java/com/stripe/model/EventDataDeserializer.java
@@ -100,7 +100,7 @@ public class EventDataDeserializer implements JsonDeserializer<EventData> {
 			} else if ("object".equals(key)) {
 				String type = element.getAsJsonObject().get("object").getAsString();
 				Class<StripeObject> cl = objectMap.get(type);
-				StripeObject object = APIResource.gson.fromJson(entry.getValue(), cl);
+				StripeObject object = APIResource.GSON.fromJson(entry.getValue(), cl);
 				eventData.setObject(object);
 			}
 		}

--- a/src/main/java/com/stripe/model/StripeObject.java
+++ b/src/main/java/com/stripe/model/StripeObject.java
@@ -8,7 +8,7 @@ import com.google.gson.GsonBuilder;
 
 public abstract class StripeObject {
 	
-	public static final Gson prettyPrintGson = new GsonBuilder().
+	public static final Gson PRETTY_PRINT_GSON = new GsonBuilder().
 		setPrettyPrinting().
 		serializeNulls().
 		setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).
@@ -21,7 +21,7 @@ public abstract class StripeObject {
 			this.getClass().getName(),
 			System.identityHashCode(this),
 			this.getIdString(),
-			prettyPrintGson.toJson(this));
+			PRETTY_PRINT_GSON.toJson(this));
 	}
 
 	private Object getIdString() {

--- a/src/main/java/com/stripe/net/StripeResponse.java
+++ b/src/main/java/com/stripe/net/StripeResponse.java
@@ -1,13 +1,23 @@
 package com.stripe.net;
 
+import java.util.List;
+import java.util.Map;
+
 public class StripeResponse {
 	
 	int responseCode;
 	String responseBody;
+        Map<String, List<String>> responseHeaders;
 	
 	public StripeResponse(int responseCode, String responseBody) {
 		this.responseCode = responseCode;
 		this.responseBody = responseBody;
+                this.responseHeaders = null;
+	}
+        public StripeResponse(int responseCode, String responseBody, Map<String, List<String>> responseHeaders) {
+		this.responseCode = responseCode;
+		this.responseBody = responseBody;
+                this.responseHeaders = responseHeaders;
 	}
 
 	public int getResponseCode() {
@@ -24,5 +34,8 @@ public class StripeResponse {
 	
 	public void setResponseBody(String responseBody) {
 		this.responseBody = responseBody;
+	}
+        public Map<String, List<String>> getResponseHeaders() {
+		return responseHeaders;
 	}
 }

--- a/src/test/java/com/stripe/StripeTest.java
+++ b/src/test/java/com/stripe/StripeTest.java
@@ -37,15 +37,15 @@ import com.stripe.model.Recipient;
 import com.stripe.model.DeletedRecipient;
 
 public class StripeTest {
-	static HashMap<String, Object> defaultCardParams = new HashMap<String, Object>();
-	static HashMap<String, Object> defaultChargeParams = new HashMap<String, Object>();
-	static HashMap<String, Object> defaultCustomerParams = new HashMap<String, Object>();
-	static HashMap<String, Object> defaultPlanParams = new HashMap<String, Object>();
-	static HashMap<String, Object> defaultCouponParams = new HashMap<String, Object>();
-	static HashMap<String, Object> defaultTokenParams = new HashMap<String, Object>();
-	static HashMap<String, Object> defaultBankAccountParams = new HashMap<String, Object>();
-	static HashMap<String, Object> defaultTransferParams = new HashMap<String, Object>();
-	static HashMap<String, Object> defaultRecipientParams = new HashMap<String, Object>();
+	static Map<String, Object> defaultCardParams = new HashMap<String, Object>();
+	static Map<String, Object> defaultChargeParams = new HashMap<String, Object>();
+	static Map<String, Object> defaultCustomerParams = new HashMap<String, Object>();
+	static Map<String, Object> defaultPlanParams = new HashMap<String, Object>();
+	static Map<String, Object> defaultCouponParams = new HashMap<String, Object>();
+	static Map<String, Object> defaultTokenParams = new HashMap<String, Object>();
+	static Map<String, Object> defaultBankAccountParams = new HashMap<String, Object>();
+	static Map<String, Object> defaultTransferParams = new HashMap<String, Object>();
+	static Map<String, Object> defaultRecipientParams = new HashMap<String, Object>();
 
 	static String getUniquePlanId() {
 		return String.format("JAVA-PLAN-%s", UUID.randomUUID());
@@ -187,7 +187,7 @@ public class StripeTest {
 
 	@Test
 	public void testChargeCapture() throws StripeException {
-		HashMap<String, Object> options = (HashMap<String, Object>)defaultChargeParams.clone();
+		Map<String, Object> options = new HashMap<String, Object>(defaultChargeParams);
 		options.put("capture", false);
 
 		Charge created = Charge.create(options);

--- a/src/test/java/com/stripe/model/EventDataDeserializerTest.java
+++ b/src/test/java/com/stripe/model/EventDataDeserializerTest.java
@@ -13,7 +13,7 @@ import static org.junit.Assert.assertThat;
 
 public class EventDataDeserializerTest {
 
-    private static Gson gson  = com.stripe.net.APIResource.gson;
+    private static Gson gson  = com.stripe.net.APIResource.GSON;
 
     @Test
     public void deserializePreviousAttributes() throws IOException {
@@ -27,7 +27,7 @@ public class EventDataDeserializerTest {
     @Test
     public void deserializeAccountEvent() throws IOException {
         String json = resource("account_event.json");
-        Event e = StripeObject.prettyPrintGson.fromJson(json, Event.class);
+        Event e = StripeObject.PRETTY_PRINT_GSON.fromJson(json, Event.class);
 
         assertEquals(e.getType(), "account.updated");
     }


### PR DESCRIPTION
Good afternoon,

I really like the project, I have made the following updates:

Added overloaded constructor for StripeResponse to pass HTTP response headers
Updated contant name so it is uppercase: prettyPrintGson -> PRETTY_PRINT_GSON / gson -> GSON
Added more readable timeout values 30000 -> 30 \* 1000 / 80000 -> 80 \* 1000
Removed trailing comments (per Steve McConnel in "Code Complete")
Replaced StringBuffer with StringBuilder
instance variable should be generic Map type
Per Josh Block on Design Copy Constructor should be used over clone (StripeTest)
Refactored createQuery so it doesn't have to call queryStringBuffer.deleteCharAt(0);

Steve
