### PR TITLE
Allow params/options to be passed when paging through subcollections

### DIFF
--- a/src/main/java/com/stripe/model/Account.java
+++ b/src/main/java/com/stripe/model/Account.java
@@ -187,9 +187,9 @@ public class Account extends APIResource implements HasId, MetadataStore<Account
 		this.transferSchedule = transferSchedule;
 	}
 
-	public ExternalAccountCollection getExternalAccounts()
+	public PagingProxy<ExternalAccount> getExternalAccounts()
 	{
-		return externalAccounts;
+		return new PagingProxy<ExternalAccount>(externalAccounts);
 	}
 
 	public static Account create(Map<String, Object> params)

--- a/src/main/java/com/stripe/model/ApplicationFee.java
+++ b/src/main/java/com/stripe/model/ApplicationFee.java
@@ -113,14 +113,14 @@ public class ApplicationFee extends APIResource implements HasId {
 		this.charge = charge;
 	}
 
-	public FeeRefundCollection getRefunds() {
+	public PagingProxy<FeeRefund> getRefunds() {
 		// API versions 2014-07-26 and earlier render charge refunds as an array
 		// instead of an object, meaning there is no sublist URL.
 		if (refunds.getURL() == null) {
 			refunds.setURL(String.format("/v1/application_fees/%s/refunds", getId()));
 		}
 
-		return refunds;
+		return new PagingProxy<FeeRefund>(refunds);
 	}
 
 	public String getBalanceTransaction() {

--- a/src/main/java/com/stripe/model/BitcoinReceiver.java
+++ b/src/main/java/com/stripe/model/BitcoinReceiver.java
@@ -160,8 +160,8 @@ public class BitcoinReceiver extends ExternalAccount implements HasId {
 		this.payment = payment;
 	}
 
-	public BitcoinTransactionCollection getTransactions() {
-		return transactions;
+	public PagingProxy<BitcoinTransaction> getTransactions() {
+		return new PagingProxy<BitcoinTransaction>(transactions);
 	}
 
 	public void setTransactions(BitcoinTransactionCollection transactions) {

--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -228,13 +228,13 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
 		this.invoice = invoice;
 	}
 
-	public ChargeRefundCollection getRefunds() {
+	public PagingProxy<Refund> getRefunds() {
 		// API versions 2014-05-19 and earlier render charge refunds as an array
 		// instead of an object, meaning there is no sublist URL.
 		if (refunds != null && refunds.getURL() == null) {
 			refunds.setURL(String.format("/v1/charges/%s/refunds", getId()));
 		}
-		return refunds;
+		return new PagingProxy<Refund>(refunds);
 	}
 
 	public Card getCard() {

--- a/src/main/java/com/stripe/model/Customer.java
+++ b/src/main/java/com/stripe/model/Customer.java
@@ -82,12 +82,12 @@ public class Customer extends APIResource implements MetadataStore<Customer>, Ha
 		this.defaultSource = defaultSource;
 	}
 
-	public CustomerCardCollection getCards() {
-		return cards;
+	public PagingProxy<Card> getCards() {
+		return new PagingProxy<Card>(cards);
 	}
 
-	public ExternalAccountCollection getSources() {
-		return sources;
+	public PagingProxy<ExternalAccount> getSources() {
+		return new PagingProxy<ExternalAccount>(sources);
 	}
 
 	public void setSources(ExternalAccountCollection sources) {
@@ -136,8 +136,8 @@ public class Customer extends APIResource implements MetadataStore<Customer>, Ha
 		this.subscription = subscription;
 	}
 
-	public CustomerSubscriptionCollection getSubscriptions() {
-		return subscriptions;
+	public PagingProxy<Subscription> getSubscriptions() {
+		return new PagingProxy<Subscription>(subscriptions);
 	}
 
 	public Boolean getDeleted() {

--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -193,8 +193,8 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
 		this.discount = discount;
 	}
 
-	public InvoiceLineItemCollection getLines() {
-		return lines;
+	public PagingProxy<InvoiceLineItem> getLines() {
+		return new PagingProxy<InvoiceLineItem>(lines);
 	}
 
 	public Boolean getLivemode() {

--- a/src/main/java/com/stripe/model/PagingIterable.java
+++ b/src/main/java/com/stripe/model/PagingIterable.java
@@ -1,9 +1,6 @@
 package com.stripe.model;
 
 import java.util.Iterator;
-import java.util.Map;
-
-import com.stripe.net.RequestOptions;
 
 /**
  * Provides an <code>{@code Iterable<T>}</code> target that automatically

--- a/src/main/java/com/stripe/model/PagingIterable.java
+++ b/src/main/java/com/stripe/model/PagingIterable.java
@@ -1,6 +1,9 @@
 package com.stripe.model;
 
 import java.util.Iterator;
+import java.util.Map;
+
+import com.stripe.net.RequestOptions;
 
 /**
  * Provides an <code>{@code Iterable<T>}</code> target that automatically

--- a/src/main/java/com/stripe/model/PagingProxy.java
+++ b/src/main/java/com/stripe/model/PagingProxy.java
@@ -1,0 +1,45 @@
+package com.stripe.model;
+
+import java.util.Map;
+
+import com.stripe.net.RequestOptions;
+
+/**
+/* Provides a simple object that allows the contents of a list call to be
+/* iterated lazily so that extra params and options can be applied to future
+/* pagination calls in the case where that's necessary.
+ */
+public class PagingProxy<T extends HasId> {
+	private StripeCollectionInterface<T> page;
+
+	PagingProxy(final StripeCollectionInterface<T> page) {
+		this.page = page;
+	}
+
+	public Iterable<T> autoPagingIterable() {
+		return autoPagingIterable(null, null);
+	}
+
+	public Iterable<T> autoPagingIterable(Map<String, Object> params) {
+		return autoPagingIterable(params, null);
+	}
+
+	public Iterable<T> autoPagingIterable(Map<String, Object> params, RequestOptions options) {
+		// This does have the side effect of manipulating the state of the
+		// given collection, but is quite likely a good practical trade-off in
+		// that these should only be used for auto pagination with that
+		// particular collection instance.
+		this.page.setRequestOptions(options);
+		this.page.setRequestParams(params);
+
+		return new PagingIterable<T>(page);
+	}
+
+	/**
+	 * Gets an <code>{@code Iterable<T>}</code> for only the current page's
+	 * worth of data. No more pages will be fetched.
+	 */
+	public Iterable<T> singlePageIterable() {
+		return this.page.getData();
+	}
+}

--- a/src/main/java/com/stripe/model/PagingProxy.java
+++ b/src/main/java/com/stripe/model/PagingProxy.java
@@ -5,9 +5,9 @@ import java.util.Map;
 import com.stripe.net.RequestOptions;
 
 /**
-/* Provides a simple object that allows the contents of a list call to be
-/* iterated lazily so that extra params and options can be applied to future
-/* pagination calls in the case where that's necessary.
+ * Provides a simple object that allows the contents of a list call to be
+ * iterated lazily so that extra params and options can be applied to future
+ * pagination calls in the case where that's necessary.
  */
 public class PagingProxy<T extends HasId> {
 	private StripeCollectionInterface<T> page;

--- a/src/main/java/com/stripe/model/Product.java
+++ b/src/main/java/com/stripe/model/Product.java
@@ -92,8 +92,8 @@ public class Product extends APIResource implements HasId, MetadataStore<Product
 		this.shippable = shippable;
 	}
 
-	public SKUCollection getSkus() {
-		return skus;
+	public PagingProxy<SKU> getSkus() {
+		return new PagingProxy<SKU>(skus);
 	}
 
 	public void setSkus(SKUCollection skus) {

--- a/src/main/java/com/stripe/model/Recipient.java
+++ b/src/main/java/com/stripe/model/Recipient.java
@@ -82,8 +82,8 @@ public class Recipient extends APIResource implements MetadataStore<Recipient>, 
 		this.defaultCard = defaultCard;
 	}
 
-	public RecipientCardCollection getCards() {
-		return cards;
+	public PagingProxy<Card> getCards() {
+		return new PagingProxy<Card>(cards);
 	}
 
 	public BankAccount getActiveAccount() {

--- a/src/main/java/com/stripe/model/Transfer.java
+++ b/src/main/java/com/stripe/model/Transfer.java
@@ -325,10 +325,10 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
 						instanceURL(Transfer.class, this.getId())), params, TransferTransactionCollection.class, options);
 	}
 
-	public TransferReversalCollection getReversals() {
+	public PagingProxy<Reversal> getReversals() {
 		if (reversals.getURL() == null) {
 			reversals.setURL(String.format("/v1/transfers/%s/reversals", getId()));
 		}
-		return reversals;
+		return new PagingProxy<Reversal>(reversals);
 	}
 }

--- a/src/test/java/com/stripe/StripeTest.java
+++ b/src/test/java/com/stripe/StripeTest.java
@@ -44,6 +44,7 @@ import com.stripe.model.FileUpload;
 import com.stripe.model.FraudDetails;
 import com.stripe.model.Invoice;
 import com.stripe.model.InvoiceItem;
+import com.stripe.model.InvoiceLineItem;
 import com.stripe.model.InvoiceLineItemCollection;
 import com.stripe.model.MetadataStore;
 import com.stripe.model.Order;
@@ -77,6 +78,7 @@ import java.net.URL;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.Iterator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -1223,15 +1225,17 @@ public class StripeTest {
 	public void testInvoiceListAndRetrieve() throws StripeException {
 		Plan plan = Plan.create(getUniquePlanParams());
 		createDefaultCustomerWithPlan(plan);
+
 		Map<String, Object> listParams = new HashMap<String, Object>();
 		listParams.put("count", 1);
+
 		Invoice createdInvoice = Invoice.all(listParams).getData().get(0);
 		Invoice retrievedInvoice = Invoice.retrieve(createdInvoice.getId());
 		assertEquals(createdInvoice.getId(), retrievedInvoice.getId());
 
-		InvoiceLineItemCollection lines = retrievedInvoice.getLines().all(
-				listParams);
-		assertNotNull(lines);
+		Iterator<InvoiceLineItem> it =
+			retrievedInvoice.getLines().autoPagingIterable().iterator();
+		assertNotNull(it.next());
 	}
 
 	@Test
@@ -1283,14 +1287,14 @@ public class StripeTest {
 		Invoice upcomingInvoice = Invoice.upcoming(upcomingParams);
 		assertFalse(upcomingInvoice.getAttempted());
 
-		InvoiceLineItemCollection lines = upcomingInvoice.getLines().all(null);
-		assertFalse(lines.getData().isEmpty());
-		assertEquals(item.getId(), lines.getData().get(0).getId());
+		Iterator<InvoiceLineItem> it =
+			upcomingInvoice.getLines().autoPagingIterable().iterator();
+		InvoiceLineItem actual = it.next();
+		assertNotNull(actual);
+		assertEquals(item.getId(), actual.getId());
 
-		Map<String, Object> fetchParams = new HashMap<String, Object>();
-		fetchParams.put("starting_after", item.getId());
-		InvoiceLineItemCollection linesAfterFirst = upcomingInvoice.getLines().all(fetchParams);
-		assertTrue(linesAfterFirst.getData().isEmpty());
+		// Expect no items after the first.
+		assertFalse(it.hasNext());
 	}
 
 	@Test

--- a/src/test/java/com/stripe/model/PagingProxyTest.java
+++ b/src/test/java/com/stripe/model/PagingProxyTest.java
@@ -1,0 +1,37 @@
+package com.stripe.model;
+
+import com.stripe.BaseStripeTest;
+import com.stripe.exception.StripeException;
+import com.stripe.net.APIResource;
+import com.stripe.net.RequestOptions;
+import com.stripe.net.RequestOptions.RequestOptionsBuilder;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class PagingProxyTest extends BaseStripeTest {
+	@Test
+	public void testAutoPagingIterable() throws IOException, StripeException {
+		String pageJSON = resource("pageable_model_page_0.json");
+		PageableModelCollection page = APIResource.GSON.fromJson(pageJSON, PageableModelCollection.class);
+
+		PagingProxy<PageableModel> pagingProxy = new PagingProxy<PageableModel>(page);
+
+		Map<String, Object> params = new HashMap<String, Object>();
+		RequestOptions options = (new RequestOptionsBuilder()).setApiKey("sk_paging_key").build();
+
+		Iterable<PageableModel> iterable = pagingProxy.autoPagingIterable(params, options);
+
+		// The iterator itself is pretty well tested, but make sure that we end
+		// up with expected parameters and options on our page object, which is
+		// the job of proxy to set.
+		assertEquals(params, page.getRequestParams());
+		assertEquals(options, page.getRequestOptions());
+	}
+}


### PR DESCRIPTION
Currently when a list is fetched from the API params and options can be
given to it as long as it's for a top-level type. If a resource includes
a subcollection (e.g. line items under invoices), the current page can
be iterated, but future pages that are fetched do not inherit the params
and options that were given to the parent.

This change suggests a breaking change to any subcollection getters
(e.g. getLines) so that we can return proxy objects which will allow use
a little like the following:

``` java
items = invoice.getLines().autoPagingIterable(params, options)
```

It would also be nice to do the same for top-level resources so that
this:

``` java
invoices = Invoice.list(params, options).autoPagingIterable()
```

Might become this:

``` java
invoices = Invoice.list().autoPagingIterable(params, options)
```

For consistency's sake. This turns out be a little more of a yakshave in
practice though because we need to have the proxy class remember a
collection type as well as the resource's type.

Note also that I've only added a proxy onto a single subcollection
getter, but in fact we'd need to put these only all of them before this
pull could be finalized.

Fixes #264.