### PR TITLE
Statics in Stripe must be volatile

### DIFF
--- a/src/main/java/com/stripe/Stripe.java
+++ b/src/main/java/com/stripe/Stripe.java
@@ -4,10 +4,10 @@ public abstract class Stripe
 {
 	public static final String LIVE_API_BASE = "https://api.stripe.com";
 	public static final String VERSION = "1.12.0";
-	public static String apiKey;
-	public static String apiVersion;
+	public static volatile String apiKey;
+	public static volatile String apiVersion;
 
-	private static String apiBase = LIVE_API_BASE;
+	private static volatile String apiBase = LIVE_API_BASE;
 
 	/**
 	 * (FOR TESTING ONLY)


### PR DESCRIPTION
According to the [Java Memory Model](http://docs.oracle.com/javase/specs/jls/se7/html/jls-17.html#jls-17.4)
writes to a shared variable from one thread are only visible to an
other thread if there is a happens-before relationship between them.
There currently is no happens-before relationship between the writes
to `Stripe` `apiKey`, `apiVersion`, `apiBase` and the reads in
`APIResource`. There are several ways to introduce a happens-before
relationship between the writes and the reads but the easiest is to
mark the fields volatile.
