### PR TITLE
Adds source_types accessor in balance objects

### DIFF
--- a/src/main/java/com/stripe/model/Money.java
+++ b/src/main/java/com/stripe/model/Money.java
@@ -1,14 +1,86 @@
 package com.stripe.model;
 
-public class Money {
+public class Money extends StripeObject {
 	Long amount;
 	String currency;
+	SourceTypes sourceTypes;
 
 	public Long getAmount() {
 		return amount;
 	}
 
+	public void setAmount(Long amount) {
+		this.amount = amount;
+	}
+
 	public String getCurrency() {
 		return currency;
+	}
+
+	public void setCurrency(String currency) {
+		this.currency = currency;
+	}
+
+	public SourceTypes getSourceTypes() {
+		return sourceTypes;
+	}
+
+	public void setSourceTypes(SourceTypes sourceTypes) {
+		this.sourceTypes = sourceTypes;
+	}
+
+	public static class SourceTypes extends StripeObject {
+		Long alipayAccount;
+		Long bankAccount;
+		Long bitcoinReceiver;
+		Long card;
+
+		public Long getAlipayAccount() {
+			return alipayAccount;
+		}
+
+		public void setAlipayAccount(Long alipayAccount) {
+			this.alipayAccount = alipayAccount;
+		}
+
+		public Long getBankAccount() {
+			return bankAccount;
+		}
+
+		public void setBankAccount(Long bankAccount) {
+			this.bankAccount = bankAccount;
+		}
+
+		public Long getBitcoinReceiver() {
+			return bitcoinReceiver;
+		}
+
+		public void setBitcoinReceiver(Long bitcoinReceiver) {
+			this.bitcoinReceiver = bitcoinReceiver;
+		}
+
+		public Long getCard() {
+			return card;
+		}
+
+		public void setCard(Long card) {
+			this.card = card;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+
+			SourceTypes st = (SourceTypes) o;
+			return equals(alipayAccount, st.alipayAccount) &&
+				equals(bankAccount, st.bankAccount) &&
+				equals(bitcoinReceiver, st.bitcoinReceiver) &&
+				equals(card, st.card);
+		}
 	}
 }

--- a/src/test/java/com/stripe/model/BalanceTest.java
+++ b/src/test/java/com/stripe/model/BalanceTest.java
@@ -1,0 +1,84 @@
+package com.stripe.model;
+
+import com.stripe.BaseStripeTest;
+import com.stripe.exception.StripeException;
+import com.stripe.model.Balance;
+import com.stripe.model.Money;
+import com.stripe.net.APIResource;
+import com.stripe.net.LiveStripeResponseGetter;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class BalanceTest extends BaseStripeTest {
+	@Before
+	public void mockStripeResponseGetter() {
+		APIResource.setStripeResponseGetter(networkMock);
+	}
+
+	@After
+	public void unmockStripeResponseGetter() {
+		/* This needs to be done because tests aren't isolated in Java */
+		APIResource.setStripeResponseGetter(new LiveStripeResponseGetter());
+	}
+
+	@Test
+	public void testDeserialize() throws StripeException, IOException {
+		String json = resource("balance.json");
+		Balance bal = APIResource.GSON.fromJson(json, Balance.class);
+
+		Money money = bal.getAvailable().get(0);
+		assertEquals("usd", money.getCurrency());
+		assertEquals(8045512867L, (long) money.getAmount());
+
+		Money.SourceTypes st = new Money.SourceTypes();
+		st.alipayAccount = null;
+		st.bankAccount = 9008784L;
+		st.bitcoinReceiver = 1449199L;
+		st.card = 8035054884L;
+		assertEquals(st, money.getSourceTypes());
+
+		money = bal.getAvailable().get(1);
+		assertEquals("cad", money.getCurrency());
+		assertEquals(1023450L, (long) money.getAmount());
+
+		st.alipayAccount = null;
+		st.bankAccount = null;
+		st.bitcoinReceiver = null;
+		st.card = 1023450L;
+		assertEquals(st, money.getSourceTypes());
+
+		money = bal.getPending().get(0);
+		assertEquals("usd", money.getCurrency());
+		assertEquals(1034273583L, (long) money.getAmount());
+
+		st.alipayAccount = null;
+		st.bankAccount = 0L;
+		st.bitcoinReceiver = 0L;
+		st.card = 1034273583L;
+		assertEquals(st, money.getSourceTypes());
+
+		money = bal.getPending().get(1);
+		assertEquals("cad", money.getCurrency());
+		assertEquals(356454L, (long) money.getAmount());
+
+		st.alipayAccount = null;
+		st.bankAccount = null;
+		st.bitcoinReceiver = null;
+		st.card = 356454L;
+		assertEquals(st, money.getSourceTypes());
+	}
+
+	@Test
+	public void testRetrieve() throws StripeException {
+		Balance.retrieve();
+
+		verifyGet(Balance.class, "https://api.stripe.com/v1/balance");
+		verifyNoMoreInteractions(networkMock);
+	}
+}

--- a/src/test/resources/com/stripe/model/balance.json
+++ b/src/test/resources/com/stripe/model/balance.json
@@ -1,0 +1,40 @@
+{
+    "object": "balance",
+    "available": [
+        {
+            "currency": "usd",
+            "amount": 8045512867,
+            "source_types": {
+                "card": 8035054884,
+                "bank_account": 9008784,
+                "bitcoin_receiver": 1449199
+            }
+        },
+        {
+            "currency": "cad",
+            "amount": 1023450,
+            "source_types": {
+                "card": 1023450
+            }
+        }
+    ],
+    "livemode": false,
+    "pending": [
+        {
+            "currency": "usd",
+            "amount": 1034273583,
+            "source_types": {
+                "card": 1034273583,
+                "bank_account": 0,
+                "bitcoin_receiver": 0
+            }
+        },
+        {
+            "currency": "cad",
+            "amount": 356454,
+            "source_types": {
+                "card": 356454
+            }
+        }
+    ]
+}


### PR DESCRIPTION
r? @brandur 
cc @stripe/api-libraries 

This PR adds an accessor to the `source_types` attribute in the `Money` class used by `Balance` objects.

It also adds a basic test to ensure that this new attribute is deserialized correctly.
