### PR TITLE
Fix encoding of Lists being sent in via API requests

### DIFF
--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -27,12 +27,23 @@ import java.net.URLStreamHandler;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Scanner;
 
 public class LiveStripeResponseGetter implements StripeResponseGetter {
 	private static final String DNS_CACHE_TTL_PROPERTY_NAME = "networkaddress.cache.ttl";
+
+    private final static class Parameter {
+        public final String key;
+        public final String value;
+
+        public Parameter(String key, String value) {
+            this.key = key;
+            this.value = value;
+        }
+    }
 
 	/*
 	 * Set this property to override your environment's default
@@ -201,57 +212,84 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 
 	static String createQuery(Map<String, Object> params)
 			throws UnsupportedEncodingException, InvalidRequestException {
-		Map<String, String> flatParams = flattenParams(params);
 		StringBuilder queryStringBuffer = new StringBuilder();
-		for (Map.Entry<String, String> entry : flatParams.entrySet()) {
+		List<Parameter> flatParams = flattenParams(params);
+        Iterator<Parameter> it = flatParams.iterator();
+
+        while (it.hasNext()) {
 			if (queryStringBuffer.length() > 0) {
 				queryStringBuffer.append("&");
 			}
-			queryStringBuffer.append(urlEncodePair(entry.getKey(),
-					entry.getValue()));
+            Parameter param = it.next();
+			queryStringBuffer.append(urlEncodePair(param.key, param.value));
 		}
+
 		return queryStringBuffer.toString();
 	}
 
+	private static List<Parameter> flattenParams(Map<String, Object> params)
+            throws InvalidRequestException {
+        return flattenParamsMap(params, null);
+    }
 
-	private static Map<String, String> flattenParams(Map<String, Object> params)
+	private static List<Parameter> flattenParamsList(List<Object> params, String keyPrefix)
 			throws InvalidRequestException {
+		List<Parameter> flatParams = new LinkedList<Parameter>();
+        Iterator<?> it = ((List<?>)params).iterator();
+        String newPrefix = String.format("%s[]", keyPrefix);
+
+        while (it.hasNext()) {
+            flatParams.addAll(flattenParamsValue(it.next(), newPrefix));
+        }
+
+        return flatParams;
+    }
+
+	private static List<Parameter> flattenParamsMap(Map<String, Object> params, String keyPrefix)
+			throws InvalidRequestException {
+		List<Parameter> flatParams = new LinkedList<Parameter>();
 		if (params == null) {
-			return new HashMap<String, String>();
+			return flatParams;
 		}
-		Map<String, String> flatParams = new LinkedHashMap<String, String>();
+
 		for (Map.Entry<String, Object> entry : params.entrySet()) {
 			String key = entry.getKey();
 			Object value = entry.getValue();
-			if (value instanceof Map<?, ?>) {
-				Map<String, Object> flatNestedMap = new LinkedHashMap<String, Object>();
-				Map<?, ?> nestedMap = (Map<?, ?>) value;
-				for (Map.Entry<?, ?> nestedEntry : nestedMap.entrySet()) {
-					flatNestedMap.put(
-							String.format("%s[%s]", key, nestedEntry.getKey()),
-							nestedEntry.getValue());
-				}
-				flatParams.putAll(flattenParams(flatNestedMap));
-			} else if (value instanceof List<?>) {
-				Map<String, Object> flatNestedMap = new LinkedHashMap<String, Object>();
-				Iterator<?> it = ((List<?>)value).iterator();
-				for (int index = 0; it.hasNext(); ++index) {
-					flatNestedMap.put(String.format("%s[%s]", key, index), it.next());
-				}
-				flatParams.putAll(flattenParams(flatNestedMap));
-			} else if ("".equals(value)) {
-					throw new InvalidRequestException("You cannot set '"+key+"' to an empty string. "+
-										"We interpret empty strings as null in requests. "+
-										"You may set '"+key+"' to null to delete the property.",
-										key, null, 0, null);
-			} else if (value == null) {
-				flatParams.put(key, "");
-			} else {
-				flatParams.put(key, value.toString());
-			}
+
+            String newPrefix = key;
+            if (keyPrefix != null) {
+                newPrefix = String.format("%s[%s]", keyPrefix, key);
+            }
+
+            flatParams.addAll(flattenParamsValue(value, newPrefix));
 		}
+
 		return flatParams;
 	}
+
+	private static List<Parameter> flattenParamsValue(Object value, String keyPrefix)
+			throws InvalidRequestException {
+		List<Parameter> flatParams = new LinkedList<Parameter>();
+
+        if (value instanceof Map<?, ?>) {
+            flatParams = flattenParamsMap((Map<String, Object>)value, keyPrefix);
+        } else if (value instanceof List<?>) {
+            flatParams = flattenParamsList((List<Object>)value, keyPrefix);
+        } else if ("".equals(value)) {
+                throw new InvalidRequestException("You cannot set '"+keyPrefix+"' to an empty string. "+
+                                    "We interpret empty strings as null in requests. "+
+                                    "You may set '"+keyPrefix+"' to null to delete the property.",
+                                    keyPrefix, null, 0, null);
+        } else if (value == null) {
+            flatParams = new LinkedList<Parameter>();
+            flatParams.add(new Parameter(keyPrefix, ""));
+        } else {
+            flatParams = new LinkedList<Parameter>();
+            flatParams.add(new Parameter(keyPrefix, value.toString()));
+        }
+
+        return flatParams;
+    }
 
 	// represents Errors returned as JSON
 	private static class ErrorContainer {

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -35,15 +35,15 @@ import java.util.Scanner;
 public class LiveStripeResponseGetter implements StripeResponseGetter {
 	private static final String DNS_CACHE_TTL_PROPERTY_NAME = "networkaddress.cache.ttl";
 
-    private final static class Parameter {
-        public final String key;
-        public final String value;
+	private final static class Parameter {
+		public final String key;
+		public final String value;
 
-        public Parameter(String key, String value) {
-            this.key = key;
-            this.value = value;
-        }
-    }
+		public Parameter(String key, String value) {
+			this.key = key;
+			this.value = value;
+		}
+	}
 
 	/*
 	 * Set this property to override your environment's default
@@ -214,13 +214,13 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 			throws UnsupportedEncodingException, InvalidRequestException {
 		StringBuilder queryStringBuffer = new StringBuilder();
 		List<Parameter> flatParams = flattenParams(params);
-        Iterator<Parameter> it = flatParams.iterator();
+		Iterator<Parameter> it = flatParams.iterator();
 
-        while (it.hasNext()) {
+		while (it.hasNext()) {
 			if (queryStringBuffer.length() > 0) {
 				queryStringBuffer.append("&");
 			}
-            Parameter param = it.next();
+			Parameter param = it.next();
 			queryStringBuffer.append(urlEncodePair(param.key, param.value));
 		}
 
@@ -228,22 +228,22 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 	}
 
 	private static List<Parameter> flattenParams(Map<String, Object> params)
-            throws InvalidRequestException {
-        return flattenParamsMap(params, null);
-    }
+			throws InvalidRequestException {
+		return flattenParamsMap(params, null);
+	}
 
 	private static List<Parameter> flattenParamsList(List<Object> params, String keyPrefix)
 			throws InvalidRequestException {
 		List<Parameter> flatParams = new LinkedList<Parameter>();
-        Iterator<?> it = ((List<?>)params).iterator();
-        String newPrefix = String.format("%s[]", keyPrefix);
+		Iterator<?> it = ((List<?>)params).iterator();
+		String newPrefix = String.format("%s[]", keyPrefix);
 
-        while (it.hasNext()) {
-            flatParams.addAll(flattenParamsValue(it.next(), newPrefix));
-        }
+		while (it.hasNext()) {
+			flatParams.addAll(flattenParamsValue(it.next(), newPrefix));
+		}
 
-        return flatParams;
-    }
+		return flatParams;
+	}
 
 	private static List<Parameter> flattenParamsMap(Map<String, Object> params, String keyPrefix)
 			throws InvalidRequestException {
@@ -256,12 +256,12 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 			String key = entry.getKey();
 			Object value = entry.getValue();
 
-            String newPrefix = key;
-            if (keyPrefix != null) {
-                newPrefix = String.format("%s[%s]", keyPrefix, key);
-            }
+			String newPrefix = key;
+			if (keyPrefix != null) {
+				newPrefix = String.format("%s[%s]", keyPrefix, key);
+			}
 
-            flatParams.addAll(flattenParamsValue(value, newPrefix));
+			flatParams.addAll(flattenParamsValue(value, newPrefix));
 		}
 
 		return flatParams;
@@ -271,25 +271,25 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 			throws InvalidRequestException {
 		List<Parameter> flatParams = new LinkedList<Parameter>();
 
-        if (value instanceof Map<?, ?>) {
-            flatParams = flattenParamsMap((Map<String, Object>)value, keyPrefix);
-        } else if (value instanceof List<?>) {
-            flatParams = flattenParamsList((List<Object>)value, keyPrefix);
-        } else if ("".equals(value)) {
-                throw new InvalidRequestException("You cannot set '"+keyPrefix+"' to an empty string. "+
-                                    "We interpret empty strings as null in requests. "+
-                                    "You may set '"+keyPrefix+"' to null to delete the property.",
-                                    keyPrefix, null, 0, null);
-        } else if (value == null) {
-            flatParams = new LinkedList<Parameter>();
-            flatParams.add(new Parameter(keyPrefix, ""));
-        } else {
-            flatParams = new LinkedList<Parameter>();
-            flatParams.add(new Parameter(keyPrefix, value.toString()));
-        }
+		if (value instanceof Map<?, ?>) {
+			flatParams = flattenParamsMap((Map<String, Object>)value, keyPrefix);
+		} else if (value instanceof List<?>) {
+			flatParams = flattenParamsList((List<Object>)value, keyPrefix);
+		} else if ("".equals(value)) {
+				throw new InvalidRequestException("You cannot set '"+keyPrefix+"' to an empty string. "+
+									"We interpret empty strings as null in requests. "+
+									"You may set '"+keyPrefix+"' to null to delete the property.",
+									keyPrefix, null, 0, null);
+		} else if (value == null) {
+			flatParams = new LinkedList<Parameter>();
+			flatParams.add(new Parameter(keyPrefix, ""));
+		} else {
+			flatParams = new LinkedList<Parameter>();
+			flatParams.add(new Parameter(keyPrefix, value.toString()));
+		}
 
-        return flatParams;
-    }
+		return flatParams;
+	}
 
 	// represents Errors returned as JSON
 	private static class ErrorContainer {

--- a/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
+++ b/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
@@ -68,27 +68,27 @@ public class LiveStripeResponseGetterTest {
 		assertEquals(encode("nested[]=A&nested[]=B&nested[]=C&a=b&c=d"), srg.createQuery(params));
 	}
 
-    // It's really arrays of hashes where things in
-    // application/x-www-urlencoded-form start to get *really* hairy, so let's
-    // have a special test to cover thsi type of case.
+	// It's really arrays of hashes where things in
+	// application/x-www-urlencoded-form start to get *really* hairy, so let's
+	// have a special test to cover thsi type of case.
 	@Test
 	public void testCreateQueryWithComplexParams() throws StripeException, UnsupportedEncodingException {
-        List<String> deepNestedList = new LinkedList<String>();
+		List<String> deepNestedList = new LinkedList<String>();
 		deepNestedList.add("A");
 		deepNestedList.add("B");
 
-        Map<String, String> deepNestedMap1 = new LinkedHashMap<String, String>();
+		Map<String, String> deepNestedMap1 = new LinkedHashMap<String, String>();
 		deepNestedMap1.put("C", "C-1");
 		deepNestedMap1.put("D", "D-1");
 
-        Map<String, String> deepNestedMap2 = new LinkedHashMap<String, String>();
+		Map<String, String> deepNestedMap2 = new LinkedHashMap<String, String>();
 		deepNestedMap2.put("C", "C-2");
 		deepNestedMap2.put("D", "D-2");
 
 		List<Object> nested = new LinkedList<Object>();
-        nested.add(deepNestedList);
-        nested.add(deepNestedMap1);
-        nested.add(deepNestedMap2);
+		nested.add(deepNestedList);
+		nested.add(deepNestedMap1);
+		nested.add(deepNestedMap2);
 
 		/* Use LinkedHashMap because it preserves iteration order */
 		Map<String, Object> params = new LinkedHashMap<String, Object>();

--- a/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
+++ b/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
@@ -52,17 +52,49 @@ public class LiveStripeResponseGetterTest {
 	}
 
 	@Test
-	public void testCreateQueryWithList() throws StripeException, UnsupportedEncodingException {
-		/* Use LinkedHashMap because it preserves iteration order */
-		Map<String, Object> params = new LinkedHashMap<String, Object>();
+	public void testCreateQueryWithListParams() throws StripeException, UnsupportedEncodingException {
+
 		List<String> nested = new LinkedList<String>();
 		nested.add("A");
 		nested.add("B");
 		nested.add("C");
+
+		/* Use LinkedHashMap because it preserves iteration order */
+		Map<String, Object> params = new LinkedHashMap<String, Object>();
 		params.put("nested", nested);
 		params.put("a", "b");
 		params.put("c", "d");
-		assertEquals(encode("nested[0]=A&nested[1]=B&nested[2]=C&a=b&c=d"), srg.createQuery(params));
+
+		assertEquals(encode("nested[]=A&nested[]=B&nested[]=C&a=b&c=d"), srg.createQuery(params));
+	}
+
+    // It's really arrays of hashes where things in
+    // application/x-www-urlencoded-form start to get *really* hairy, so let's
+    // have a special test to cover thsi type of case.
+	@Test
+	public void testCreateQueryWithComplexParams() throws StripeException, UnsupportedEncodingException {
+        List<String> deepNestedList = new LinkedList<String>();
+		deepNestedList.add("A");
+		deepNestedList.add("B");
+
+        Map<String, String> deepNestedMap1 = new LinkedHashMap<String, String>();
+		deepNestedMap1.put("C", "C-1");
+		deepNestedMap1.put("D", "D-1");
+
+        Map<String, String> deepNestedMap2 = new LinkedHashMap<String, String>();
+		deepNestedMap2.put("C", "C-2");
+		deepNestedMap2.put("D", "D-2");
+
+		List<Object> nested = new LinkedList<Object>();
+        nested.add(deepNestedList);
+        nested.add(deepNestedMap1);
+        nested.add(deepNestedMap2);
+
+		/* Use LinkedHashMap because it preserves iteration order */
+		Map<String, Object> params = new LinkedHashMap<String, Object>();
+		params.put("nested", nested);
+
+		assertEquals(encode("nested[][]=A&nested[][]=B&nested[][C]=C-1&nested[][D]=D-1&nested[][C]=C-2&nested[][D]=D-2"), srg.createQuery(params));
 	}
 }
 

--- a/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
+++ b/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
@@ -96,5 +96,38 @@ public class LiveStripeResponseGetterTest {
 
 		assertEquals(encode("nested[][]=A&nested[][]=B&nested[][C]=C-1&nested[][D]=D-1&nested[][C]=C-2&nested[][D]=D-2"), srg.createQuery(params));
 	}
-}
 
+	@Test
+	public void testIncorrectAdditionalOwners() throws StripeException, UnsupportedEncodingException {
+		Map<String, String> ownerParams = new HashMap<String, String>();
+		ownerParams.put("first_name", "Stripe");
+
+		List<Object> additionalOwners = new LinkedList<Object>();
+		additionalOwners.add(ownerParams);
+
+		Map<String, Object> legalEntityParams = new HashMap<String, Object>();
+		legalEntityParams.put("additional_owners", additionalOwners);
+
+		Map<String, Object> params = new HashMap<String, Object>();
+		params.put("legal_entity", legalEntityParams);
+
+		assertEquals(encode("legal_entity[additional_owners][][first_name]=Stripe"), srg.createQuery(params));
+	}
+
+	@Test
+	public void testCorrectAdditionalOwners() throws StripeException, UnsupportedEncodingException {
+		Map<String, String> ownerParams = new HashMap<String, String>();
+		ownerParams.put("first_name", "Stripe");
+
+		Map<String, Object> additionalOwnersMap = new HashMap<String, Object>();
+		additionalOwnersMap.put("0", ownerParams);
+
+		Map<String, Object> legalEntityParams = new HashMap<String, Object>();
+		legalEntityParams.put("additional_owners", additionalOwnersMap);
+
+		Map<String, Object> params = new HashMap<String, Object>();
+		params.put("legal_entity", legalEntityParams);
+
+		assertEquals(encode("legal_entity[additional_owners][0][first_name]=Stripe"), srg.createQuery(params));
+	}
+}

--- a/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
+++ b/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
@@ -68,25 +68,17 @@ public class LiveStripeResponseGetterTest {
 		assertEquals(encode("nested[]=A&nested[]=B&nested[]=C&a=b&c=d"), srg.createQuery(params));
 	}
 
-	// It's really arrays of hashes where things in
-	// application/x-www-urlencoded-form start to get *really* hairy, so let's
-	// have a special test to cover thsi type of case.
 	@Test
-	public void testCreateQueryWithComplexParams() throws StripeException, UnsupportedEncodingException {
-		List<String> deepNestedList = new LinkedList<String>();
-		deepNestedList.add("A");
-		deepNestedList.add("B");
-
+	public void testCreateQueryWithArrayOfHashes() throws StripeException, UnsupportedEncodingException {
 		Map<String, String> deepNestedMap1 = new LinkedHashMap<String, String>();
-		deepNestedMap1.put("C", "C-1");
-		deepNestedMap1.put("D", "D-1");
+		deepNestedMap1.put("A", "A-1");
+		deepNestedMap1.put("B", "B-1");
 
 		Map<String, String> deepNestedMap2 = new LinkedHashMap<String, String>();
-		deepNestedMap2.put("C", "C-2");
-		deepNestedMap2.put("D", "D-2");
+		deepNestedMap2.put("A", "A-2");
+		deepNestedMap2.put("B", "B-2");
 
 		List<Object> nested = new LinkedList<Object>();
-		nested.add(deepNestedList);
 		nested.add(deepNestedMap1);
 		nested.add(deepNestedMap2);
 
@@ -94,7 +86,7 @@ public class LiveStripeResponseGetterTest {
 		Map<String, Object> params = new LinkedHashMap<String, Object>();
 		params.put("nested", nested);
 
-		assertEquals(encode("nested[][]=A&nested[][]=B&nested[][C]=C-1&nested[][D]=D-1&nested[][C]=C-2&nested[][D]=D-2"), srg.createQuery(params));
+		assertEquals(encode("nested[][A]=A-1&nested[][B]=B-1&nested[][A]=A-2&nested[][B]=B-2"), srg.createQuery(params));
 	}
 
 	@Test


### PR DESCRIPTION
As described in #229, we were previously translating lists to a special type of indexed object when sending them into the API via a request.  This patch corrects that behavior, adds some significant clean-up to the encoding utilities, and adds some additional testing so that we'll have better guarantees that everything works.

@kyleconroy As far as I can tell, there isn't anything special-cased around `LegalEntity`'s `additionalOwners` accessor and/or parameters, meaning that you'd probably want to modify these the "usual" way (I think):

``` java
Account account = Account.retrieve("acct_16ozEuCdGbJFKhCu");
LegalEntity entity = account.getLegalEntity();
List<Owner> additionalOwners = entity.getAdditionalOwners();
Owner owner = additionalOwner[3];

//
// set the information we'd like to see
//

Map<String, String> ownerParams = new HashMap<String, String>();
ownerParams["first_name"] = "Stripe";

//
// and then start nesting parameters like crazy ...
//

Map<String, Object> additionalOwnerParams = new HashMap<String, Object>();
additionalOwnerParams["3"] = ownerParams;

Map<String, Object> legalEntityParams = new HashMap<String, Object>();
legalEntityParams["additional_owners"] = additionalOwnerParams;

Map<String, Object> params = new HashMap<String, Object>();
params["legal_entity"] = legalEntityParams;

owner.update(params);
```

This is obviously terrible, but I haven't seen any evidence yet that having the currently broken List-handing logic would make it any better. Any thoughts?