### PR TITLE
Add deprecation annotations for disputed field

### DIFF
--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -97,10 +97,20 @@ public class Charge extends APIResource implements MetadataStore<Charge> {
 		this.captured = captured;
 	}
 
+	/**
+	 * @deprecated
+	 * Use `dispute` field (https://stripe.com/docs/upgrades#2012-11-07)
+	 */
+	@Deprecated
 	public Boolean getDisputed() {
 		return disputed;
 	}
 
+	/**
+	 * @deprecated
+	 * Use `dispute` field (https://stripe.com/docs/upgrades#2012-11-07)
+	 */
+	@Deprecated
 	public void setDisputed(Boolean disputed) {
 		this.disputed = disputed;
 	}


### PR DESCRIPTION
Adds annotation for the deprecated `disputed` field, nice to have the inline feedback when using the SDK. Feel free to reject if the `Legacy` tag takes precedence or we should do the whole refactor over for legacy fields at once.

Thanks!
