### PR TITLE
Add some missing attributes

### DIFF
--- a/src/main/java/com/stripe/model/ApplicationFee.java
+++ b/src/main/java/com/stripe/model/ApplicationFee.java
@@ -11,19 +11,22 @@ import com.stripe.net.RequestOptions;
 import java.util.Map;
 
 public class ApplicationFee extends APIResource implements HasId {
+	String id;
+	String account;
 	Integer amount;
+	Integer amountRefunded;
+	String application;
+	String balanceTransaction;
+	String charge;
 	Long created;
 	String currency;
-	String id;
 	Boolean livemode;
+	String originatingTransaction;
 	Boolean refunded;
-	Integer amountRefunded;
-	String account;
-	String user;
-	String application;
-	String charge;
 	FeeRefundCollection refunds;
-	String balanceTransaction;
+
+	@Deprecated
+	String user;
 
 	public String getId() {
 		return id;
@@ -33,12 +36,52 @@ public class ApplicationFee extends APIResource implements HasId {
 		this.id = id;
 	}
 
+	public String getAccount() {
+		return account;
+	}
+
+	public void setAccount(String account) {
+		this.account = account;
+	}
+
 	public Integer getAmount() {
 		return amount;
 	}
 
 	public void setAmount(Integer amount) {
 		this.amount = amount;
+	}
+
+	public Integer getAmountRefunded() {
+		return amountRefunded;
+	}
+
+	public void setAmountRefunded(Integer amountRefunded) {
+		this.amountRefunded = amountRefunded;
+	}
+
+	public String getApplication() {
+		return application;
+	}
+
+	public void setApplication(String application) {
+		this.application = application;
+	}
+
+	public String getBalanceTransaction() {
+		return balanceTransaction;
+	}
+
+	public void setBalanceTransaction(String balanceTransaction) {
+		this.balanceTransaction = balanceTransaction;
+	}
+
+	public String getCharge() {
+		return charge;
+	}
+
+	public void setCharge(String charge) {
+		this.charge = charge;
 	}
 
 	public Long getCreated() {
@@ -65,52 +108,20 @@ public class ApplicationFee extends APIResource implements HasId {
 		this.livemode = livemode;
 	}
 
+	public String getOriginatingTransaction() {
+		return originatingTransaction;
+	}
+
+	public void setOriginatingTransaction(String originatingTransaction) {
+		this.originatingTransaction = originatingTransaction;
+	}
+
 	public Boolean getRefunded() {
 		return refunded;
 	}
 
 	public void setRefunded(Boolean refunded) {
 		this.refunded = refunded;
-	}
-
-	public Integer getAmountRefunded() {
-		return amountRefunded;
-	}
-
-	public void setAmountRefunded(Integer amountRefunded) {
-		this.amountRefunded = amountRefunded;
-	}
-
-	public String getAccount() {
-		return account;
-	}
-
-	public void setAccount(String account) {
-		this.account = account;
-	}
-
-	public String getUser() {
-		return user;
-	}
-
-	public void setUser(String user) {
-		this.user = user;
-	}
-
-	public String getApplication() {
-		return application;
-	}
-
-	public void setApplication(String application) {
-		this.application = application;
-	}
-
-	public String getCharge() {
-		return charge;
-	}
-
-	public void setCharge(String charge) {
-		this.charge = charge;
 	}
 
 	public FeeRefundCollection getRefunds() {
@@ -123,12 +134,22 @@ public class ApplicationFee extends APIResource implements HasId {
 		return refunds;
 	}
 
-	public String getBalanceTransaction() {
-		return balanceTransaction;
+	/**
+	 * @deprecated
+	 * Use `account` field (https://stripe.com/docs/upgrades#2013-12-03)
+	 */
+	@Deprecated
+	public String getUser() {
+		return user;
 	}
 
-	public void setBalanceTransaction(String balanceTransaction) {
-		this.balanceTransaction = balanceTransaction;
+	/**
+	 * @deprecated
+	 * Use `account` field (https://stripe.com/docs/upgrades#2013-12-03)
+	 */
+	@Deprecated
+	public void setUser(String user) {
+		this.user = user;
 	}
 
 	public static ApplicationFee retrieve(String id) throws AuthenticationException,

--- a/src/main/java/com/stripe/model/BalanceTransaction.java
+++ b/src/main/java/com/stripe/model/BalanceTransaction.java
@@ -14,17 +14,18 @@ import java.util.Map;
 
 public class BalanceTransaction extends APIResource implements HasId {
 	String id;
-	String source;
 	Integer amount;
-	String currency;
-	Integer net;
-	String type;
-	Long created;
 	Long availableOn;
-	String status;
+	Long created;
+	String currency;
+	String description;
 	Integer fee;
 	List<Fee> feeDetails;
-	String description;
+	Integer net;
+	String source;
+	TransferCollection sourcedTransfers;
+	String status;
+	String type;
 
 	public String getId() {
 		return id;
@@ -32,14 +33,6 @@ public class BalanceTransaction extends APIResource implements HasId {
 
 	public void setId(String id) {
 		this.id = id;
-	}
-
-	public String getSource() {
-		return source;
-	}
-
-	public void setSource(String source) {
-		this.source = source;
 	}
 
 	public Integer getAmount() {
@@ -50,28 +43,12 @@ public class BalanceTransaction extends APIResource implements HasId {
 		this.amount = amount;
 	}
 
-	public String getCurrency() {
-		return currency;
+	public Long getAvailableOn() {
+		return availableOn;
 	}
 
-	public void setCurrency(String currency) {
-		this.currency = currency;
-	}
-
-	public Integer getNet() {
-		return net;
-	}
-
-	public void setNet(Integer net) {
-		this.net = net;
-	}
-
-	public String getType() {
-		return type;
-	}
-
-	public void setType(String type) {
-		this.type = type;
+	public void setAvailableOn(Long availableOn) {
+		this.availableOn = availableOn;
 	}
 
 	public Long getCreated() {
@@ -82,20 +59,20 @@ public class BalanceTransaction extends APIResource implements HasId {
 		this.created = created;
 	}
 
-	public Long getAvailableOn() {
-		return availableOn;
+	public String getCurrency() {
+		return currency;
 	}
 
-	public void setAvailableOn(Long availableOn) {
-		this.availableOn = availableOn;
+	public void setCurrency(String currency) {
+		this.currency = currency;
 	}
 
-	public String getStatus() {
-		return status;
+	public String getDescription() {
+		return description;
 	}
 
-	public void setStatus(String status) {
-		this.status = status;
+	public void setDescription(String description) {
+		this.description = description;
 	}
 
 	public Integer getFee() {
@@ -114,12 +91,43 @@ public class BalanceTransaction extends APIResource implements HasId {
 		this.feeDetails = feeDetails;
 	}
 
-	public String getDescription() {
-		return description;
+	public Integer getNet() {
+		return net;
 	}
 
-	public void setDescription(String description) {
-		this.description = description;
+	public void setNet(Integer net) {
+		this.net = net;
+	}
+
+	public String getSource() {
+		return source;
+	}
+
+	public void setSource(String source) {
+		this.source = source;
+	}
+
+	public TransferCollection getSourcedTransfers() {
+		if (sourcedTransfers != null && sourcedTransfers.getURL() == null && getSource() != null) {
+			sourcedTransfers.setURL(String.format("/v1/transfers?source_transaction=%s", getSource()));
+		}
+		return sourcedTransfers;
+	}
+
+	public String getStatus() {
+		return status;
+	}
+
+	public void setStatus(String status) {
+		this.status = status;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
 	}
 
 	public static BalanceTransaction retrieve(String id) throws AuthenticationException,

--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -12,49 +12,46 @@ import java.util.Collections;
 import java.util.Map;
 
 public class Charge extends APIResource implements MetadataStore<Charge>, HasId {
+	public static final String FRAUD_DETAILS = "fraud_details";
+
+	String id;
 	Integer amount;
+	Integer amountRefunded;
+	String applicationFee;
+	String balanceTransaction;
+	Boolean captured;
 	Long created;
 	String currency;
-	String id;
-	String status;
-	String applicationFee;
-	Boolean livemode;
-	Boolean paid;
-	Boolean refunded;
-	/** Legacy; use `dispute` field (https://stripe.com/docs/upgrades#2012-11-07) */
-	Boolean disputed;
-	Boolean captured;
-	String description;
-	String failureMessage;
-	String failureCode;
-	Integer amountRefunded;
 	String customer;
-	String invoice;
-	ChargeRefundCollection refunds;
-	Card card;
+	String description;
+	String destination;
 	Dispute dispute;
-	String balanceTransaction;
+	String failureCode;
+	String failureMessage;
+	FraudDetails fraudDetails;
+	String invoice;
+	Boolean livemode;
 	Map<String, String> metadata;
+	String order;
+	Boolean paid;
 	String receiptEmail;
 	String receiptNumber;
-	String statementDescriptor;
-	@Deprecated
-	String statementDescription;
+	Boolean refunded;
+	ChargeRefundCollection refunds;
 	ShippingDetails shipping;
 	ExternalAccount source;
+	String sourceTransfer;
+	String statementDescriptor;
+	String status;
 	String transfer;
-	String destination;
 
-	public static final String FRAUD_DETAILS = "fraud_details";
-	FraudDetails fraudDetails;
-
-	public FraudDetails getFraudDetails() {
-		return fraudDetails;
-	}
-
-	public void setFraudDetails(FraudDetails fraudDetails) {
-		this.fraudDetails = fraudDetails;
-	}
+	@Deprecated
+	Card card;
+	/** Legacy; use `dispute` field (https://stripe.com/docs/upgrades#2012-11-07) */
+	@Deprecated
+	Boolean disputed;
+	@Deprecated
+	String statementDescription;
 
 	public String getId() {
 		return id;
@@ -64,12 +61,20 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
 		this.id = id;
 	}
 
-	public String getStatus() {
-		return status;
+	public Integer getAmount() {
+		return amount;
 	}
 
-	public void setStatus(String status) {
-		this.status = status;
+	public void setAmount(Integer amount) {
+		this.amount = amount;
+	}
+
+	public Integer getAmountRefunded() {
+		return amountRefunded;
+	}
+
+	public void setAmountRefunded(Integer amountRefunded) {
+		this.amountRefunded = amountRefunded;
 	}
 
 	public String getApplicationFee() {
@@ -80,12 +85,20 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
 		this.applicationFee = applicationFee;
 	}
 
-	public Integer getAmount() {
-		return amount;
+	public String getBalanceTransaction() {
+		return balanceTransaction;
 	}
 
-	public void setAmount(Integer amount) {
-		this.amount = amount;
+	public void setBalanceTransaction(String balanceTransaction) {
+		this.balanceTransaction = balanceTransaction;
+	}
+
+	public Boolean getCaptured() {
+		return captured;
+	}
+
+	public void setCaptured(Boolean captured) {
+		this.captured = captured;
 	}
 
 	public Long getCreated() {
@@ -104,12 +117,92 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
 		this.currency = currency;
 	}
 
+	public String getCustomer() {
+		return customer;
+	}
+
+	public void setCustomer(String customer) {
+		this.customer = customer;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	public String getDestination() {
+		return destination;
+	}
+
+	public void setDestination(String destination) {
+		this.destination = destination;
+	}
+
+	public Dispute getDispute() {
+		return dispute;
+	}
+
+	public void setDispute(Dispute dispute) {
+		this.dispute = dispute;
+	}
+
+	public String getFailureCode() {
+		return failureCode;
+	}
+
+	public void setFailureCode(String failureCode) {
+		this.failureCode = failureCode;
+	}
+
+	public String getFailureMessage() {
+		return failureMessage;
+	}
+
+	public void setFailureMessage(String failureMessage) {
+		this.failureMessage = failureMessage;
+	}
+
+	public FraudDetails getFraudDetails() {
+		return fraudDetails;
+	}
+
+	public void setFraudDetails(FraudDetails fraudDetails) {
+		this.fraudDetails = fraudDetails;
+	}
+
+	public String getInvoice() {
+		return invoice;
+	}
+
+	public void setInvoice(String invoice) {
+		this.invoice = invoice;
+	}
+
 	public Boolean getLivemode() {
 		return livemode;
 	}
 
 	public void setLivemode(Boolean livemode) {
 		this.livemode = livemode;
+	}
+
+	public Map<String, String> getMetadata() {
+		return metadata;
+	}
+
+	public void setMetadata(Map<String, String> metadata) {
+		this.metadata = metadata;
+	}
+
+	public String getOrder() {
+		return order;
+	}
+
+	public void setOrder(String order) {
+		this.order = order;
 	}
 
 	public Boolean getPaid() {
@@ -120,6 +213,22 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
 		this.paid = paid;
 	}
 
+	public String getReceiptEmail() {
+		return receiptEmail;
+	}
+
+	public void setReceiptEmail(String receiptEmail) {
+		this.receiptEmail = receiptEmail;
+	}
+
+	public String getReceiptNumber() {
+		return receiptNumber;
+	}
+
+	public void setReceiptNumber(String receiptNumber) {
+		this.receiptNumber = receiptNumber;
+	}
+
 	public Boolean getRefunded() {
 		return refunded;
 	}
@@ -128,12 +237,13 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
 		this.refunded = refunded;
 	}
 
-	public Boolean getCaptured() {
-		return captured;
-	}
-
-	public void setCaptured(Boolean captured) {
-		this.captured = captured;
+	public ChargeRefundCollection getRefunds() {
+		// API versions 2014-05-19 and earlier render charge refunds as an array
+		// instead of an object, meaning there is no sublist URL.
+		if (refunds != null && refunds.getURL() == null) {
+			refunds.setURL(String.format("/v1/charges/%s/refunds", getId()));
+		}
+		return refunds;
 	}
 
 	public ShippingDetails getShipping() {
@@ -142,6 +252,64 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
 
 	public void setShipping(ShippingDetails shipping) {
 		this.shipping = shipping;
+	}
+
+	public ExternalAccount getSource() {
+		return source;
+	}
+
+	public void setSource(ExternalAccount source) {
+		this.source = source;
+	}
+
+	public String getSourceTransfer() {
+		return sourceTransfer;
+	}
+
+	public void setSourceTransfer(String sourceTransfer) {
+		this.sourceTransfer = sourceTransfer;
+	}
+
+	public String getStatementDescriptor() {
+		return statementDescriptor;
+	}
+
+	public void setStatementDescriptor(String statementDescriptor) {
+		this.statementDescriptor = statementDescriptor;
+	}
+
+	public String getStatus() {
+		return status;
+	}
+
+	public void setStatus(String status) {
+		this.status = status;
+	}
+
+	public String getTransfer() {
+		return transfer;
+	}
+
+	public void setTransfer(String transfer) {
+		this.transfer = transfer;
+	}
+
+	/**
+	 * @deprecated
+	 * Use `source` field (https://stripe.com/docs/upgrades#2015-02-18)
+	 */
+	@Deprecated
+	public Card getCard() {
+		return card;
+	}
+
+	/**
+	 * @deprecated
+	 * Use `source` field (https://stripe.com/docs/upgrades#2015-02-18)
+	 */
+	@Deprecated
+	public void setCard(Card card) {
+		this.card = card;
 	}
 
 	/**
@@ -162,151 +330,22 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
 		this.disputed = disputed;
 	}
 
-	public String getDescription() {
-		return description;
-	}
-
-	public void setDescription(String description) {
-		this.description = description;
-	}
-
-	public String getStatementDescriptor() {
-		return statementDescriptor;
-	}
-
-	public void setStatementDescriptor(String statementDescriptor) {
-		this.statementDescriptor = statementDescriptor;
-	}
-
+	/**
+	 * @deprecated
+	 * Use `statement_descriptor` field (https://stripe.com/docs/upgrades#2014-12-17)
+	 */
 	@Deprecated
 	public String getStatementDescription() {
 		return statementDescription;
 	}
 
+	/**
+	 * @deprecated
+	 * Use `statement_descriptor` field (https://stripe.com/docs/upgrades#2014-12-17)
+	 */
 	@Deprecated
 	public void setStatementDescription(String statementDescription) {
 		this.statementDescription = statementDescription;
-	}
-
-	public String getFailureMessage() {
-		return failureMessage;
-	}
-
-	public void setFailureMessage(String failureMessage) {
-		this.failureMessage = failureMessage;
-	}
-
-	public String getFailureCode() {
-		return failureCode;
-	}
-
-	public void setFailureCode(String failureCode) {
-		this.failureCode = failureCode;
-	}
-
-	public Integer getAmountRefunded() {
-		return amountRefunded;
-	}
-
-	public void setAmountRefunded(Integer amountRefunded) {
-		this.amountRefunded = amountRefunded;
-	}
-
-	public String getCustomer() {
-		return customer;
-	}
-
-	public void setCustomer(String customer) {
-		this.customer = customer;
-	}
-
-	public String getInvoice() {
-		return invoice;
-	}
-
-	public void setInvoice(String invoice) {
-		this.invoice = invoice;
-	}
-
-	public ChargeRefundCollection getRefunds() {
-		// API versions 2014-05-19 and earlier render charge refunds as an array
-		// instead of an object, meaning there is no sublist URL.
-		if (refunds != null && refunds.getURL() == null) {
-			refunds.setURL(String.format("/v1/charges/%s/refunds", getId()));
-		}
-		return refunds;
-	}
-
-	public Card getCard() {
-		return card;
-	}
-
-	public void setCard(Card card) {
-		this.card = card;
-	}
-
-	public Dispute getDispute() {
-		return dispute;
-	}
-
-	public void setDispute(Dispute dispute) {
-		this.dispute = dispute;
-	}
-
-	public String getBalanceTransaction() {
-		return balanceTransaction;
-	}
-
-	public void setBalanceTransaction(String balanceTransaction) {
-		this.balanceTransaction = balanceTransaction;
-	}
-
-	public Map<String, String> getMetadata() {
-		return metadata;
-	}
-
-	public void setMetadata(Map<String, String> metadata) {
-		this.metadata = metadata;
-	}
-
-	public String getReceiptNumber() {
-		return receiptNumber;
-	}
-
-	public void setReceiptNumber(String receiptNumber) {
-		this.receiptNumber = receiptNumber;
-	}
-
-	public String getReceiptEmail() {
-		return receiptEmail;
-	}
-
-	public void setReceiptEmail(String receiptEmail) {
-		this.receiptEmail = receiptEmail;
-	}
-
-	public ExternalAccount getSource() {
-		return source;
-	}
-
-	public void setSource(ExternalAccount source) {
-		this.source = source;
-	}
-
-	public String getTransfer() {
-		return transfer;
-	}
-
-	public void setTransfer(String transfer) {
-		this.transfer = transfer;
-	}
-
-	public String getDestination() {
-		return destination;
-	}
-
-	public void setDestination(String destination) {
-		this.destination = destination;
 	}
 
 	public static Charge create(Map<String, Object> params)

--- a/src/main/java/com/stripe/model/Order.java
+++ b/src/main/java/com/stripe/model/Order.java
@@ -12,118 +12,176 @@ import com.stripe.net.APIResource;
 import com.stripe.net.RequestOptions;
 
 public class Order extends APIResource implements HasId, MetadataStore<Order> {
-	Long created;
-	Long updated;
 	String id;
-	Boolean livemode;
 	Integer amount;
-	String currency;
-	List<OrderItem> items;
-	Map<String, String> metadata;
-	String status;
+	String application;
+	Long applicationFee;
 	String charge;
+	Long created;
+	String currency;
 	String customer;
 	String email;
+	String externalCouponCode;
+	List<OrderItem> items;
+	Boolean livemode;
+	Map<String, String> metadata;
 	String selectedShippingMethod;
 	ShippingDetails shipping;
 	List<ShippingMethod> shippingMethods;
-	Long applicationFee;
+	String status;
+	StatusTransitions statusTransitions;
+	Long updated;
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public Integer getAmount() {
+		return amount;
+	}
+
+	public void setAmount(Integer amount) {
+		this.amount = amount;
+	}
+
+	public String getApplication() {
+		return application;
+	}
+
+	public void setApplication(String application) {
+		this.application = application;
+	}
+
+	public Long getApplicationFee() {
+		return applicationFee;
+	}
+
+	public void setApplicationFee(Long applicationFee) {
+		this.applicationFee = applicationFee;
+	}
+
+	public String getCharge() {
+		return charge;
+	}
+
+	public void setCharge(String charge) {
+		this.charge = charge;
+	}
 
 	public Long getCreated() {
 		return created;
 	}
+
 	public void setCreated(Long created) {
 		this.created = created;
 	}
-	public Long getUpdated() {
-		return updated;
-	}
-	public void setUpdated(Long updated) {
-		this.updated = updated;
-	}
-	public String getId() {
-		return id;
-	}
-	public void setId(String id) {
-		this.id = id;
-	}
-	public Boolean getLivemode() {
-		return livemode;
-	}
-	public void setLivemode(Boolean livemode) {
-		this.livemode = livemode;
-	}
-	public Integer getAmount() {
-		return amount;
-	}
-	public void setAmount(Integer amount) {
-		this.amount = amount;
-	}
+
 	public String getCurrency() {
 		return currency;
 	}
+
 	public void setCurrency(String currency) {
 		this.currency = currency;
 	}
-	public List<OrderItem> getItems() {
-		return items;
-	}
-	public void setItems(List<OrderItem> items) {
-		this.items = items;
-	}
-	public Map<String, String> getMetadata() {
-		return metadata;
-	}
-	public void setMetadata(Map<String, String> metadata) {
-		this.metadata = metadata;
-	}
-	public String getStatus() {
-		return status;
-	}
-	public void setStatus(String status) {
-		this.status = status;
-	}
-	public String getCharge() {
-		return charge;
-	}
-	public void setCharge(String charge) {
-		this.charge = charge;
-	}
+
 	public String getCustomer() {
 		return customer;
 	}
+
 	public void setCustomer(String customer) {
 		this.customer = customer;
 	}
+
 	public String getEmail() {
 		return email;
 	}
+
 	public void setEmail(String email) {
 		this.email = email;
 	}
+
+	public String getExternalCouponCode() {
+		return externalCouponCode;
+	}
+
+	public void setExternalCouponCode(String externalCouponCode) {
+		this.externalCouponCode = externalCouponCode;
+	}
+
+	public List<OrderItem> getItems() {
+		return items;
+	}
+
+	public void setItems(List<OrderItem> items) {
+		this.items = items;
+	}
+
+	public Boolean getLivemode() {
+		return livemode;
+	}
+
+	public void setLivemode(Boolean livemode) {
+		this.livemode = livemode;
+	}
+
+	public Map<String, String> getMetadata() {
+		return metadata;
+	}
+
+	public void setMetadata(Map<String, String> metadata) {
+		this.metadata = metadata;
+	}
+
 	public String getSelectedShippingMethod() {
 		return selectedShippingMethod;
 	}
+
 	public void setSelectedShippingMethod(String selectedShippingMethod) {
 		this.selectedShippingMethod = selectedShippingMethod;
 	}
+
 	public ShippingDetails getShipping() {
 		return shipping;
 	}
+
 	public void setShipping(ShippingDetails shipping) {
 		this.shipping = shipping;
 	}
+
 	public List<ShippingMethod> getShippingMethods() {
 		return shippingMethods;
 	}
+
 	public void setShippingMethods(List<ShippingMethod> shippingMethods) {
 		this.shippingMethods = shippingMethods;
 	}
-	public Long getApplicationFee() {
-		return applicationFee;
+
+	public String getStatus() {
+		return status;
 	}
-	public void setApplicationFee(Long applicationFee) {
-		this.applicationFee = applicationFee;
+
+	public void setStatus(String status) {
+		this.status = status;
+	}
+
+	public StatusTransitions getStatusTransitions() {
+		return statusTransitions;
+	}
+
+	public void setStatusTransitions(StatusTransitions statusTransitions) {
+		this.statusTransitions = statusTransitions;
+	}
+
+	public Long getUpdated() {
+		return updated;
+	}
+
+	public void setUpdated(Long updated) {
+		this.updated = updated;
 	}
 
 	public static Order create(Map<String, Object> params)

--- a/src/main/java/com/stripe/model/Product.java
+++ b/src/main/java/com/stripe/model/Product.java
@@ -12,37 +12,22 @@ import com.stripe.net.APIResource;
 import com.stripe.net.RequestOptions;
 
 public class Product extends APIResource implements HasId, MetadataStore<Product> {
-	Long created;
-	Long updated;;
 	String id;
-	Boolean livemode;
 	Boolean active;
-	List<String> images;
-	String name;
-	Boolean shippable;
-	SKUCollection skus;
 	List<String> attributes;
 	String caption;
+	Long created;
+	List<String> deactivateOn;
 	String description;
-	PackageDimensions packageDimensions;
-	String url;
+	List<String> images;
+	Boolean livemode;
 	Map<String, String> metadata;
-
-	public Long getCreated() {
-		return created;
-	}
-
-	public void setCreated(Long created) {
-		this.created = created;
-	}
-
-	public Long getUpdated() {
-		return updated;
-	}
-
-	public void setUpdated(Long updated) {
-		this.updated = updated;
-	}
+	String name;
+	PackageDimensions packageDimensions;
+	Boolean shippable;
+	SKUCollection skus;
+	Long updated;
+	String url;
 
 	public String getId() {
 		return id;
@@ -52,52 +37,12 @@ public class Product extends APIResource implements HasId, MetadataStore<Product
 		this.id = id;
 	}
 
-	public Boolean getLivemode() {
-		return livemode;
-	}
-
-	public void setLivemode(Boolean livemode) {
-		this.livemode = livemode;
-	}
-
 	public Boolean getActive() {
 		return active;
 	}
 
 	public void setActive(Boolean active) {
 		this.active = active;
-	}
-
-	public List<String> getImages() {
-		return images;
-	}
-
-	public void setImages(List<String> images) {
-		this.images = images;
-	}
-
-	public String getName() {
-		return name;
-	}
-
-	public void setName(String name) {
-		this.name = name;
-	}
-
-	public Boolean getShippable() {
-		return shippable;
-	}
-
-	public void setShippable(Boolean shippable) {
-		this.shippable = shippable;
-	}
-
-	public SKUCollection getSkus() {
-		return skus;
-	}
-
-	public void setSkus(SKUCollection skus) {
-		this.skus = skus;
 	}
 
 	public List<String> getAttributes() {
@@ -116,12 +61,60 @@ public class Product extends APIResource implements HasId, MetadataStore<Product
 		this.caption = caption;
 	}
 
+	public Long getCreated() {
+		return created;
+	}
+
+	public void setCreated(Long created) {
+		this.created = created;
+	}
+
+	public List<String> getDeactivateOn() {
+		return deactivateOn;
+	}
+
+	public void setDeactivateOn(List<String> deactivateOn) {
+		this.deactivateOn = deactivateOn;
+	}
+
 	public String getDescription() {
 		return description;
 	}
 
 	public void setDescription(String description) {
 		this.description = description;
+	}
+
+	public List<String> getImages() {
+		return images;
+	}
+
+	public void setImages(List<String> images) {
+		this.images = images;
+	}
+
+	public Boolean getLivemode() {
+		return livemode;
+	}
+
+	public void setLivemode(Boolean livemode) {
+		this.livemode = livemode;
+	}
+
+	public Map<String, String> getMetadata() {
+		return metadata;
+	}
+
+	public void setMetadata(Map<String, String> metadata) {
+		this.metadata = metadata;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
 	}
 
 	public PackageDimensions getPackageDimensions() {
@@ -132,20 +125,36 @@ public class Product extends APIResource implements HasId, MetadataStore<Product
 		this.packageDimensions = packageDimensions;
 	}
 
+	public Boolean getShippable() {
+		return shippable;
+	}
+
+	public void setShippable(Boolean shippable) {
+		this.shippable = shippable;
+	}
+
+	public SKUCollection getSkus() {
+		return skus;
+	}
+
+	public void setSkus(SKUCollection skus) {
+		this.skus = skus;
+	}
+
+	public Long getUpdated() {
+		return updated;
+	}
+
+	public void setUpdated(Long updated) {
+		this.updated = updated;
+	}
+
 	public String getURL() {
 		return url;
 	}
 
 	public void setURL(String url) {
 		this.url = url;
-	}
-
-	public Map<String, String> getMetadata() {
-		return metadata;
-	}
-
-	public void setMetadata(Map<String, String> metadata) {
-		this.metadata = metadata;
 	}
 
 	public static Product create(Map<String, Object> params)

--- a/src/main/java/com/stripe/model/Refund.java
+++ b/src/main/java/com/stripe/model/Refund.java
@@ -11,15 +11,105 @@ import com.stripe.net.RequestOptions;
 import java.util.Map;
 
 public class Refund extends APIResource implements MetadataStore<Charge>, HasId {
-	Integer amount;
-	String currency;
-	Long created;
-	String balanceTransaction;
 	String id;
+	Integer amount;
+	String balanceTransaction;
 	String charge;
+	Long created;
+	String currency;
+	String description;
+	Map<String, String> metadata;
 	String reason;
 	String receiptNumber;
-	Map<String, String> metadata;
+	String status;
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public Integer getAmount() {
+		return amount;
+	}
+
+	public void setAmount(Integer amount) {
+		this.amount = amount;
+	}
+
+	public String getBalanceTransaction() {
+		return balanceTransaction;
+	}
+
+	public void setBalanceTransaction(String balanceTransaction) {
+		this.balanceTransaction = balanceTransaction;
+	}
+
+	public String getCharge() {
+		return charge;
+	}
+
+	public void setCharge(String charge) {
+		this.charge = charge;
+	}
+
+	public Long getCreated() {
+		return created;
+	}
+
+	public void setCreated(Long created) {
+		this.created = created;
+	}
+
+	public String getCurrency() {
+		return currency;
+	}
+
+	public void setCurrency(String currency) {
+		this.currency = currency;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	public Map<String, String> getMetadata() {
+		return metadata;
+	}
+
+	public void setMetadata(Map<String, String> metadata) {
+		this.metadata = metadata;
+	}
+
+	public String getReason() {
+		return reason;
+	}
+
+	public void setReason(String reason) {
+		this.reason = reason;
+	}
+
+	public String getReceiptNumber() {
+		return receiptNumber;
+	}
+
+	public void setReceiptNumber(String receiptNumber) {
+		this.receiptNumber = receiptNumber;
+	}
+
+	public String getStatus() {
+		return status;
+	}
+
+	public void setStatus(String status) {
+		this.status = status;
+	}
 
 	public Refund update(Map<String, Object> params)
 			throws AuthenticationException, InvalidRequestException,
@@ -87,64 +177,5 @@ public class Refund extends APIResource implements MetadataStore<Charge>, HasId 
 			throws AuthenticationException, InvalidRequestException,
 			APIConnectionException, CardException, APIException {
 		return request(RequestMethod.POST, classURL(Refund.class), params, Refund.class, options);
-	}
-
-	public String getId() {
-		return id;
-	}
-
-	public void setId(String id) {
-		this.id = id;
-	}
-
-	public Integer getAmount() {
-		return amount;
-	}
-	public void setAmount(Integer amount) {
-		this.amount = amount;
-	}
-	public String getCurrency() {
-		return currency;
-	}
-	public void setCurrency(String currency) {
-		this.currency = currency;
-	}
-	public Long getCreated() {
-		return created;
-	}
-	public void setCreated(Long created) {
-		this.created = created;
-	}
-	public String getBalanceTransaction() {
-		return balanceTransaction;
-	}
-	public void setBalanceTransaction(String balanceTransaction) {
-		this.balanceTransaction = balanceTransaction;
-	}
-	public String getCharge() {
-		return charge;
-	}
-	public void setCharge(String charge) {
-		this.charge = charge;
-	}
-	public Map<String, String> getMetadata() {
-		return metadata;
-	}
-	public void setMetadata(Map<String, String> metadata) {
-		this.metadata = metadata;
-	}
-	public String getReason() {
-		return reason;
-	}
-	public void setReason(String reason) {
-		this.reason = reason;
-	}
-
-	public String getReceiptNumber() {
-		return receiptNumber;
-	}
-	
-	public void setReceiptNumber(String receiptNumber) {
-		this.receiptNumber = receiptNumber;
 	}
 }

--- a/src/main/java/com/stripe/model/StatusTransitions.java
+++ b/src/main/java/com/stripe/model/StatusTransitions.java
@@ -1,0 +1,42 @@
+package com.stripe.model;
+
+import com.stripe.net.APIResource;
+
+public class StatusTransitions extends APIResource {
+  Long canceled;
+  Long fulfiled;
+  Long paid;
+  Long returned;
+
+  public Long getCanceled() {
+    return canceled;
+  }
+
+  public void setCanceled(Long canceled) {
+    this.canceled = canceled;
+  }
+
+  public Long getFulfiled() {
+    return fulfiled;
+  }
+
+  public void setFulfiled(Long fulfiled) {
+    this.fulfiled = fulfiled;
+  }
+
+  public Long getPaid() {
+    return paid;
+  }
+
+  public void setPaid(Long paid) {
+    this.paid = paid;
+  }
+
+  public Long getReturned() {
+    return returned;
+  }
+
+  public void setReturned(Long returned) {
+    this.returned = returned;
+  }
+}

--- a/src/main/java/com/stripe/model/Transfer.java
+++ b/src/main/java/com/stripe/model/Transfer.java
@@ -13,27 +13,39 @@ import java.util.Map;
 
 public class Transfer extends APIResource implements MetadataStore<Transfer>, HasId {
 	String id;
-	String status;
-	Long date;
-	Boolean livemode;
-	Summary summary;
-	String description;
-	String statementDescriptor;
-	@Deprecated
-	String statementDescription;
 	Integer amount;
+	Integer amountReversed;
+	String applicationFee;
+	String balanceTransaction;
+	BankAccount bankAccount;
+	Long created;
 	String currency;
+	Long date;
+	String description;
+	String destination;
+	String destinationPayment;
+	String failureCode;
+	String failureMessage;
+	Boolean livemode;
+	Map<String, String> metadata;
+	TransferReversalCollection reversals;
+	Boolean reversed;
+	String sourceTransaction;
+	String sourceType;
+	String statementDescriptor;
+	String status;
+	String type;
+
+	@Deprecated
+	BankAccount account;
+	@Deprecated
 	List<String> otherTransfers;
 	@Deprecated
 	String recipient;
-	String destination;
-	String destinationPayment;
-	BankAccount account;
-	String balanceTransaction;
-	Map<String, String> metadata;
-	String failureCode;
-	String failureMessage;
-	TransferReversalCollection reversals;
+	@Deprecated
+	String statementDescription;
+	@Deprecated
+	Summary summary;
 
 	public String getId() {
 		return id;
@@ -41,64 +53,6 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
 
 	public void setId(String id) {
 		this.id = id;
-	}
-
-	public Boolean getLivemode() {
-		return livemode;
-	}
-
-	public void setLivemode(Boolean livemode) {
-		this.livemode = livemode;
-	}
-
-	public String getStatus() {
-		return status;
-	}
-
-	public void setStatus(String status) {
-		this.status = status;
-	}
-
-	public Long getDate() {
-		return date;
-	}
-
-	public void setDate(Long date) {
-		this.date = date;
-	}
-
-	public Summary getSummary() {
-		return summary;
-	}
-
-	public void setSummary(Summary summary) {
-		this.summary = summary;
-	}
-
-	public String getDescription() {
-		return description;
-	}
-
-	public void setDescription(String description) {
-		this.description = description;
-	}
-
-	public String getStatementDescriptor() {
-		return statementDescriptor;
-	}
-
-	public void setStatementDescriptor(String statementDescriptor) {
-		this.statementDescriptor = statementDescriptor;
-	}
-
-	@Deprecated
-	public String getStatementDescription() {
-		return statementDescription;
-	}
-
-	@Deprecated
-	public void setStatementDescription(String statementDescription) {
-		this.statementDescription = statementDescription;
 	}
 
 	public Integer getAmount() {
@@ -109,18 +63,68 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
 		this.amount = amount;
 	}
 
+	public Integer getAmountReversed() {
+		return amountReversed;
+	}
+
+	public void setAmountReversed(Integer amountReversed) {
+		this.amountReversed = amountReversed;
+	}
+
+	public String getApplicationFee() {
+		return applicationFee;
+	}
+
+	public void setApplicationFee(String applicationFee) {
+		this.applicationFee = applicationFee;
+	}
+
+	public String getBalanceTransaction() {
+		return balanceTransaction;
+	}
+
+	public void setBalanceTransaction(String balanceTransaction) {
+		this.balanceTransaction = balanceTransaction;
+	}
+
+	public BankAccount getBankAccount() {
+		return bankAccount;
+	}
+
+	public void setBankAccount(BankAccount bankAccount) {
+		this.bankAccount = bankAccount;
+	}
+
+	public Long getCreated() {
+		return created;
+	}
+
+	public void setCreated(Long created) {
+		this.created = created;
+	}
+
 	public String getCurrency() {
 		return currency;
 	}
 
-	@Deprecated
-	public String getRecipient() {
-		return recipient;
+	public void setCurrency(String currency) {
+		this.currency = currency;
 	}
 
-	@Deprecated
-	public void setRecipient(String recipient) {
-		this.recipient = recipient;
+	public Long getDate() {
+		return date;
+	}
+
+	public void setDate(Long date) {
+		this.date = date;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
 	}
 
 	public String getDestination() {
@@ -139,34 +143,6 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
 		this.destinationPayment = destinationPayment;
 	}
 
-	public BankAccount getAccount() {
-		return account;
-	}
-
-	public void setAccount(BankAccount account) {
-		this.account = account;
-	}
-
-	public void setCurrency(String currency) {
-		this.currency = currency;
-	}
-
-	public List<String> getOtherTransfers() {
-		return otherTransfers;
-	}
-
-	public void setOtherTransfers(List<String> otherTransfers) {
-		this.otherTransfers = otherTransfers;
-	}
-
-	public String getBalanceTransaction() {
-		return balanceTransaction;
-	}
-
-	public void setBalanceTransaction(String balanceTransaction) {
-		this.balanceTransaction = balanceTransaction;
-	}
-
 	public String getFailureCode() {
 		return failureCode;
 	}
@@ -183,12 +159,157 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
 		this.failureMessage = failureMessage;
 	}
 
+	public Boolean getLivemode() {
+		return livemode;
+	}
+
+	public void setLivemode(Boolean livemode) {
+		this.livemode = livemode;
+	}
+
 	public Map<String, String> getMetadata() {
 		return metadata;
 	}
 
 	public void setMetadata(Map<String, String> metadata) {
 		this.metadata = metadata;
+	}
+
+	public TransferReversalCollection getReversals() {
+		if (reversals.getURL() == null) {
+			reversals.setURL(String.format("/v1/transfers/%s/reversals", getId()));
+		}
+		return reversals;
+	}
+
+	public Boolean getReversed() {
+		return reversed;
+	}
+
+	public void setReversed(Boolean reversed) {
+		this.reversed = reversed;
+	}
+
+	public String getSourceTransaction() {
+		return sourceTransaction;
+	}
+
+	public void setSourceTransaction(String sourceTransaction) {
+		this.sourceTransaction = sourceTransaction;
+	}
+
+	public String getSourceType() {
+		return sourceType;
+	}
+
+	public void setSourceType(String sourceType) {
+		this.sourceType = sourceType;
+	}
+
+	public String getStatementDescriptor() {
+		return statementDescriptor;
+	}
+
+	public void setStatementDescriptor(String statementDescriptor) {
+		this.statementDescriptor = statementDescriptor;
+	}
+
+	public String getStatus() {
+		return status;
+	}
+
+	public void setStatus(String status) {
+		this.status = status;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	/**
+	 * @deprecated
+	 * Use `bank_account` field (https://stripe.com/docs/upgrades#2014-05-19)
+	 */
+	@Deprecated
+	public BankAccount getAccount() {
+		return account;
+	}
+
+	/**
+	 * @deprecated
+	 * Use `bank_account` field (https://stripe.com/docs/upgrades#2014-05-19)
+	 */
+	@Deprecated
+	public void setAccount(BankAccount account) {
+		this.account = account;
+	}
+
+	/**
+	 * @deprecated
+	 * Use the balance history endpoint (https://stripe.com/docs/upgrades#2014-08-04)
+	 */
+	@Deprecated
+	public List<String> getOtherTransfers() {
+		return otherTransfers;
+	}
+
+	/**
+	 * @deprecated
+	 * Use the balance history endpoint (https://stripe.com/docs/upgrades#2014-08-04)
+	 */
+	@Deprecated
+	public void setOtherTransfers(List<String> otherTransfers) {
+		this.otherTransfers = otherTransfers;
+	}
+
+	@Deprecated
+	public String getRecipient() {
+		return recipient;
+	}
+
+	@Deprecated
+	public void setRecipient(String recipient) {
+		this.recipient = recipient;
+	}
+
+	/**
+	 * @deprecated
+	 * Use `statement_descriptor` field (https://stripe.com/docs/upgrades#2014-12-17)
+	 */
+	@Deprecated
+	public String getStatementDescription() {
+		return statementDescription;
+	}
+
+	/**
+	 * @deprecated
+	 * Use `statement_descriptor` field (https://stripe.com/docs/upgrades#2014-12-17)
+	 */
+	@Deprecated
+	public void setStatementDescription(String statementDescription) {
+		this.statementDescription = statementDescription;
+	}
+
+	/**
+	 * @deprecated
+	 * Use the balance history endpoint (https://stripe.com/docs/upgrades#2014-08-04)
+	 */
+	@Deprecated
+	public Summary getSummary() {
+		return summary;
+	}
+
+	/**
+	 * @deprecated
+	 * Use the balance history endpoint (https://stripe.com/docs/upgrades#2014-08-04)
+	 */
+	@Deprecated
+	public void setSummary(Summary summary) {
+		this.summary = summary;
 	}
 
 	public static Transfer create(Map<String, Object> params)
@@ -323,12 +444,5 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
 			APIConnectionException, CardException, APIException {
 		return request(RequestMethod.GET, String.format("%s/transactions",
 						instanceURL(Transfer.class, this.getId())), params, TransferTransactionCollection.class, options);
-	}
-
-	public TransferReversalCollection getReversals() {
-		if (reversals.getURL() == null) {
-			reversals.setURL(String.format("/v1/transfers/%s/reversals", getId()));
-		}
-		return reversals;
 	}
 }


### PR DESCRIPTION
This PR adds a bunch of missing attributes to several objects, and deprecates some attributes that have been removed in recent API versions.

To facilitate maintainability, I have reordered the attributes (and their accessors) in the same order as in the API reference, i.e. `id` first, then alphabetic order.

r? @brandur 
cc @stripe/api-libraries 