### PR TITLE
Add test to demonstrate event deserialization

### DIFF
--- a/src/test/java/com/stripe/model/EventTest.java
+++ b/src/test/java/com/stripe/model/EventTest.java
@@ -1,0 +1,24 @@
+package com.stripe.model;
+
+import com.stripe.BaseStripeTest;
+import com.stripe.model.Event;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class EventTest extends BaseStripeTest {
+	@Test
+	public void nestedObjectDeserializesToModel() throws IOException {
+		String json = resource("account_event.json");
+		Event event = StripeObject.PRETTY_PRINT_GSON.fromJson(json, Event.class);
+
+		// Thanks to some GSON magic, the object nested within the event can be
+		// typecast to its expected type.
+		Account account = (com.stripe.model.Account)event.getData().getObject();
+
+		assertEquals(account.getEmail(), "test@stripe.com");
+	}
+}


### PR DESCRIPTION
Adds a basic test to demonstrate how to deserialize an event and then
typecast the `StripeObject` nested in it to a model that's appropriate
based on the type of event.

Not a true fix for #297, but at least produces some sample code for this
operation, even if not particularly discoverable.