### PR TITLE
Add create, retrieve, and all methods to Refund

### DIFF
--- a/src/main/java/com/stripe/model/Refund.java
+++ b/src/main/java/com/stripe/model/Refund.java
@@ -26,6 +26,24 @@ public class Refund extends APIResource implements MetadataStore<Charge> {
 		return update(params, (RequestOptions) null);
 	}
 
+	public static Refund retrieve(String id)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return retrieve(id, (RequestOptions) null);
+	}
+
+	public static RefundCollection all(Map<String, Object> params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return all(params, (RequestOptions) null);
+	}
+
+	public static Refund create(Map<String, Object> params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params, (RequestOptions) null);
+	}
+
 	@Deprecated
 	public Refund update(Map<String, Object> params, String apiKey)
 			throws AuthenticationException, InvalidRequestException,
@@ -35,19 +53,35 @@ public class Refund extends APIResource implements MetadataStore<Charge> {
 	public Refund update(Map<String, Object> params, RequestOptions options)
 			throws AuthenticationException, InvalidRequestException,
 			APIConnectionException, CardException, APIException {
-		return request(RequestMethod.POST, this.getInstanceURL(), params, Refund.class, options);
+		return request(RequestMethod.POST, instanceURL(Refund.class, id), params, Refund.class, options);
 	}
 
-	public String getInstanceURL() {
-		if (this.charge != null) {
-			return String.format("%s/%s/refunds/%s", classURL(Charge.class), this.charge, this.getId());
-		}
-		return null;
+	public static Refund retrieve(String id, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return request(RequestMethod.GET, instanceURL(Refund.class, id), null, Refund.class, options);
+	}
+
+	public static RefundCollection all(Map<String, Object> params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return request(RequestMethod.GET, classURL(Refund.class), params, RefundCollection.class, options);
+	}
+
+	public static Refund create(Map<String, Object> params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return request(RequestMethod.POST, classURL(Refund.class), params, Refund.class, options);
 	}
 
 	public String getId() {
 		return id;
 	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
 	public Integer getAmount() {
 		return amount;
 	}

--- a/src/main/java/com/stripe/model/RefundCollection.java
+++ b/src/main/java/com/stripe/model/RefundCollection.java
@@ -1,0 +1,14 @@
+package com.stripe.model;
+
+import com.stripe.Stripe;
+import com.stripe.exception.APIConnectionException;
+import com.stripe.exception.APIException;
+import com.stripe.exception.AuthenticationException;
+import com.stripe.exception.CardException;
+import com.stripe.exception.InvalidRequestException;
+import com.stripe.net.RequestOptions;
+
+import java.util.Map;
+
+public class RefundCollection extends StripeCollection<Refund> {
+}

--- a/src/test/java/com/stripe/model/RefundTest.java
+++ b/src/test/java/com/stripe/model/RefundTest.java
@@ -1,0 +1,73 @@
+package com.stripe.model;
+
+import com.stripe.BaseStripeTest;
+import com.stripe.exception.StripeException;
+import com.stripe.model.Refund;
+import com.stripe.net.APIResource;
+import com.stripe.net.LiveStripeResponseGetter;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.HashMap;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class RefundTest extends BaseStripeTest {
+
+    @Before
+    public void mockStripeResponseGetter() {
+        APIResource.setStripeResponseGetter(networkMock);
+    }
+
+    @After
+    public void unmockStripeResponseGetter() {
+        /* This needs to be done because tests aren't isolated in Java */
+        APIResource.setStripeResponseGetter(new LiveStripeResponseGetter());
+    }
+
+    @Test
+    public void testRetrieve() throws StripeException {
+        Refund.retrieve("re_foo");
+
+        verifyGet(Refund.class, "https://api.stripe.com/v1/refunds/re_foo");
+        verifyNoMoreInteractions(networkMock);
+    }
+
+    @Test
+    public void testAll() throws StripeException {
+		HashMap<String, Object> params = new HashMap<String, Object>();
+		params.put("limit", 3);
+
+        Refund.all(params);
+
+        verifyGet(RefundCollection.class, "https://api.stripe.com/v1/refunds", params);
+        verifyNoMoreInteractions(networkMock);
+    }
+
+    @Test
+    public void testUpdate() throws StripeException {
+		Refund refund = new Refund();
+		refund.setId("re_foo");
+
+		HashMap<String, Object> params = new HashMap<String, Object>();
+		params.put("reason", "fraudulent");
+
+		refund.update(params);
+
+        verifyPost(Refund.class, "https://api.stripe.com/v1/refunds/re_foo", params);
+        verifyNoMoreInteractions(networkMock);
+    }
+
+    @Test
+    public void testCreate() throws StripeException {
+		HashMap<String, Object> params = new HashMap<String, Object>();
+		params.put("charge", "ch_foo");
+
+		Refund refund = Refund.create(params);
+
+        verifyPost(Refund.class, "https://api.stripe.com/v1/refunds", params);
+        verifyNoMoreInteractions(networkMock);
+    }
+}


### PR DESCRIPTION
I took a different approach than usual with testing this PR. Instead of functional tests, I used the mocking framework to verify API calls. I think it works well for what we're trying to do.