### PR TITLE
fixes #202. Add status setter to Charge

### DIFF
--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -65,6 +65,10 @@ public class Charge extends APIResource implements MetadataStore<Charge> {
 		return status;
 	}
 
+	public void setStatus(String status) {
+		this.status = status;
+	}
+
 	public Integer getAmount() {
 		return amount;
 	}


### PR DESCRIPTION
Pretty much all other attributes in Charge.java have both getters and setters except for status. Adding a setter to status will provide better consistency. 