### PR TITLE
Quick fix for account.reject event NPE

### DIFF
--- a/src/main/java/com/stripe/model/EventDataDeserializer.java
+++ b/src/main/java/com/stripe/model/EventDataDeserializer.java
@@ -102,8 +102,14 @@ public class EventDataDeserializer implements JsonDeserializer<EventData> {
 				populateMapFromJSONObject(previousAttributes, element.getAsJsonObject());
 				eventData.setPreviousAttributes(previousAttributes);
 			} else if ("object".equals(key)) {
-				String type = element.getAsJsonObject().get("object").getAsString();
-				Class<StripeObject> cl = objectMap.get(type);
+                                String type = "";
+                                try {
+			                type = element.getAsJsonObject().get("object").getAsString();				        
+                                } catch (NullPointerException e) {
+                                        type = element.getAsJsonObject().get("type").getAsString().split("\\.")[0];
+                                }
+
+                                Class<StripeObject> cl = objectMap.get(type);
 				StripeObject object = APIResource.GSON.fromJson(entry.getValue(), cl != null ? cl : StripeRawJsonObject.class);
 				eventData.setObject(object);
 			}

--- a/src/test/java/com/stripe/model/DeserializerTest.java
+++ b/src/test/java/com/stripe/model/DeserializerTest.java
@@ -68,6 +68,14 @@ public class DeserializerTest extends BaseStripeTest {
 		assertEquals(e.getType(), "account.updated");
 	}
 
+    	@Test
+	public void deserializeEventDataRejectEvent() throws IOException {
+		String json = resource("reject_event.json");
+		Event e = StripeObject.PRETTY_PRINT_GSON.fromJson(json, Event.class);
+
+		assertEquals(e.getType(), "account.reject");
+	}
+
 	@Test
 	public void deserializeRefundList() throws IOException {
 		String json = resource("charge_refund_list.json");

--- a/src/test/resources/com/stripe/model/reject_event.json
+++ b/src/test/resources/com/stripe/model/reject_event.json
@@ -1,0 +1,24 @@
+{
+  "id": "evt_00000000000000",  
+  "created": 1432769421,
+  "livemode": true,
+  "type": "account.reject",
+  "data": {
+    "object": {
+      "id":"vuJEYvcYMexPckSv0bsIJYJBPTK82lWJ_00000000000000",
+      "created": 1432769421,
+      "livemode": true,
+      "body": "Fraudulent account. Please close and refund charges.",
+      "type": "account.reject",
+      "category": "fraud",
+      "author_name": "Stripe Admin",
+      "data": null,
+      "in_reply_to": null
+    }
+  },
+  "object": "event",
+  "pending_webhooks": 1,
+  "request": null,
+  "api_version": null,
+  "user_id": "acct_00000000000000"
+}


### PR DESCRIPTION
This is a less than ideal solution for issue #176. If the "object" field is missing but "type" is present, the information necessary for deserialization can be extracted from the latter. This will work as a temporary fix for anyone currently suffering from this issue.