### PR TITLE
Adds more missing attributes

### DIFF
--- a/src/main/java/com/stripe/model/Account.java
+++ b/src/main/java/com/stripe/model/Account.java
@@ -19,7 +19,6 @@ public class Account extends APIResource implements HasId, MetadataStore<Account
 	String businessURL;
 	Boolean chargesEnabled;
 	String country;
-	List<String> currenciesSupported;
 	Boolean debitNegativeBalances;
 	AccountDeclineChargeOn declineChargeOn;
 	String defaultCurrency;
@@ -41,6 +40,9 @@ public class Account extends APIResource implements HasId, MetadataStore<Account
 	AccountTransferSchedule transferSchedule;
 	Boolean transfersEnabled;
 	Verification verification;
+
+	@Deprecated
+	List<String> currenciesSupported;
 
 	public String getId() {
 		return id;
@@ -75,10 +77,6 @@ public class Account extends APIResource implements HasId, MetadataStore<Account
 
 	public String getCountry() {
 		return country;
-	}
-
-	public List<String> getCurrenciesSupported() {
-		return currenciesSupported;
 	}
 
 	public Boolean getDebitNegativeBalances() {
@@ -190,6 +188,15 @@ public class Account extends APIResource implements HasId, MetadataStore<Account
 
 	public Verification getVerification() {
 		return verification;
+	}
+
+	/**
+	 * @deprecated
+	 * Use the country_specs endpoint (https://stripe.com/docs/upgrades#2016-03-07)
+	 */
+	@Deprecated
+	public List<String> getCurrenciesSupported() {
+		return currenciesSupported;
 	}
 
 	public static Account create(Map<String, Object> params)

--- a/src/main/java/com/stripe/model/AlipayAccount.java
+++ b/src/main/java/com/stripe/model/AlipayAccount.java
@@ -15,7 +15,7 @@ import java.util.Map;
 public class AlipayAccount extends ExternalAccount {
 	Long created;
 	String fingerprint;
-	Map<String, String> metadata;
+	Boolean livemode;
 	Integer paymentAmount;
 	String paymentCurrency;
 	Boolean reusable;
@@ -39,12 +39,12 @@ public class AlipayAccount extends ExternalAccount {
 		this.fingerprint = fingerprint;
 	}
 
-	public Map<String, String> getMetadata() {
-		return metadata;
+	public Boolean getLivemode() {
+		return livemode;
 	}
 
-	public void setMetadata(Map<String, String> metadata) {
-		this.metadata = metadata;
+	public void setLivemode(Boolean livemode) {
+		this.livemode = livemode;
 	}
 
 	public Integer getPaymentAmount() {

--- a/src/main/java/com/stripe/model/BankAccount.java
+++ b/src/main/java/com/stripe/model/BankAccount.java
@@ -10,6 +10,8 @@ import com.stripe.net.RequestOptions;
 import java.util.Map;
 
 public class BankAccount extends ExternalAccount {
+	String accountHolderName;
+	String accountHolderType;
 	String bankName;
 	String country;
 	String currency;
@@ -19,6 +21,22 @@ public class BankAccount extends ExternalAccount {
 	String routingNumber;
 	String status;
 	Boolean validated;
+
+	public String getAccountHolderName() {
+		return accountHolderName;
+	}
+
+	public void setAccountHolderName(String accountHolderName) {
+		this.accountHolderName = accountHolderName;
+	}
+
+	public String getAccountHolderType() {
+		return accountHolderType;
+	}
+
+	public void setAccountHolderType(String accountHolderType) {
+		this.accountHolderType = accountHolderType;
+	}
 
 	public String getBankName() {
 		return bankName;

--- a/src/main/java/com/stripe/model/BitcoinReceiver.java
+++ b/src/main/java/com/stripe/model/BitcoinReceiver.java
@@ -12,7 +12,7 @@ import com.stripe.net.RequestOptions;
 import java.util.Collections;
 import java.util.Map;
 
-public class BitcoinReceiver extends ExternalAccount implements HasId {
+public class BitcoinReceiver extends ExternalAccount {
 	Boolean active;
 	Integer amount;
 	Integer amountReceived;
@@ -25,12 +25,14 @@ public class BitcoinReceiver extends ExternalAccount implements HasId {
 	String email;
 	Boolean filled;
 	String inboundAddress;
-	Map<String, String> metadata;
+	Boolean livemode;
 	String payment;
 	String refundAddress;
 	Boolean rejectTransactions;
 	String status;
 	BitcoinTransactionCollection transactions;
+	Boolean uncapturedFunds;
+	Boolean usedForPayment;
 
 	public Boolean getActive() {
 		return active;
@@ -128,12 +130,12 @@ public class BitcoinReceiver extends ExternalAccount implements HasId {
 		this.inboundAddress = inboundAddress;
 	}
 
-	public Map<String, String> getMetadata() {
-		return metadata;
+	public Boolean getLivemode() {
+		return livemode;
 	}
 
-	public void setMetadata(Map<String, String> metadata) {
-		this.metadata = metadata;
+	public void setLivemode(Boolean livemode) {
+		this.livemode = livemode;
 	}
 
 	public String getPayment() {
@@ -174,6 +176,22 @@ public class BitcoinReceiver extends ExternalAccount implements HasId {
 
 	public void setTransactions(BitcoinTransactionCollection transactions) {
 		this.transactions = transactions;
+	}
+
+	public Boolean getUncapturedFunds() {
+		return uncapturedFunds;
+	}
+
+	public void setUncapturedFunds(Boolean uncapturedFunds) {
+		this.uncapturedFunds = uncapturedFunds;
+	}
+
+	public Boolean getUsedForPayment() {
+		return usedForPayment;
+	}
+
+	public void setUsedForPayment(Boolean usedForPayment) {
+		this.usedForPayment = usedForPayment;
 	}
 
 	public static BitcoinReceiver create(Map<String, Object> params)

--- a/src/main/java/com/stripe/model/Card.java
+++ b/src/main/java/com/stripe/model/Card.java
@@ -9,7 +9,7 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
-public class Card extends ExternalAccount implements MetadataStore<Card>, HasId {
+public class Card extends ExternalAccount {
 	String addressCity;
 	String addressCountry;
 	String addressLine1;
@@ -22,17 +22,19 @@ public class Card extends ExternalAccount implements MetadataStore<Card>, HasId 
 	String country;
 	String currency;
 	String cvcCheck;
+	Boolean defaultForCurrency;
 	String dynamicLast4;
 	Integer expMonth;
 	Integer expYear;
 	String fingerprint;
 	String funding;
 	String last4;
-	Map<String, String> metadata;
 	String name;
 	String recipient;
 	String status;
 	String tokenizationMethod;
+
+	@Deprecated
 	String type;
 
 	public String getAddressCity() {
@@ -131,6 +133,14 @@ public class Card extends ExternalAccount implements MetadataStore<Card>, HasId 
 		this.cvcCheck = cvcCheck;
 	}
 
+	public Boolean getDefaultForCurrency() {
+		return defaultForCurrency;
+	}
+
+	public void setDefaultForCurrency(Boolean defaultForCurrency) {
+		this.defaultForCurrency = defaultForCurrency;
+	}
+
 	public String getDynamicLast4() {
 		return dynamicLast4;
 	}
@@ -179,14 +189,6 @@ public class Card extends ExternalAccount implements MetadataStore<Card>, HasId 
 		this.last4 = last4;
 	}
 
-	public Map<String, String> getMetadata() {
-		return metadata;
-	}
-
-	public void setMetadata(Map<String, String> metadata) {
-		this.metadata = metadata;
-	}
-
 	public String getName() {
 		return name;
 	}
@@ -219,10 +221,20 @@ public class Card extends ExternalAccount implements MetadataStore<Card>, HasId 
 		this.tokenizationMethod = tokenizationMethod;
 	}
 
+	/**
+	 * @deprecated
+	 * Use `brand` field (https://stripe.com/docs/upgrades#2014-06-13)
+	 */
+	@Deprecated
 	public String getType() {
 		return type;
 	}
 
+	/**
+	 * @deprecated
+	 * Use `brand` field (https://stripe.com/docs/upgrades#2014-06-13)
+	 */
+	@Deprecated
 	public void setType(String type) {
 		this.type = type;
 	}

--- a/src/main/java/com/stripe/model/Customer.java
+++ b/src/main/java/com/stripe/model/Customer.java
@@ -14,10 +14,9 @@ import java.util.Map;
 public class Customer extends APIResource implements MetadataStore<Customer>, HasId {
 	String id;
 	Integer accountBalance;
-	CustomerCardCollection cards;
+	String businessVatId;
 	Long created;
 	String currency;
-	String defaultCard;
 	String defaultSource;
 	Boolean deleted;
 	Boolean delinquent;
@@ -26,12 +25,19 @@ public class Customer extends APIResource implements MetadataStore<Customer>, Ha
 	String email;
 	Boolean livemode;
 	Map<String, String> metadata;
-	NextRecurringCharge nextRecurringCharge;
 	ShippingDetails shipping;
 	ExternalAccountCollection sources;
-	/** 1/2014: Legacy (from before multiple subscriptions per customer) */
-	Subscription subscription;
 	CustomerSubscriptionCollection subscriptions;
+
+	@Deprecated
+	CustomerCardCollection cards;
+	@Deprecated
+	String defaultCard;
+	@Deprecated
+	NextRecurringCharge nextRecurringCharge;
+	@Deprecated
+	Subscription subscription;
+	@Deprecated
 	Long trialEnd;
 
 	public String getId() {
@@ -50,8 +56,12 @@ public class Customer extends APIResource implements MetadataStore<Customer>, Ha
 		this.accountBalance = accountBalance;
 	}
 
-	public CustomerCardCollection getCards() {
-		return cards;
+	public String getBusinessVatId() {
+		return businessVatId;
+	}
+
+	public void setBusinessVatId(String businessVatId) {
+		this.businessVatId = businessVatId;
 	}
 
 	public Long getCreated() {
@@ -68,14 +78,6 @@ public class Customer extends APIResource implements MetadataStore<Customer>, Ha
 
 	public void setCurrency(String currency) {
 		this.currency = currency;
-	}
-
-	public String getDefaultCard() {
-		return defaultCard;
-	}
-
-	public void setDefaultCard(String defaultCard) {
-		this.defaultCard = defaultCard;
 	}
 
 	public String getDefaultSource() {
@@ -138,14 +140,6 @@ public class Customer extends APIResource implements MetadataStore<Customer>, Ha
 		this.metadata = metadata;
 	}
 
-	public NextRecurringCharge getNextRecurringCharge() {
-		return nextRecurringCharge;
-	}
-
-	public void setNextRecurringCharge(NextRecurringCharge nextRecurringCharge) {
-		this.nextRecurringCharge = nextRecurringCharge;
-	}
-
 	public ShippingDetails getShipping() {
 		return shipping;
 	}
@@ -162,24 +156,91 @@ public class Customer extends APIResource implements MetadataStore<Customer>, Ha
 		this.sources = sources;
 	}
 
-	/** 1/2014: Legacy (from before multiple subscriptions per customer) */
-	public Subscription getSubscription() {
-		return subscription;
-	}
-
-	/** 1/2014: Legacy (from before multiple subscriptions per customer) */
-	public void setSubscription(Subscription subscription) {
-		this.subscription = subscription;
-	}
-
 	public CustomerSubscriptionCollection getSubscriptions() {
 		return subscriptions;
 	}
 
+	public void setSubscriptions(CustomerSubscriptionCollection subscriptions) {
+		this.subscriptions = subscriptions;
+	}
+
+	/**
+	 * @deprecated
+	 * Use `sources` field (https://stripe.com/docs/upgrades#2015-02-18)
+	 */
+	@Deprecated
+	public CustomerCardCollection getCards() {
+		return cards;
+	}
+
+	/**
+	 * @deprecated
+	 * Use `default_source` field (https://stripe.com/docs/upgrades#2015-02-18)
+	 */
+	@Deprecated
+	public String getDefaultCard() {
+		return defaultCard;
+	}
+
+	/**
+	 * @deprecated
+	 * Use `default_source` field (https://stripe.com/docs/upgrades#2015-02-18)
+	 */
+	@Deprecated
+	public void setDefaultCard(String defaultCard) {
+		this.defaultCard = defaultCard;
+	}
+
+	/**
+	 * @deprecated
+	 * Use the upcoming invoice endpoint (https://stripe.com/docs/upgrades#2012-03-25)
+	 */
+	@Deprecated
+	public NextRecurringCharge getNextRecurringCharge() {
+		return nextRecurringCharge;
+	}
+
+	/**
+	 * @deprecated
+	 * Use the upcoming invoice endpoint (https://stripe.com/docs/upgrades#2012-03-25)
+	 */
+	@Deprecated
+	public void setNextRecurringCharge(NextRecurringCharge nextRecurringCharge) {
+		this.nextRecurringCharge = nextRecurringCharge;
+	}
+
+	/**
+	 * @deprecated
+	 * Use `subscriptions` field (https://stripe.com/docs/upgrades#2014-01-31)
+	 */
+	@Deprecated
+	public Subscription getSubscription() {
+		return subscription;
+	}
+
+	/**
+	 * @deprecated
+	 * Use `subscriptions` field (https://stripe.com/docs/upgrades#2014-01-31)
+	 */
+	@Deprecated
+	public void setSubscription(Subscription subscription) {
+		this.subscription = subscription;
+	}
+
+	/**
+	 * @deprecated
+	 * Use `subscriptions` field (https://stripe.com/docs/upgrades#2014-01-31)
+	 */
+	@Deprecated
 	public Long getTrialEnd() {
 		return trialEnd;
 	}
 
+	/**
+	 * @deprecated
+	 * Use `subscriptions` field (https://stripe.com/docs/upgrades#2014-01-31)
+	 */
+	@Deprecated
 	public void setTrialEnd(Long trialEnd) {
 		this.trialEnd = trialEnd;
 	}

--- a/src/main/java/com/stripe/model/Dispute.java
+++ b/src/main/java/com/stripe/model/Dispute.java
@@ -14,23 +14,27 @@ import java.util.Map;
 public class Dispute extends APIResource implements HasId {
 	String id;
 	Integer amount;
-	/** 8/2014: Legacy (now use balanceTransactions) -- https://stripe.com/docs/upgrades#2014-08-20 */
-	String balanceTransaction;
 	List<BalanceTransaction> balanceTransactions;
 	String charge;
 	Long created;
 	String currency;
-	/** 12/2014: Legacy (now use evidenceSubObject) -- https://stripe.com/docs/upgrades */
-	String evidence;
+	EvidenceSubObject evidenceSubObject; // `evidence`
 	EvidenceDetails evidenceDetails;
-	/** 12/2014: Legacy (now use evidenceDetails.dueBy) -- https://stripe.com/docs/upgrades */
-	Long evidenceDueBy;
-	EvidenceSubObject evidenceSubObject;
 	Boolean isChargeRefundable;
 	Boolean livemode;
 	Map<String, String> metadata;
 	String reason;
 	String status;
+
+	/** 8/2014: Legacy (now use balanceTransactions) -- https://stripe.com/docs/upgrades#2014-08-20 */
+	@Deprecated
+	String balanceTransaction;
+	/** 12/2014: Legacy (now use evidenceSubObject) -- https://stripe.com/docs/upgrades */
+	@Deprecated
+	String evidence;
+	/** 12/2014: Legacy (now use evidenceDetails.dueBy) -- https://stripe.com/docs/upgrades */
+	@Deprecated
+	Long evidenceDueBy;
 
 	public String getId() {
 		return id;
@@ -46,14 +50,6 @@ public class Dispute extends APIResource implements HasId {
 
 	public void setAmount(Integer amount) {
 		this.amount = amount;
-	}
-
-	public String getBalanceTransaction() {
-		return balanceTransaction;
-	}
-
-	public void setBalanceTransaction(String balanceTransaction) {
-		this.balanceTransaction = balanceTransaction;
 	}
 
 	public List<BalanceTransaction> getBalanceTransactions() {
@@ -88,14 +84,12 @@ public class Dispute extends APIResource implements HasId {
 		this.currency = currency;
 	}
 
-	/** 12/2014 Legacy (now use evidenceSubObject) */
-	public String getEvidence() {
-		return evidence;
+	public EvidenceSubObject getEvidenceSubObject() {
+		return evidenceSubObject;
 	}
 
-	/** 12/2014 Legacy (now use evidenceSubObject) */
-	public void setEvidence(String evidence) {
-		this.evidence = evidence;
+	public void setEvidenceSubObject(EvidenceSubObject evidence) {
+		this.evidenceSubObject = evidence;
 	}
 
 	public EvidenceDetails getEvidenceDetails() {
@@ -104,22 +98,6 @@ public class Dispute extends APIResource implements HasId {
 
 	public void setEvidenceDetails(EvidenceDetails evidenceDetails) {
 		this.evidenceDetails = evidenceDetails;
-	}
-
-	public Long getEvidenceDueBy() {
-		return evidenceDueBy;
-	}
-
-	public void setEvidenceDueBy(Long evidenceDueBy) {
-		this.evidenceDueBy = evidenceDueBy;
-	}
-
-	public EvidenceSubObject getEvidenceSubObject() {
-		return evidenceSubObject;
-	}
-
-	public void setEvidenceSubObject(EvidenceSubObject evidence) {
-		this.evidenceSubObject = evidence;
 	}
 
 	public boolean getIsChargeRefundable() {
@@ -158,6 +136,60 @@ public class Dispute extends APIResource implements HasId {
 
 	public void setStatus(String status) {
 		this.status = status;
+	}
+
+	/**
+	 * @deprecated
+	 * Use `balance_transactions` field
+	 */
+	@Deprecated
+	public String getBalanceTransaction() {
+		return balanceTransaction;
+	}
+
+	/**
+	 * @deprecated
+	 * Use `balance_transactions` field
+	 */
+	@Deprecated
+	public void setBalanceTransaction(String balanceTransaction) {
+		this.balanceTransaction = balanceTransaction;
+	}
+
+	/**
+	 * @deprecated
+	 * Use evidenceSubObject (https://stripe.com/docs/upgrades#2014-12-08)
+	 */
+	@Deprecated
+	public String getEvidence() {
+		return evidence;
+	}
+
+	/**
+	 * @deprecated
+	 * Use evidenceSubObject (https://stripe.com/docs/upgrades#2014-12-08)
+	 */
+	@Deprecated
+	public void setEvidence(String evidence) {
+		this.evidence = evidence;
+	}
+
+	/**
+	 * @deprecated
+	 * Use evidenceDetails.dueBy (https://stripe.com/docs/upgrades#2014-12-08)
+	 */
+	@Deprecated
+	public Long getEvidenceDueBy() {
+		return evidenceDueBy;
+	}
+
+	/**
+	 * @deprecated
+	 * Use evidenceDetails.dueBy (https://stripe.com/docs/upgrades#2014-12-08)
+	 */
+	@Deprecated
+	public void setEvidenceDueBy(Long evidenceDueBy) {
+		this.evidenceDueBy = evidenceDueBy;
 	}
 
 	public static Dispute retrieve(String id) throws AuthenticationException,

--- a/src/main/java/com/stripe/model/ExternalAccount.java
+++ b/src/main/java/com/stripe/model/ExternalAccount.java
@@ -12,11 +12,12 @@ import com.stripe.net.RequestOptions;
 import java.util.Collections;
 import java.util.Map;
 
-public class ExternalAccount extends APIResource implements HasId {
+public class ExternalAccount extends APIResource implements HasId, MetadataStore<ExternalAccount> {
 	String id;
 	String object;
 	String account;
 	String customer;
+	Map<String, String> metadata;
 
 	public String getId() {
 		return id;
@@ -42,6 +43,14 @@ public class ExternalAccount extends APIResource implements HasId {
 	// For testing
 	public void setCustomer(String customer) {
 		this.customer = customer;
+	}
+
+	public Map<String, String> getMetadata() {
+		return metadata;
+	}
+
+	public void setMetadata(Map<String, String> metadata) {
+		this.metadata = metadata;
 	}
 
 	public String getInstanceURL() {

--- a/src/main/java/com/stripe/model/FeeRefund.java
+++ b/src/main/java/com/stripe/model/FeeRefund.java
@@ -11,13 +11,65 @@ import com.stripe.net.RequestOptions;
 import java.util.Map;
 
 public class FeeRefund extends APIResource implements MetadataStore<ApplicationFee>, HasId {
+	String id;
 	Integer amount;
+	String balanceTransaction;
 	String currency;
 	Long created;
-	String balanceTransaction;
-	String id;
 	String fee;
 	Map<String, String> metadata;
+
+	public String getId() {
+		return id;
+	}
+
+	public Integer getAmount() {
+		return amount;
+	}
+
+	public void setAmount(Integer amount) {
+		this.amount = amount;
+	}
+
+	public String getBalanceTransaction() {
+		return balanceTransaction;
+	}
+
+	public void setBalanceTransaction(String balanceTransaction) {
+		this.balanceTransaction = balanceTransaction;
+	}
+
+	public String getCurrency() {
+		return currency;
+	}
+
+	public void setCurrency(String currency) {
+		this.currency = currency;
+	}
+
+	public Long getCreated() {
+		return created;
+	}
+
+	public void setCreated(Long created) {
+		this.created = created;
+	}
+
+	public String getFee() {
+		return fee;
+	}
+
+	public void setFee(String fee) {
+		this.fee = fee;
+	}
+
+	public Map<String, String> getMetadata() {
+		return metadata;
+	}
+
+	public void setMetadata(Map<String, String> metadata) {
+		this.metadata = metadata;
+	}
 
 	public FeeRefund update(Map<String, Object> params)
 			throws AuthenticationException, InvalidRequestException,
@@ -42,44 +94,5 @@ public class FeeRefund extends APIResource implements MetadataStore<ApplicationF
 			return String.format("%s/%s/refunds/%s", classURL(ApplicationFee.class), this.fee, this.getId());
 		}
 		return null;
-	}
-	public String getId() {
-		return id;
-	}
-	public Integer getAmount() {
-		return amount;
-	}
-	public void setAmount(Integer amount) {
-		this.amount = amount;
-	}
-	public String getCurrency() {
-		return currency;
-	}
-	public void setCurrency(String currency) {
-		this.currency = currency;
-	}
-	public Long getCreated() {
-		return created;
-	}
-	public void setCreated(Long created) {
-		this.created = created;
-	}
-	public String getBalanceTransaction() {
-		return balanceTransaction;
-	}
-	public void setBalanceTransaction(String balanceTransaction) {
-		this.balanceTransaction = balanceTransaction;
-	}
-	public String getFee() {
-		return fee;
-	}
-	public void setFee(String fee) {
-		this.fee = fee;
-	}
-	public Map<String, String> getMetadata() {
-		return metadata;
-	}
-	public void setMetadata(Map<String, String> metadata) {
-		this.metadata = metadata;
 	}
 }

--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -37,10 +37,12 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
 	Integer startingBalance;
 	String statementDescriptor;
 	String subscription;
+	Long subscriptionProrationDate;
 	Integer subtotal;
 	Integer tax;
 	Double taxPercent;
 	Integer total;
+	Long webhooksDeliveredAt;
 
 	public String getId() {
 		return id;
@@ -246,6 +248,14 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
 		this.subscription = subscription;
 	}
 
+	public Long getSubscriptionProrationDate() {
+		return subscriptionProrationDate;
+	}
+
+	public void setSubscriptionProrationDate(Long subscriptionProrationDate) {
+		this.subscriptionProrationDate = subscriptionProrationDate;
+	}
+
 	public Integer getSubtotal() {
 		return subtotal;
 	}
@@ -276,6 +286,14 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
 
 	public void setTotal(Integer total) {
 		this.total = total;
+	}
+
+	public Long getWebhooksDeliveredAt() {
+		return webhooksDeliveredAt;
+	}
+
+	public void setWebhooksDeliveredAt(Long webhooksDeliveredAt) {
+		this.webhooksDeliveredAt = webhooksDeliveredAt;
 	}
 
 	public static Invoice retrieve(String id) throws AuthenticationException,

--- a/src/main/java/com/stripe/model/InvoiceItem.java
+++ b/src/main/java/com/stripe/model/InvoiceItem.java
@@ -17,9 +17,14 @@ public class InvoiceItem extends APIResource implements MetadataStore<InvoiceIte
 	String customer;
 	Long date;
 	String description;
+	Boolean discountable;
 	String invoice;
 	Boolean livemode;
 	Map<String, String> metadata;
+	InvoiceLineItemPeriod period;
+	Plan plan;
+	Boolean proration;
+	Integer quantity;
 	String subscription;
 
 	public String getId() {
@@ -70,6 +75,14 @@ public class InvoiceItem extends APIResource implements MetadataStore<InvoiceIte
 		this.description = description;
 	}
 
+	public Boolean getDiscountable() {
+		return discountable;
+	}
+
+	public void setDiscountable(Boolean discountable) {
+		this.discountable = discountable;
+	}
+
 	public String getInvoice() {
 		return invoice;
 	}
@@ -92,6 +105,38 @@ public class InvoiceItem extends APIResource implements MetadataStore<InvoiceIte
 
 	public void setMetadata(Map<String, String> metadata) {
 		this.metadata = metadata;
+	}
+
+	public InvoiceLineItemPeriod getPeriod() {
+		return period;
+	}
+
+	public void setPeriod(InvoiceLineItemPeriod period) {
+		this.period = period;
+	}
+
+	public Plan getPlan() {
+		return plan;
+	}
+
+	public void setPlan(Plan plan) {
+		this.plan = plan;
+	}
+
+	public Boolean getProration() {
+		return proration;
+	}
+
+	public void setProration(Boolean proration) {
+		this.proration = proration;
+	}
+
+	public Integer getQuantity() {
+		return quantity;
+	}
+
+	public void setQuantity(Integer quantity) {
+		this.quantity = quantity;
 	}
 
 	public String getSubscription() {

--- a/src/main/java/com/stripe/model/InvoiceLineItem.java
+++ b/src/main/java/com/stripe/model/InvoiceLineItem.java
@@ -7,6 +7,7 @@ public class InvoiceLineItem extends StripeObject implements HasId {
 	Integer amount;
 	String currency;
 	String description;
+	Boolean discountable;
 	Boolean livemode;
 	Map<String, String> metadata;
 	InvoiceLineItemPeriod period;
@@ -30,6 +31,10 @@ public class InvoiceLineItem extends StripeObject implements HasId {
 
 	public String getDescription() {
 		return this.description;
+	}
+
+	public Boolean getDiscountable() {
+		return this.discountable;
 	}
 
 	public Boolean getLivemode() {

--- a/src/main/java/com/stripe/model/OrderItem.java
+++ b/src/main/java/com/stripe/model/OrderItem.java
@@ -1,6 +1,6 @@
 package com.stripe.model;
 
-public class OrderItem {
+public class OrderItem extends StripeObject {
 	Integer amount;
 	String currency;
 	String description;

--- a/src/main/java/com/stripe/model/PackageDimensions.java
+++ b/src/main/java/com/stripe/model/PackageDimensions.java
@@ -1,6 +1,6 @@
 package com.stripe.model;
 
-public class PackageDimensions {
+public class PackageDimensions extends StripeObject {
 	Double height;
 	Double length;
 	Double weight;

--- a/src/main/java/com/stripe/model/Plan.java
+++ b/src/main/java/com/stripe/model/Plan.java
@@ -114,11 +114,19 @@ public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
 		this.trialPeriodDays = trialPeriodDays;
 	}
 
+	/**
+	 * @deprecated
+	 * Use `statement_descriptor` field (https://stripe.com/docs/upgrades#2014-12-17)
+	 */
 	@Deprecated
 	public String getStatementDescription() {
 		return statementDescription;
 	}
 
+	/**
+	 * @deprecated
+	 * Use `statement_descriptor` field (https://stripe.com/docs/upgrades#2014-12-17)
+	 */
 	@Deprecated
 	public void setStatementDescription(String statementDescription) {
 		this.statementDescription = statementDescription;

--- a/src/main/java/com/stripe/model/Recipient.java
+++ b/src/main/java/com/stripe/model/Recipient.java
@@ -22,6 +22,7 @@ public class Recipient extends APIResource implements MetadataStore<Recipient>, 
 	String email;
 	Boolean livemode;
 	Map<String, String> metadata;
+	String migratedTo;
 	String name;
 	String type;
 	Boolean verified;
@@ -96,6 +97,14 @@ public class Recipient extends APIResource implements MetadataStore<Recipient>, 
 
 	public void setMetadata(Map<String, String> metadata) {
 		this.metadata = metadata;
+	}
+
+	public String getMigratedTo() {
+		return migratedTo;
+	}
+
+	public void setMigratedTo(String migratedTo) {
+		this.migratedTo = migratedTo;
 	}
 
 	public String getName() {

--- a/src/main/java/com/stripe/model/ShippingMethod.java
+++ b/src/main/java/com/stripe/model/ShippingMethod.java
@@ -1,31 +1,39 @@
 package com.stripe.model;
 
-public class ShippingMethod {
+public class ShippingMethod extends StripeObject {
 	String id;
 	Integer amount;
 	String currency;
 	String description;
+
 	public String getId() {
 		return id;
 	}
+
 	public void setId(String id) {
 		this.id = id;
 	}
+
 	public Integer getAmount() {
 		return amount;
 	}
+
 	public void setAmount(Integer amount) {
 		this.amount = amount;
 	}
+
 	public String getCurrency() {
 		return currency;
 	}
+
 	public void setCurrency(String currency) {
 		this.currency = currency;
 	}
+
 	public String getDescription() {
 		return description;
 	}
+
 	public void setDescription(String description) {
 		this.description = description;
 	}

--- a/src/test/java/com/stripe/model/ExternalAccountTest.java
+++ b/src/test/java/com/stripe/model/ExternalAccountTest.java
@@ -41,6 +41,9 @@ public class ExternalAccountTest extends BaseStripeTest {
 		ExternalAccount ea = cus.getSources().getData().get(0);
 		assertEquals(true, ea instanceof ExternalAccount);
 		assertEquals("unknown_external_account", ea.getObject());
+		Map<String, String> metadata = new HashMap<String, String>();
+		metadata.put("mdkey", "mdvalue");
+		assertEquals(metadata, ea.getMetadata());
 	}
 
 	@Test

--- a/src/test/resources/com/stripe/model/customer_with_external_account.json
+++ b/src/test/resources/com/stripe/model/customer_with_external_account.json
@@ -8,7 +8,10 @@
         "data": [{
             "id": "extacct_123",
             "object": "unknown_external_account",
-            "customer": "cus_123"
+            "customer": "cus_123",
+            "metadata": {
+                "mdkey": "mdvalue"
+            }
         }]
     }
 }


### PR DESCRIPTION
r? @brandur 
cc @stripe/api-libraries 

This PR adds the following attributes and the necessary accessors:
- `AlipayAccount.livemode`
- `BankAccount.accountHolderName`
- `BankAccount.accountHolderType`
- `BitcoinReceiver.livemode`
- `BitcoinReceiver.uncapturedFunds `
- `BitcoinReceiver.usedForPayment`
- `Card.defaultForCurrency`
- `Customer.businessVatId`
- `ExternalAccount.metadata` [0]
- `Invoice.subscriptionProrationDate`
- `Invoice.webhooksDeliveredAt`
- `InvoiceItem.discountable`
- `InvoiceItem.period`
- `InvoiceItem.plan`
- `InvoiceItem.proration`
- `InvoiceItem.quantity`
- `InvoiceLineItem.discountable`
- `Recipient.migratedTo`

[0] All classes that derive from `ExternalAccount` (`AlipayAccount`, `BankAccount`, `BitcoinReceiver` and `Card`) have metadata. Some derived classes had it, some didn't, so I removed it from all the derived classes and added it to `ExternalAccount` directly.

It marks the following attributes as deprecated:
- `Account.currenciesSupported`
- `Card.type`
- `Customer.cards`
- `Customer.defaultCard`
- `Customer.nextRecurringCharge`
- `Customer.subscription`
- `Customer.trialEnd`
- `Dispute.balanceTransaction`
- `Dispute.evidence` (as a string, `evidenceSubObject` is untouched)
- `Dispute.evidenceDueBy`

It reorders the attributes in `FeeRefund` but doesn't change anything (sorry, forgot this in the earlier PR).

It makes `OrderItem`, `PackageDimensions` and `ShippingMethod` extend `StripeObject` to be consistent with other sub-resources.

Sorry for the churn. I probably missed a few things but this PR should for the most part bring the bindings up to speed with the current version of the API.
