### PR TITLE
Deprecate transfer recipient, use destination instead

### DIFF
--- a/src/main/java/com/stripe/model/Transfer.java
+++ b/src/main/java/com/stripe/model/Transfer.java
@@ -26,6 +26,7 @@ public class Transfer extends APIResource implements MetadataStore<Transfer> {
 	List<String> otherTransfers;
 	@Deprecated
 	String recipient;
+	String destination;
 	BankAccount account;
 	String balanceTransaction;
 	Map<String, String> metadata;
@@ -117,6 +118,14 @@ public class Transfer extends APIResource implements MetadataStore<Transfer> {
 	@Deprecated
 	public void setRecipient(String recipient) {
 		this.recipient = recipient;
+	}
+
+	public String getDestination() {
+		return destination;
+	}
+
+	public void setDestination(String destination) {
+		this.destination = destination;
 	}
 
 	public BankAccount getAccount() {

--- a/src/main/java/com/stripe/model/Transfer.java
+++ b/src/main/java/com/stripe/model/Transfer.java
@@ -24,6 +24,7 @@ public class Transfer extends APIResource implements MetadataStore<Transfer> {
 	Integer amount;
 	String currency;
 	List<String> otherTransfers;
+	@Deprecated
 	String recipient;
 	BankAccount account;
 	String balanceTransaction;
@@ -108,10 +109,12 @@ public class Transfer extends APIResource implements MetadataStore<Transfer> {
 		return currency;
 	}
 
+	@Deprecated
 	public String getRecipient() {
 		return recipient;
 	}
 
+	@Deprecated
 	public void setRecipient(String recipient) {
 		this.recipient = recipient;
 	}

--- a/src/test/java/com/stripe/StripeTest.java
+++ b/src/test/java/com/stripe/StripeTest.java
@@ -1286,16 +1286,6 @@ public class StripeTest {
 		assertEquals(transfers.size(), 1);
 	}
 
-	@Test(expected=InvalidRequestException.class)
-  public void testTransferReversalCreate() throws StripeException {
-		Transfer tr = Transfer.create(getTransferParams());
-		Map<String, Object> params = new HashMap<String, Object>();
-		TransferReversalCollection reversals = tr.getReversals();
-		reversals.create(params);
-		// post-condition: we expect an InvalidRequestException here (caught by JUnit),
-		// because in test mode, transfers are automatically sent
-  }
-
 	@Test
 	public void testRecipientCreate() throws StripeException {
 		Recipient recipient = Recipient.create(defaultRecipientParams);


### PR DESCRIPTION
Deprecate the `recipient` field in the `Transfer` class in favour of using the `destination` field instead.

R? @kyleconroy 