### PR TITLE
Add STRIPE-ACCOUNT header support

### DIFF
--- a/src/main/java/com/stripe/net/APIResource.java
+++ b/src/main/java/com/stripe/net/APIResource.java
@@ -169,6 +169,9 @@ public abstract class APIResource extends StripeObject {
 		if (options.getIdempotencyKey() != null) {
 			headers.put("Idempotency-Key", options.getIdempotencyKey());
 		}
+		if (options.getStripeAccount() != null) {
+			headers.put("Stripe-Account", options.getStripeAccount());
+		}
 		return headers;
 	}
 

--- a/src/main/java/com/stripe/net/RequestOptions.java
+++ b/src/main/java/com/stripe/net/RequestOptions.java
@@ -4,17 +4,19 @@ import com.stripe.Stripe;
 
 public class RequestOptions {
 	public static RequestOptions getDefault() {
-		return new RequestOptions(Stripe.apiKey, Stripe.apiVersion, null);
+		return new RequestOptions(Stripe.apiKey, Stripe.apiVersion, null, null);
 	}
 
 	private final String apiKey;
 	private final String stripeVersion;
 	private final String idempotencyKey;
+	private final String stripeAccount;
 
-	private RequestOptions(String apiKey, String stripeVersion, String idempotencyKey) {
+	private RequestOptions(String apiKey, String stripeVersion, String idempotencyKey, String stripeAccount) {
 		this.apiKey = apiKey;
 		this.stripeVersion = stripeVersion;
 		this.idempotencyKey = idempotencyKey;
+		this.stripeAccount = stripeAccount;
 	}
 
 	public String getApiKey() {
@@ -27,6 +29,10 @@ public class RequestOptions {
 
 	public String getIdempotencyKey() {
 		return idempotencyKey;
+	}
+
+	public String getStripeAccount() {
+		return stripeAccount;
 	}
 
 	@Override
@@ -62,13 +68,14 @@ public class RequestOptions {
 	}
 
 	public RequestOptionsBuilder toBuilder() {
-		return new RequestOptionsBuilder().setApiKey(this.apiKey).setStripeVersion(this.stripeVersion);
+		return new RequestOptionsBuilder().setApiKey(this.apiKey).setStripeVersion(this.stripeVersion).setStripeAccount(this.stripeAccount);
 	}
 
 	public static final class RequestOptionsBuilder {
 		private String apiKey;
 		private String stripeVersion;
 		private String idempotencyKey;
+		private String stripeAccount;
 
 		public RequestOptionsBuilder() {
 			this.apiKey = Stripe.apiKey;
@@ -113,8 +120,25 @@ public class RequestOptions {
 			return this.idempotencyKey;
 		}
 
+		public String getStripeAccount() {
+			return this.stripeAccount;
+		}
+
+		public RequestOptionsBuilder setStripeAccount(String stripeAccount) {
+			this.stripeAccount = stripeAccount;
+			return this;
+		}
+
+		public RequestOptionsBuilder clearStripeAccount() {
+			return setStripeAccount(null);
+		}
+
 		public RequestOptions build() {
-			return new RequestOptions(normalizeApiKey(this.apiKey), normalizeStripeVersion(this.stripeVersion), normalizeIdempotencyKey(this.idempotencyKey));
+			return new RequestOptions(
+				normalizeApiKey(this.apiKey),
+				normalizeStripeVersion(this.stripeVersion),
+				normalizeIdempotencyKey(this.idempotencyKey),
+				normalizeStripeAccount(this.stripeAccount));
 		}
 	}
 
@@ -152,6 +176,17 @@ public class RequestOptions {
 		}
 		if (normalized.length() > 255) {
 			throw new InvalidRequestOptionsException(String.format("Idempotency Key length was %d, which is larger than the 255 character maximum!", normalized.length()));
+		}
+		return normalized;
+	}
+
+	private static String normalizeStripeAccount(String stripeAccount) {
+		if (stripeAccount == null) {
+			return null;
+		}
+		String normalized = stripeAccount.trim();
+		if (normalized.isEmpty()) {
+			throw new InvalidRequestOptionsException("Empty stripe account specified!");
 		}
 		return normalized;
 	}


### PR DESCRIPTION
r? @bkrausz @jimdanz 

Add support for `Stripe-Account` header in `RequestOptions`.

This can currently only be used on methods with `RequestOptions` as the final parameter in their signature (none with `String apiKey`).

There's no tests because there's no way to test the existence of the headers without creating new accounts (if the real API is to be used, in the style of the existing tests) or ripping a lot of things apart (if mocks/captors are to be used). I tested using my own account + a test account in a super simple program:

```
  public static void main(String[] args) {
    Stripe.apiKey = "my test secret key";
    String connectedAccount = "the token of my connected account";
    Map<String, Object> params = new HashMap<String, Object>();

    try {
      ChargeCollection all = Charge.all(params, RequestOptions.builder().setApiKey(Stripe.apiKey).setStripeAccount(connectedAccount).build());
      System.out.println(all);
    } catch (StripeException e) {
      e.printStackTrace();
    }
  }
```

and verified that it returned charges from the connected account.

The issue of testing seems like too big to shave right now, and I'm pretty confident in the correctness of this.