### PR TITLE
Support property deletion

### DIFF
--- a/src/main/java/com/stripe/net/APIResource.java
+++ b/src/main/java/com/stripe/net/APIResource.java
@@ -190,7 +190,7 @@ public abstract class APIResource extends StripeObject {
 	}
 
 	private static String createQuery(Map<String, Object> params)
-			throws UnsupportedEncodingException {
+	    throws UnsupportedEncodingException, InvalidRequestException {
 		Map<String, String> flatParams = flattenParams(params);
 		StringBuffer queryStringBuffer = new StringBuffer();
 		for (Map.Entry<String, String> entry : flatParams.entrySet()) {
@@ -204,7 +204,8 @@ public abstract class APIResource extends StripeObject {
 		return queryStringBuffer.toString();
 	}
 
-	private static Map<String, String> flattenParams(Map<String, Object> params) {
+	private static Map<String, String> flattenParams(Map<String, Object> params)
+			throws InvalidRequestException {
 		if (params == null) {
 			return new HashMap<String, String>();
 		}
@@ -222,9 +223,10 @@ public abstract class APIResource extends StripeObject {
 				}
 				flatParams.putAll(flattenParams(flatNestedMap));
 			} else if ("".equals(value)) {
-			    throw new IllegalArgumentException("You cannot set '"+key+"' to an empty string. "+
-							       "We interpret empty strings as null in requests. "+
-							       "You may set '"+key+"' to null to delete the property.");
+			    throw new InvalidRequestException("You cannot set '"+key+"' to an empty string. "+
+							      "We interpret empty strings as null in requests. "+
+							      "You may set '"+key+"' to null to delete the property.",
+							      key, null);
 			} else if (value == null) {
 				flatParams.put(key, "");
 			} else if (value != null) {

--- a/src/test/java/com/stripe/StripeTest.java
+++ b/src/test/java/com/stripe/StripeTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 
 import com.stripe.exception.CardException;
 import com.stripe.exception.StripeException;
+import com.stripe.exception.InvalidRequestException;
 import com.stripe.model.Account;
 import com.stripe.model.Balance;
 import com.stripe.model.BankAccount;
@@ -310,7 +311,7 @@ public class StripeTest {
 		assertEquals(updatedCustomer.getDescription(), "Updated Description");
 	}
 
-	@Test(expected=IllegalArgumentException.class)
+	@Test(expected=InvalidRequestException.class)
 	public void testCustomerUpdateToBlank() throws StripeException {
 		Customer createdCustomer = Customer.create(defaultCustomerParams);
 		Map<String, Object> updateParams = new HashMap<String, Object>();


### PR DESCRIPTION
Changes to support property deletion in the API (e.g. deleting description on customer)
- Setting attributes to null passes an empty string to the API, leading to legal properties being deleted
- Setting an attribute to an empty string is an error to avoid accidental unsets
