### PR TITLE
Minor code cleanup in BankAccount.java

### DIFF
--- a/src/main/java/com/stripe/model/BankAccount.java
+++ b/src/main/java/com/stripe/model/BankAccount.java
@@ -28,7 +28,7 @@ public class BankAccount extends StripeObject {
 	}
 
 	public void setBankName(String bankName) {
-		this.bankName= bankName;
+		this.bankName = bankName;
 	}
 
 	public Boolean getValidated() {


### PR DESCRIPTION
Added a space before the assignment operator in `setBankName()`.
