### PR TITLE
Configure travis to test against multiple jdks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,7 @@
 language: java
 install: mvn install -Dgpg.skip=true
+jdk:
+  - openjdk6
+  - openjdk7
+  - oraclejdk7
+  - oraclejdk8


### PR DESCRIPTION
Testing against multiple jdks is offered by travis by default, so
we may as well. I'm currently investigating running it against gae (appengine)
as well, but I'm not sure that travis supports running against that
environment.
