### PR TITLE
Missing fields on Account object

### DIFF
--- a/src/main/java/com/stripe/model/Account.java
+++ b/src/main/java/com/stripe/model/Account.java
@@ -25,6 +25,15 @@ public class Account extends APIResource {
 	String displayName;
 	Verification verification;
 	LegalEntity legalEntity;
+	Keys keys;
+	Map<String, String> metadata;
+	String businessName;
+	String businessUrl;
+	String businessLogo;
+	String supportPhone;
+	String supportUrl;
+	String supportEmail;
+	Boolean managed;
 
 	public String getId() {
 		return id;
@@ -76,6 +85,51 @@ public class Account extends APIResource {
 
 	public LegalEntity getLegalEntity() {
 		return legalEntity;
+	}
+
+	public Keys getKeys()
+	{
+		return keys;
+	}
+
+	public Map<String, String> getMetadata()
+	{
+		return metadata;
+	}
+
+	public String getBusinessName()
+	{
+		return businessName;
+	}
+
+	public String getBusinessUrl()
+	{
+		return businessUrl;
+	}
+
+	public String getBusinessLogo()
+	{
+		return businessLogo;
+	}
+
+	public String getSupportPhone()
+	{
+		return supportPhone;
+	}
+
+	public String getSupportUrl()
+	{
+		return supportUrl;
+	}
+
+	public String getSupportEmail()
+	{
+		return supportEmail;
+	}
+
+	public Boolean getManaged()
+	{
+		return managed;
 	}
 
 	public static Account create(Map<String, Object> params)
@@ -164,7 +218,16 @@ public class Account extends APIResource {
 			equals(timezone, account.timezone) &&
 			equals(displayName, account.displayName) &&
 			equals(verification, account.verification) &&
-			equals(legalEntity, account.legalEntity);
+			equals(legalEntity, account.legalEntity) &&
+			equals(keys, account.keys) &&
+			equals(metadata, account.metadata) &&
+			equals(businessName, account.businessName) &&
+			equals(businessUrl, account.businessUrl) &&
+			equals(businessLogo, account.businessLogo) &&
+			equals(supportPhone, account.supportPhone) &&
+			equals(supportUrl, account.supportUrl) &&
+			equals(supportEmail, account.supportEmail) &&
+			equals(managed, account.managed);
 	}
 
 	public static class Verification extends StripeObject {
@@ -180,6 +243,21 @@ public class Account extends APIResource {
 		}
 		public Boolean getContacted() {
 			return contacted;
+		}
+	}
+
+	public static class Keys extends StripeObject {
+		String secret;
+		String publishable;
+
+		public String getSecret()
+		{
+			return secret;
+		}
+
+		public String getPublishable()
+		{
+			return publishable;
 		}
 	}
 }

--- a/src/test/java/com/stripe/model/AccountTest.java
+++ b/src/test/java/com/stripe/model/AccountTest.java
@@ -55,6 +55,7 @@ public class AccountTest extends BaseStripeTest {
 		expected.country = "US";
 		expected.timezone = "US/Pacific";
 		expected.displayName = "Stripe.com";
+		expected.businessName = "Stripe.com";
 
 		assertEquals(expected, acc);
 	}


### PR DESCRIPTION
Add missing `Account` fields needed when creating a standalone `Account` for Connect
Fix for issue stripe/stripe-java#163