### PR TITLE
Corrected typo in setTransfer declaration

### DIFF
--- a/src/main/java/com/stripe/model/Reversal.java
+++ b/src/main/java/com/stripe/model/Reversal.java
@@ -74,7 +74,7 @@ public class Reversal extends APIResource implements MetadataStore<Transfer> {
 	public String getTransfer() {
 		return transfer;
 	}
-	public void setTransfer(String tarnsfer) {
+	public void setTransfer(String transfer) {
 		this.transfer = transfer;
 	}
 	public Map<String, String> getMetadata() {


### PR DESCRIPTION
Typo in Reversal.setTransfer() declaration prevented the method from working.