### PR TITLE
Changed ssnLast4Provided field to ssnLast_4Provided

### DIFF
--- a/src/main/java/com/stripe/model/LegalEntity.java
+++ b/src/main/java/com/stripe/model/LegalEntity.java
@@ -20,7 +20,7 @@ public class LegalEntity extends StripeObject {
 	String lastName;
 	Address personalAddress;
 	Boolean personalIdNumberProvided;
-	Boolean ssnLast4Provided;
+	Boolean ssnLast_4Provided;
 	Verification verification;
 	List<Owner> additionalOwners;
 
@@ -52,10 +52,10 @@ public class LegalEntity extends StripeObject {
 		this.personalIdNumberProvided = personalIdNumberProvided;
 	}
 	public Boolean getSsnLast4Provided() {
-		return ssnLast4Provided;
+		return ssnLast_4Provided;
 	}
-	public void setSsnLast4Provided(Boolean ssnLast4Provided) {
-		this.ssnLast4Provided = ssnLast4Provided;
+	public void setSsnLast4Provided(Boolean ssnLast_4Provided) {
+		this.ssnLast_4Provided = ssnLast_4Provided;
 	}
 	public Verification getVerification() {
 		return verification;

--- a/src/main/java/com/stripe/model/LegalEntity.java
+++ b/src/main/java/com/stripe/model/LegalEntity.java
@@ -82,7 +82,7 @@ public class LegalEntity extends StripeObject {
 			equals(lastName, le.lastName) &&
 			equals(personalAddress, le.personalAddress) &&
 			equals(personalIdNumberProvided, le.personalIdNumberProvided) &&
-			equals(ssnLast4Provided, le.ssnLast4Provided) &&
+			equals(ssnLast_4Provided, le.ssnLast_4Provided) &&
 			equals(verification, le.verification) &&
 			equals(additionalOwners, le.additionalOwners);
 	}


### PR DESCRIPTION
Google GSON FieldNamingPolicy for LOWER_CASE_WITH_UNDERSCORES skips numbers for separation. Added underscore before number in order to have it convert to proper Stripe JSON field name "ssn_last_4_provided"