### PR TITLE
Fixes the case where previous_attributes is null

### DIFF
--- a/src/main/java/com/stripe/model/EventDataDeserializer.java
+++ b/src/main/java/com/stripe/model/EventDataDeserializer.java
@@ -110,11 +110,13 @@ public class EventDataDeserializer implements JsonDeserializer<EventData> {
 			String key = entry.getKey();
 			JsonElement element = entry.getValue();
 			if("previous_attributes".equals(key)) {
-				Map<String, Object> previousAttributes = new HashMap<String, Object>();
-				if (element.getAsJsonObject() != null) {
+				if (element.isJsonNull()) {
+					eventData.setPreviousAttributes(null);
+				} else if (element.isJsonObject()) {
+					Map<String, Object> previousAttributes = new HashMap<String, Object>();
 					populateMapFromJSONObject(previousAttributes, element.getAsJsonObject());
+					eventData.setPreviousAttributes(previousAttributes);
 				}
-				eventData.setPreviousAttributes(previousAttributes);
 			} else if ("object".equals(key)) {
 				String type = element.getAsJsonObject().get("object").getAsString();
 				Class<StripeObject> cl = objectMap.get(type);

--- a/src/test/java/com/stripe/model/DeserializerTest.java
+++ b/src/test/java/com/stripe/model/DeserializerTest.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.List;
 
 import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
@@ -22,6 +23,14 @@ public class DeserializerTest extends BaseStripeTest {
 		EventData ed = gson.fromJson(json,EventData.class);
 
 		assertThat(ed.getPreviousAttributes().get("fee"), notNullValue());
+	}
+
+	@Test
+	public void deserializeEventPreviousAttributesNull() throws IOException {
+		String json = resource("previous_attributes_null.json");
+		EventData ed = gson.fromJson(json, EventData.class);
+
+		assertThat(ed.getPreviousAttributes(), nullValue());
 	}
 
 	@Test

--- a/src/test/resources/com/stripe/model/previous_attributes_null.json
+++ b/src/test/resources/com/stripe/model/previous_attributes_null.json
@@ -1,0 +1,27 @@
+{
+  "object": {
+    "id": "card_00000000000000",
+    "object": "card",
+    "address_city": null,
+    "address_country": null,
+    "address_line1": null,
+    "address_line1_check": null,
+    "address_line2": null,
+    "address_state": null,
+    "address_zip": null,
+    "address_zip_check": null,
+    "brand": "Visa",
+    "country": "US",
+    "customer": "cus_00000000000000",
+    "cvc_check": null,
+    "dynamic_last4": null,
+    "exp_month": 10,
+    "exp_year": 2016,
+    "funding": "credit",
+    "last4": "4242",
+    "metadata": {},
+    "name": null,
+    "tokenization_method": null
+  },
+  "previous_attributes": null
+}


### PR DESCRIPTION
Fixes #290.

In practice, an event's `previous_attributes` should never be set to `null` -- it should either be entirely absent from the JSON payload, or have a non-null value if present.

However, some of the dummy events sent by the "Send test webhook" button do have `previous_attributes=null`. Ideally, we should also fix this, but this PR does make the event deserializer a little more robust.

r? @kyleconroy 
cc @stripe/api-libraries 