### PR TITLE
Make all references to URLs upper case "URL" instead of "Url"

### DIFF
--- a/src/main/java/com/stripe/model/Account.java
+++ b/src/main/java/com/stripe/model/Account.java
@@ -29,11 +29,11 @@ public class Account extends APIResource implements HasId, MetadataStore<Account
 	Keys keys;
 	Map<String, String> metadata;
 	String businessName;
-	String businessUrl;
+	String businessURL;
 	String businessLogo;
 	String businessPrimaryColor;
 	String supportPhone;
-	String supportUrl;
+	String supportURL;
 	String supportEmail;
 	String productDescription;
 	Boolean managed;
@@ -117,9 +117,9 @@ public class Account extends APIResource implements HasId, MetadataStore<Account
 		return businessName;
 	}
 
-	public String getBusinessUrl()
+	public String getBusinessURL()
 	{
-		return businessUrl;
+		return businessURL;
 	}
 
 	public String getBusinessLogo()
@@ -140,9 +140,9 @@ public class Account extends APIResource implements HasId, MetadataStore<Account
 		return supportPhone;
 	}
 
-	public String getSupportUrl()
+	public String getSupportURL()
 	{
-		return supportUrl;
+		return supportURL;
 	}
 
 	public String getSupportEmail()

--- a/src/main/java/com/stripe/model/PagingIterator.java
+++ b/src/main/java/com/stripe/model/PagingIterator.java
@@ -21,7 +21,7 @@ public class PagingIterator<T extends HasId> extends APIResource implements Iter
 	private String lastId;
 	
 	PagingIterator(final StripeCollectionInterface<T> stripeCollection) {
-		this.url = Stripe.getApiBase() + stripeCollection.getUrl();
+		this.url = Stripe.getApiBase() + stripeCollection.getURL();
 
 		this.collectionType = stripeCollection.getClass();
 		

--- a/src/main/java/com/stripe/model/Product.java
+++ b/src/main/java/com/stripe/model/Product.java
@@ -132,14 +132,13 @@ public class Product extends APIResource implements HasId, MetadataStore<Product
 		this.packageDimensions = packageDimensions;
 	}
 
-	public String getUrl() {
+	public String getURL() {
 		return url;
 	}
 
-	public void setUrl(String url) {
+	public void setURL(String url) {
 		this.url = url;
 	}
-
 
 	public Map<String, String> getMetadata() {
 		return metadata;

--- a/src/main/java/com/stripe/model/StripeCollection.java
+++ b/src/main/java/com/stripe/model/StripeCollection.java
@@ -61,10 +61,10 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject imp
 	public void setHasMore(Boolean hasMore) {
 		this.hasMore = hasMore;
 	}
-	public String getUrl() {
+	public String getURL() {
 		return url;
 	}
-	public void setUrl(String url) {
+	public void setURL(String url) {
 		this.url = url;
 	}
 	/** 3/2014: Legacy (from before newstyle pagination API) */

--- a/src/main/java/com/stripe/model/StripeCollectionAPIResource.java
+++ b/src/main/java/com/stripe/model/StripeCollectionAPIResource.java
@@ -39,11 +39,6 @@ public abstract class StripeCollectionAPIResource<T extends HasId> extends APIRe
 		return url;
 	}
 
-	@Deprecated
-	public String getUrl() {
-		return getURL();
-	}
-
 	public void setURL(String url) {
 		this.url = url;
 	}

--- a/src/main/java/com/stripe/model/StripeCollectionInterface.java
+++ b/src/main/java/com/stripe/model/StripeCollectionInterface.java
@@ -9,7 +9,7 @@ public interface StripeCollectionInterface<T> {
 	public List<T> getData();
 	public Integer getTotalCount();
 	public Boolean getHasMore();
-	public String getUrl();
+	public String getURL();
 
 	/**
 	 * Get request options that were used to fetch the collection. This is

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -203,9 +203,9 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 
 	private static java.net.HttpURLConnection createDeleteConnection(
 			String url, String query, RequestOptions options) throws IOException {
-		String deleteUrl = formatURL(url, query);
+		String deleteURL = formatURL(url, query);
 		java.net.HttpURLConnection conn = createStripeConnection(
-				deleteUrl, options);
+				deleteURL, options);
 		conn.setRequestMethod("DELETE");
 
 		return conn;


### PR DESCRIPTION
We also remove a deprecated method from a class that had both.

Fixes #278.