### PR TITLE
Added `created` attribute and accessors to Plan and Coupon models

### DIFF
--- a/src/main/java/com/stripe/model/Coupon.java
+++ b/src/main/java/com/stripe/model/Coupon.java
@@ -16,6 +16,7 @@ public class Coupon extends APIResource implements MetadataStore<Coupon>, HasId 
 	String currency;
 	String duration;
 	String id;
+	Long created;
 	Boolean livemode;
 	Integer durationInMonths;
 	Long maxRedemptions;
@@ -169,6 +170,14 @@ public class Coupon extends APIResource implements MetadataStore<Coupon>, HasId 
 
 	public void setId(String id) {
 		this.id = id;
+	}
+
+	public Long getCreated() {
+		return created;
+	}
+
+	public void setCreated(Long created) {
+		this.created = created;
 	}
 
 	public Boolean getLivemode() {

--- a/src/main/java/com/stripe/model/Plan.java
+++ b/src/main/java/com/stripe/model/Plan.java
@@ -15,6 +15,7 @@ public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
 	Integer amount;
 	String currency;
 	String id;
+	Long created;
 	String interval;
 	Integer intervalCount;
 	String name;
@@ -152,6 +153,14 @@ public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
 
 	public void setId(String id) {
 		this.id = id;
+	}
+
+	public Long getCreated() {
+		return created;
+	}
+
+	public void setCreated(Long created) {
+		this.created = created;
 	}
 
 	public String getInterval() {


### PR DESCRIPTION
Fixes #245.

(Hopefully without any git shenanigans this time.)