### PR TITLE
Add account retrieval by ID and support for lists in params

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,12 @@
             <version>4.10</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <description>Stripe Java Bindings</description>
     <organization>

--- a/src/main/java/com/stripe/model/Account.java
+++ b/src/main/java/com/stripe/model/Account.java
@@ -9,6 +9,7 @@ import com.stripe.net.APIResource;
 import com.stripe.net.RequestOptions;
 
 import java.util.List;
+import java.util.Map;
 
 public class Account extends APIResource {
 	String id;
@@ -22,6 +23,8 @@ public class Account extends APIResource {
 	String country;
 	String timezone;
 	String displayName;
+	Verification verification;
+	LegalEntity legalEntity;
 
 	public String getId() {
 		return id;
@@ -67,18 +70,49 @@ public class Account extends APIResource {
 		return displayName;
 	}
 
+	public Verification getVerification() {
+		return verification;
+	}
+
+	public LegalEntity getLegalEntity() {
+		return legalEntity;
+	}
+
+	public static Account create(Map<String, Object> params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params, (RequestOptions) null);
+	}
+
+	public static Account create(Map<String, Object> params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return request(RequestMethod.POST, classURL(Account.class), params, Account.class, options);
+	}
+
 	public static Account retrieve()
 			throws AuthenticationException, InvalidRequestException,
 			APIConnectionException, CardException, APIException {
 		return retrieve((RequestOptions) null);
 	}
 
+	/**
+	 * In order to preserve backwards-compatibility, this method does two things.
+	 * If the parameter looks like an API key (starts with sk_), retrieve the
+	 * account resource with no ID parameter set. Otherwise, use the String
+	 * parameter as the account ID.
+	 */
 	@Deprecated
-	public static Account retrieve(String apiKey)
+	public static Account retrieve(String apiKeyOrAccountId)
 			throws AuthenticationException, InvalidRequestException,
 			APIConnectionException, CardException, APIException {
-		return retrieve(RequestOptions.builder().setApiKey(apiKey).build());
+		if (null == apiKeyOrAccountId || apiKeyOrAccountId.startsWith("sk_")) {
+			return retrieve(RequestOptions.builder().setApiKey(apiKeyOrAccountId).build());
+		} else {
+			return retrieve(apiKeyOrAccountId, (RequestOptions) null);
+		}
 	}
+
 	public static Account retrieve(RequestOptions options)
 			throws AuthenticationException, InvalidRequestException,
 			APIConnectionException, CardException, APIException {
@@ -88,5 +122,64 @@ public class Account extends APIResource {
 			null,
 			Account.class,
 			options);
+	}
+
+	public static Account retrieve(String id, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return request(RequestMethod.GET, instanceURL(Account.class, id), null, Account.class, options);
+	}
+
+	public Account update(Map<String, Object> params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params, (RequestOptions) null);
+	}
+
+	public Account update(Map<String, Object> params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return request(RequestMethod.POST, instanceURL(Account.class, this.id), params, Account.class, options);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		Account account = (Account) o;
+		return equals(id, account.id) &&
+			equals(chargesEnabled, account.chargesEnabled) &&
+			equals(detailsSubmitted, account.detailsSubmitted) &&
+			equals(transfersEnabled, account.transfersEnabled) &&
+			equals(currenciesSupported, account.currenciesSupported) &&
+			equals(email, account.email) &&
+			equals(statementDescriptor, account.statementDescriptor) &&
+			equals(defaultCurrency, account.defaultCurrency) &&
+			equals(country, account.country) &&
+			equals(timezone, account.timezone) &&
+			equals(displayName, account.displayName) &&
+			equals(verification, account.verification) &&
+			equals(legalEntity, account.legalEntity);
+	}
+
+	public static class Verification extends StripeObject {
+		List<String> fieldsNeeded;
+		Long dueBy;
+		Boolean contacted;
+
+		public List<String> getFieldsNeeded() {
+			return fieldsNeeded;
+		}
+		public Long getDueBy() {
+			return dueBy;
+		}
+		public Boolean getContacted() {
+			return contacted;
+		}
 	}
 }

--- a/src/main/java/com/stripe/model/LegalEntity.java
+++ b/src/main/java/com/stripe/model/LegalEntity.java
@@ -1,0 +1,176 @@
+package com.stripe.model;
+
+import com.stripe.exception.APIConnectionException;
+import com.stripe.exception.APIException;
+import com.stripe.exception.AuthenticationException;
+import com.stripe.exception.CardException;
+import com.stripe.exception.InvalidRequestException;
+import com.stripe.net.APIResource;
+import com.stripe.net.RequestOptions;
+
+import java.util.List;
+import java.util.Map;
+
+public class LegalEntity extends StripeObject {
+	String type;
+	Address address;
+	String businessName;
+	DateOfBirth dob;
+	String firstName;
+	String lastName;
+	Address personalAddress;
+	Verification verification;
+	List<Owner> additionalOwners;
+
+	public String getType() {
+		return type;
+	}
+	public Address getAddress() {
+		return address;
+	}
+	public String getBusinessName() {
+		return businessName;
+	}
+	public DateOfBirth getDob() {
+		return dob;
+	}
+	public String getFirstName() {
+		return firstName;
+	}
+	public String getLastName() {
+		return lastName;
+	}
+	public Address getPersonalAddress() {
+		return personalAddress;
+	}
+	public Verification getVerification() {
+		return verification;
+	}
+	public List<Owner> getAdditionalOwners() {
+		return additionalOwners;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		LegalEntity le = (LegalEntity) o;
+		return equals(type, le.type) &&
+			equals(address, le.address) &&
+			equals(businessName, le.businessName) &&
+			equals(dob, le.dob) &&
+			equals(firstName, le.firstName) &&
+			equals(lastName, le.lastName) &&
+			equals(personalAddress, le.personalAddress) &&
+			equals(verification, le.verification) &&
+			equals(additionalOwners, le.additionalOwners);
+	}
+
+	public static class DateOfBirth extends StripeObject {
+		Integer day;
+		Integer month;
+		Integer year;
+
+		public Integer getDay() {
+			return day;
+		}
+		public Integer getMonth() {
+			return month;
+		}
+		public Integer getYear() {
+			return year;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+
+			DateOfBirth dob = (DateOfBirth) o;
+			return equals(day, dob.day) &&
+				equals(month, dob.month) &&
+				equals(year, dob.year);
+		}
+	}
+
+	public static class Verification extends StripeObject {
+		String status;
+		String document;
+		String details;
+
+		public String getStatus() {
+			return status;
+		}
+		public String getDocument() {
+			return document;
+		}
+		public String getDetails() {
+			return details;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+
+			Verification verification = (Verification) o;
+			return equals(status, verification.status) &&
+				equals(document, verification.document) &&
+				equals(details, verification.details);
+		}
+	}
+
+	public static class Owner extends StripeObject {
+		Address address;
+		DateOfBirth dob;
+		String firstName;
+		String lastName;
+		Verification verification;
+
+		public Address getAddress() {
+			return address;
+		}
+		public DateOfBirth getDob() {
+			return dob;
+		}
+		public String getFirstName() {
+			return firstName;
+		}
+		public String getLastName() {
+			return lastName;
+		}
+		public Verification getVerification() {
+			return verification;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+
+			Owner owner = (Owner) o;
+			return equals(address, owner.address) &&
+				equals(dob, owner.dob) &&
+				equals(firstName, owner.firstName) &&
+				equals(lastName, owner.lastName) &&
+				equals(verification, owner.verification);
+		}
+	}
+}

--- a/src/main/java/com/stripe/model/StripeObject.java
+++ b/src/main/java/com/stripe/model/StripeObject.java
@@ -7,14 +7,14 @@ import com.google.gson.GsonBuilder;
 import java.lang.reflect.Field;
 
 public abstract class StripeObject {
-	
+
 	public static final Gson PRETTY_PRINT_GSON = new GsonBuilder().
 		setPrettyPrinting().
 		serializeNulls().
 		setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).
 		registerTypeAdapter(EventData.class, new EventDataDeserializer()).
 		create();
-	
+
 	@Override public String toString() {
 		return String.format(
 			"<%s@%s id=%s> JSON: %s",
@@ -37,5 +37,9 @@ public abstract class StripeObject {
 		} catch (IllegalAccessException e) {
 			return "";
 		}
+	}
+
+	protected static boolean equals(Object a, Object b) {
+		return a == null ? b == null : a.equals(b);
 	}
 }

--- a/src/main/java/com/stripe/net/APIResource.java
+++ b/src/main/java/com/stripe/net/APIResource.java
@@ -113,11 +113,11 @@ public abstract class APIResource extends StripeObject {
 
 	public static final String CHARSET = "UTF-8";
 
-	protected enum RequestMethod {
+	public enum RequestMethod {
 		GET, POST, DELETE
 	}
 
-	protected enum RequestType {
+	public enum RequestType {
 		NORMAL, MULTIPART
 	}
 

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -1,0 +1,185 @@
+package com.stripe;
+
+import com.stripe.exception.StripeException;
+import com.stripe.net.APIResource;
+import com.stripe.net.RequestOptions;
+import com.stripe.net.StripeResponseGetter;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mockito;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.*;
+
+public class BaseStripeTest {
+	public static StripeResponseGetter networkMock;
+
+	public static <T> void verifyGet(
+			Class<T> clazz,
+			String url) throws StripeException {
+		verifyRequest(APIResource.RequestMethod.GET, clazz, url, null,
+				APIResource.RequestType.NORMAL, RequestOptions.getDefault());
+	}
+
+	public static <T> void verifyGet(
+			Class<T> clazz,
+			String url,
+			Map<String, Object> params) throws StripeException {
+		verifyRequest(APIResource.RequestMethod.GET, clazz, url, params,
+				APIResource.RequestType.NORMAL, RequestOptions.getDefault());
+	}
+
+	public static <T> void verifyGet(
+			Class<T> clazz,
+			String url,
+			RequestOptions requestOptions) throws StripeException {
+		verifyRequest(APIResource.RequestMethod.GET, clazz, url, null,
+				APIResource.RequestType.NORMAL, requestOptions);
+	}
+
+	public static <T> void verifyGet(
+			Class<T> clazz,
+			String url,
+			Map<String, Object> params,
+			RequestOptions requestOptions) throws StripeException {
+		verifyRequest(APIResource.RequestMethod.GET, clazz, url, params,
+				APIResource.RequestType.NORMAL, requestOptions);
+	}
+
+	public static <T> void verifyPost(
+			Class<T> clazz,
+			String url) throws StripeException {
+		verifyRequest(APIResource.RequestMethod.POST, clazz, url, null,
+				APIResource.RequestType.NORMAL, RequestOptions.getDefault());
+	}
+
+	public static <T> void verifyPost(
+			Class<T> clazz,
+			String url,
+			Map<String, Object> params) throws StripeException {
+		verifyRequest(APIResource.RequestMethod.POST, clazz, url, params,
+				APIResource.RequestType.NORMAL, RequestOptions.getDefault());
+	}
+
+	public static <T> void verifyPost(
+			Class<T> clazz,
+			String url,
+			RequestOptions requestOptions) throws StripeException {
+		verifyRequest(APIResource.RequestMethod.POST, clazz, url, null,
+				APIResource.RequestType.NORMAL, requestOptions);
+	}
+
+	public static <T> void verifyPost(
+			Class<T> clazz,
+			String url,
+			Map<String, Object> params,
+			RequestOptions requestOptions) throws StripeException {
+		verifyRequest(APIResource.RequestMethod.POST, clazz, url, params,
+				APIResource.RequestType.NORMAL, requestOptions);
+	}
+
+	public static <T> void verifyRequest(
+			APIResource.RequestMethod method,
+			Class<T> clazz,
+			String url,
+			Map<String, Object> params,
+			APIResource.RequestType requestType,
+			RequestOptions options) throws StripeException {
+		verify(networkMock).request(
+				eq(method),
+				eq(url),
+				argThat(new ParamMapMatcher(params)),
+				eq(clazz),
+				eq(requestType),
+				argThat(new RequestOptionsMatcher(options)));
+	}
+
+	public static <T> void stubNetwork(Class<T> clazz, String response) throws StripeException {
+		when(networkMock.request(
+					Mockito.any(APIResource.RequestMethod.class),
+					Mockito.anyString(),
+					Mockito.<Map<String, Object>>any(),
+					Mockito.<Class<T>>any(),
+					Mockito.any(APIResource.RequestType.class),
+					Mockito.any(RequestOptions.class))).thenReturn(APIResource.GSON.fromJson(response, clazz));
+	}
+
+	public static class ParamMapMatcher extends ArgumentMatcher<Map<String, Object>> {
+		private Map<String, Object> other;
+
+		public ParamMapMatcher(Map<String, Object> other) {
+			this.other = other;
+		}
+
+		/* Treat null references as equal to empty maps */
+		public boolean matches(Object obj) {
+			if (obj == null) {
+				return this.other == null || this.other.isEmpty();
+			} else if (obj instanceof Map) {
+				Map<String, Object> paramMap = (Map<String, Object>) obj;
+				if (this.other == null) {
+					return paramMap.isEmpty();
+				} else {
+					return this.other.equals(paramMap);
+				}
+			} else {
+				return false;
+			}
+		}
+	}
+
+	public static class RequestOptionsMatcher extends ArgumentMatcher<RequestOptions> {
+		private RequestOptions other;
+
+		public RequestOptionsMatcher(RequestOptions other) {
+			this.other = other;
+		}
+
+		/* Treat null reference as RequestOptions.getDefault() */
+		public boolean matches(Object obj) {
+			RequestOptions defaultOptions = RequestOptions.getDefault();
+			if (obj == null) {
+				return this.other == null || this.other.equals(defaultOptions);
+			} else if (obj instanceof RequestOptions) {
+				RequestOptions requestOptions = (RequestOptions) obj;
+				if (this.other == null) {
+					return requestOptions.equals(defaultOptions);
+				} else {
+					return this.other.equals(requestOptions);
+				}
+			} else {
+				return false;
+			}
+		}
+	}
+
+	@BeforeClass
+	public static void setUp() {
+		Stripe.apiKey = "foobar";
+	}
+
+	@Before
+	public void setUpMock() {
+		networkMock = mock(StripeResponseGetter.class);
+	}
+
+	protected String resource(String path) throws IOException {
+		InputStream resource = getClass().getResourceAsStream(path);
+
+		ByteArrayOutputStream os = new ByteArrayOutputStream(1024);
+		byte[] buf = new byte [1024];
+
+		for( int i = resource.read(buf); i > 0; i = resource.read(buf)) {
+			os.write(buf,0,i);
+		}
+
+		return os.toString("utf8");
+
+	}
+}

--- a/src/test/java/com/stripe/model/AccountTest.java
+++ b/src/test/java/com/stripe/model/AccountTest.java
@@ -1,0 +1,107 @@
+package com.stripe.model;
+
+import com.stripe.BaseStripeTest;
+import com.stripe.exception.StripeException;
+import com.stripe.model.Account;
+import com.stripe.net.APIResource;
+import com.stripe.net.LiveStripeResponseGetter;
+import com.stripe.net.RequestOptions.RequestOptionsBuilder;
+import com.stripe.net.RequestOptions;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class AccountTest extends BaseStripeTest {
+	@Before
+	public void mockStripeResponseGetter() {
+		APIResource.setStripeResponseGetter(networkMock);
+	}
+
+	@After
+	public void unmockStripeResponseGetter() {
+		/* This needs to be done because tests aren't isolated in Java */
+		APIResource.setStripeResponseGetter(new LiveStripeResponseGetter());
+	}
+
+	@Test
+	public void testDeserialize() throws StripeException, IOException {
+		String json = resource("account.json");
+		Account acc = APIResource.GSON.fromJson(json, Account.class);
+
+		Account expected = new Account();
+		expected.id = "acct_1032D82eZvKYlo2C";
+		expected.chargesEnabled = false;
+		expected.detailsSubmitted = false;
+		expected.transfersEnabled = false;
+		expected.currenciesSupported = new LinkedList<String>();
+		expected.currenciesSupported.add("usd");
+		expected.currenciesSupported.add("aud");
+		expected.legalEntity = new LegalEntity();
+		expected.legalEntity.type = "company";
+		expected.legalEntity.address = new Address();
+		expected.legalEntity.address.city = "San Francisco";
+		expected.email = "site@stripe.com";
+		expected.defaultCurrency = "usd";
+		expected.country = "US";
+		expected.timezone = "US/Pacific";
+		expected.displayName = "Stripe.com";
+
+		assertEquals(expected, acc);
+	}
+
+	@Test
+	public void testRetrieve() throws StripeException {
+		Account.retrieve();
+
+		verifyGet(Account.class, "https://api.stripe.com/v1/account");
+		verifyNoMoreInteractions(networkMock);
+	}
+
+	@Test
+	public void testOverloadedSingleArgumentRetrieve() throws StripeException {
+		Account.retrieve("sk_foobar");
+
+		RequestOptions options = (new RequestOptionsBuilder()).setApiKey("sk_foobar").build();
+		verifyGet(Account.class, "https://api.stripe.com/v1/account", options);
+
+		Account.retrieve("anything_else");
+
+		verifyGet(Account.class, "https://api.stripe.com/v1/accounts/anything_else");
+		verifyNoMoreInteractions(networkMock);
+	}
+
+	@Test
+	public void testRetrieveAccountWithId() throws StripeException {
+		Account.retrieve("acct_something", null);
+
+		verifyGet(Account.class, "https://api.stripe.com/v1/accounts/acct_something");
+		verifyNoMoreInteractions(networkMock);
+	}
+
+	@Test
+	public void testAccountUpdateById() throws StripeException, IOException {
+		String json = resource("account.json");
+		stubNetwork(Account.class, json);
+		Account acc = Account.retrieve("acct_1032D82eZvKYlo2C");
+		verifyGet(Account.class, "https://api.stripe.com/v1/accounts/acct_1032D82eZvKYlo2C");
+
+		Map<String, Object> params = new HashMap<String, Object>();
+		Map<String, Object> legalEntity = new HashMap<String, Object>();
+		legalEntity.put("type", "individual");
+		params.put("legal_entity", legalEntity);
+		acc.update(params);
+
+		verifyPost(Account.class, "https://api.stripe.com/v1/accounts/acct_1032D82eZvKYlo2C", params);
+		verifyNoMoreInteractions(networkMock);
+	}
+}

--- a/src/test/java/com/stripe/model/DeserializerTest.java
+++ b/src/test/java/com/stripe/model/DeserializerTest.java
@@ -1,19 +1,18 @@
 package com.stripe.model;
 
 import com.google.gson.Gson;
+import com.stripe.BaseStripeTest;
 import com.stripe.net.APIResource;
 import org.junit.Test;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.List;
 
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
-public class DeserializerTest {
+public class DeserializerTest extends BaseStripeTest {
 
 	private static Gson gson = APIResource.GSON;
 
@@ -116,19 +115,5 @@ public class DeserializerTest {
 		assertEquals((Integer) 2, fee.refunds.getTotalCount());
 		assertEquals("fr_104Buu4hAU1NpT8JMBAc564Q", refunds.get(0).getId());
 		assertEquals("fee_4UNP26L2Vuc42P", refunds.get(0).getFee());
-	}
-
-	private String resource(String path) throws IOException {
-		InputStream resource = getClass().getResourceAsStream(path);
-
-		ByteArrayOutputStream os = new ByteArrayOutputStream(1024);
-		byte[] buf = new byte [1024];
-
-		for( int i = resource.read(buf); i > 0; i = resource.read(buf)) {
-			os.write(buf,0,i);
-		}
-
-		return os.toString("utf8");
-
 	}
 }

--- a/src/test/java/com/stripe/model/LegalEntityTest.java
+++ b/src/test/java/com/stripe/model/LegalEntityTest.java
@@ -1,0 +1,44 @@
+package com.stripe.model;
+
+import com.stripe.BaseStripeTest;
+import com.stripe.exception.StripeException;
+import com.stripe.model.Account;
+import com.stripe.model.LegalEntity;
+import com.stripe.net.APIResource;
+import com.stripe.net.RequestOptions;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class LegalEntityTest extends BaseStripeTest {
+	@Test
+	public void testDeserialize() throws StripeException, IOException {
+		String json = resource("legal_entity.json");
+		LegalEntity le = APIResource.GSON.fromJson(json, LegalEntity.class);
+
+		assertEquals("sole_prop", le.getType());
+		assertEquals("business name", le.getBusinessName());
+		assertEquals("12 Grove Street", le.getAddress().getLine1());
+		assertEquals(null, le.getAddress().getLine2());
+		assertEquals("New York", le.getAddress().getCity());
+		assertEquals("NY", le.getAddress().getState());
+		assertEquals("10014", le.getAddress().getPostalCode());
+		assertEquals("US", le.getAddress().getCountry());
+		assertEquals("Monica", le.getFirstName());
+		assertEquals("Geller", le.getLastName());
+		assertEquals(new Integer(4), le.getDob().getDay());
+		assertEquals(new Integer(4), le.getDob().getMonth());
+		assertEquals(new Integer(1969), le.getDob().getYear());
+		assertEquals(new LinkedList<Object>(), le.getAdditionalOwners());
+		assertEquals("verified", le.getVerification().getStatus());
+		assertEquals(null, le.getVerification().getDocument());
+		assertEquals(null, le.getVerification().getDetails());
+	}
+}

--- a/src/test/java/com/stripe/model/LiveStripeResponseGetterTest.java
+++ b/src/test/java/com/stripe/model/LiveStripeResponseGetterTest.java
@@ -1,0 +1,68 @@
+package com.stripe.net;
+
+import com.stripe.exception.StripeException;
+import com.stripe.model.Account;
+import com.stripe.net.LiveStripeResponseGetter;
+import com.stripe.net.RequestOptions;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class LiveStripeResponseGetterTest {
+	LiveStripeResponseGetter srg;
+
+	@Before
+	public void before() {
+		srg = new LiveStripeResponseGetter();
+	}
+
+	/* Kind of hacky, but makes tests readable */
+	public String encode(String s) throws UnsupportedEncodingException {
+		return s.replace("[", "%5B").replace("]", "%5D");
+	}
+
+	@Test
+	public void testCreateQuery() throws StripeException, UnsupportedEncodingException {
+		Map<String, Object> params = new HashMap<String, Object>();
+		params.put("a", "b");
+		assertEquals("a=b", srg.createQuery(params));
+	}
+
+	@Test
+	public void testCreateQueryWithNestedParams() throws StripeException, UnsupportedEncodingException {
+		/* Use LinkedHashMap because it preserves iteration order */
+		Map<String, Object> params = new LinkedHashMap<String, Object>();
+		Map<String, Object> nested = new LinkedHashMap<String, Object>();
+		nested.put("A", "B");
+		nested.put("C", "D");
+		params.put("nested", nested);
+		params.put("c", "d");
+		params.put("e", "f");
+		assertEquals(encode("nested[A]=B&nested[C]=D&c=d&e=f"), srg.createQuery(params));
+	}
+
+	@Test
+	public void testCreateQueryWithList() throws StripeException, UnsupportedEncodingException {
+		/* Use LinkedHashMap because it preserves iteration order */
+		Map<String, Object> params = new LinkedHashMap<String, Object>();
+		List<String> nested = new LinkedList<String>();
+		nested.add("A");
+		nested.add("B");
+		nested.add("C");
+		params.put("nested", nested);
+		params.put("a", "b");
+		params.put("c", "d");
+		assertEquals(encode("nested[0]=A&nested[1]=B&nested[2]=C&a=b&c=d"), srg.createQuery(params));
+	}
+}
+

--- a/src/test/java/com/stripe/model/StandardizationTest.java
+++ b/src/test/java/com/stripe/model/StandardizationTest.java
@@ -52,6 +52,10 @@ public class StandardizationTest {
 				if (method.getDeclaringClass() != aClass) {
 					continue;
 				}
+				// Skip equals
+				if (method.getName().equals("equals")) {
+					continue;
+				}
 				// Skip setters
 				if (method.getName().startsWith("set")) {
 					continue;

--- a/src/test/resources/com/stripe/model/account.json
+++ b/src/test/resources/com/stripe/model/account.json
@@ -1,0 +1,27 @@
+{
+  "id": "acct_1032D82eZvKYlo2C",
+    "email": "site@stripe.com",
+    "statement_descriptor": null,
+    "display_name": "Stripe.com",
+    "timezone": "US/Pacific",
+    "details_submitted": false,
+    "charges_enabled": false,
+    "transfers_enabled": false,
+    "currencies_supported": [
+      "usd",
+    "aud"
+      ],
+    "legal_entity": {
+      "type": "company",
+      "address": {
+        "city": "San Francisco"
+      }
+    },
+    "default_currency": "usd",
+    "country": "US",
+    "object": "account",
+    "business_name": "Stripe.com",
+    "business_url": null,
+    "support_phone": null,
+    "managed": null
+}

--- a/src/test/resources/com/stripe/model/legal_entity.json
+++ b/src/test/resources/com/stripe/model/legal_entity.json
@@ -1,0 +1,25 @@
+{
+  "type": "sole_prop",
+  "business_name": "business name",
+  "address": {
+    "line1": "12 Grove Street",
+    "line2": null,
+    "city": "New York",
+    "state": "NY",
+    "postal_code": "10014",
+    "country": "US"
+  },
+  "first_name": "Monica",
+  "last_name": "Geller",
+  "dob": {
+    "day": 4,
+    "month": 4,
+    "year": 1969
+  },
+  "additional_owners": [],
+  "verification": {
+    "status": "verified",
+    "document": null,
+    "details": null
+  }
+}


### PR DESCRIPTION
r? @jimdanz @bkrausz 

Add account retrieval by ID and add a super basic (stubbed!) unit test. This is an example of how #148 will work.

TODO:
- [x] add more tests for `Account`
- [x] ~~add nested map support~~ (already exists)
- [x] add support for lists
- [x] add support for legal entity
  - [x] verification
  - [x] address
  - [x] dob
  - [x] personal_address
  - [x] additional_owners
- [x] C
- [x] R
- [x] U