### PR TITLE
Explicitly cast the double object.

### DIFF
--- a/src/main/java/com/stripe/net/APIResource.java
+++ b/src/main/java/com/stripe/net/APIResource.java
@@ -546,7 +546,7 @@ public abstract class APIResource extends StripeObject {
 			// some time for the application to handle a slow Stripe
 			fetchOptionsClass.getDeclaredMethod("setDeadline",
 					java.lang.Double.class)
-					.invoke(fetchOptions, 55);
+					.invoke(fetchOptions, new Double(55));
 
 			Class<?> requestClass = Class
 					.forName("com.google.appengine.api.urlfetch.HTTPRequest");


### PR DESCRIPTION
As per issue 106, there was a regression introduced in 1.18->1.19 where
methods in GAE found through reflection neither coerce types nor autobox
them.
