### PR TITLE
Encode empty lists as blank strings

### DIFF
--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -239,8 +239,12 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 		Iterator<?> it = ((List<?>)params).iterator();
 		String newPrefix = String.format("%s[]", keyPrefix);
 
-		while (it.hasNext()) {
-			flatParams.addAll(flattenParamsValue(it.next(), newPrefix));
+		if (params.isEmpty()) {
+			flatParams.add(new Parameter(keyPrefix, ""));
+		} else {
+			while (it.hasNext()) {
+				flatParams.addAll(flattenParamsValue(it.next(), newPrefix));
+			}
 		}
 
 		return flatParams;

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -239,6 +239,10 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 		Iterator<?> it = ((List<?>)params).iterator();
 		String newPrefix = String.format("%s[]", keyPrefix);
 
+		// Because application/x-www-form-urlencoded cannot represent an empty
+		// list, convention is to take the list parameter and just set it to an
+		// empty string. (e.g. A regular list might look like `a[]=1&b[]=2`.
+		// Emptying it would look like `a=`.)
 		if (params.isEmpty()) {
 			flatParams.add(new Parameter(keyPrefix, ""));
 		} else {

--- a/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
+++ b/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
@@ -90,6 +90,13 @@ public class LiveStripeResponseGetterTest {
 	}
 
 	@Test
+	public void testCreateQueryWithEmptyList() throws StripeException, UnsupportedEncodingException {
+		Map<String, Object> params = new HashMap<String, Object>();
+		params.put("a", new LinkedList<String>());
+		assertEquals("a=", srg.createQuery(params));
+	}
+
+	@Test
 	public void testIncorrectAdditionalOwners() throws StripeException, UnsupportedEncodingException {
 		Map<String, String> ownerParams = new HashMap<String, String>();
 		ownerParams.put("first_name", "Stripe");


### PR DESCRIPTION
It's currently impossible to empty a list via the Java bindings due to the fact
that an empty list gets "skipped" by the parameter encoder. This problem is
described more completely in [T7312][T7312].

This patch corrects that behavior with a contribution from @olivierbellone and
adds regression testing.

For reference, [here's the server-side code that demonstrates how the list 
unsetting actually works for `additional_owners`][pay-server].

[pay-server]: https://github.com/stripe-internal/pay-server/blob/6f5c81a9e85f1a1ff028cdeade688f7794d95d61/api/lib/account_common.rb#L1141,L1142
[T7312]: https://phab.stripe.com/T7312