### PR TITLE
Adds http status code to InvalidRequestException

### DIFF
--- a/src/main/java/com/stripe/exception/InvalidRequestException.java
+++ b/src/main/java/com/stripe/exception/InvalidRequestException.java
@@ -5,14 +5,19 @@ public class InvalidRequestException extends StripeException {
 	private static final long serialVersionUID = 1L;
 
 	private final String param;
+	private final Integer code;
 
-	public InvalidRequestException(String message, String param, Throwable e) {
+	public InvalidRequestException(String message, String param, Integer code, Throwable e) {
 		super(message, e);
 		this.param = param;
+		this.code = code;
 	}
 
 	public String getParam() {
 		return param;
 	}
 
+	public Integer getCode() {
+		return code;
+	}
 }

--- a/src/main/java/com/stripe/net/APIResource.java
+++ b/src/main/java/com/stripe/net/APIResource.java
@@ -22,23 +22,9 @@ import com.stripe.model.StripeObject;
 import com.stripe.model.StripeRawJsonObject;
 import com.stripe.model.StripeRawJsonObjectDeserializer;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.net.URLEncoder;
-import java.net.URLStreamHandler;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Scanner;
 
 public abstract class APIResource extends StripeObject {
 	private static StripeResponseGetter stripeResponseGetter = new LiveStripeResponseGetter();
@@ -102,7 +88,7 @@ public abstract class APIResource extends StripeObject {
 			throw new InvalidRequestException("Unable to encode parameters to "
 					+ CHARSET
 					+ ". Please contact support@stripe.com for assistance.",
-					null, e);
+					null, null, e);
 		}
 	}
 

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -17,9 +17,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.URLEncoder;
 import java.net.URLStreamHandler;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -223,7 +221,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 					throw new InvalidRequestException("You cannot set '"+key+"' to an empty string. "+
 										"We interpret empty strings as null in requests. "+
 										"You may set '"+key+"' to null to delete the property.",
-										key, null);
+										key, null, null);
 			} else if (value == null) {
 				flatParams.put(key, "");
 			} else {
@@ -394,7 +392,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 			throw new InvalidRequestException("Unable to encode parameters to "
 					+ APIResource.CHARSET
 					+ ". Please contact support@stripe.com for assistance.",
-					null, e);
+					null, null, e);
 		}
 
 		try {
@@ -422,7 +420,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 		if (method != APIResource.RequestMethod.POST) {
 			throw new InvalidRequestException(
 					"Multipart requests for HTTP methods other than POST "
-							+ "are currently not supported.", null, null);
+							+ "are currently not supported.", null, null, null);
 		}
 
 		java.net.HttpURLConnection conn = null;
@@ -448,16 +446,16 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 						File currentFile = (File) value;
 						if (!currentFile.exists()) {
 							throw new InvalidRequestException("File for key "
-									+ key + " must exist.", null, null);
+									+ key + " must exist.", null, null, null);
 						} else if (!currentFile.isFile()) {
 							throw new InvalidRequestException("File for key "
 									+ key
 									+ " must be a file and not a directory.",
-									null, null);
+									null, null, null);
 						} else if (!currentFile.canRead()) {
 							throw new InvalidRequestException(
 									"Must have read permissions on file for key "
-									+ key + ".", null, null);
+									+ key + ".", null, null, null);
 						}
 						multipartProcessor.addFileField(key, currentFile);
 					} else {
@@ -509,9 +507,9 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 				LiveStripeResponseGetter.ErrorContainer.class).error;
 		switch (rCode) {
 		case 400:
-			throw new InvalidRequestException(error.message, error.param, null);
+			throw new InvalidRequestException(error.message, error.param, rCode, null);
 		case 404:
-			throw new InvalidRequestException(error.message, error.param, null);
+			throw new InvalidRequestException(error.message, error.param, rCode, null);
 		case 401:
 			throw new AuthenticationException(error.message);
 		case 402:

--- a/src/test/java/com/stripe/StripeTest.java
+++ b/src/test/java/com/stripe/StripeTest.java
@@ -1150,6 +1150,20 @@ public class StripeTest {
 	}
 
 	@Test
+	public void testUpcomingInvoiceNotFound() throws CardException, APIException, AuthenticationException,
+		InvalidRequestException, APIConnectionException {
+		Customer customer = Customer.create(defaultCustomerParams);
+		Map<String, Object> upcomingParams = new HashMap<String, Object>();
+		upcomingParams.put("customer", customer.getId());
+		try {
+			Invoice.upcoming(upcomingParams);
+			fail();
+		} catch (InvalidRequestException expected) {
+			assertEquals(404, (int)expected.getCode());
+		}
+	}
+
+	@Test
 	public void testTokenCreate() throws StripeException {
 		Token token = Token.create(defaultTokenParams);
 		assertFalse(token.getUsed());


### PR DESCRIPTION
There is currently no way in the Java api bindings to tell the difference between a `404` and a `400` response. These are both identically mapped to `InvalidRequestException`.

Example use case:
Getting the upcoming invoice for a customer. There is a meaningful difference between a 'not found' vs a 'bad request' response.
