### PR TITLE
Manually enable TLSv1.2 for the benefit of Java 6 and 7

### DIFF
--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -7,6 +7,8 @@ import com.stripe.exception.AuthenticationException;
 import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
 
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSocketFactory;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -37,6 +39,8 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 	 * environments.
 	 */
 	private static final String CUSTOM_URL_STREAM_HANDLER_PROPERTY_NAME = "com.stripe.net.customURLStreamHandler";
+
+	private static final SSLSocketFactory socketFactory = new StripeSSLSocketFactory(HttpsURLConnection.getDefaultSSLSocketFactory());
 
 	public <T> T request(
 			APIResource.RequestMethod method,
@@ -136,6 +140,9 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 		conn.setUseCaches(false);
 		for (Map.Entry<String, String> header : getHeaders(options).entrySet()) {
 			conn.setRequestProperty(header.getKey(), header.getValue());
+		}
+		if (conn instanceof HttpsURLConnection) {
+			((HttpsURLConnection) conn).setSSLSocketFactory(socketFactory);
 		}
 
 		return conn;

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -40,7 +40,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 	 */
 	private static final String CUSTOM_URL_STREAM_HANDLER_PROPERTY_NAME = "com.stripe.net.customURLStreamHandler";
 
-	private static final SSLSocketFactory socketFactory = new StripeSSLSocketFactory(HttpsURLConnection.getDefaultSSLSocketFactory());
+	private static final SSLSocketFactory socketFactory = new StripeSSLSocketFactory();
 
 	public <T> T request(
 			APIResource.RequestMethod method,

--- a/src/main/java/com/stripe/net/StripeSSLSocketFactory.java
+++ b/src/main/java/com/stripe/net/StripeSSLSocketFactory.java
@@ -1,0 +1,72 @@
+package com.stripe.net;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+
+/**
+ * Wraps a SSLSocketFactory and enables more TLS versions
+ */
+public class StripeSSLSocketFactory extends SSLSocketFactory {
+    private final SSLSocketFactory under;
+
+    public StripeSSLSocketFactory(SSLSocketFactory under) {
+        this.under = under;
+    }
+
+    private Socket fixupSocket(Socket sock) {
+        if (!(sock instanceof SSLSocket)) {
+            return sock;
+        }
+
+        SSLSocket sslSock = (SSLSocket) sock;
+
+        String[] protos = sslSock.getEnabledProtocols();
+        String[] newProtos = new String[protos.length + 1];
+        newProtos[0] = "TLSv1.2";
+        System.arraycopy(protos, 0, newProtos, 1, protos.length);
+
+        sslSock.setEnabledProtocols(newProtos);
+        return sslSock;
+    }
+
+    @Override
+    public String[] getDefaultCipherSuites() {
+        return this.under.getDefaultCipherSuites();
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return this.under.getSupportedCipherSuites();
+    }
+
+    @Override
+    public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
+        return fixupSocket(this.under.createSocket(s, host, port, autoClose));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException, UnknownHostException {
+        return fixupSocket(this.under.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException, UnknownHostException {
+        return fixupSocket(this.under.createSocket(host, port, localHost, localPort));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+        return fixupSocket(this.under.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) throws IOException {
+        return fixupSocket(this.under.createSocket(address, port, localAddress, localPort));
+    }
+}


### PR DESCRIPTION
Java 6 and 7 both support TLSv1.2, but don't enable it (or TLSv1.1) by default for TLS connections due to concerns at release-time around server compatibility. At this point, those are largely addressed, and TLSv1.0 is being deprecated by, among others, the PCI DSS within the next year.

We don't want to pin specifically to TLSv1.2, as that makes us not forward-compatible when TLSv1.3 (and later) is eventually released. However, the only way I could find to update the list of protocol versions was to call the `setEnabledProtocols` method on an `SSLSocket`.

And the only way I could find to do that was to provide my own `SSLSocketFactory` to `HttpsURLConnection`, which this PR does. The new factory accepts an "underlying" factory as an argument, and proxies all calls to it, enabling TLSv1.2 on the resulting sockets as appropriate.

r? @jimdanz
cc @kyleconroy @shalecraig  

I'm open to other ideas on how to make this happen (I considered messing around with the `https.protocols` property, but this seemed cleaner). I'm also not sure if it's a good idea to grab the `HttpsURLConnection` default `SSLSocketFactory` in the static initializer, but it seemed to work in my testing (it might not work on, e.g., AppEngine? I don't know how to test that).

I'm _also_ unclear why the tests are failing on openjdk6, but we should probably figure it out. (It seems to be coming from deep in the guts of the TLS handshake, which is more than a little terrifying)