### PR TITLE
Add shipping to the charge object

### DIFF
--- a/src/main/java/com/stripe/model/Address.java
+++ b/src/main/java/com/stripe/model/Address.java
@@ -1,0 +1,110 @@
+package com.stripe.model;
+
+import com.stripe.net.APIResource;
+
+public final class Address extends StripeObject {
+	protected String line1;
+	protected String city;
+	protected String country;
+	protected String line2;
+	protected String postalCode;
+	protected String state;
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		Address address = (Address) o;
+
+		if (city != null ? !city.equals(address.city) : address.city != null) {
+			return false;
+		}
+		if (country != null ? !country.equals(address.country) : address.country != null) {
+			return false;
+		}
+		if (line1 != null ? !line1.equals(address.line1) : address.line1 != null) {
+			return false;
+		}
+		if (line2 != null ? !line2.equals(address.line2) : address.line2 != null) {
+			return false;
+		}
+		if (postalCode != null ? !postalCode.equals(address.postalCode) : address.postalCode != null) {
+			return false;
+		}
+		if (state != null ? !state.equals(address.state) : address.state != null) {
+			return false;
+		}
+
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = line1 != null ? line1.hashCode() : 0;
+		result = 31 * result + (city != null ? city.hashCode() : 0);
+		result = 31 * result + (country != null ? country.hashCode() : 0);
+		result = 31 * result + (line2 != null ? line2.hashCode() : 0);
+		result = 31 * result + (postalCode != null ? postalCode.hashCode() : 0);
+		result = 31 * result + (state != null ? state.hashCode() : 0);
+		return result;
+	}
+
+	public String getLine1() {
+		return line1;
+	}
+
+	public Address setLine1(String line1) {
+		this.line1 = line1;
+		return this;
+	}
+
+	public String getCity() {
+		return city;
+	}
+
+	public Address setCity(String city) {
+		this.city = city;
+		return this;
+	}
+
+	public String getCountry() {
+		return country;
+	}
+
+	public Address setCountry(String country) {
+		this.country = country;
+		return this;
+	}
+
+	public String getLine2() {
+		return line2;
+	}
+
+	public Address setLine2(String line2) {
+		this.line2 = line2;
+		return this;
+	}
+
+	public String getPostalCode() {
+		return postalCode;
+	}
+
+	public Address setPostalCode(String postalCode) {
+		this.postalCode = postalCode;
+		return this;
+	}
+
+	public String getState() {
+		return state;
+	}
+
+	public Address setState(String state) {
+		this.state = state;
+		return this;
+	}
+}

--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -35,6 +35,7 @@ public class Charge extends APIResource implements MetadataStore<Charge> {
 	String receiptEmail;
 	String receiptNumber;
 	String statementDescription;
+	ShippingDetails shipping;
 
 	public String getId() {
 		return id;
@@ -98,6 +99,14 @@ public class Charge extends APIResource implements MetadataStore<Charge> {
 
 	public void setCaptured(Boolean captured) {
 		this.captured = captured;
+	}
+
+	public ShippingDetails getShipping() {
+		return shipping;
+	}
+
+	public void setShipping(ShippingDetails shipping) {
+		this.shipping = shipping;
 	}
 
 	/**

--- a/src/main/java/com/stripe/model/ShippingDetails.java
+++ b/src/main/java/com/stripe/model/ShippingDetails.java
@@ -1,0 +1,63 @@
+package com.stripe.model;
+
+public final class ShippingDetails extends StripeObject {
+	protected Address address;
+	protected String name;
+	protected String phone;
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		ShippingDetails that = (ShippingDetails) o;
+
+		if (address != null ? !address.equals(that.address) : that.address != null) {
+			return false;
+		}
+		if (name != null ? !name.equals(that.name) : that.name != null) {
+			return false;
+		}
+		if (phone != null ? !phone.equals(that.phone) : that.phone != null) {
+			return false;
+		}
+
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = address != null ? address.hashCode() : 0;
+		result = 31 * result + (name != null ? name.hashCode() : 0);
+		result = 31 * result + (phone != null ? phone.hashCode() : 0);
+		return result;
+	}
+
+	public Address getAddress() {
+		return address;
+	}
+
+	public void setAddress(Address address) {
+		this.address = address;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getPhone() {
+		return phone;
+	}
+
+	public void setPhone(String phone) {
+		this.phone = phone;
+	}
+}

--- a/src/test/java/com/stripe/StripeTest.java
+++ b/src/test/java/com/stripe/StripeTest.java
@@ -1,9 +1,11 @@
 package com.stripe;
 
+import com.google.common.collect.ImmutableMap;
 import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
 import com.stripe.exception.StripeException;
 import com.stripe.model.Account;
+import com.stripe.model.Address;
 import com.stripe.model.ApplicationFee;
 import com.stripe.model.Balance;
 import com.stripe.model.BalanceTransaction;
@@ -29,6 +31,7 @@ import com.stripe.model.MetadataStore;
 import com.stripe.model.Plan;
 import com.stripe.model.Recipient;
 import com.stripe.model.Refund;
+import com.stripe.model.ShippingDetails;
 import com.stripe.model.Subscription;
 import com.stripe.model.Token;
 import com.stripe.model.Transfer;
@@ -233,6 +236,28 @@ public class StripeTest {
 
 		Charge createdCharge = Charge.create(chargeWithStatementDescriptionParams);
 		assertEquals("Stripe", createdCharge.getStatementDescription());
+	}
+
+	@Test
+	public void testChargeCreateWithShippingDetails() throws StripeException {
+		ShippingDetails shippingDetails = new ShippingDetails();
+		shippingDetails.setName("name");
+		shippingDetails.setPhone("123-456-7890");
+		Address address = new Address()
+				.setCity("Washington")
+				.setCountry("USA")
+				.setLine1("1600 Pennsylvania Ave.")
+				.setLine2("line 2 address")
+				.setPostalCode("20500")
+				.setState("D.C.");
+		shippingDetails.setAddress(address);
+
+		Map<String, Object> params = ImmutableMap.<String, Object>builder()
+				.putAll(defaultChargeParams)
+				.put("shipping", ImmutableMap.builder().put("address", ImmutableMap.builder().put("line1", address.getLine1()).put("line2", address.getLine2()).put("city", address.getCity()).put("country", address.getCountry()).put("postal_code", address.getPostalCode()).put("state", address.getState()).build()).put("name", shippingDetails.getName()).put("phone", shippingDetails.getPhone()).build())
+				.build();
+		Charge createdCharge = Charge.create(params);
+		assertEquals(createdCharge.getShipping(), shippingDetails);
 	}
 
 	@Test


### PR DESCRIPTION
R: @jimdanz || @berg 
cc: @anurag 

The charge object[0] has a shipping field, but stripe-java wasn't updated to reflect the change.

[0] https://stripe.com/docs/api#charge_object
