### PR TITLE
Allow request params and options to be overridden on `autoPagingIterator`

### DIFF
--- a/src/main/java/com/stripe/model/StripeCollectionAPIResource.java
+++ b/src/main/java/com/stripe/model/StripeCollectionAPIResource.java
@@ -59,9 +59,24 @@ public abstract class StripeCollectionAPIResource<T extends HasId> extends APIRe
 	/**
 	 * Returns an iterable that can be used to iterate across all objects
 	 * across all pages. As page boundaries are encountered, the next page will
-	 * be fetch automatically for continued iteration.
+	 * be fetched automatically for continued iteration.
 	 */
 	public Iterable<T> autoPagingIterable() {
+		return autoPagingIterable(null, null);
+	}
+
+	public Iterable<T> autoPagingIterable(Map<String, Object> params) {
+		return autoPagingIterable(params, null);
+	}
+
+	public Iterable<T> autoPagingIterable(Map<String, Object> params, RequestOptions options) {
+		// This does have the side effect of manipulating the state of the
+		// given collection, which is an unfortunate side effect, but is quite
+		// likely a good practical trade-off in that these should only be used
+		// for auto pagination with that particular collection instance.
+		this.setRequestOptions(options);
+		this.setRequestParams(params);
+
 		return new PagingIterable<T>(this);
 	}
 


### PR DESCRIPTION
We normally pass params and options with the `list` method:

    invoices = Invoice.list(params, options).autoPagingIterable()

This patch adds support for them to also be overridden from
`autoPagingIterator`:

    invoices = Invoice.list().autoPagingIterable(params, options)

The reason for this is to support custom params and options for
subcollections, which unfortunately do not inherit options from their
parent collections. For example:

    lineItems = invoice.getLines().autoPagingIterable(params, options)

There's more context for this in #264, and I tried a more elegant
solution (which failed) in #269. This seems like the easiest option for
the time being, with the possibility that we could do something more
sophisticated later to start consolidating our interfaces.

Fixes #264.