### PR TITLE
Drop support for java 1.5.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,8 +70,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.6</source>
+                    <target>1.6</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Java 1.5 isn't supported by Travis, and is something that doesn't
see wide usage in our API.

R? @jimdanz 
