### PR TITLE
added support for iterating over stripe collections lazily-loading

### DIFF
--- a/src/main/java/com/stripe/model/ApplicationFee.java
+++ b/src/main/java/com/stripe/model/ApplicationFee.java
@@ -10,7 +10,7 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
-public class ApplicationFee extends APIResource {
+public class ApplicationFee extends APIResource implements HasId {
 	Integer amount;
 	Long created;
 	String currency;

--- a/src/main/java/com/stripe/model/BalanceTransaction.java
+++ b/src/main/java/com/stripe/model/BalanceTransaction.java
@@ -12,7 +12,7 @@ import com.stripe.net.RequestOptions;
 import java.util.List;
 import java.util.Map;
 
-public class BalanceTransaction extends APIResource {
+public class BalanceTransaction extends APIResource implements HasId {
 	String id;
 	String source;
 	Integer amount;

--- a/src/main/java/com/stripe/model/BitcoinReceiver.java
+++ b/src/main/java/com/stripe/model/BitcoinReceiver.java
@@ -12,7 +12,7 @@ import com.stripe.net.RequestOptions;
 import java.util.Collections;
 import java.util.Map;
 
-public class BitcoinReceiver extends ExternalAccount {
+public class BitcoinReceiver extends ExternalAccount implements HasId {
     String status;
     Long created;
     String currency;

--- a/src/main/java/com/stripe/model/BitcoinTransaction.java
+++ b/src/main/java/com/stripe/model/BitcoinTransaction.java
@@ -12,7 +12,7 @@ import com.stripe.net.RequestOptions;
 import java.util.Collections;
 import java.util.Map;
 
-public class BitcoinTransaction extends APIResource {
+public class BitcoinTransaction extends APIResource implements HasId {
     String id;
     Long created;
     String currency;

--- a/src/main/java/com/stripe/model/Card.java
+++ b/src/main/java/com/stripe/model/Card.java
@@ -9,7 +9,7 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
-public class Card extends ExternalAccount implements MetadataStore<Card> {
+public class Card extends ExternalAccount implements MetadataStore<Card>, HasId {
 	String status;
 	Integer expMonth;
 	Integer expYear;

--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -11,7 +11,7 @@ import com.stripe.net.RequestOptions;
 import java.util.Collections;
 import java.util.Map;
 
-public class Charge extends APIResource implements MetadataStore<Charge> {
+public class Charge extends APIResource implements MetadataStore<Charge>, HasId {
 	Integer amount;
 	Long created;
 	String currency;

--- a/src/main/java/com/stripe/model/Coupon.java
+++ b/src/main/java/com/stripe/model/Coupon.java
@@ -10,7 +10,7 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
-public class Coupon extends APIResource implements MetadataStore<Coupon> {
+public class Coupon extends APIResource implements MetadataStore<Coupon>, HasId {
 	Integer percentOff;
 	Integer amountOff;
 	String currency;

--- a/src/main/java/com/stripe/model/Customer.java
+++ b/src/main/java/com/stripe/model/Customer.java
@@ -11,7 +11,7 @@ import com.stripe.net.RequestOptions;
 import java.util.HashMap;
 import java.util.Map;
 
-public class Customer extends APIResource implements MetadataStore<Customer> {
+public class Customer extends APIResource implements MetadataStore<Customer>, HasId {
 	Long created;
 	String id;
 	Boolean livemode;

--- a/src/main/java/com/stripe/model/Dispute.java
+++ b/src/main/java/com/stripe/model/Dispute.java
@@ -11,7 +11,7 @@ import com.stripe.net.RequestOptions;
 import java.util.List;
 import java.util.Map;
 
-public class Dispute extends APIResource {
+public class Dispute extends APIResource implements HasId {
 	String id;
 	Boolean livemode;
 	Integer amount;

--- a/src/main/java/com/stripe/model/Event.java
+++ b/src/main/java/com/stripe/model/Event.java
@@ -10,7 +10,7 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
-public class Event extends APIResource {
+public class Event extends APIResource implements HasId {
 	String id;
 	String type;
 	String userId;

--- a/src/main/java/com/stripe/model/ExternalAccount.java
+++ b/src/main/java/com/stripe/model/ExternalAccount.java
@@ -12,7 +12,7 @@ import com.stripe.net.RequestOptions;
 import java.util.Collections;
 import java.util.Map;
 
-public class ExternalAccount extends APIResource {
+public class ExternalAccount extends APIResource implements HasId {
     String id;
     String object;
     String customer;

--- a/src/main/java/com/stripe/model/FeeRefund.java
+++ b/src/main/java/com/stripe/model/FeeRefund.java
@@ -10,7 +10,7 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
-public class FeeRefund extends APIResource implements MetadataStore<ApplicationFee> {
+public class FeeRefund extends APIResource implements MetadataStore<ApplicationFee>, HasId {
 	Integer amount;
 	String currency;
 	Long created;

--- a/src/main/java/com/stripe/model/FileUpload.java
+++ b/src/main/java/com/stripe/model/FileUpload.java
@@ -1,7 +1,6 @@
 package com.stripe.model;
 
 import com.stripe.Stripe;
-
 import com.stripe.exception.APIConnectionException;
 import com.stripe.exception.APIException;
 import com.stripe.exception.AuthenticationException;
@@ -12,7 +11,7 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
-public class FileUpload extends APIResource {
+public class FileUpload extends APIResource implements HasId {
 	String id;
 	Long created;
 	Long size;

--- a/src/main/java/com/stripe/model/HasId.java
+++ b/src/main/java/com/stripe/model/HasId.java
@@ -1,0 +1,5 @@
+package com.stripe.model;
+
+public interface HasId {
+	public String getId();
+}

--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -10,7 +10,7 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
-public class Invoice extends APIResource implements MetadataStore<Invoice>{
+public class Invoice extends APIResource implements MetadataStore<Invoice>, HasId {
 	Integer subtotal;
 	Integer total;
 	Integer amountDue;

--- a/src/main/java/com/stripe/model/InvoiceItem.java
+++ b/src/main/java/com/stripe/model/InvoiceItem.java
@@ -10,7 +10,7 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
-public class InvoiceItem extends APIResource implements MetadataStore<InvoiceItem> {
+public class InvoiceItem extends APIResource implements MetadataStore<InvoiceItem>, HasId {
 	Integer amount;
 	String id;
 	String currency;

--- a/src/main/java/com/stripe/model/InvoiceLineItem.java
+++ b/src/main/java/com/stripe/model/InvoiceLineItem.java
@@ -2,7 +2,7 @@ package com.stripe.model;
 
 import java.util.Map;
 
-public class InvoiceLineItem extends StripeObject {
+public class InvoiceLineItem extends StripeObject implements HasId {
 	String id;
 	String type;
 	Boolean livemode;

--- a/src/main/java/com/stripe/model/Plan.java
+++ b/src/main/java/com/stripe/model/Plan.java
@@ -10,7 +10,7 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
-public class Plan extends APIResource implements MetadataStore<Plan> {
+public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
 
 	Integer amount;
 	String currency;

--- a/src/main/java/com/stripe/model/Recipient.java
+++ b/src/main/java/com/stripe/model/Recipient.java
@@ -11,7 +11,7 @@ import com.stripe.net.RequestOptions;
 import java.util.HashMap;
 import java.util.Map;
 
-public class Recipient extends APIResource implements MetadataStore<Recipient> {
+public class Recipient extends APIResource implements MetadataStore<Recipient>, HasId {
 	Long created;
 	String id;
 	String type;

--- a/src/main/java/com/stripe/model/Refund.java
+++ b/src/main/java/com/stripe/model/Refund.java
@@ -10,7 +10,7 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
-public class Refund extends APIResource implements MetadataStore<Charge> {
+public class Refund extends APIResource implements MetadataStore<Charge>, HasId {
 	Integer amount;
 	String currency;
 	Long created;

--- a/src/main/java/com/stripe/model/Reversal.java
+++ b/src/main/java/com/stripe/model/Reversal.java
@@ -10,7 +10,7 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
-public class Reversal extends APIResource implements MetadataStore<Transfer> {
+public class Reversal extends APIResource implements MetadataStore<Transfer>, HasId {
 	Integer amount;
 	String currency;
 	Long created;

--- a/src/main/java/com/stripe/model/StripeCollection.java
+++ b/src/main/java/com/stripe/model/StripeCollection.java
@@ -1,8 +1,12 @@
 package com.stripe.model;
 
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
-public abstract class StripeCollection<T> extends StripeObject {
+import com.stripe.net.RequestOptions;
+
+public abstract class StripeCollection<T extends HasId> extends StripeObject implements StripeCollectionInterface<T>, Iterable<T> {
 	List<T> data;
 	Integer totalCount;
 	Boolean hasMore;
@@ -41,5 +45,9 @@ public abstract class StripeCollection<T> extends StripeObject {
 	/** 3/2014: Legacy (from before newstyle pagination API) */
 	public void setCount(Integer count) {
 		this.count = count;
+	}
+	
+	public Iterator<T> iterator() {
+		return new StripeCollectionIterator<T>(this);
 	}
 }

--- a/src/main/java/com/stripe/model/StripeCollectionAPIResource.java
+++ b/src/main/java/com/stripe/model/StripeCollectionAPIResource.java
@@ -2,9 +2,10 @@ package com.stripe.model;
 
 import com.stripe.net.APIResource;
 
+import java.util.Iterator;
 import java.util.List;
 
-public abstract class StripeCollectionAPIResource<T> extends APIResource {
+public abstract class StripeCollectionAPIResource<T extends HasId> extends APIResource implements StripeCollectionInterface<T>, Iterable<T>  {
 	List<T> data;
 	Integer totalCount;
 	Boolean hasMore;
@@ -33,6 +34,9 @@ public abstract class StripeCollectionAPIResource<T> extends APIResource {
 	public String getURL() {
 		return url;
 	}
+	public String getUrl() {
+		return url;
+	}
 	public void setURL(String url) {
 		this.url = url;
 	}
@@ -43,5 +47,9 @@ public abstract class StripeCollectionAPIResource<T> extends APIResource {
 	/** 3/2014: Legacy (from before newstyle pagination API) */
 	public void setCount(Integer count) {
 		this.count = count;
+	}
+	
+	public Iterator<T> iterator() {
+		return new StripeCollectionIterator<T>(this);
 	}
 }

--- a/src/main/java/com/stripe/model/StripeCollectionInterface.java
+++ b/src/main/java/com/stripe/model/StripeCollectionInterface.java
@@ -1,0 +1,10 @@
+package com.stripe.model;
+
+import java.util.List;
+
+public interface StripeCollectionInterface<T> {
+	public List<T> getData();
+	public Integer getTotalCount();
+	public Boolean getHasMore();
+	public String getUrl();
+}

--- a/src/main/java/com/stripe/model/StripeCollectionIterator.java
+++ b/src/main/java/com/stripe/model/StripeCollectionIterator.java
@@ -45,7 +45,7 @@ public class StripeCollectionIterator<T extends HasId> extends APIResource imple
 			this.lastId = 
 				next.getId();
 			
-			return currentDataIterator.next();
+			return next;
 			
 		} else if (currentCollection.getHasMore()) {
 			try {

--- a/src/main/java/com/stripe/model/StripeCollectionIterator.java
+++ b/src/main/java/com/stripe/model/StripeCollectionIterator.java
@@ -1,0 +1,80 @@
+package com.stripe.model;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+import com.stripe.Stripe;
+import com.stripe.net.APIResource;
+import com.stripe.net.RequestOptions;
+
+public class StripeCollectionIterator<T extends HasId> extends APIResource implements Iterator<T> {
+	private final String url;
+	
+	@SuppressWarnings("rawtypes")
+	private final Class<? extends StripeCollectionInterface> collectionType;
+	
+	private StripeCollectionInterface<T> currentCollection;
+	private Iterator<T> currentDataIterator;
+	
+	private String lastId;
+	
+	StripeCollectionIterator(final StripeCollectionInterface<T> stripeCollection) {
+        this.url = Stripe.getApiBase() + stripeCollection.getUrl();
+        
+		this.collectionType = stripeCollection.getClass();
+		
+		this.currentCollection = stripeCollection;
+		this.currentDataIterator = stripeCollection.getData().iterator();
+	}
+
+	@Override
+	public boolean hasNext() {
+		return 
+			currentDataIterator.hasNext() ||
+			currentCollection.getHasMore();
+	}
+
+	@Override
+	public T next() {
+		if (currentDataIterator.hasNext()) {
+			final T next =
+				currentDataIterator.next();
+			
+			this.lastId = 
+				next.getId();
+			
+			return currentDataIterator.next();
+			
+		} else if (currentCollection.getHasMore()) {
+			try {
+				this.currentCollection =
+					list(Collections.<String, Object>singletonMap("starting_after", lastId), null);
+				
+				this.currentDataIterator =
+					currentCollection.getData().iterator();
+				
+				return next();
+			} catch (final Exception e) {
+				throw new RuntimeException("Unable to lazy-load stripe objects", e);
+			}
+			
+		} else {
+			throw new NoSuchElementException();
+		}
+	}
+
+	@Override
+	public void remove() {
+		throw new UnsupportedOperationException();
+	}
+
+	@SuppressWarnings("unchecked")
+	protected StripeCollectionInterface<T> list(
+		final Map<String, Object> params, 
+		final RequestOptions options
+	) throws Exception {
+		return APIResource.request(RequestMethod.GET, url, params, collectionType, options);
+	}
+}

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -11,7 +11,7 @@ import com.stripe.net.RequestOptions;
 import java.util.Map;
 
 
-public class Subscription extends APIResource implements MetadataStore<Subscription>{
+public class Subscription extends APIResource implements MetadataStore<Subscription>, HasId {
 	String id;
 	Long currentPeriodEnd;
 	Long currentPeriodStart;

--- a/src/main/java/com/stripe/model/Transfer.java
+++ b/src/main/java/com/stripe/model/Transfer.java
@@ -11,7 +11,7 @@ import com.stripe.net.RequestOptions;
 import java.util.List;
 import java.util.Map;
 
-public class Transfer extends APIResource implements MetadataStore<Transfer> {
+public class Transfer extends APIResource implements MetadataStore<Transfer>, HasId {
 	String id;
 	String status;
 	Long date;

--- a/src/main/java/com/stripe/model/TransferTransaction.java
+++ b/src/main/java/com/stripe/model/TransferTransaction.java
@@ -1,6 +1,6 @@
 package com.stripe.model;
 
-public class TransferTransaction extends StripeObject {
+public class TransferTransaction extends StripeObject implements HasId {
 	String id;
 	Long amount;
 	Long net;


### PR DESCRIPTION
lazy loading iteration over StripeCollections per latest conversation in pull request #125 "Make StripeCollection implement java.util.Iterable"

This required a couple of interfaces to be added to normalize stripe objects and collections across the api:
1. HasId interface with getId() method was added to stripe objects that can be iterated over.
2. StripeCollectionInterface was added to normalize StripeCollection and StripeCollectionAPIResource classes which previously did not share a common base class.  StripeCollectionAPIResource unfortunately contains getURL() and getUrl() now.  I suggest that one of them should be deprecated in favor of the other.