### PR TITLE
Adding Account.all(accountParams)

### DIFF
--- a/src/main/java/com/stripe/model/Account.java
+++ b/src/main/java/com/stripe/model/Account.java
@@ -150,6 +150,18 @@ public class Account extends APIResource implements MetadataStore<Account> {
 		return request(RequestMethod.POST, classURL(Account.class), params, Account.class, options);
 	}
 
+	public static AccountCollection all(Map<String, Object> params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return all(params, (RequestOptions) null);
+	}
+
+	public static AccountCollection all(Map<String, Object> params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return request(RequestMethod.GET, classURL(Account.class), params, AccountCollection.class, options);
+	}
+
 	public static Account retrieve()
 			throws AuthenticationException, InvalidRequestException,
 			APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/AccountCollection.java
+++ b/src/main/java/com/stripe/model/AccountCollection.java
@@ -1,0 +1,4 @@
+package com.stripe.model;
+
+public class AccountCollection extends StripeCollection<Account> {
+}

--- a/src/main/java/com/stripe/model/Money.java
+++ b/src/main/java/com/stripe/model/Money.java
@@ -1,10 +1,10 @@
 package com.stripe.model;
 
 public class Money {
-	Integer amount;
+	Long amount;
 	String currency;
 
-	public Integer getAmount() {
+	public Long getAmount() {
 		return amount;
 	}
 

--- a/src/test/java/com/stripe/StripeTest.java
+++ b/src/test/java/com/stripe/StripeTest.java
@@ -8,6 +8,7 @@ import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
 import com.stripe.exception.StripeException;
 import com.stripe.model.Account;
+import com.stripe.model.AccountCollection;
 import com.stripe.model.Address;
 import com.stripe.model.AlipayAccount;
 import com.stripe.model.ApplicationFee;
@@ -90,6 +91,7 @@ public class StripeTest {
 	static Map<String, Object> defaultRecipientParams = new HashMap<String, Object>();
 	static Map<String, Object> defaultBitcoinReceiverParams = new HashMap<String, Object>();
 	static Map<String, Object> defaultAlipayTokenParams = new HashMap<String, Object>();
+	static Map<String, Object> defaultManagedAccountParams = new HashMap<String, Object>();
 	static RequestOptions cardSupportedRequestOptions;
 
 	static String getUniqueEmail() {
@@ -255,6 +257,10 @@ public class StripeTest {
 		alipayParams.put("alipay_username", "stripe+alipay");
 		defaultAlipayTokenParams.put("alipay_account", alipayParams);
 		defaultAlipayTokenParams.put("email", "alipay+account@stripe.com");
+
+		defaultManagedAccountParams.put("managed", true);
+		defaultManagedAccountParams.put("country", "US");
+		defaultManagedAccountParams.put("default_currency", "usd");
 	}
 
 	static Map<String, Object> getDefaultAccountParams() {
@@ -2262,5 +2268,19 @@ public class StripeTest {
 
 		Order paid = updated.pay(ImmutableMap.<String,Object>of("source", defaultSourceParams));
 		assertEquals("paid", paid.getStatus());
+	}
+
+	@Test(expected = InvalidRequestException.class)
+	public void getAllExternalAccounts() throws StripeException {
+		Stripe.apiKey = "sk_test_JieJALRz7rPz7boV17oMma7a";
+
+		Account account = Account.create(defaultManagedAccountParams);
+		Assert.assertNotNull(account);
+
+		Map<String, Object> accountParams = new HashMap<String, Object>();
+		accountParams.put("limit", 3);
+		AccountCollection accountCollection = Account.all(accountParams);
+
+		Assert.assertNotNull(accountCollection);
 	}
 }


### PR DESCRIPTION
The stripe API docs show a java method .all on the Account object. (here: https://stripe.com/docs/api?lang=java#list_accounts) I could not find it so I added it. I added a test getAllExternalAccounts() but it currently fails because the test account for this repo is not a platform. The specific error is ```You can only create new accounts if you've registered your platform, which you can do at https://dashboard.stripe.com/account/applications/settings``` The test works when I use my account. 
