### PR TITLE
Handle very large values for coupon redemptions

### DIFF
--- a/src/main/java/com/stripe/model/Coupon.java
+++ b/src/main/java/com/stripe/model/Coupon.java
@@ -17,7 +17,7 @@ public class Coupon extends APIResource {
 	String id;
 	Boolean livemode;
 	Integer durationInMonths;
-	Integer maxRedemptions;
+	Long maxRedemptions;
 	Long redeemBy;
 	Integer timesRedeemed;
 	Boolean valid;
@@ -131,11 +131,11 @@ public class Coupon extends APIResource {
 		this.durationInMonths = durationInMonths;
 	}
 
-	public Integer getMaxRedemptions() {
+	public Long getMaxRedemptions() {
 		return maxRedemptions;
 	}
 
-	public void setMaxRedemptions(Integer maxRedemptions) {
+	public void setMaxRedemptions(Long maxRedemptions) {
 		this.maxRedemptions = maxRedemptions;
 	}
 


### PR DESCRIPTION
My manager created a coupon with 10 billion redemptions. When loading in voices gson threw NumberFormatException trying to parse said coupon. I fixed this issue by changing maxRedemptions from an Integer into a Long.
