### PR TITLE
Add license information to the pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,12 @@
     <version>1.31.0</version>
     <name>stripe-java</name>
     <url>https://github.com/stripe/stripe-java</url>
+    <licenses>
+      <license>
+        <name>MIT</name>
+        <url>http://choosealicense.com/licenses/mit/</url>
+      </license>
+    </licenses>
     <dependencies>
         <dependency>
             <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
Adding the MIT license to the pom.xml. That way the license is available via the package manager. 