### PR TITLE
Add member variables for "client ip" and "email" in Token model

### DIFF
--- a/src/main/java/com/stripe/model/Token.java
+++ b/src/main/java/com/stripe/model/Token.java
@@ -15,6 +15,8 @@ public class Token extends APIResource {
 	Long created;
 	String currency;
 	String id;
+	String email;
+	String clientIp;
 	Boolean livemode;
 	Boolean used;
 	Card card;
@@ -50,6 +52,22 @@ public class Token extends APIResource {
 
 	public void setId(String id) {
 		this.id = id;
+	}
+
+	public String getEmail() {
+		return email;
+	}
+
+	public void setEmail(String email) {
+		this.email = email;
+	}
+
+	public String getClientIp() {
+		return clientIp;
+	}
+
+	public void setClientIp(String clientIp) {
+		this.clientIp = clientIp;
 	}
 
 	public Boolean getLivemode() {


### PR DESCRIPTION
As specified in the API docs https://stripe.com/docs/api/java#retrieve_token while retrieving `Token` it should return `client_ip` which is missing from the Token model.

Also `curl request` and `Ruby API` returns `email` field in the response, it would be really helpful if Token has email field