### PR TITLE
Add ReceiptNumber and ReceiptEmail support

### DIFF
--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -174,7 +174,7 @@ public class Charge extends APIResource implements MetadataStore<Charge> {
 	}
 
 	public ChargeRefundCollection getRefunds() {
-		// API versions 2014-05-19 and earlier render charge refunds as an array 
+		// API versions 2014-05-19 and earlier render charge refunds as an array
 		// instead of an object, meaning there is no sublist URL.
 		if (refunds.getURL() == null) {
 			refunds.setURL(String.format("/v1/charges/%s/refunds", getId()));


### PR DESCRIPTION
As per [0], we support receipt_number and receipt_email in the
charge object in the Stripe API. Somehow, it looks like those did
not make their way into the java bindings.

This PR adds them.

[0] https://stripe.com/docs/api/java#charge_object
