### PR TITLE
Fix non-deterministic test

### DIFF
--- a/src/test/java/com/stripe/StripeTest.java
+++ b/src/test/java/com/stripe/StripeTest.java
@@ -43,6 +43,7 @@ import com.stripe.model.InvoiceItem;
 import com.stripe.model.InvoiceLineItemCollection;
 import com.stripe.model.MetadataStore;
 import com.stripe.model.Order;
+import com.stripe.model.OrderItem;
 import com.stripe.model.Plan;
 import com.stripe.model.Product;
 import com.stripe.model.Recipient;
@@ -2254,14 +2255,29 @@ public class StripeTest {
 		orderCreateParams.put("currency", "usd");
 		orderCreateParams.put("email", "foo@bar.com");
 		Order created = Order.create(orderCreateParams);
-		String orderId = created.getId();
-		assertEquals("sku", created.getItems().get(0).getType());
-		assertEquals(skuId, created.getItems().get(0).getParent());
 		assertEquals("created", created.getStatus());
 
-		Order retrieved = Order.retrieve(orderId);
-		assertEquals("sku", retrieved.getItems().get(0).getType());
-		assertEquals(skuId, retrieved.getItems().get(0).getParent());
+		OrderItem item = null;
+		for (OrderItem i : created.getItems()) {
+			if (skuId.equals(i.getParent())) {
+				item = i;
+				break;
+			}
+		}
+		assertNotNull(item);
+		assertEquals("sku", item.getType());
+
+		Order retrieved = Order.retrieve(created.getId());
+
+		item = null;
+		for (OrderItem i : created.getItems()) {
+			if (skuId.equals(i.getParent())) {
+				item = i;
+				break;
+			}
+		}
+		assertNotNull(item);
+		assertEquals("sku", item.getType());
 
 		Order updated = retrieved.update(ImmutableMap.<String,Object>of("metadata", ImmutableMap.of("foo", "bar")));
 		assertEquals("bar", updated.getMetadata().get("foo"));


### PR DESCRIPTION
Something has changed recently (probably in the server-side
implementation on which these bindings rely) where a specific sorting
of order items coming back in an order is no longer guaranteed. These
tests were written so that in a list of (1) sku, (2) shipping, and (3)
tax, it was always assumed that the sku would appear first. This
assumption no longer holds up.

Patch now searches order items for sku and compares against that instead
of assuming that it's in 0th position.