### PR TITLE
Add `ChargeOutcome` to `Charge`

### DIFF
--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -32,6 +32,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
 	String invoice;
 	Boolean livemode;
 	Map<String, String> metadata;
+	ChargeOutcome outcome;
 	String order;
 	Boolean paid;
 	String receiptEmail;
@@ -203,6 +204,14 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
 
 	public void setOrder(String order) {
 		this.order = order;
+	}
+
+	public ChargeOutcome getOutcome() {
+		return outcome;
+	}
+
+	public void setOutcome(ChargeOutcome outcome) {
+		this.outcome = outcome;
 	}
 
 	public Boolean getPaid() {

--- a/src/main/java/com/stripe/model/ChargeOutcome.java
+++ b/src/main/java/com/stripe/model/ChargeOutcome.java
@@ -1,0 +1,40 @@
+package com.stripe.model;
+
+public class ChargeOutcome extends StripeObject {
+	protected String networkStatus;
+	protected String reason;
+	protected String sellerMessage;
+	protected String type;
+
+	public String getNetworkStatus() {
+		return networkStatus;
+	}
+
+	public String getReason() {
+		return reason;
+	}
+
+	public String getSellerMessage() {
+		return sellerMessage;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public void setNetworkStatus(String networkStatus) {
+		this.networkStatus = networkStatus;
+	}
+
+	public void setReason(String reason) {
+		this.reason = reason;
+	}
+
+	public void setSellerMessage(String sellerMessage) {
+		this.sellerMessage = sellerMessage;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+}

--- a/src/test/java/com/stripe/model/ChargeOutcomeTest.java
+++ b/src/test/java/com/stripe/model/ChargeOutcomeTest.java
@@ -1,0 +1,24 @@
+package com.stripe.model;
+
+import com.stripe.BaseStripeTest;
+import com.stripe.exception.StripeException;
+import com.stripe.net.APIResource;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ChargeOutcomeTest extends BaseStripeTest {
+	@Test
+	public void testDeserialize() throws StripeException, IOException {
+		String json = resource("charge_outcome.json");
+		ChargeOutcome outcome = APIResource.GSON.fromJson(json, ChargeOutcome.class);
+
+		assertEquals("approved_by_network", outcome.getNetworkStatus());
+		assertEquals(null, outcome.getReason());
+		assertEquals("Payment complete.", outcome.getSellerMessage());
+		assertEquals("authorized", outcome.getType());
+	}
+}

--- a/src/test/resources/com/stripe/model/charge_outcome.json
+++ b/src/test/resources/com/stripe/model/charge_outcome.json
@@ -1,0 +1,6 @@
+{
+    "network_status": "approved_by_network",
+    "reason": null,
+    "seller_message": "Payment complete.",
+    "type": "authorized"
+}


### PR DESCRIPTION
Adds a type for a charge's outcome and puts it into the `Charge` model.

/cc @brahn