### PR TITLE
Use Project Lombok

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
     "recommendations": [
         "vscjava.vscode-java-pack",
         "shengchen.vscode-checkstyle",
+        "GabrielBB.vscode-lombok",
         "naco-siren.gradle-language"
     ]
 }

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
 plugins {
     id 'java'
     id 'maven'
+    id 'io.franzbecker.gradle-lombok' version '1.11'
     id 'checkstyle'
     id 'net.saliman.cobertura' version '2.5.2'
     id 'com.github.kt3k.coveralls' version '2.8.2'
@@ -54,6 +55,11 @@ jar {
 
         instruction 'Export-Package', '*'
     }
+}
+
+lombok {
+    version = "1.16.22"
+    sha256 = ""
 }
 
 apply from: 'deploy.gradle'

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.getter.noIsPrefix = true

--- a/src/main/java/com/stripe/model/Account.java
+++ b/src/main/java/com/stripe/model/Account.java
@@ -13,6 +13,13 @@ import com.stripe.net.RequestOptions;
 import java.util.List;
 import java.util.Map;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class Account extends APIResource implements HasId, MetadataStore<Account> {
   String id;
   String object;
@@ -33,7 +40,6 @@ public class Account extends APIResource implements HasId, MetadataStore<Account
   ExternalAccountCollection externalAccounts;
   Keys keys;
   LegalEntity legalEntity;
-  Boolean managed;
   Map<String, String> metadata;
   Boolean payoutsEnabled;
   AccountPayoutSchedule payoutSchedule;
@@ -50,201 +56,24 @@ public class Account extends APIResource implements HasId, MetadataStore<Account
   String type;
   Verification verification;
 
-  @Deprecated
-  List<String> currenciesSupported;
-
-  public String getId() {
-    return id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public String getBusinessLogo() {
-    return businessLogo;
-  }
-
-  public String getBusinessName() {
-    return businessName;
-  }
-
-  public String getBusinessPrimaryColor() {
-    return businessPrimaryColor;
-  }
-
-  public void setBusinessPrimaryColor(String businessPrimaryColor) {
-    this.businessPrimaryColor = businessPrimaryColor;
-  }
-
-  public String getBusinessURL() {
-    return businessURL;
-  }
-
-  public Boolean getChargesEnabled() {
-    return chargesEnabled;
-  }
-
-  public String getCountry() {
-    return country;
-  }
-
-  public Boolean getDebitNegativeBalances() {
-    return debitNegativeBalances;
-  }
-
-  public void setDebitNegativeBalances(Boolean debitNegativeBalances) {
-    this.debitNegativeBalances = debitNegativeBalances;
-  }
-
-  public AccountDeclineChargeOn getDeclineChargeOn() {
-    return declineChargeOn;
-  }
-
-  public void setDeclineChargeOn(AccountDeclineChargeOn declineChargeOn) {
-    this.declineChargeOn = declineChargeOn;
-  }
-
-  public String getDefaultCurrency() {
-    return defaultCurrency;
-  }
-
-  public Boolean getDetailsSubmitted() {
-    return detailsSubmitted;
-  }
-
-  public String getDisplayName() {
-    return displayName;
-  }
-
-  public LoginLinkCollection getLoginLinks() {
-    return loginLinks;
-  }
-
-  public String getEmail() {
-    return email;
-  }
-
-  public ExternalAccountCollection getExternalAccounts() {
-    return externalAccounts;
-  }
-
-  public Keys getKeys() {
-    return keys;
-  }
-
-  public LegalEntity getLegalEntity() {
-    return legalEntity;
-  }
-
   /**
-   * Returns the {@code managed} attribute.
+   * The {@code managed} attribute.
    *
-   * @return the {@code managed} attribute
-   * @deprecated Prefer using the {@code type} attribute instead.
+   * @deprecated Prefer using the {@link #type} attribute instead.
    * @see <a href="https://stripe.com/docs/upgrades#2017-05-25">API version 2017-05-25</a>
    */
   @Deprecated
-  public Boolean getManaged() {
-    return managed;
-  }
-
-  public Map<String, String> getMetadata() {
-    return metadata;
-  }
-
-  public Boolean getPayoutsEnabled() {
-    return payoutsEnabled;
-  }
-
-  public void setPayoutsEnabled(Boolean payoutsEnabled) {
-    this.payoutsEnabled = payoutsEnabled;
-  }
-
-  public AccountPayoutSchedule getPayoutSchedule() {
-    return payoutSchedule;
-  }
-
-  public void setPayoutSchedule(AccountPayoutSchedule payoutSchedule) {
-    this.payoutSchedule = payoutSchedule;
-  }
-
-  public String getProductDescription() {
-    return productDescription;
-  }
-
-  public void setProductDescription(String productDescription) {
-    this.productDescription = productDescription;
-  }
-
-  public String getStatementDescriptor() {
-    return statementDescriptor;
-  }
-
-  public String getSupportEmail() {
-    return supportEmail;
-  }
-
-  public String getSupportPhone() {
-    return supportPhone;
-  }
-
-  public String getSupportURL() {
-    return supportURL;
-  }
-
-  public String getTimezone() {
-    return timezone;
-  }
-
-  public AccountTosAcceptance getTosAcceptance() {
-    return tosAcceptance;
-  }
-
-  public void setTosAcceptance(AccountTosAcceptance tosAcceptance) {
-    this.tosAcceptance = tosAcceptance;
-  }
-
-  public AccountTransferSchedule getTransferSchedule() {
-    return transferSchedule;
-  }
-
-  public void setTransferSchedule(AccountTransferSchedule transferSchedule) {
-    this.transferSchedule = transferSchedule;
-  }
-
-  public Boolean getTransfersEnabled() {
-    return transfersEnabled;
-  }
-
-  public String getType() {
-    return type;
-  }
-
-  public void setType(String type) {
-    this.type = type;
-  }
-
-  public Verification getVerification() {
-    return verification;
-  }
+  Boolean managed;
 
   /**
-   * Returns the {@code currencies_supported} attribute.
+   * The {@code currencies_supported} attribute.
    *
-   * @return the {@code currencies_supported} attribute
    * @deprecated Prefer using the {@link CountrySpec#getSupportedPaymentCurrencies()} method
    *     instead.
    * @see <a href="https://stripe.com/docs/upgrades#2016-03-07">API version 2016-03-07</a>
    */
   @Deprecated
-  public List<String> getCurrenciesSupported() {
-    return currenciesSupported;
-  }
+  List<String> currenciesSupported;
 
   public static Account create(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
@@ -377,55 +206,21 @@ public class Account extends APIResource implements HasId, MetadataStore<Account
         instanceURL(Account.class, this.getId())), params, Account.class, options);
   }
 
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
   public static class Verification extends StripeObject {
     Boolean contacted;
     String disabledReason;
     Long dueBy;
     List<String> fieldsNeeded;
-
-    public Boolean getContacted() {
-      return contacted;
-    }
-
-    public String getDisabledReason() {
-      return disabledReason;
-    }
-
-    public Long getDueBy() {
-      return dueBy;
-    }
-
-    public List<String> getFieldsNeeded() {
-      return fieldsNeeded;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-
-      Verification ve = (Verification) o;
-      return equals(contacted, ve.contacted)
-          && equals(disabledReason, ve.disabledReason)
-          && equals(dueBy, ve.dueBy)
-          && equals(fieldsNeeded, ve.fieldsNeeded);
-    }
   }
 
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
   public static class Keys extends StripeObject {
     String publishable;
     String secret;
-
-    public String getPublishable() {
-      return publishable;
-    }
-
-    public String getSecret() {
-      return secret;
-    }
   }
 }

--- a/src/main/java/com/stripe/model/AccountDeclineChargeOn.java
+++ b/src/main/java/com/stripe/model/AccountDeclineChargeOn.java
@@ -1,22 +1,13 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class AccountDeclineChargeOn extends StripeObject {
   Boolean avsFailure;
   Boolean cvcFailure;
-
-  public Boolean getAvsFailure() {
-    return avsFailure;
-  }
-
-  public void setAvsFailure(Boolean avsFailure) {
-    this.avsFailure = avsFailure;
-  }
-
-  public Boolean getCvcFailure() {
-    return cvcFailure;
-  }
-
-  public void setCvcFailure(Boolean cvcFailure) {
-    this.cvcFailure = cvcFailure;
-  }
 }

--- a/src/main/java/com/stripe/model/AccountPayoutSchedule.java
+++ b/src/main/java/com/stripe/model/AccountPayoutSchedule.java
@@ -1,56 +1,15 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class AccountPayoutSchedule extends StripeObject {
   Integer delayDays;
   String interval;
   Integer monthlyAnchor;
   String weeklyAnchor;
-
-  public Integer getDelayDays() {
-    return delayDays;
-  }
-
-  public void setDelayDays(Integer delayDays) {
-    this.delayDays = delayDays;
-  }
-
-  public String getInterval() {
-    return interval;
-  }
-
-  public void setInterval(String interval) {
-    this.interval = interval;
-  }
-
-  public Integer getMonthlyAnchor() {
-    return monthlyAnchor;
-  }
-
-  public void setMonthlyAnchor(Integer monthlyAnchor) {
-    this.monthlyAnchor = monthlyAnchor;
-  }
-
-  public String getWeeklyAnchor() {
-    return weeklyAnchor;
-  }
-
-  public void setWeeklyAnchor(String weeklyAnchor) {
-    this.weeklyAnchor = weeklyAnchor;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-
-    AccountPayoutSchedule schedule = (AccountPayoutSchedule) o;
-    return equals(delayDays, schedule.delayDays)
-        && equals(interval, schedule.interval)
-        && equals(monthlyAnchor, schedule.monthlyAnchor)
-        && equals(weeklyAnchor, schedule.weeklyAnchor);
-  }
 }

--- a/src/main/java/com/stripe/model/AccountTosAcceptance.java
+++ b/src/main/java/com/stripe/model/AccountTosAcceptance.java
@@ -1,31 +1,14 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class AccountTosAcceptance extends StripeObject {
   Long date;
   String ip;
   String userAgent;
-
-  public Long getDate() {
-    return date;
-  }
-
-  public void setDate(Long date) {
-    this.date = date;
-  }
-
-  public String getIp() {
-    return ip;
-  }
-
-  public void setIp(String ip) {
-    this.ip = ip;
-  }
-
-  public String getUserAgent() {
-    return userAgent;
-  }
-
-  public void setUserAgent(String userAgent) {
-    this.userAgent = userAgent;
-  }
 }

--- a/src/main/java/com/stripe/model/AccountTransferSchedule.java
+++ b/src/main/java/com/stripe/model/AccountTransferSchedule.java
@@ -1,40 +1,15 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class AccountTransferSchedule extends StripeObject {
   Integer delayDays;
   String interval;
   Integer monthlyAnchor;
   String weeklyAnchor;
-
-  public Integer getDelayDays() {
-    return delayDays;
-  }
-
-  public void setDelayDays(Integer delayDays) {
-    this.delayDays = delayDays;
-  }
-
-  public String getInterval() {
-    return interval;
-  }
-
-  public void setInterval(String interval) {
-    this.interval = interval;
-  }
-
-  public Integer getMonthlyAnchor() {
-    return monthlyAnchor;
-  }
-
-  public void setMonthlyAnchor(Integer monthlyAnchor) {
-    this.monthlyAnchor = monthlyAnchor;
-  }
-
-  public String getWeeklyAnchor() {
-    return weeklyAnchor;
-  }
-
-  public void setWeeklyAnchor(String weeklyAnchor) {
-    this.weeklyAnchor = weeklyAnchor;
-  }
 }

--- a/src/main/java/com/stripe/model/Address.java
+++ b/src/main/java/com/stripe/model/Address.java
@@ -1,5 +1,14 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+@Getter
+@Setter
+@Accessors(chain = true)
+@EqualsAndHashCode(callSuper = false)
 public final class Address extends StripeObject {
   protected String city;
   protected String country;
@@ -7,98 +16,4 @@ public final class Address extends StripeObject {
   protected String line2;
   protected String postalCode;
   protected String state;
-
-  public String getCity() {
-    return city;
-  }
-
-  public Address setCity(String city) {
-    this.city = city;
-    return this;
-  }
-
-  public String getCountry() {
-    return country;
-  }
-
-  public Address setCountry(String country) {
-    this.country = country;
-    return this;
-  }
-
-  public String getLine1() {
-    return line1;
-  }
-
-  public Address setLine1(String line1) {
-    this.line1 = line1;
-    return this;
-  }
-
-  public String getLine2() {
-    return line2;
-  }
-
-  public Address setLine2(String line2) {
-    this.line2 = line2;
-    return this;
-  }
-
-  public String getPostalCode() {
-    return postalCode;
-  }
-
-  public Address setPostalCode(String postalCode) {
-    this.postalCode = postalCode;
-    return this;
-  }
-
-  public String getState() {
-    return state;
-  }
-
-  public Address setState(String state) {
-    this.state = state;
-    return this;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-
-    Address address = (Address) o;
-
-    if (city != null ? !city.equals(address.city) : address.city != null) {
-      return false;
-    }
-    if (country != null ? !country.equals(address.country) : address.country != null) {
-      return false;
-    }
-    if (line1 != null ? !line1.equals(address.line1) : address.line1 != null) {
-      return false;
-    }
-    if (line2 != null ? !line2.equals(address.line2) : address.line2 != null) {
-      return false;
-    }
-    if (postalCode != null ? !postalCode.equals(address.postalCode) : address.postalCode != null) {
-      return false;
-    }
-    return state != null ? state.equals(address.state) : address.state == null;
-  }
-
-  @Override
-  public int hashCode() {
-    int result = city != null ? city.hashCode() : 0;
-    result = 31 * result + (country != null ? country.hashCode() : 0);
-    result = 31 * result + (line1 != null ? line1.hashCode() : 0);
-    result = 31 * result + (line2 != null ? line2.hashCode() : 0);
-    result = 31 * result + (postalCode != null ? postalCode.hashCode() : 0);
-    result = 31 * result + (state != null ? state.hashCode() : 0);
-    return result;
-  }
 }

--- a/src/main/java/com/stripe/model/AlipayAccount.java
+++ b/src/main/java/com/stripe/model/AlipayAccount.java
@@ -9,6 +9,13 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
 public class AlipayAccount extends ExternalAccount {
   Long created;
   String fingerprint;
@@ -19,78 +26,6 @@ public class AlipayAccount extends ExternalAccount {
   Boolean used;
   String username;
   String status;
-
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
-  public String getFingerprint() {
-    return fingerprint;
-  }
-
-  public void setFingerprint(String fingerprint) {
-    this.fingerprint = fingerprint;
-  }
-
-  public Boolean getLivemode() {
-    return livemode;
-  }
-
-  public void setLivemode(Boolean livemode) {
-    this.livemode = livemode;
-  }
-
-  public Long getPaymentAmount() {
-    return paymentAmount;
-  }
-
-  public void setPaymentAmount(Long paymentAmount) {
-    this.paymentAmount = paymentAmount;
-  }
-
-  public String getPaymentCurrency() {
-    return paymentCurrency;
-  }
-
-  public void setPaymentCurrency(String paymentCurrency) {
-    this.paymentCurrency = paymentCurrency;
-  }
-
-  public Boolean getReusable() {
-    return reusable;
-  }
-
-  public void setReusable(Boolean reusable) {
-    this.reusable = reusable;
-  }
-
-  public Boolean getUsed() {
-    return used;
-  }
-
-  public void setUsed(Boolean used) {
-    this.used = used;
-  }
-
-  public String getUsername() {
-    return username;
-  }
-
-  public void setUsername(String username) {
-    this.username = username;
-  }
-
-  public String getStatus() {
-    return status;
-  }
-
-  public void setStatus(String status) {
-    this.status = status;
-  }
 
   public AlipayAccount update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
@@ -117,4 +52,3 @@ public class AlipayAccount extends ExternalAccount {
         options);
   }
 }
-

--- a/src/main/java/com/stripe/model/AlternateStatementDescriptors.java
+++ b/src/main/java/com/stripe/model/AlternateStatementDescriptors.java
@@ -1,46 +1,13 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public final class AlternateStatementDescriptors extends StripeObject {
   protected String kana;
   protected String kanji;
-
-  public String getKana() {
-    return kana;
-  }
-
-  public void setKana(String kana) {
-    this.kana = kana;
-  }
-
-  public String getKanji() {
-    return kanji;
-  }
-
-  public void setKanji(String kanji) {
-    this.kanji = kanji;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-
-    AlternateStatementDescriptors that = (AlternateStatementDescriptors) o;
-
-    if (kana != null ? !kana.equals(that.kana) : that.kana != null) {
-      return false;
-    }
-    return kanji != null ? kanji.equals(that.kanji) : that.kanji == null;
-  }
-
-  @Override
-  public int hashCode() {
-    int result = kana != null ? kana.hashCode() : 0;
-    result = 31 * result + (kanji != null ? kanji.hashCode() : 0);
-    return result;
-  }
 }

--- a/src/main/java/com/stripe/model/ApplePayDomain.java
+++ b/src/main/java/com/stripe/model/ApplePayDomain.java
@@ -11,52 +11,19 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class ApplePayDomain extends APIResource implements HasId {
   String id;
   String object;
   Long created;
   String domainName;
   Boolean livemode;
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
-  public Boolean getLivemode() {
-    return livemode;
-  }
-
-  public void setLivemode(Boolean livemode) {
-    this.livemode = livemode;
-  }
-
-  public String getDomainName() {
-    return domainName;
-  }
-
-  public void setDomainName(String domainName) {
-    this.domainName = domainName;
-  }
 
   public static ApplePayDomain create(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,

--- a/src/main/java/com/stripe/model/Application.java
+++ b/src/main/java/com/stripe/model/Application.java
@@ -1,22 +1,13 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class Application extends StripeObject implements HasId {
   String id;
   String name;
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
 }

--- a/src/main/java/com/stripe/model/ApplicationFee.java
+++ b/src/main/java/com/stripe/model/ApplicationFee.java
@@ -10,41 +10,43 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class ApplicationFee extends APIResource implements HasId {
   String id;
   String object;
-  ExpandableField<Account> account;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Account> account;
   Long amount;
   Long amountRefunded;
-  ExpandableField<Application> application;
-  ExpandableField<BalanceTransaction> balanceTransaction;
-  ExpandableField<Charge> charge;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Application> application;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+      ExpandableField<BalanceTransaction> balanceTransaction;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Charge> charge;
   Long created;
   String currency;
   Boolean livemode;
-  ExpandableField<Charge> originatingTransaction;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+      ExpandableField<Charge> originatingTransaction;
   Boolean refunded;
-  FeeRefundCollection refunds;
+  @Getter(AccessLevel.NONE) FeeRefundCollection refunds;
 
+  /**
+   * The {@code user} attribute.
+   *
+   * @return the {@code user} attribute
+   * @deprecated Prefer using the {@link #account} attribute instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2013-12-03">API version 2013-12-03</a>
+   */
   @Deprecated
   String user;
 
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
+  // <editor-fold desc="account">
   public String getAccount() {
     return (this.account != null) ? this.account.getId() : null;
   }
@@ -60,23 +62,9 @@ public class ApplicationFee extends APIResource implements HasId {
   public void setAccountObject(Account c) {
     this.account = new ExpandableField<Account>(c.getId(), c);
   }
+  // </editor-fold>
 
-  public Long getAmount() {
-    return amount;
-  }
-
-  public void setAmount(Long amount) {
-    this.amount = amount;
-  }
-
-  public Long getAmountRefunded() {
-    return amountRefunded;
-  }
-
-  public void setAmountRefunded(Long amountRefunded) {
-    this.amountRefunded = amountRefunded;
-  }
-
+  // <editor-fold desc="application">
   public String getApplication() {
     return (this.application != null) ? this.application.getId() : null;
   }
@@ -92,7 +80,9 @@ public class ApplicationFee extends APIResource implements HasId {
   public void setApplicationObject(Application c) {
     this.application = new ExpandableField<Application>(c.getId(), c);
   }
+  // </editor-fold>
 
+  // <editor-fold desc="balanceTransaction">
   public String getBalanceTransaction() {
     return (this.balanceTransaction != null) ? this.balanceTransaction.getId() : null;
   }
@@ -108,7 +98,9 @@ public class ApplicationFee extends APIResource implements HasId {
   public void setBalanceTransactionObject(BalanceTransaction c) {
     this.balanceTransaction = new ExpandableField<BalanceTransaction>(c.getId(), c);
   }
+  // </editor-fold>
 
+  // <editor-fold desc="charge">
   public String getCharge() {
     return (this.charge != null) ? this.charge.getId() : null;
   }
@@ -124,31 +116,9 @@ public class ApplicationFee extends APIResource implements HasId {
   public void setChargeObject(Charge c) {
     this.charge = new ExpandableField<Charge>(c.getId(), c);
   }
+  // </editor-fold>
 
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  public Boolean getLivemode() {
-    return livemode;
-  }
-
-  public void setLivemode(Boolean livemode) {
-    this.livemode = livemode;
-  }
-
+  // <editor-fold desc="originatingTransaction">
   public String getOriginatingTransaction() {
     return (this.originatingTransaction != null) ? this.originatingTransaction.getId() : null;
   }
@@ -165,14 +135,7 @@ public class ApplicationFee extends APIResource implements HasId {
   public void setOriginatingTransactionObject(Charge c) {
     this.originatingTransaction = new ExpandableField<Charge>(c.getId(), c);
   }
-
-  public Boolean getRefunded() {
-    return refunded;
-  }
-
-  public void setRefunded(Boolean refunded) {
-    this.refunded = refunded;
-  }
+  // </editor-fold>
 
   /**
    * Returns the {@code refunds} list.
@@ -188,23 +151,6 @@ public class ApplicationFee extends APIResource implements HasId {
     }
 
     return refunds;
-  }
-
-  /**
-   * Returns the {@code user} attribute.
-   *
-   * @return the {@code user} attribute
-   * @deprecated Prefer using the {@code account} attribute instead.
-   * @see <a href="https://stripe.com/docs/upgrades#2013-12-03">API version 2013-12-03</a>
-   */
-  @Deprecated
-  public String getUser() {
-    return user;
-  }
-
-  @Deprecated
-  public void setUser(String user) {
-    this.user = user;
   }
 
   public static ApplicationFee retrieve(String id) throws AuthenticationException,

--- a/src/main/java/com/stripe/model/Balance.java
+++ b/src/main/java/com/stripe/model/Balance.java
@@ -10,31 +10,18 @@ import com.stripe.net.RequestOptions;
 
 import java.util.List;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class Balance extends APIResource {
   String object;
   List<Money> available;
   Boolean livemode;
   List<Money> pending;
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public List<Money> getAvailable() {
-    return available;
-  }
-
-  public Boolean getLivemode() {
-    return livemode;
-  }
-
-  public List<Money> getPending() {
-    return pending;
-  }
 
   public static Balance retrieve() throws AuthenticationException,
       InvalidRequestException, APIConnectionException, CardException,

--- a/src/main/java/com/stripe/model/BalanceTransaction.java
+++ b/src/main/java/com/stripe/model/BalanceTransaction.java
@@ -12,6 +12,14 @@ import com.stripe.net.RequestOptions;
 import java.util.List;
 import java.util.Map;
 
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class BalanceTransaction extends APIResource implements HasId {
   String id;
   String object;
@@ -23,109 +31,21 @@ public class BalanceTransaction extends APIResource implements HasId {
   Long fee;
   List<Fee> feeDetails;
   Integer net;
-  ExpandableField<HasId> source;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<HasId> source;
   String status;
   String type;
 
+  /**
+   * The {@code sourced_transfers} attribute.
+   *
+   * @deprecated Prefer using the {@link Transfer#list} method with the {@code transfer_group}
+   *     parameter.
+   * @see <a href="https://stripe.com/docs/upgrades#2017-01-27">API version 2017-01-27</a>
+   */
   @Deprecated
   TransferCollection sourcedTransfers;
 
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public Long getAmount() {
-    return amount;
-  }
-
-  public void setAmount(Long amount) {
-    this.amount = amount;
-  }
-
-  public Long getAvailableOn() {
-    return availableOn;
-  }
-
-  public void setAvailableOn(Long availableOn) {
-    this.availableOn = availableOn;
-  }
-
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  public Long getFee() {
-    return fee;
-  }
-
-  public void setFee(Long fee) {
-    this.fee = fee;
-  }
-
-  public List<Fee> getFeeDetails() {
-    return feeDetails;
-  }
-
-  public void setFeeDetails(List<Fee> feeDetails) {
-    this.feeDetails = feeDetails;
-  }
-
-  public Integer getNet() {
-    return net;
-  }
-
-  public void setNet(Integer net) {
-    this.net = net;
-  }
-
-  public String getStatus() {
-    return status;
-  }
-
-  public void setStatus(String status) {
-    this.status = status;
-  }
-
-  public String getType() {
-    return type;
-  }
-
-  public void setType(String type) {
-    this.type = type;
-  }
-
+  // <editor-fold desc="source">
   public String getSource() {
     return (this.source != null) ? this.source.getId() : null;
   }
@@ -145,22 +65,7 @@ public class BalanceTransaction extends APIResource implements HasId {
   public <O extends HasId> O getSourceObjectAs() {
     return (this.source != null) ? (O) this.source.getExpanded() : null;
   }
-
-  /**
-   * Returns the {@code sourced_transfers} attribute.
-   *
-   * @return the {@code sourced_transfers} attribute
-   * @deprecated Prefer using the {@link Transfer#list} method with the {@code transfer_group}
-   *     parameter.
-   * @see <a href="https://stripe.com/docs/upgrades#2017-01-27">API version 2017-01-27</a>
-   */
-  @Deprecated
-  public TransferCollection getSourcedTransfers() {
-    if (sourcedTransfers != null && sourcedTransfers.getURL() == null && getSource() != null) {
-      sourcedTransfers.setURL(String.format("/v1/transfers?source_transaction=%s", getSource()));
-    }
-    return sourcedTransfers;
-  }
+  // </editor-fold>
 
   public static BalanceTransaction retrieve(String id) throws AuthenticationException,
       InvalidRequestException, APIConnectionException, CardException,

--- a/src/main/java/com/stripe/model/BankAccount.java
+++ b/src/main/java/com/stripe/model/BankAccount.java
@@ -9,6 +9,13 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
 public class BankAccount extends ExternalAccount {
   String accountHolderName;
   String accountHolderType;
@@ -21,94 +28,6 @@ public class BankAccount extends ExternalAccount {
   String routingNumber;
   String status;
   Boolean validated;
-
-  public String getAccountHolderName() {
-    return accountHolderName;
-  }
-
-  public void setAccountHolderName(String accountHolderName) {
-    this.accountHolderName = accountHolderName;
-  }
-
-  public String getAccountHolderType() {
-    return accountHolderType;
-  }
-
-  public void setAccountHolderType(String accountHolderType) {
-    this.accountHolderType = accountHolderType;
-  }
-
-  public String getBankName() {
-    return bankName;
-  }
-
-  public void setBankName(String bankName) {
-    this.bankName = bankName;
-  }
-
-  public String getCountry() {
-    return country;
-  }
-
-  public void setCountry(String country) {
-    this.country = country;
-  }
-
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  public Boolean getDefaultForCurrency() {
-    return defaultForCurrency;
-  }
-
-  public void setDefaultForCurrency(Boolean defaultForCurrency) {
-    this.defaultForCurrency = defaultForCurrency;
-  }
-
-  public String getFingerprint() {
-    return fingerprint;
-  }
-
-  public void setFingerprint(String fingerprint) {
-    this.fingerprint = fingerprint;
-  }
-
-  public String getLast4() {
-    return last4;
-  }
-
-  public void setLast4(String last4) {
-    this.last4 = last4;
-  }
-
-  public String getRoutingNumber() {
-    return routingNumber;
-  }
-
-  public void setRoutingNumber(String routingNumber) {
-    this.routingNumber = routingNumber;
-  }
-
-  public String getStatus() {
-    return status;
-  }
-
-  public void setStatus(String status) {
-    this.status = status;
-  }
-
-  public Boolean getValidated() {
-    return validated;
-  }
-
-  public void setValidated(Boolean validated) {
-    this.validated = validated;
-  }
 
   public BankAccount update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException, APIConnectionException,

--- a/src/main/java/com/stripe/model/BitcoinReceiver.java
+++ b/src/main/java/com/stripe/model/BitcoinReceiver.java
@@ -10,6 +10,13 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
 public class BitcoinReceiver extends ExternalAccount {
   Boolean active;
   Long amount;
@@ -31,166 +38,6 @@ public class BitcoinReceiver extends ExternalAccount {
   BitcoinTransactionCollection transactions;
   Boolean uncapturedFunds;
   Boolean usedForPayment;
-
-  public Boolean getActive() {
-    return active;
-  }
-
-  public void setActive(Boolean active) {
-    this.active = active;
-  }
-
-  public Long getAmount() {
-    return amount;
-  }
-
-  public void setAmount(Long amount) {
-    this.amount = amount;
-  }
-
-  public Long getAmountReceived() {
-    return amountReceived;
-  }
-
-  public void setAmountReceived(Long amountReceived) {
-    this.amountReceived = amountReceived;
-  }
-
-  public Long getBitcoinAmount() {
-    return bitcoinAmount;
-  }
-
-  public void setBitcoinAmount(Long bitcoinAmount) {
-    this.bitcoinAmount = bitcoinAmount;
-  }
-
-  public Long getBitcoinAmountReceived() {
-    return bitcoinAmountReceived;
-  }
-
-  public void setBitcoinAmountReceived(Long bitcoinAmountReceived) {
-    this.bitcoinAmountReceived = bitcoinAmountReceived;
-  }
-
-  public String getBitcoinUri() {
-    return bitcoinUri;
-  }
-
-  public void setBitcoinUri(String bitcoinUri) {
-    this.bitcoinUri = bitcoinUri;
-  }
-
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  public String getEmail() {
-    return email;
-  }
-
-  public void setEmail(String email) {
-    this.email = email;
-  }
-
-  public Boolean getFilled() {
-    return filled;
-  }
-
-  public void setFilled(Boolean filled) {
-    this.filled = filled;
-  }
-
-  public String getInboundAddress() {
-    return inboundAddress;
-  }
-
-  public void setInboundAddress(String inboundAddress) {
-    this.inboundAddress = inboundAddress;
-  }
-
-  public Boolean getLivemode() {
-    return livemode;
-  }
-
-  public void setLivemode(Boolean livemode) {
-    this.livemode = livemode;
-  }
-
-  public String getPayment() {
-    return payment;
-  }
-
-  public void setPayment(String payment) {
-    this.payment = payment;
-  }
-
-  public String getRefundAddress() {
-    return refundAddress;
-  }
-
-  public void setRefundAddress(String refundAddress) {
-    this.refundAddress = refundAddress;
-  }
-
-  public Boolean getRejectTransactions() {
-    return rejectTransactions;
-  }
-
-  public void setRejectTransactions(Boolean rejectTransactions) {
-    this.rejectTransactions = rejectTransactions;
-  }
-
-  public String getStatus() {
-    return status;
-  }
-
-  public void setStatus(String status) {
-    this.status = status;
-  }
-
-  public BitcoinTransactionCollection getTransactions() {
-    return transactions;
-  }
-
-  public void setTransactions(BitcoinTransactionCollection transactions) {
-    this.transactions = transactions;
-  }
-
-  public Boolean getUncapturedFunds() {
-    return uncapturedFunds;
-  }
-
-  public void setUncapturedFunds(Boolean uncapturedFunds) {
-    this.uncapturedFunds = uncapturedFunds;
-  }
-
-  public Boolean getUsedForPayment() {
-    return usedForPayment;
-  }
-
-  public void setUsedForPayment(Boolean usedForPayment) {
-    this.usedForPayment = usedForPayment;
-  }
 
   public static BitcoinReceiver create(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,

--- a/src/main/java/com/stripe/model/BitcoinTransaction.java
+++ b/src/main/java/com/stripe/model/BitcoinTransaction.java
@@ -2,6 +2,13 @@ package com.stripe.model;
 
 import com.stripe.net.APIResource;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class BitcoinTransaction extends APIResource implements HasId {
   String id;
   Long amount;
@@ -10,60 +17,4 @@ public class BitcoinTransaction extends APIResource implements HasId {
   String currency;
   String customer;
   String receiver;
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public Long getAmount() {
-    return amount;
-  }
-
-  public void setAmount(Long amount) {
-    this.amount = amount;
-  }
-
-  public Long getBitcoinAmount() {
-    return bitcoinAmount;
-  }
-
-  public void setBitcoinAmount(Long bitcoinAmount) {
-    this.bitcoinAmount = bitcoinAmount;
-  }
-
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  public String getCustomer() {
-    return customer;
-  }
-
-  public void setCustomer(String customer) {
-    this.customer = customer;
-  }
-
-  public String getReceiver() {
-    return receiver;
-  }
-
-  public void setReceiver(String receiver) {
-    this.receiver = receiver;
-  }
 }

--- a/src/main/java/com/stripe/model/Card.java
+++ b/src/main/java/com/stripe/model/Card.java
@@ -10,6 +10,13 @@ import com.stripe.net.RequestOptions;
 import java.util.List;
 import java.util.Map;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
 public class Card extends ExternalAccount {
   String addressCity;
   String addressCountry;
@@ -43,249 +50,14 @@ public class Card extends ExternalAccount {
   String iin;
   String issuer;
 
-  @Deprecated
-  String type;
-
-  public String getAddressCity() {
-    return addressCity;
-  }
-
-  public void setAddressCity(String addressCity) {
-    this.addressCity = addressCity;
-  }
-
-  public String getAddressCountry() {
-    return addressCountry;
-  }
-
-  public void setAddressCountry(String addressCountry) {
-    this.addressCountry = addressCountry;
-  }
-
-  public String getAddressLine1() {
-    return addressLine1;
-  }
-
-  public void setAddressLine1(String addressLine1) {
-    this.addressLine1 = addressLine1;
-  }
-
-  public String getAddressLine1Check() {
-    return addressLine1Check;
-  }
-
-  public void setAddressLine1Check(String addressLine1Check) {
-    this.addressLine1Check = addressLine1Check;
-  }
-
-  public String getAddressLine2() {
-    return addressLine2;
-  }
-
-  public void setAddressLine2(String addressLine2) {
-    this.addressLine2 = addressLine2;
-  }
-
-  public String getAddressState() {
-    return addressState;
-  }
-
-  public void setAddressState(String addressState) {
-    this.addressState = addressState;
-  }
-
-  public String getAddressZip() {
-    return addressZip;
-  }
-
-  public void setAddressZip(String addressZip) {
-    this.addressZip = addressZip;
-  }
-
-  public String getAddressZipCheck() {
-    return addressZipCheck;
-  }
-
-  public void setAddressZipCheck(String addressZipCheck) {
-    this.addressZipCheck = addressZipCheck;
-  }
-
-  public List<String> getAvailablePayoutMethods() {
-    return availablePayoutMethods;
-  }
-
-  public void setAvailablePayoutMethods(List<String> availablePayoutMethods) {
-    this.availablePayoutMethods = availablePayoutMethods;
-  }
-
-  public String getBrand() {
-    return brand;
-  }
-
-  public void setBrand(String brand) {
-    this.brand = brand;
-  }
-
-  public String getCountry() {
-    return country;
-  }
-
-  public void setCountry(String country) {
-    this.country = country;
-  }
-
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  public String getCvcCheck() {
-    return cvcCheck;
-  }
-
-  public void setCvcCheck(String cvcCheck) {
-    this.cvcCheck = cvcCheck;
-  }
-
-  public Boolean getDefaultForCurrency() {
-    return defaultForCurrency;
-  }
-
-  public void setDefaultForCurrency(Boolean defaultForCurrency) {
-    this.defaultForCurrency = defaultForCurrency;
-  }
-
-  public String getDynamicLast4() {
-    return dynamicLast4;
-  }
-
-  public void setDynamicLast4(String dynamicLast4) {
-    this.dynamicLast4 = dynamicLast4;
-  }
-
-  public Integer getExpMonth() {
-    return expMonth;
-  }
-
-  public void setExpMonth(Integer expMonth) {
-    this.expMonth = expMonth;
-  }
-
-  public Integer getExpYear() {
-    return expYear;
-  }
-
-  public void setExpYear(Integer expYear) {
-    this.expYear = expYear;
-  }
-
-  public String getFingerprint() {
-    return fingerprint;
-  }
-
-  public void setFingerprint(String fingerprint) {
-    this.fingerprint = fingerprint;
-  }
-
-  public String getFunding() {
-    return funding;
-  }
-
-  public void setFunding(String funding) {
-    this.funding = funding;
-  }
-
-  public String getLast4() {
-    return last4;
-  }
-
-  public void setLast4(String last4) {
-    this.last4 = last4;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public String getRecipient() {
-    return recipient;
-  }
-
-  public void setRecipient(String recipient) {
-    this.recipient = recipient;
-  }
-
-  public String getStatus() {
-    return status;
-  }
-
-  public void setStatus(String status) {
-    this.status = status;
-  }
-
-  public ThreeDSecure getThreeDSecure() {
-    return threeDSecure;
-  }
-
-  public void setThreeDSecure(ThreeDSecure threeDSecure) {
-    this.threeDSecure = threeDSecure;
-  }
-
-  public String getTokenizationMethod() {
-    return tokenizationMethod;
-  }
-
-  public void setTokenizationMethod(String tokenizationMethod) {
-    this.tokenizationMethod = tokenizationMethod;
-  }
-
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  public String getIin() {
-    return iin;
-  }
-
-  public void setIin(String iin) {
-    this.iin = iin;
-  }
-
-  public String getIssuer() {
-    return issuer;
-  }
-
-  public void setIssuer(String issuer) {
-    this.issuer = issuer;
-  }
-
   /**
-   * Returns the {@code type} attribute.
+   * The {@code type} attribute.
    *
-   * @return the {@code type} attribute
    * @deprecated Prefer using the {@code brand} attribute instead.
    * @see <a href="https://stripe.com/docs/upgrades#2014-06-13">API version 2014-06-13</a>
    */
   @Deprecated
-  public String getType() {
-    return type;
-  }
-
-  @Deprecated
-  public void setType(String type) {
-    this.type = type;
-  }
+  String type;
 
   public Card update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,

--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -11,6 +11,14 @@ import com.stripe.net.RequestOptions;
 import java.util.Collections;
 import java.util.Map;
 
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class Charge extends APIResource implements MetadataStore<Charge>, HasId {
   public static final String FRAUD_DETAILS = "fraud_details";
 
@@ -18,21 +26,23 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   String object;
   Long amount;
   Long amountRefunded;
-  ExpandableField<Application> application;
-  ExpandableField<ApplicationFee> applicationFee;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Application> application;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+      ExpandableField<ApplicationFee> applicationFee;
   AlternateStatementDescriptors alternateStatementDescriptors;
-  ExpandableField<BalanceTransaction> balanceTransaction;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+      ExpandableField<BalanceTransaction> balanceTransaction;
   Boolean captured;
   Long created;
   String currency;
-  ExpandableField<Customer> customer;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Customer> customer;
   String description;
-  ExpandableField<Account> destination;
-  ExpandableField<Dispute> dispute;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Account> destination;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Dispute> dispute;
   String failureCode;
   String failureMessage;
   FraudDetails fraudDetails;
-  ExpandableField<Invoice> invoice;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Invoice> invoice;
   Boolean livemode;
   Map<String, String> metadata;
   ChargeOutcome outcome;
@@ -41,64 +51,47 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   String receiptEmail;
   String receiptNumber;
   Boolean refunded;
-  ChargeRefundCollection refunds;
-  ExpandableField<Review> review;
+  @Getter(AccessLevel.NONE) ChargeRefundCollection refunds;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Review> review;
   ShippingDetails shipping;
   ExternalAccount source;
-  ExpandableField<Transfer> sourceTransfer;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Transfer> sourceTransfer;
   String statementDescriptor;
   String status;
-  ExpandableField<Transfer> transfer;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Transfer> transfer;
   String transferGroup;
 
+  /**
+   * The {@code card} attribute.
+   *
+   * @return the {@code card} attribute
+   * @deprecated Prefer using the {@link #source} attribute instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2015-02-18">API version 2015-02-18</a>
+   */
   @Deprecated
   Card card;
+
+  /**
+   * The {@code disputed} attribute.
+   *
+   * @return the {@code disputed} attribute
+   * @deprecated Prefer using the {@link #dispute} attribute instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2012-11-07">API version 2012-11-07</a>
+   */
   @Deprecated
   Boolean disputed;
+
+  /**
+   * The {@code statement_description} attribute.
+   *
+   * @return the {@code cards} attribute
+   * @deprecated Prefer using the {@link #statementDescriptor} attribute instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2014-12-17">API version 2014-12-17</a>
+   */
   @Deprecated
   String statementDescription;
 
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public AlternateStatementDescriptors getAlternateStatementDescriptors() {
-    return alternateStatementDescriptors;
-  }
-
-  public void setAlternateStatementDescriptors(
-      AlternateStatementDescriptors alternateStatementDescriptors) {
-    this.alternateStatementDescriptors = alternateStatementDescriptors;
-  }
-
-  public Long getAmount() {
-    return amount;
-  }
-
-  public void setAmount(Long amount) {
-    this.amount = amount;
-  }
-
-  public Long getAmountRefunded() {
-    return amountRefunded;
-  }
-
-  public void setAmountRefunded(Long amountRefunded) {
-    this.amountRefunded = amountRefunded;
-  }
-
+  // <editor-fold desc="application">
   public String getApplication() {
     return (this.application != null) ? this.application.getId() : null;
   }
@@ -114,7 +107,9 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   public void setApplicationObject(Application c) {
     this.application = new ExpandableField<Application>(c.getId(), c);
   }
+  // </editor-fold>
 
+  // <editor-fold desc="applicationFee">
   public String getApplicationFee() {
     return (this.applicationFee != null) ? this.applicationFee.getId() : null;
   }
@@ -130,7 +125,9 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   public void setApplicationFeeObject(ApplicationFee c) {
     this.applicationFee = new ExpandableField<ApplicationFee>(c.getId(), c);
   }
+  // </editor-fold>
 
+  // <editor-fold desc="balanceTransaction">
   public String getBalanceTransaction() {
     return (this.balanceTransaction != null) ? this.balanceTransaction.getId() : null;
   }
@@ -146,31 +143,9 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   public void setBalanceTransactionObject(BalanceTransaction c) {
     this.balanceTransaction = new ExpandableField<BalanceTransaction>(c.getId(), c);
   }
+  // </editor-fold>
 
-  public Boolean getCaptured() {
-    return captured;
-  }
-
-  public void setCaptured(Boolean captured) {
-    this.captured = captured;
-  }
-
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
+  // <editor-fold desc="customer">
   public String getCustomer() {
     return (this.customer != null) ? this.customer.getId() : null;
   }
@@ -187,15 +162,9 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   public void setCustomerObject(Customer c) {
     this.customer = new ExpandableField<Customer>(c.getId(), c);
   }
+  // </editor-fold>
 
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
+  // <editor-fold desc="destination">
   public String getDestination() {
     return (this.destination != null) ? this.destination.getId() : null;
   }
@@ -211,7 +180,9 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   public void setDestinationObject(Account c) {
     this.destination = new ExpandableField<Account>(c.getId(), c);
   }
+  // </editor-fold>
 
+  // <editor-fold desc="dispute">
   public String getDispute() {
     return (this.dispute != null) ? this.dispute.getId() : null;
   }
@@ -227,31 +198,9 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   public void setDisputeObject(Dispute dispute) {
     this.dispute = new ExpandableField<Dispute>(dispute.getId(), dispute);
   }
+  // </editor-fold>
 
-  public String getFailureCode() {
-    return failureCode;
-  }
-
-  public void setFailureCode(String failureCode) {
-    this.failureCode = failureCode;
-  }
-
-  public String getFailureMessage() {
-    return failureMessage;
-  }
-
-  public void setFailureMessage(String failureMessage) {
-    this.failureMessage = failureMessage;
-  }
-
-  public FraudDetails getFraudDetails() {
-    return fraudDetails;
-  }
-
-  public void setFraudDetails(FraudDetails fraudDetails) {
-    this.fraudDetails = fraudDetails;
-  }
-
+  // <editor-fold desc="invoice">
   public String getInvoice() {
     return (this.invoice != null) ? this.invoice.getId() : null;
   }
@@ -267,23 +216,9 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   public void setInvoiceObject(Invoice c) {
     this.invoice = new ExpandableField<Invoice>(c.getId(), c);
   }
+  // </editor-fold>
 
-  public Boolean getLivemode() {
-    return livemode;
-  }
-
-  public void setLivemode(Boolean livemode) {
-    this.livemode = livemode;
-  }
-
-  public Map<String, String> getMetadata() {
-    return metadata;
-  }
-
-  public void setMetadata(Map<String, String> metadata) {
-    this.metadata = metadata;
-  }
-
+  // <editor-fold desc="order">
   public String getOrder() {
     return (this.order != null) ? this.order.getId() : null;
   }
@@ -299,46 +234,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   public void setOrderObject(Order c) {
     this.order = new ExpandableField<Order>(c.getId(), c);
   }
-
-  public ChargeOutcome getOutcome() {
-    return outcome;
-  }
-
-  public void setOutcome(ChargeOutcome outcome) {
-    this.outcome = outcome;
-  }
-
-  public Boolean getPaid() {
-    return paid;
-  }
-
-  public void setPaid(Boolean paid) {
-    this.paid = paid;
-  }
-
-  public String getReceiptEmail() {
-    return receiptEmail;
-  }
-
-  public void setReceiptEmail(String receiptEmail) {
-    this.receiptEmail = receiptEmail;
-  }
-
-  public String getReceiptNumber() {
-    return receiptNumber;
-  }
-
-  public void setReceiptNumber(String receiptNumber) {
-    this.receiptNumber = receiptNumber;
-  }
-
-  public Boolean getRefunded() {
-    return refunded;
-  }
-
-  public void setRefunded(Boolean refunded) {
-    this.refunded = refunded;
-  }
+  // </editor-fold>
 
   /**
    * Returns the {@code refunds} list.
@@ -354,6 +250,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
     return refunds;
   }
 
+  // <editor-fold desc="review">
   public String getReview() {
     return (this.review != null) ? this.review.getId() : null;
   }
@@ -369,23 +266,9 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   public void setReviewObject(Review r) {
     this.review = new ExpandableField<Review>(r.getId(), r);
   }
+  // </editor-fold>
 
-  public ShippingDetails getShipping() {
-    return shipping;
-  }
-
-  public void setShipping(ShippingDetails shipping) {
-    this.shipping = shipping;
-  }
-
-  public ExternalAccount getSource() {
-    return source;
-  }
-
-  public void setSource(ExternalAccount source) {
-    this.source = source;
-  }
-
+  // <editor-fold desc="sourceTransfer">
   public String getSourceTransfer() {
     return (this.sourceTransfer != null) ? this.sourceTransfer.getId() : null;
   }
@@ -401,37 +284,15 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   public void setSourceTransferObject(Transfer c) {
     this.sourceTransfer = new ExpandableField<Transfer>(c.getId(), c);
   }
+  // </editor-fold>
 
-  public String getStatementDescriptor() {
-    return statementDescriptor;
-  }
-
-  public void setStatementDescriptor(String statementDescriptor) {
-    this.statementDescriptor = statementDescriptor;
-  }
-
-  public String getStatus() {
-    return status;
-  }
-
-  public void setStatus(String status) {
-    this.status = status;
-  }
-
+  // <editor-fold desc="transfer">
   public String getTransfer() {
     return (this.transfer != null) ? this.transfer.getId() : null;
   }
 
   public void setTransfer(String transferID) {
     this.transfer = setExpandableFieldID(transferID, this.transfer);
-  }
-
-  public String getTransferGroup() {
-    return this.transferGroup;
-  }
-
-  public void setTransferGroup(String transferGroup) {
-    this.transferGroup = transferGroup;
   }
 
   public Transfer getTransferObject() {
@@ -441,57 +302,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   public void setTransferObject(Transfer c) {
     this.transfer = new ExpandableField<Transfer>(c.getId(), c);
   }
-
-  /**
-   * Returns the {@code card} attribute.
-   *
-   * @return the {@code card} attribute
-   * @deprecated Prefer using the {@code source} attribute instead.
-   * @see <a href="https://stripe.com/docs/upgrades#2015-02-18">API version 2015-02-18</a>
-   */
-  @Deprecated
-  public Card getCard() {
-    return card;
-  }
-
-  @Deprecated
-  public void setCard(Card card) {
-    this.card = card;
-  }
-
-  /**
-   * Returns the {@code disputed} attribute.
-   *
-   * @return the {@code disputed} attribute
-   * @deprecated Prefer using the {@code dispute} attribute instead.
-   * @see <a href="https://stripe.com/docs/upgrades#2012-11-07">API version 2012-11-07</a>
-   */
-  @Deprecated
-  public Boolean getDisputed() {
-    return disputed;
-  }
-
-  @Deprecated
-  public void setDisputed(Boolean disputed) {
-    this.disputed = disputed;
-  }
-
-  /**
-   * Returns the {@code statement_description} attribute.
-   *
-   * @return the {@code statement_description} attribute
-   * @deprecated Prefer using the {@code statement_descriptor} attribute instead.
-   * @see <a href="https://stripe.com/docs/upgrades#2014-12-17">API version 2014-12-17</a>
-   */
-  @Deprecated
-  public String getStatementDescription() {
-    return statementDescription;
-  }
-
-  @Deprecated
-  public void setStatementDescription(String statementDescription) {
-    this.statementDescription = statementDescription;
-  }
+  // </editor-fold>
 
   public static Charge create(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,

--- a/src/main/java/com/stripe/model/ChargeOutcome.java
+++ b/src/main/java/com/stripe/model/ChargeOutcome.java
@@ -2,34 +2,24 @@ package com.stripe.model;
 
 import com.stripe.net.APIResource;
 
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class ChargeOutcome extends APIResource {
   protected String networkStatus;
   protected String reason;
   protected String riskLevel;
-  protected ExpandableField<ChargeOutcomeRule> rule;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+      protected ExpandableField<ChargeOutcomeRule> rule;
   protected String sellerMessage;
   protected String type;
 
-  public String getNetworkStatus() {
-    return networkStatus;
-  }
-
-  public String getReason() {
-    return reason;
-  }
-
-  public String getRiskLevel() {
-    return riskLevel;
-  }
-
-  public String getSellerMessage() {
-    return sellerMessage;
-  }
-
-  public String getType() {
-    return type;
-  }
-
+  // <editor-fold desc="rule">
   /**
    * Returns the {@code rule} object, if expanded. If not expanded, use {@link #getRuleId()} to get
    * the ID.
@@ -44,44 +34,25 @@ public class ChargeOutcome extends APIResource {
     return (this.rule != null) ? this.rule.getExpanded() : null;
   }
 
-  public String getRuleId() {
-    return (this.rule != null) ? this.rule.getId() : null;
-  }
-
-  public ChargeOutcomeRule getRuleObject() {
-    return (this.rule != null) ? this.rule.getExpanded() : null;
-  }
-
-  public void setNetworkStatus(String networkStatus) {
-    this.networkStatus = networkStatus;
-  }
-
-  public void setRiskLevel(String riskLevel) {
-    this.riskLevel = riskLevel;
-  }
-
-  public void setReason(String reason) {
-    this.reason = reason;
-  }
-
-  public void setSellerMessage(String sellerMessage) {
-    this.sellerMessage = sellerMessage;
-  }
-
-  public void setType(String type) {
-    this.type = type;
-  }
-
   @Deprecated
   public void setRule(ChargeOutcomeRule rule) {
     this.rule = new ExpandableField<ChargeOutcomeRule>(rule.getId(), rule);
+  }
+
+  public String getRuleId() {
+    return (this.rule != null) ? this.rule.getId() : null;
   }
 
   public void setRuleId(String ruleId) {
     this.rule = setExpandableFieldID(ruleId, this.rule);
   }
 
+  public ChargeOutcomeRule getRuleObject() {
+    return (this.rule != null) ? this.rule.getExpanded() : null;
+  }
+
   public void setRuleObject(ChargeOutcomeRule rule) {
     this.rule = new ExpandableField<ChargeOutcomeRule>(rule.getId(), rule);
   }
+  // </editor-fold>
 }

--- a/src/main/java/com/stripe/model/ChargeOutcomeRule.java
+++ b/src/main/java/com/stripe/model/ChargeOutcomeRule.java
@@ -1,31 +1,14 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class ChargeOutcomeRule extends StripeObject implements HasId {
   protected String action;
   protected String id;
   protected String predicate;
-
-  public String getAction() {
-    return action;
-  }
-
-  public String getId() {
-    return id;
-  }
-
-  public String getPredicate() {
-    return predicate;
-  }
-
-  public void setAction(String action) {
-    this.action = action;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public void setPredicate(String predicate) {
-    this.predicate = predicate;
-  }
 }

--- a/src/main/java/com/stripe/model/CountrySpec.java
+++ b/src/main/java/com/stripe/model/CountrySpec.java
@@ -11,6 +11,13 @@ import com.stripe.net.RequestOptions;
 import java.util.List;
 import java.util.Map;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class CountrySpec extends APIResource implements HasId {
   String id;
   String object;
@@ -19,63 +26,6 @@ public class CountrySpec extends APIResource implements HasId {
   List<String> supportedPaymentCurrencies;
   List<String> supportedPaymentMethods;
   VerificationFields verificationFields;
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public String getDefaultCurrency() {
-    return defaultCurrency;
-  }
-
-  public void setDefaultCurrency(String defaultCurrency) {
-    this.defaultCurrency = defaultCurrency;
-  }
-
-  public Map<String, List<String>> getSupportedBankAccountCurrencies() {
-    return supportedBankAccountCurrencies;
-  }
-
-  public void setSupportedBankAccountCurrencies(
-      Map<String, List<String>> supportedBankAccountCurrencies) {
-    this.supportedBankAccountCurrencies = supportedBankAccountCurrencies;
-  }
-
-  public List<String> getSupportedPaymentCurrencies() {
-    return supportedPaymentCurrencies;
-  }
-
-  public void setSupportedPaymentCurrencies(List<String> supportedPaymentCurrencies) {
-    this.supportedPaymentCurrencies = supportedPaymentCurrencies;
-  }
-
-  public List<String> getSupportedPaymentMethods() {
-    return supportedPaymentMethods;
-  }
-
-  public void setSupportedPaymentMethods(List<String> supportedPaymentMethods) {
-    this.supportedPaymentMethods = supportedPaymentMethods;
-  }
-
-  public VerificationFields getVerificationFields() {
-    return verificationFields;
-  }
-
-  public void setVerificationFields(VerificationFields verificationFields) {
-    this.verificationFields = verificationFields;
-  }
 
   public static CountrySpec retrieve(String country) throws AuthenticationException,
       InvalidRequestException, APIConnectionException, CardException,

--- a/src/main/java/com/stripe/model/Coupon.java
+++ b/src/main/java/com/stripe/model/Coupon.java
@@ -10,6 +10,13 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class Coupon extends APIResource implements MetadataStore<Coupon>, HasId {
   String id;
   String object;
@@ -25,118 +32,6 @@ public class Coupon extends APIResource implements MetadataStore<Coupon>, HasId 
   Long redeemBy;
   Integer timesRedeemed;
   Boolean valid;
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public Long getAmountOff() {
-    return amountOff;
-  }
-
-  public void setAmountOff(Long amountOff) {
-    this.amountOff = amountOff;
-  }
-
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  public String getDuration() {
-    return duration;
-  }
-
-  public void setDuration(String duration) {
-    this.duration = duration;
-  }
-
-  public Integer getDurationInMonths() {
-    return durationInMonths;
-  }
-
-  public void setDurationInMonths(Integer durationInMonths) {
-    this.durationInMonths = durationInMonths;
-  }
-
-  public Boolean getLivemode() {
-    return livemode;
-  }
-
-  public void setLivemode(Boolean livemode) {
-    this.livemode = livemode;
-  }
-
-  public Long getMaxRedemptions() {
-    return maxRedemptions;
-  }
-
-  public void setMaxRedemptions(Long maxRedemptions) {
-    this.maxRedemptions = maxRedemptions;
-  }
-
-  public Map<String, String> getMetadata() {
-    return metadata;
-  }
-
-  public void setMetadata(Map<String, String> metadata) {
-    this.metadata = metadata;
-  }
-
-  public Integer getPercentOff() {
-    return percentOff;
-  }
-
-  public void setPercentOff(Integer percentOff) {
-    this.percentOff = percentOff;
-  }
-
-  public Long getRedeemBy() {
-    return redeemBy;
-  }
-
-  public void setRedeemBy(Long redeemBy) {
-    this.redeemBy = redeemBy;
-  }
-
-  public Integer getTimesRedeemed() {
-    return timesRedeemed;
-  }
-
-  public void setTimesRedeemed(Integer timesRedeemed) {
-    this.timesRedeemed = timesRedeemed;
-  }
-
-  public Boolean getValid() {
-    return valid;
-  }
-
-  public void setValid(Boolean valid) {
-    this.valid = valid;
-  }
 
   public static Coupon create(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,

--- a/src/main/java/com/stripe/model/Customer.java
+++ b/src/main/java/com/stripe/model/Customer.java
@@ -11,6 +11,14 @@ import com.stripe.net.RequestOptions;
 import java.util.HashMap;
 import java.util.Map;
 
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class Customer extends APIResource implements MetadataStore<Customer>, HasId {
   String id;
   String object;
@@ -18,7 +26,8 @@ public class Customer extends APIResource implements MetadataStore<Customer>, Ha
   String businessVatId;
   Long created;
   String currency;
-  ExpandableField<ExternalAccount> defaultSource;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+      ExpandableField<ExternalAccount> defaultSource;
   Boolean deleted;
   Boolean delinquent;
   String description;
@@ -30,65 +39,57 @@ public class Customer extends APIResource implements MetadataStore<Customer>, Ha
   ExternalAccountCollection sources;
   CustomerSubscriptionCollection subscriptions;
 
+  /**
+   * The {@code cards} attribute.
+   *
+   * @return the {@code cards} attribute
+   * @deprecated Prefer using the {@link #sources} attribute instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2015-02-18">API version 2015-02-18</a>
+   */
   @Deprecated
   CustomerCardCollection cards;
+
+  /**
+   * The {@code default_card} attribute.
+   *
+   * @return the {@code default_card} attribute
+   * @deprecated Prefer using the {@link #defaultSsource} attribute instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2015-02-18">API version 2015-02-18</a>
+   */
   @Deprecated
   String defaultCard;
+
+  /**
+   * The {@code next_recurring_charge} attribute.
+   *
+   * @return the {@code next_recurring_charge} attribute
+   * @deprecated Prefer using the {@link Invoice#upcoming} method instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2012-03-25">API version 2012-03-25</a>
+   */
   @Deprecated
   NextRecurringCharge nextRecurringCharge;
+
+  /**
+   * The {@code subscription} attribute.
+   *
+   * @return the {@code subscription} attribute
+   * @deprecated Prefer using the {@link #subscriptions} attribute instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2014-01-31">API version 2014-01-31</a>
+   */
   @Deprecated
   Subscription subscription;
+
+  /**
+   * The {@code trial_end} attribute.
+   *
+   * @return the {@code trial_end} attribute
+   * @deprecated Prefer using the {@link #subscriptions} attribute instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2014-01-31">API version 2014-01-31</a>
+   */
   @Deprecated
   Long trialEnd;
 
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public Long getAccountBalance() {
-    return accountBalance;
-  }
-
-  public void setAccountBalance(Long accountBalance) {
-    this.accountBalance = accountBalance;
-  }
-
-  public String getBusinessVatId() {
-    return businessVatId;
-  }
-
-  public void setBusinessVatId(String businessVatId) {
-    this.businessVatId = businessVatId;
-  }
-
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
+  // <editor-fold desc="defaultSource">
   public String getDefaultSource() {
     return (this.defaultSource != null) ? this.defaultSource.getId() : null;
   }
@@ -104,162 +105,7 @@ public class Customer extends APIResource implements MetadataStore<Customer>, Ha
   public void setDefaultSourceObject(ExternalAccount c) {
     this.defaultSource = new ExpandableField<ExternalAccount>(c.getId(), c);
   }
-
-  public Boolean getDeleted() {
-    return deleted;
-  }
-
-  public Boolean getDelinquent() {
-    return delinquent;
-  }
-
-  public void setDelinquent(Boolean delinquent) {
-    this.delinquent = delinquent;
-  }
-
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  public Discount getDiscount() {
-    return discount;
-  }
-
-  public void setDiscount(Discount discount) {
-    this.discount = discount;
-  }
-
-  public String getEmail() {
-    return email;
-  }
-
-  public void setEmail(String email) {
-    this.email = email;
-  }
-
-  public Boolean getLivemode() {
-    return livemode;
-  }
-
-  public void setLivemode(Boolean livemode) {
-    this.livemode = livemode;
-  }
-
-  public Map<String, String> getMetadata() {
-    return metadata;
-  }
-
-  public void setMetadata(Map<String, String> metadata) {
-    this.metadata = metadata;
-  }
-
-  public ShippingDetails getShipping() {
-    return shipping;
-  }
-
-  public void setShipping(ShippingDetails shipping) {
-    this.shipping = shipping;
-  }
-
-  public ExternalAccountCollection getSources() {
-    return sources;
-  }
-
-  public void setSources(ExternalAccountCollection sources) {
-    this.sources = sources;
-  }
-
-  public CustomerSubscriptionCollection getSubscriptions() {
-    return subscriptions;
-  }
-
-  public void setSubscriptions(CustomerSubscriptionCollection subscriptions) {
-    this.subscriptions = subscriptions;
-  }
-
-  /**
-   * Returns the {@code cards} attribute.
-   *
-   * @return the {@code cards} attribute
-   * @deprecated Prefer using the {@code sources} attribute instead.
-   * @see <a href="https://stripe.com/docs/upgrades#2015-02-18">API version 2015-02-18</a>
-   */
-  @Deprecated
-  public CustomerCardCollection getCards() {
-    return cards;
-  }
-
-  /**
-   * Returns the {@code default_card} attribute.
-   *
-   * @return the {@code default_card} attribute
-   * @deprecated Prefer using the {@code default_source} attribute instead.
-   * @see <a href="https://stripe.com/docs/upgrades#2015-02-18">API version 2015-02-18</a>
-   */
-  @Deprecated
-  public String getDefaultCard() {
-    return defaultCard;
-  }
-
-  @Deprecated
-  public void setDefaultCard(String defaultCard) {
-    this.defaultCard = defaultCard;
-  }
-
-  /**
-   * Returns the {@code next_recurring_charge} attribute.
-   *
-   * @return the {@code next_recurring_charge} attribute
-   * @deprecated Prefer using the {@link Invoice#upcoming} method instead.
-   * @see <a href="https://stripe.com/docs/upgrades#2012-03-25">API version 2012-03-25</a>
-   */
-  @Deprecated
-  public NextRecurringCharge getNextRecurringCharge() {
-    return nextRecurringCharge;
-  }
-
-  @Deprecated
-  public void setNextRecurringCharge(NextRecurringCharge nextRecurringCharge) {
-    this.nextRecurringCharge = nextRecurringCharge;
-  }
-
-  /**
-   * Returns the {@code subscription} attribute.
-   *
-   * @return the {@code subscription} attribute
-   * @deprecated Prefer using the {@code subscriptions} attribute instead.
-   * @see <a href="https://stripe.com/docs/upgrades#2014-01-31">API version 2014-01-31</a>
-   */
-  @Deprecated
-  public Subscription getSubscription() {
-    return subscription;
-  }
-
-  @Deprecated
-  public void setSubscription(Subscription subscription) {
-    this.subscription = subscription;
-  }
-
-  /**
-   * Returns the {@code trial_end} attribute.
-   *
-   * @return the {@code trial_end} attribute
-   * @deprecated Prefer using the {@code subscriptions} attribute instead.
-   * @see <a href="https://stripe.com/docs/upgrades#2014-01-31">API version 2014-01-31</a>
-   */
-  @Deprecated
-  public Long getTrialEnd() {
-    return trialEnd;
-  }
-
-  @Deprecated
-  public void setTrialEnd(Long trialEnd) {
-    this.trialEnd = trialEnd;
-  }
+  // </editor-fold>
 
   public static Customer create(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,

--- a/src/main/java/com/stripe/model/DeletedAccount.java
+++ b/src/main/java/com/stripe/model/DeletedAccount.java
@@ -1,23 +1,13 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class DeletedAccount extends StripeObject implements DeletedStripeObject {
   String id;
   Boolean deleted;
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public Boolean getDeleted() {
-    return deleted;
-  }
-
-  public void setDeleted(Boolean deleted) {
-    this.deleted = deleted;
-  }
 }

--- a/src/main/java/com/stripe/model/DeletedApplePayDomain.java
+++ b/src/main/java/com/stripe/model/DeletedApplePayDomain.java
@@ -1,22 +1,14 @@
 package com.stripe.model;
 
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class DeletedApplePayDomain extends StripeObject implements DeletedStripeObject {
   String id;
   Boolean deleted;
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public Boolean getDeleted() {
-    return deleted;
-  }
-
-  public void setDeleted(Boolean deleted) {
-    this.deleted = deleted;
-  }
 }

--- a/src/main/java/com/stripe/model/DeletedCoupon.java
+++ b/src/main/java/com/stripe/model/DeletedCoupon.java
@@ -1,23 +1,13 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class DeletedCoupon extends StripeObject implements DeletedStripeObject {
   String id;
   Boolean deleted;
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public Boolean getDeleted() {
-    return deleted;
-  }
-
-  public void setDeleted(Boolean deleted) {
-    this.deleted = deleted;
-  }
 }

--- a/src/main/java/com/stripe/model/DeletedCustomer.java
+++ b/src/main/java/com/stripe/model/DeletedCustomer.java
@@ -1,23 +1,13 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class DeletedCustomer extends StripeObject implements DeletedStripeObject {
   String id;
   Boolean deleted;
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public Boolean getDeleted() {
-    return deleted;
-  }
-
-  public void setDeleted(Boolean deleted) {
-    this.deleted = deleted;
-  }
 }

--- a/src/main/java/com/stripe/model/DeletedExternalAccount.java
+++ b/src/main/java/com/stripe/model/DeletedExternalAccount.java
@@ -1,23 +1,13 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class DeletedExternalAccount extends StripeObject implements DeletedStripeObject {
   String id;
   Boolean deleted;
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public Boolean getDeleted() {
-    return deleted;
-  }
-
-  public void setDeleted(Boolean deleted) {
-    this.deleted = deleted;
-  }
 }

--- a/src/main/java/com/stripe/model/DeletedInvoiceItem.java
+++ b/src/main/java/com/stripe/model/DeletedInvoiceItem.java
@@ -1,23 +1,13 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class DeletedInvoiceItem extends StripeObject implements DeletedStripeObject {
   String id;
   Boolean deleted;
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public Boolean getDeleted() {
-    return deleted;
-  }
-
-  public void setDeleted(Boolean deleted) {
-    this.deleted = deleted;
-  }
 }

--- a/src/main/java/com/stripe/model/DeletedPlan.java
+++ b/src/main/java/com/stripe/model/DeletedPlan.java
@@ -1,23 +1,13 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class DeletedPlan extends StripeObject implements DeletedStripeObject {
   String id;
   Boolean deleted;
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public Boolean getDeleted() {
-    return deleted;
-  }
-
-  public void setDeleted(Boolean deleted) {
-    this.deleted = deleted;
-  }
 }

--- a/src/main/java/com/stripe/model/DeletedProduct.java
+++ b/src/main/java/com/stripe/model/DeletedProduct.java
@@ -1,23 +1,13 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class DeletedProduct extends StripeObject implements DeletedStripeObject {
   String id;
   Boolean deleted;
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public Boolean getDeleted() {
-    return deleted;
-  }
-
-  public void setDeleted(Boolean deleted) {
-    this.deleted = deleted;
-  }
 }

--- a/src/main/java/com/stripe/model/DeletedRecipient.java
+++ b/src/main/java/com/stripe/model/DeletedRecipient.java
@@ -1,23 +1,13 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class DeletedRecipient extends StripeObject implements DeletedStripeObject {
   String id;
   Boolean deleted;
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public Boolean getDeleted() {
-    return deleted;
-  }
-
-  public void setDeleted(Boolean deleted) {
-    this.deleted = deleted;
-  }
 }

--- a/src/main/java/com/stripe/model/DeletedSKU.java
+++ b/src/main/java/com/stripe/model/DeletedSKU.java
@@ -1,23 +1,13 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class DeletedSKU extends StripeObject implements DeletedStripeObject {
   String id;
   Boolean deleted;
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public Boolean getDeleted() {
-    return deleted;
-  }
-
-  public void setDeleted(Boolean deleted) {
-    this.deleted = deleted;
-  }
 }

--- a/src/main/java/com/stripe/model/DeletedSubscriptionItem.java
+++ b/src/main/java/com/stripe/model/DeletedSubscriptionItem.java
@@ -1,23 +1,13 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class DeletedSubscriptionItem extends StripeObject implements DeletedStripeObject {
   String id;
   Boolean deleted;
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public Boolean getDeleted() {
-    return deleted;
-  }
-
-  public void setDeleted(Boolean deleted) {
-    this.deleted = deleted;
-  }
 }

--- a/src/main/java/com/stripe/model/Discount.java
+++ b/src/main/java/com/stripe/model/Discount.java
@@ -1,6 +1,12 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class Discount extends StripeObject {
   String id;
   String object;
@@ -9,60 +15,4 @@ public class Discount extends StripeObject {
   Long end;
   Long start;
   String subscription;
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public Coupon getCoupon() {
-    return coupon;
-  }
-
-  public void setCoupon(Coupon coupon) {
-    this.coupon = coupon;
-  }
-
-  public String getCustomer() {
-    return customer;
-  }
-
-  public void setCustomer(String customer) {
-    this.customer = customer;
-  }
-
-  public Long getEnd() {
-    return end;
-  }
-
-  public void setEnd(Long end) {
-    this.end = end;
-  }
-
-  public Long getStart() {
-    return start;
-  }
-
-  public void setStart(Long start) {
-    this.start = start;
-  }
-
-  public String getSubscription() {
-    return subscription;
-  }
-
-  public void setSubscription(String subscription) {
-    this.subscription = subscription;
-  }
 }

--- a/src/main/java/com/stripe/model/Dispute.java
+++ b/src/main/java/com/stripe/model/Dispute.java
@@ -11,17 +11,25 @@ import com.stripe.net.RequestOptions;
 import java.util.List;
 import java.util.Map;
 
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class Dispute extends APIResource implements HasId {
   String id;
   String object;
   Long amount;
   List<BalanceTransaction> balanceTransactions;
-  ExpandableField<Charge> charge;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Charge> charge;
   Long created;
   String currency;
   EvidenceSubObject evidenceSubObject; // `evidence`
   EvidenceDetails evidenceDetails;
-  Boolean isChargeRefundable;
+  @Getter(AccessLevel.NONE) Boolean isChargeRefundable;
   Boolean livemode;
   Map<String, String> metadata;
   String reason;
@@ -29,53 +37,36 @@ public class Dispute extends APIResource implements HasId {
   String networkReasonCode; // Not part of the public API.
 
   /**
-   * 8/2014: Legacy (now use balanceTransactions) -- https://stripe.com/docs/upgrades#2014-08-20
+   * The {@code balance_transaction} attribute.
+   *
+   * @return the {@code balance_transaction} attribute
+   * @deprecated Prefer using the {@link #balanceTransactions} attribute instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2014-08-20">API version 2014-08-20</a>
    */
   @Deprecated
   String balanceTransaction;
+
   /**
-   * 12/2014: Legacy (now use evidenceSubObject) -- https://stripe.com/docs/upgrades
+   * The {@code evidence} String attribute.
+   *
+   * @return the {@code evidence} String attribute
+   * @deprecated Prefer using the {@link #getEvidenceSubObject} method instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2014-12-08">API version 2014-12-08</a>
    */
   @Deprecated
   String evidence;
+
   /**
-   * 12/2014: Legacy (now use evidenceDetails.dueBy) -- https://stripe.com/docs/upgrades
+   * The {@code evidence_due_by} attribute.
+   *
+   * @return the {@code evidence_due_by} attribute
+   * @deprecated Prefer using the {@code getEvidenceDetails().getDueBy()} method instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2014-12-08">API version 2014-12-08</a>
    */
   @Deprecated
   Long evidenceDueBy;
 
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public Long getAmount() {
-    return amount;
-  }
-
-  public void setAmount(Long amount) {
-    this.amount = amount;
-  }
-
-  public List<BalanceTransaction> getBalanceTransactions() {
-    return balanceTransactions;
-  }
-
-  public void setBalanceTransactions(List<BalanceTransaction> balanceTransactions) {
-    this.balanceTransactions = balanceTransactions;
-  }
-
+  // <editor-fold desc="charge">
   public String getCharge() {
     return (this.charge != null) ? this.charge.getId() : null;
   }
@@ -91,139 +82,11 @@ public class Dispute extends APIResource implements HasId {
   public void setChargeObject(Charge charge) {
     this.charge = new ExpandableField<Charge>(charge.getId(), charge);
   }
+  // </editor-fold>
 
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  public EvidenceSubObject getEvidenceSubObject() {
-    return evidenceSubObject;
-  }
-
-  public void setEvidenceSubObject(EvidenceSubObject evidence) {
-    this.evidenceSubObject = evidence;
-  }
-
-  public EvidenceDetails getEvidenceDetails() {
-    return evidenceDetails;
-  }
-
-  public void setEvidenceDetails(EvidenceDetails evidenceDetails) {
-    this.evidenceDetails = evidenceDetails;
-  }
-
+  // TODO: change return type to Boolean in next major version
   public boolean getIsChargeRefundable() {
     return isChargeRefundable;
-  }
-
-  public void setIsChargeRefundable(Boolean isChargeRefundable) {
-    this.isChargeRefundable = isChargeRefundable;
-  }
-
-  public Boolean getLivemode() {
-    return livemode;
-  }
-
-  public void setLivemode(Boolean livemode) {
-    this.livemode = livemode;
-  }
-
-  public Map<String, String> getMetadata() {
-    return metadata;
-  }
-
-  public void setMetadata(Map<String, String> metadata) {
-    this.metadata = metadata;
-  }
-
-  public String getReason() {
-    return reason;
-  }
-
-  public void setReason(String reason) {
-    this.reason = reason;
-  }
-
-  public String getStatus() {
-    return status;
-  }
-
-  public void setStatus(String status) {
-    this.status = status;
-  }
-
-  public String getNetworkReasonCode() {
-    return networkReasonCode;
-  }
-
-  /**
-   * This method is not part of the public API and for internal use only.
-   */
-  public void setNetworkReasonCode(String networkReasonCode) {
-    this.networkReasonCode = networkReasonCode;
-  }
-
-  /**
-   * Returns the {@code balance_transaction} attribute.
-   *
-   * @return the {@code balance_transaction} attribute
-   * @deprecated Prefer using the {@code balance_transactions} attribute instead.
-   * @see <a href="https://stripe.com/docs/upgrades#2014-08-20">API version 2014-08-20</a>
-   */
-  @Deprecated
-  public String getBalanceTransaction() {
-    return balanceTransaction;
-  }
-
-  @Deprecated
-  public void setBalanceTransaction(String balanceTransaction) {
-    this.balanceTransaction = balanceTransaction;
-  }
-
-  /**
-   * Returns the {@code evidence} String attribute.
-   *
-   * @return the {@code evidence} String attribute
-   * @deprecated Prefer using the {@link #getEvidenceSubObject} method instead.
-   * @see <a href="https://stripe.com/docs/upgrades#2014-12-08">API version 2014-12-08</a>
-   */
-  @Deprecated
-  public String getEvidence() {
-    return evidence;
-  }
-
-  @Deprecated
-  public void setEvidence(String evidence) {
-    this.evidence = evidence;
-  }
-
-  /**
-   * Returns the {@code evidence_due_by} attribute.
-   *
-   * @return the {@code evidence_due_by} attribute
-   * @deprecated Prefer using the {@code getEvidenceDetails().getDueBy()} method instead.
-   * @see <a href="https://stripe.com/docs/upgrades#2014-12-08">API version 2014-12-08</a>
-   */
-  @Deprecated
-  public Long getEvidenceDueBy() {
-    return evidenceDueBy;
-  }
-
-  @Deprecated
-  public void setEvidenceDueBy(Long evidenceDueBy) {
-    this.evidenceDueBy = evidenceDueBy;
   }
 
   public static Dispute retrieve(String id) throws AuthenticationException,

--- a/src/main/java/com/stripe/model/EphemeralKey.java
+++ b/src/main/java/com/stripe/model/EphemeralKey.java
@@ -11,6 +11,13 @@ import com.stripe.net.RequestOptions;
 import java.util.List;
 import java.util.Map;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class EphemeralKey extends APIResource implements HasId {
   String id;
   String object;
@@ -20,70 +27,6 @@ public class EphemeralKey extends APIResource implements HasId {
   String secret;
   List<EphemeralKeyAssociatedObject> associatedObjects;
   transient String rawJson;
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
-  public Long getExpires() {
-    return expires;
-  }
-
-  public void setExpires(Long expires) {
-    this.expires = expires;
-  }
-
-  public Boolean getLivemode() {
-    return livemode;
-  }
-
-  public void setLivemode(Boolean livemode) {
-    this.livemode = livemode;
-  }
-
-  public String getSecret() {
-    return secret;
-  }
-
-  public void setSecret(String secret) {
-    this.secret = secret;
-  }
-
-  public List<EphemeralKeyAssociatedObject> getAssociatedObjects() {
-    return associatedObjects;
-  }
-
-  public void setAssociatedObjects(List<EphemeralKeyAssociatedObject> associatedObjects) {
-    this.associatedObjects = associatedObjects;
-  }
-
-  public String getRawJson() {
-    return rawJson;
-  }
-
-  public void setRawJson(String rawJson) {
-    this.rawJson = rawJson;
-  }
 
   /**
    * Creates an ephemeral key.

--- a/src/main/java/com/stripe/model/Event.java
+++ b/src/main/java/com/stripe/model/Event.java
@@ -10,6 +10,13 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class Event extends APIResource implements HasId {
   String id;
   String object;
@@ -21,103 +28,12 @@ public class Event extends APIResource implements HasId {
   Integer pendingWebhooks;
   EventRequest request;
   String type;
+
+  /**
+   * Legacy; use `account` instead (https://stripe.com/docs/upgrades#2017-05-25)
+   */
+  @Deprecated
   String userId;
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public String getAccount() {
-    return account;
-  }
-
-  public void setAccount(String account) {
-    this.account = account;
-  }
-
-  public String getApiVersion() {
-    return apiVersion;
-  }
-
-  public void setApiVersion(String apiVersion) {
-    this.apiVersion = apiVersion;
-  }
-
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
-  public EventData getData() {
-    return data;
-  }
-
-  public void setData(EventData data) {
-    this.data = data;
-  }
-
-  public Boolean getLivemode() {
-    return livemode;
-  }
-
-  public void setLivemode(Boolean livemode) {
-    this.livemode = livemode;
-  }
-
-  public Integer getPendingWebhooks() {
-    return pendingWebhooks;
-  }
-
-  public void setPendingWebhooks(Integer pendingWebhooks) {
-    this.pendingWebhooks = pendingWebhooks;
-  }
-
-  public EventRequest getRequest() {
-    return request;
-  }
-
-  public void setRequest(EventRequest request) {
-    this.request = request;
-  }
-
-  public String getType() {
-    return type;
-  }
-
-  public void setType(String name) {
-    this.type = name;
-  }
-
-  /**
-   * Legacy; use `getAccount` instead (https://stripe.com/docs/upgrades#2017-05-25)
-   */
-  @Deprecated
-  public String getUserId() {
-    return userId;
-  }
-
-  /**
-   * Legacy; use `setAccount` instead (https://stripe.com/docs/upgrades#2017-05-25)
-   */
-  @Deprecated
-  public void setUserId(String userId) {
-    this.userId = userId;
-  }
 
   public static Event retrieve(String id) throws AuthenticationException,
       InvalidRequestException, APIConnectionException, CardException,

--- a/src/main/java/com/stripe/model/EventData.java
+++ b/src/main/java/com/stripe/model/EventData.java
@@ -2,23 +2,14 @@ package com.stripe.model;
 
 import java.util.Map;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class EventData extends StripeObject {
   StripeObject object;
   Map<String, Object> previousAttributes;
-
-  public StripeObject getObject() {
-    return object;
-  }
-
-  public void setObject(StripeObject object) {
-    this.object = object;
-  }
-
-  public Map<String, Object> getPreviousAttributes() {
-    return previousAttributes;
-  }
-
-  public void setPreviousAttributes(Map<String, Object> previousAttributes) {
-    this.previousAttributes = previousAttributes;
-  }
 }

--- a/src/main/java/com/stripe/model/EventRequest.java
+++ b/src/main/java/com/stripe/model/EventRequest.java
@@ -1,22 +1,13 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class EventRequest extends StripeObject {
   String id;
   String idempotencyKey;
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getIdempotencyKey() {
-    return idempotencyKey;
-  }
-
-  public void setIdempotencyKey(String idempotencyKey) {
-    this.idempotencyKey = idempotencyKey;
-  }
 }

--- a/src/main/java/com/stripe/model/EvidenceDetails.java
+++ b/src/main/java/com/stripe/model/EvidenceDetails.java
@@ -1,22 +1,13 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public final class EvidenceDetails extends StripeObject {
   protected Long dueBy;
   protected Integer submissionCount;
-
-  public Long getDueBy() {
-    return dueBy;
-  }
-
-  public void setDueBy(Long dueBy) {
-    this.dueBy = dueBy;
-  }
-
-  public Integer getSubmissionCount() {
-    return submissionCount;
-  }
-
-  public void setSubmissionCount(Integer submissionCount) {
-    this.submissionCount = submissionCount;
-  }
 }

--- a/src/main/java/com/stripe/model/EvidenceSubObject.java
+++ b/src/main/java/com/stripe/model/EvidenceSubObject.java
@@ -1,25 +1,17 @@
 package com.stripe.model;
 
-public final class EvidenceSubObject extends StripeObject {
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
+public final class EvidenceSubObject extends StripeObject {
   /**
    * A description of the product or service which was sold.
    */
   protected String productDescription;
-
-  /**
-   * A description of the product or service which was sold.
-   */
-  public String getProductDescription() {
-    return this.productDescription;
-  }
-
-  /**
-   * A description of the product or service which was sold.
-   */
-  public void setProductDescription(String productDescription) {
-    this.productDescription = productDescription;
-  }
 
   /**
    * The name of the customer.
@@ -27,37 +19,9 @@ public final class EvidenceSubObject extends StripeObject {
   protected String customerName;
 
   /**
-   * The name of the customer.
-   */
-  public String getCustomerName() {
-    return this.customerName;
-  }
-
-  /**
-   * The name of the customer.
-   */
-  public void setCustomerName(String customerName) {
-    this.customerName = customerName;
-  }
-
-  /**
    * The email address of the customer.
    */
   protected String customerEmailAddress;
-
-  /**
-   * The email address of the customer.
-   */
-  public String getCustomerEmailAddress() {
-    return this.customerEmailAddress;
-  }
-
-  /**
-   * The email address of the customer.
-   */
-  public void setCustomerEmailAddress(String customerEmailAddress) {
-    this.customerEmailAddress = customerEmailAddress;
-  }
 
   /**
    * The IP address that the customer used when making the purchase (this will be automatically
@@ -66,39 +30,9 @@ public final class EvidenceSubObject extends StripeObject {
   protected String customerPurchaseIp;
 
   /**
-   * The IP address that the customer used when making the purchase (this will be automatically
-   * expanded to include geographical data when possible).
-   */
-  public String getCustomerPurchaseIp() {
-    return this.customerPurchaseIp;
-  }
-
-  /**
-   * The IP address that the customer used when making the purchase (this will be automatically
-   * expanded to include geographical data when possible).
-   */
-  public void setCustomerPurchaseIp(String customerPurchaseIp) {
-    this.customerPurchaseIp = customerPurchaseIp;
-  }
-
-  /**
    * The billing addess provided by the customer.
    */
   protected String billingAddress;
-
-  /**
-   * The billing addess provided by the customer.
-   */
-  public String getBillingAddress() {
-    return this.billingAddress;
-  }
-
-  /**
-   * The billing addess provided by the customer.
-   */
-  public void setBillingAddress(String billingAddress) {
-    this.billingAddress = billingAddress;
-  }
 
   /**
    * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Any receipt or message sent
@@ -108,66 +42,16 @@ public final class EvidenceSubObject extends StripeObject {
   protected String receipt;
 
   /**
-   * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Any receipt or message sent
-   * to the customer notifying them of the charge. This field will be automatically filled with a
-   * Stripe generated email receipt if any such receipt was sent.
-   */
-  public String getReceipt() {
-    return this.receipt;
-  }
-
-  /**
-   * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Any receipt or message sent
-   * to the customer notifying them of the charge. This field will be automatically filled with a
-   * Stripe generated email receipt if any such receipt was sent.
-   */
-  public void setReceipt(String receipt) {
-    this.receipt = receipt;
-  }
-
-  /**
    * The address to which a physical product was shipped. You should try to include as much complete
    * address information as possible.
    */
   protected String shippingAddress;
 
   /**
-   * The address to which a physical product was shipped. You should try to include as much complete
-   * address information as possible.
-   */
-  public String getShippingAddress() {
-    return this.shippingAddress;
-  }
-
-  /**
-   * The address to which a physical product was shipped. You should try to include as much complete
-   * address information as possible.
-   */
-  public void setShippingAddress(String shippingAddress) {
-    this.shippingAddress = shippingAddress;
-  }
-
-  /**
    * The date on which a physical product began its route to the shipping address, in a clear
    * human-readable format.
    */
   protected String shippingDate;
-
-  /**
-   * The date on which a physical product began its route to the shipping address, in a clear
-   * human-readable format.
-   */
-  public String getShippingDate() {
-    return this.shippingDate;
-  }
-
-  /**
-   * The date on which a physical product began its route to the shipping address, in a clear
-   * human-readable format.
-   */
-  public void setShippingDate(String shippingDate) {
-    this.shippingDate = shippingDate;
-  }
 
   /**
    * The tracking number for a physical product, usually obtained from a delivery service such as
@@ -178,46 +62,10 @@ public final class EvidenceSubObject extends StripeObject {
   protected String shippingTrackingNumber;
 
   /**
-   * The tracking number for a physical product, usually obtained from a delivery service such as
-   * Fedex, UPS, USPS, etc. If multiple tracking numbers were generated for this purchase, please
-   * separate them with commas. These tracking numbers will be expanded to include detailed delivery
-   * information from the carrier when possible.
-   */
-  public String getShippingTrackingNumber() {
-    return this.shippingTrackingNumber;
-  }
-
-  /**
-   * The tracking number for a physical product, usually obtained from a delivery service such as
-   * Fedex, UPS, USPS, etc. If multiple tracking numbers were generated for this purchase, please
-   * separate them with commas. These tracking numbers will be expanded to include detailed delivery
-   * information from the carrier when possible.
-   */
-  public void setShippingTrackingNumber(String shippingTrackingNumber) {
-    this.shippingTrackingNumber = shippingTrackingNumber;
-  }
-
-  /**
    * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) A relevant document or
    * contract showing the customer's signature.
    */
   protected String customerSignature;
-
-  /**
-   * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) A relevant document or
-   * contract showing the customer's signature.
-   */
-  public String getCustomerSignature() {
-    return this.customerSignature;
-  }
-
-  /**
-   * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) A relevant document or
-   * contract showing the customer's signature.
-   */
-  public void setCustomerSignature(String customerSignature) {
-    this.customerSignature = customerSignature;
-  }
 
   /**
    * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Documentation showing proof
@@ -228,26 +76,6 @@ public final class EvidenceSubObject extends StripeObject {
   protected String shippingDocumentation;
 
   /**
-   * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Documentation showing proof
-   * that a product was shipped to the customer at the same address the customer provided to you.
-   * This could include a copy of the shipment receipt, shipping label, etc, and should show the
-   * full shipping address of the customer, if possible.
-   */
-  public String getShippingDocumentation() {
-    return this.shippingDocumentation;
-  }
-
-  /**
-   * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Documentation showing proof
-   * that a product was shipped to the customer at the same address the customer provided to you.
-   * This could include a copy of the shipment receipt, shipping label, etc, and should show the
-   * full shipping address of the customer, if possible.
-   */
-  public void setShippingDocumentation(String shippingDocumentation) {
-    this.shippingDocumentation = shippingDocumentation;
-  }
-
-  /**
    * Any server or activity logs showing proof that the customer accessed or downloaded the
    * purchased digital product. This information should include IP addresses, corresponding
    * timestamps, and any detailed recorded activity.
@@ -255,44 +83,10 @@ public final class EvidenceSubObject extends StripeObject {
   protected String accessActivityLog;
 
   /**
-   * Any server or activity logs showing proof that the customer accessed or downloaded the
-   * purchased digital product. This information should include IP addresses, corresponding
-   * timestamps, and any detailed recorded activity.
-   */
-  public String getAccessActivityLog() {
-    return this.accessActivityLog;
-  }
-
-  /**
-   * Any server or activity logs showing proof that the customer accessed or downloaded the
-   * purchased digital product. This information should include IP addresses, corresponding
-   * timestamps, and any detailed recorded activity.
-   */
-  public void setAccessActivityLog(String accessActivityLog) {
-    this.accessActivityLog = accessActivityLog;
-  }
-
-  /**
    * The date on which the customer received or began receiving the purchased service, in a clear
    * human-readable format.
    */
   protected String serviceDate;
-
-  /**
-   * The date on which the customer received or began receiving the purchased service, in a clear
-   * human-readable format.
-   */
-  public String getServiceDate() {
-    return this.serviceDate;
-  }
-
-  /**
-   * The date on which the customer received or began receiving the purchased service, in a clear 
-   * human-readable format.
-   */
-  public void setServiceDate(String serviceDate) {
-    this.serviceDate = serviceDate;
-  }
 
   /**
    * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Documentation showing proof
@@ -302,47 +96,11 @@ public final class EvidenceSubObject extends StripeObject {
   protected String serviceDocumentation;
 
   /**
-   * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Documentation showing proof
-   * that a service was provided to the customer. This could include a copy of a signed contract,
-   * work order, or other form of written agreement.
-   */
-  public String getServiceDocumentation() {
-    return this.serviceDocumentation;
-  }
-
-  /**
-   * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Documentation showing proof
-   * that a service was provided to the customer. This could include a copy of a signed contract,
-   * work order, or other form of written agreement.
-   */
-  public void setServiceDocumentation(String serviceDocumentation) {
-    this.serviceDocumentation = serviceDocumentation;
-  }
-
-  /**
    * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Any communications with the
    * customer proving that they received the product or service that demonstrates their use of or
    * satisfaction with the product or service.
    */
   protected String customerCommunication;
-
-  /**
-   * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Any communications with the
-   * customer proving that they received the product or service that demonstrates their use of or
-   * satisfaction with the product or service.
-   */
-  public String getCustomerCommunication() {
-    return this.customerCommunication;
-  }
-
-  /**
-   * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Any communications with the
-   * customer proving that they received the product or service that demonstrates their use of or
-   * satisfaction with the product or service.
-   */
-  public void setCustomerCommunication(String customerCommunication) {
-    this.customerCommunication = customerCommunication;
-  }
 
   /**
    * The Stripe ID for the prior charge which appears to be a duplicate of the disputed charge (only
@@ -351,42 +109,10 @@ public final class EvidenceSubObject extends StripeObject {
   protected String duplicateChargeId;
 
   /**
-   * The Stripe ID for the prior charge which appears to be a duplicate of the disputed charge (only
-   * for disputes of reason `duplicate`).
-   */
-  public String getDuplicateChargeId() {
-    return this.duplicateChargeId;
-  }
-
-  /**
-   * The Stripe ID for the prior charge which appears to be a duplicate of the disputed charge (only
-   * for disputes of reason `duplicate`).
-   */
-  public void setDuplicateChargeId(String duplicateChargeId) {
-    this.duplicateChargeId = duplicateChargeId;
-  }
-
-  /**
    * An explanation of the difference between the disputed charge and the prior charge that appears
    * to be a duplicate (only for disputes of reason `duplicate`).
    */
   protected String duplicateChargeExplanation;
-
-  /**
-   * An explanation of the difference between the disputed charge and the prior charge that appears
-   * to be a duplicate (only for disputes of reason `duplicate`).
-   */
-  public String getDuplicateChargeExplanation() {
-    return this.duplicateChargeExplanation;
-  }
-
-  /**
-   * An explanation of the difference between the disputed charge and the prior charge that appears
-   * to be a duplicate (only for disputes of reason `duplicate`).
-   */
-  public void setDuplicateChargeExplanation(String duplicateChargeExplanation) {
-    this.duplicateChargeExplanation = duplicateChargeExplanation;
-  }
 
   /**
    * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Documentation for the prior
@@ -397,46 +123,10 @@ public final class EvidenceSubObject extends StripeObject {
   protected String duplicateChargeDocumentation;
 
   /**
-   * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Documentation for the prior
-   * charge that can uniquely identify the charge, such as a receipt, shipping label, work order,
-   * etc. (only for disputes of reason `duplicate`). This document should be paired with a similar
-   * document from the disputed payment that proves the two payments are separate.
-   */
-  public String getDuplicateChargeDocumentation() {
-    return this.duplicateChargeDocumentation;
-  }
-
-  /**
-   * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Documentation for the prior
-   * charge that can uniquely identify the charge, such as a receipt, shipping label, work order,
-   * etc. (only for disputes of reason `duplicate`). This document should be paired with a similar
-   * document from the disputed payment that proves the two payments are separate.
-   */
-  public void setDuplicateChargeDocumentation(String duplicateChargeDocumentation) {
-    this.duplicateChargeDocumentation = duplicateChargeDocumentation;
-  }
-
-  /**
    * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Your refund policy, as
    * shown to the customer.
    */
   protected String refundPolicy;
-
-  /**
-   * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Your refund policy, as
-   * shown to the customer.
-   */
-  public String getRefundPolicy() {
-    return this.refundPolicy;
-  }
-
-  /**
-   * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Your refund policy, as
-   * shown to the customer.
-   */
-  public void setRefundPolicy(String refundPolicy) {
-    this.refundPolicy = refundPolicy;
-  }
 
   /**
    * Documentation demonstrating that the customer was shown your refund policy prior to purchase.
@@ -444,37 +134,9 @@ public final class EvidenceSubObject extends StripeObject {
   protected String refundPolicyDisclosure;
 
   /**
-   * Documentation demonstrating that the customer was shown your refund policy prior to purchase.
-   */
-  public String getRefundPolicyDisclosure() {
-    return this.refundPolicyDisclosure;
-  }
-
-  /**
-   * Documentation demonstrating that the customer was shown your refund policy prior to purchase.
-   */
-  public void setRefundPolicyDisclosure(String refundPolicyDisclosure) {
-    this.refundPolicyDisclosure = refundPolicyDisclosure;
-  }
-
-  /**
    * Justification for why the customer is not entitled to a refund.
    */
   protected String refundRefusalExplanation;
-
-  /**
-   * Justification for why the customer is not entitled to a refund.
-   */
-  public String getRefundRefusalExplanation() {
-    return this.refundRefusalExplanation;
-  }
-
-  /**
-   * Justification for why the customer is not entitled to a refund.
-   */
-  public void setRefundRefusalExplanation(String refundRefusalExplanation) {
-    this.refundRefusalExplanation = refundRefusalExplanation;
-  }
 
   /**
    * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Your subscription
@@ -483,42 +145,10 @@ public final class EvidenceSubObject extends StripeObject {
   protected String cancellationPolicy;
 
   /**
-   * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Your subscription
-   * cancellation policy, as shown to the customer.
-   */
-  public String getCancellationPolicy() {
-    return this.cancellationPolicy;
-  }
-
-  /**
-   * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Your subscription
-   * cancellation policy, as shown to the customer.
-   */
-  public void setCancellationPolicy(String cancellationPolicy) {
-    this.cancellationPolicy = cancellationPolicy;
-  }
-
-  /**
    * Documentation demonstrating that the customer was shown your cancellation policy prior to
    * purchase.
    */
   protected String cancellationPolicyDisclosure;
-
-  /**
-   * Documentation demonstrating that the customer was shown your cancellation policy prior to
-   * purchase.
-   */
-  public String getCancellationPolicyDisclosure() {
-    return this.cancellationPolicyDisclosure;
-  }
-
-  /**
-   * Documentation demonstrating that the customer was shown your cancellation policy prior to
-   * purchase.
-   */
-  public void setCancellationPolicyDisclosure(String cancellationPolicyDisclosure) {
-    this.cancellationPolicyDisclosure = cancellationPolicyDisclosure;
-  }
 
   /**
    * Justification for why the customer's subscription was not canceled.
@@ -526,211 +156,13 @@ public final class EvidenceSubObject extends StripeObject {
   protected String cancellationRebuttal;
 
   /**
-   * Justification for why the customer's subscription was not canceled.
-   */
-  public String getCancellationRebuttal() {
-    return this.cancellationRebuttal;
-  }
-
-  /**
-   * Justification for why the customer's subscription was not canceled.
-   */
-  public void setCancellationRebuttal(String cancellationRebuttal) {
-    this.cancellationRebuttal = cancellationRebuttal;
-  }
-
-  /**
    * Any additional evidence or statements.
    */
   protected String uncategorizedText;
-
-  /**
-   * Any additional evidence or statements.
-   */
-  public String getUncategorizedText() {
-    return this.uncategorizedText;
-  }
-
-  /**
-   * Any additional evidence or statements.
-   */
-  public void setUncategorizedText(String uncategorizedText) {
-    this.uncategorizedText = uncategorizedText;
-  }
 
   /**
    * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Any additional evidence or
    * statements.
    */
   protected String uncategorizedFile;
-
-  /**
-   * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Any additional evidence or
-   * statements.
-   */
-  public String getUncategorizedFile() {
-    return this.uncategorizedFile;
-  }
-
-  /**
-   * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Any additional evidence or
-   * statements.
-   */
-  public void setUncategorizedFile(String uncategorizedFile) {
-    this.uncategorizedFile = uncategorizedFile;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-
-    EvidenceSubObject that = (EvidenceSubObject) o;
-
-    if (accessActivityLog != null ? !accessActivityLog.equals(that.accessActivityLog)
-        : that.accessActivityLog != null) {
-      return false;
-    }
-    if (billingAddress != null ? !billingAddress.equals(that.billingAddress)
-        : that.billingAddress != null) {
-      return false;
-    }
-    if (cancellationPolicy != null ? !cancellationPolicy.equals(that.cancellationPolicy)
-        : that.cancellationPolicy != null) {
-      return false;
-    }
-    if (cancellationPolicyDisclosure != null
-        ? !cancellationPolicyDisclosure.equals(that.cancellationPolicyDisclosure)
-        : that.cancellationPolicyDisclosure != null) {
-      return false;
-    }
-    if (cancellationRebuttal != null ? !cancellationRebuttal.equals(that.cancellationRebuttal)
-        : that.cancellationRebuttal != null) {
-      return false;
-    }
-    if (customerCommunication != null ? !customerCommunication.equals(that.customerCommunication)
-        : that.customerCommunication != null) {
-      return false;
-    }
-    if (customerEmailAddress != null ? !customerEmailAddress.equals(that.customerEmailAddress)
-        : that.customerEmailAddress != null) {
-      return false;
-    }
-    if (customerName != null ? !customerName.equals(that.customerName)
-        : that.customerName != null) {
-      return false;
-    }
-    if (customerPurchaseIp != null ? !customerPurchaseIp.equals(that.customerPurchaseIp)
-        : that.customerPurchaseIp != null) {
-      return false;
-    }
-    if (customerSignature != null ? !customerSignature.equals(that.customerSignature)
-        : that.customerSignature != null) {
-      return false;
-    }
-    if (duplicateChargeDocumentation != null
-        ? !duplicateChargeDocumentation.equals(that.duplicateChargeDocumentation)
-        : that.duplicateChargeDocumentation != null) {
-      return false;
-    }
-    if (duplicateChargeExplanation != null
-        ? !duplicateChargeExplanation.equals(that.duplicateChargeExplanation)
-        : that.duplicateChargeExplanation != null) {
-      return false;
-    }
-    if (duplicateChargeId != null ? !duplicateChargeId.equals(that.duplicateChargeId)
-        : that.duplicateChargeId != null) {
-      return false;
-    }
-    if (productDescription != null ? !productDescription.equals(that.productDescription)
-        : that.productDescription != null) {
-      return false;
-    }
-    if (receipt != null ? !receipt.equals(that.receipt) : that.receipt != null) {
-      return false;
-    }
-    if (refundPolicy != null ? !refundPolicy.equals(that.refundPolicy)
-        : that.refundPolicy != null) {
-      return false;
-    }
-    if (refundPolicyDisclosure != null
-        ? !refundPolicyDisclosure.equals(that.refundPolicyDisclosure)
-        : that.refundPolicyDisclosure != null) {
-      return false;
-    }
-    if (refundRefusalExplanation != null
-        ? !refundRefusalExplanation.equals(that.refundRefusalExplanation)
-        : that.refundRefusalExplanation != null) {
-      return false;
-    }
-    if (serviceDate != null ? !serviceDate.equals(that.serviceDate) : that.serviceDate != null) {
-      return false;
-    }
-    if (serviceDocumentation != null ? !serviceDocumentation.equals(that.serviceDocumentation)
-        : that.serviceDocumentation != null) {
-      return false;
-    }
-    if (shippingAddress != null ? !shippingAddress.equals(that.shippingAddress)
-        : that.shippingAddress != null) {
-      return false;
-    }
-    if (shippingDate != null ? !shippingDate.equals(that.shippingDate)
-        : that.shippingDate != null) {
-      return false;
-    }
-    if (shippingDocumentation != null ? !shippingDocumentation.equals(that.shippingDocumentation)
-        : that.shippingDocumentation != null) {
-      return false;
-    }
-    if (shippingTrackingNumber != null
-        ? !shippingTrackingNumber.equals(that.shippingTrackingNumber)
-        : that.shippingTrackingNumber != null) {
-      return false;
-    }
-    if (uncategorizedFile != null ? !uncategorizedFile.equals(that.uncategorizedFile)
-        : that.uncategorizedFile != null) {
-      return false;
-    }
-    return uncategorizedText != null ? uncategorizedText.equals(that.uncategorizedText)
-        : that.uncategorizedText == null;
-  }
-
-  @Override
-  public int hashCode() {
-    int result = productDescription != null ? productDescription.hashCode() : 0;
-    result = 31 * result + (customerName != null ? customerName.hashCode() : 0);
-    result = 31 * result + (customerEmailAddress != null ? customerEmailAddress.hashCode() : 0);
-    result = 31 * result + (customerPurchaseIp != null ? customerPurchaseIp.hashCode() : 0);
-    result = 31 * result + (billingAddress != null ? billingAddress.hashCode() : 0);
-    result = 31 * result + (receipt != null ? receipt.hashCode() : 0);
-    result = 31 * result + (shippingAddress != null ? shippingAddress.hashCode() : 0);
-    result = 31 * result + (shippingDate != null ? shippingDate.hashCode() : 0);
-    result = 31 * result + (shippingTrackingNumber != null ? shippingTrackingNumber.hashCode() : 0);
-    result = 31 * result + (customerSignature != null ? customerSignature.hashCode() : 0);
-    result = 31 * result + (shippingDocumentation != null ? shippingDocumentation.hashCode() : 0);
-    result = 31 * result + (accessActivityLog != null ? accessActivityLog.hashCode() : 0);
-    result = 31 * result + (serviceDate != null ? serviceDate.hashCode() : 0);
-    result = 31 * result + (serviceDocumentation != null ? serviceDocumentation.hashCode() : 0);
-    result = 31 * result + (customerCommunication != null ? customerCommunication.hashCode() : 0);
-    result = 31 * result + (duplicateChargeId != null ? duplicateChargeId.hashCode() : 0);
-    result = 31 * result
-        + (duplicateChargeExplanation != null ? duplicateChargeExplanation.hashCode() : 0);
-    result = 31 * result
-        + (duplicateChargeDocumentation != null ? duplicateChargeDocumentation.hashCode() : 0);
-    result = 31 * result + (refundPolicy != null ? refundPolicy.hashCode() : 0);
-    result = 31 * result + (refundPolicyDisclosure != null ? refundPolicyDisclosure.hashCode() : 0);
-    result = 31 * result
-        + (refundRefusalExplanation != null ? refundRefusalExplanation.hashCode() : 0);
-    result = 31 * result + (cancellationPolicy != null ? cancellationPolicy.hashCode() : 0);
-    result = 31 * result
-        + (cancellationPolicyDisclosure != null ? cancellationPolicyDisclosure.hashCode() : 0);
-    result = 31 * result + (cancellationRebuttal != null ? cancellationRebuttal.hashCode() : 0);
-    result = 31 * result + (uncategorizedText != null ? uncategorizedText.hashCode() : 0);
-    result = 31 * result + (uncategorizedFile != null ? uncategorizedFile.hashCode() : 0);
-    return result;
-  }
 }

--- a/src/main/java/com/stripe/model/ExchangeRate.java
+++ b/src/main/java/com/stripe/model/ExchangeRate.java
@@ -10,34 +10,17 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class ExchangeRate extends APIResource implements HasId {
   String id;
   String object;
   Map<String, Float> rates;
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public Map<String, Float> getRates() {
-    return rates;
-  }
-
-  public void setRates(Map<String, Float> rates) {
-    this.rates = rates;
-  }
 
   public static ExchangeRate retrieve(String currency) throws AuthenticationException,
       InvalidRequestException, APIConnectionException, CardException,

--- a/src/main/java/com/stripe/model/ExternalAccount.java
+++ b/src/main/java/com/stripe/model/ExternalAccount.java
@@ -10,54 +10,19 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class ExternalAccount extends APIResource implements HasId, MetadataStore<ExternalAccount> {
   String id;
   String object;
   String account;
   String customer;
   Map<String, String> metadata;
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public String getAccount() {
-    return account;
-  }
-
-  // For testing
-  public void setAccount(String account) {
-    this.account = account;
-  }
-
-  public String getCustomer() {
-    return customer;
-  }
-
-  // For testing
-  public void setCustomer(String customer) {
-    this.customer = customer;
-  }
-
-  public Map<String, String> getMetadata() {
-    return metadata;
-  }
-
-  public void setMetadata(Map<String, String> metadata) {
-    this.metadata = metadata;
-  }
 
   public ExternalAccount verify(Map<String, Object> params) throws
       AuthenticationException, InvalidRequestException,

--- a/src/main/java/com/stripe/model/Fee.java
+++ b/src/main/java/com/stripe/model/Fee.java
@@ -2,50 +2,17 @@ package com.stripe.model;
 
 import com.stripe.net.APIResource;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class Fee extends APIResource {
   Long amount;
   String application;
   String currency;
   String description;
   String type;
-
-  public Long getAmount() {
-    return amount;
-  }
-
-  public void setAmount(Long amount) {
-    this.amount = amount;
-  }
-
-  public String getApplication() {
-    return application;
-  }
-
-  public void setApplication(String application) {
-    this.application = application;
-  }
-
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  public String getType() {
-    return type;
-  }
-
-  public void setType(String type) {
-    this.type = type;
-  }
 }

--- a/src/main/java/com/stripe/model/FeeRefund.java
+++ b/src/main/java/com/stripe/model/FeeRefund.java
@@ -10,36 +10,26 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class FeeRefund extends APIResource implements MetadataStore<ApplicationFee>, HasId {
   String id;
   String object;
   Long amount;
-  ExpandableField<BalanceTransaction> balanceTransaction;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+      ExpandableField<BalanceTransaction> balanceTransaction;
   String currency;
   Long created;
-  ExpandableField<ApplicationFee> fee;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<ApplicationFee> fee;
   Map<String, String> metadata;
 
-  public String getId() {
-    return id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public Long getAmount() {
-    return amount;
-  }
-
-  public void setAmount(Long amount) {
-    this.amount = amount;
-  }
-
+  // <editor-fold desc="balanceTransaction">
   public String getBalanceTransaction() {
     return (this.balanceTransaction != null) ? this.balanceTransaction.getId() : null;
   }
@@ -55,23 +45,9 @@ public class FeeRefund extends APIResource implements MetadataStore<ApplicationF
   public void setBalanceTransactionObject(BalanceTransaction c) {
     this.balanceTransaction = new ExpandableField<BalanceTransaction>(c.getId(), c);
   }
+  // </editor-fold>
 
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
+  // <editor-fold desc="fee">
   public String getFee() {
     return (this.fee != null) ? this.fee.getId() : null;
   }
@@ -87,14 +63,7 @@ public class FeeRefund extends APIResource implements MetadataStore<ApplicationF
   public void setFeeObject(ApplicationFee c) {
     this.fee = new ExpandableField<ApplicationFee>(c.getId(), c);
   }
-
-  public Map<String, String> getMetadata() {
-    return metadata;
-  }
-
-  public void setMetadata(Map<String, String> metadata) {
-    this.metadata = metadata;
-  }
+  // </editor-fold>
 
   public FeeRefund update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,

--- a/src/main/java/com/stripe/model/FileUpload.java
+++ b/src/main/java/com/stripe/model/FileUpload.java
@@ -11,6 +11,14 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class FileUpload extends APIResource implements HasId {
   String id;
   String object;
@@ -18,56 +26,9 @@ public class FileUpload extends APIResource implements HasId {
   String purpose;
   Long size;
   String type;
-  String url;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) String url;
 
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
-  public String getPurpose() {
-    return purpose;
-  }
-
-  public void setPurpose(String purpose) {
-    this.purpose = purpose;
-  }
-
-  public Long getSize() {
-    return size;
-  }
-
-  public void setSize(Long size) {
-    this.size = size;
-  }
-
-  public String getType() {
-    return type;
-  }
-
-  public void setType(String type) {
-    this.type = type;
-  }
-
+  // <editor-fold desc="url">
   public String getURL() {
     return url;
   }
@@ -75,6 +36,7 @@ public class FileUpload extends APIResource implements HasId {
   public void setURL(String url) {
     this.url = url;
   }
+  // </editor-fold>
 
   public static FileUpload create(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,

--- a/src/main/java/com/stripe/model/FraudDetails.java
+++ b/src/main/java/com/stripe/model/FraudDetails.java
@@ -1,52 +1,16 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class FraudDetails extends StripeObject {
   public static final String USER_REPORT = "user_report";
+
   protected String userReport;
 
   protected String stripeReport;
-
-  public String getUserReport() {
-    return userReport;
-  }
-
-  public void setUserReport(String userReport) {
-    this.userReport = userReport;
-  }
-
-  public String getStripeReport() {
-    return stripeReport;
-  }
-
-  /**
-   * stripeReport is set by Stripe, the field is exposed because it may be useful within unit tests.
-   */
-  public void setStripeReport(String stripeReport) {
-    this.stripeReport = stripeReport;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-
-    FraudDetails that = (FraudDetails) o;
-
-    if (stripeReport != null ? !stripeReport.equals(that.stripeReport)
-        : that.stripeReport != null) {
-      return false;
-    }
-    return userReport != null ? userReport.equals(that.userReport) : that.userReport == null;
-  }
-
-  @Override
-  public int hashCode() {
-    int result = userReport != null ? userReport.hashCode() : 0;
-    result = 31 * result + (stripeReport != null ? stripeReport.hashCode() : 0);
-    return result;
-  }
 }

--- a/src/main/java/com/stripe/model/Inventory.java
+++ b/src/main/java/com/stripe/model/Inventory.java
@@ -1,31 +1,14 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class Inventory {
   String type;
   Integer quantity;
   String value;
-
-  public String getType() {
-    return type;
-  }
-
-  public void setType(String type) {
-    this.type = type;
-  }
-
-  public Integer getQuantity() {
-    return quantity;
-  }
-
-  public void setQuantity(Integer quantity) {
-    this.quantity = quantity;
-  }
-
-  public String getValue() {
-    return value;
-  }
-
-  public void setValue(String value) {
-    this.value = value;
-  }
 }

--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -10,6 +10,14 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class Invoice extends APIResource implements MetadataStore<Invoice>, HasId {
   String id;
   String object;
@@ -18,7 +26,7 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
   Integer attemptCount;
   Boolean attempted;
   String billing;
-  ExpandableField<Charge> charge;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Charge> charge;
   Boolean closed;
   Long created;
   String currency;
@@ -40,7 +48,7 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
   String receiptNumber;
   Long startingBalance;
   String statementDescriptor;
-  ExpandableField<Subscription> subscription;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Subscription> subscription;
   Long subscriptionProrationDate;
   Long subtotal;
   Long tax;
@@ -48,62 +56,7 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
   Long total;
   Long webhooksDeliveredAt;
 
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public Long getAmountDue() {
-    return amountDue;
-  }
-
-  public void setAmountDue(Long amountDue) {
-    this.amountDue = amountDue;
-  }
-
-  public Long getApplicationFee() {
-    return applicationFee;
-  }
-
-  public void setApplicationFee(Long applicationFee) {
-    this.applicationFee = applicationFee;
-  }
-
-  public Integer getAttemptCount() {
-    return attemptCount;
-  }
-
-  public void setAttemptCount(Integer attemptCount) {
-    this.attemptCount = attemptCount;
-  }
-
-  public Boolean getAttempted() {
-    return attempted;
-  }
-
-  public void setAttempted(Boolean attempted) {
-    this.attempted = attempted;
-  }
-
-  public String getBilling() {
-    return billing;
-  }
-
-  public void setBilling(String billing) {
-    this.billing = billing;
-  }
-
+  // <editor-fold desc="charge">
   public String getCharge() {
     return (this.charge != null) ? this.charge.getId() : null;
   }
@@ -119,171 +72,9 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
   public void setChargeObject(Charge charge) {
     this.charge = new ExpandableField<Charge>(charge.getId(), charge);
   }
+  // </editor-fold>
 
-  public Boolean getClosed() {
-    return closed;
-  }
-
-  public void setClosed(Boolean closed) {
-    this.closed = closed;
-  }
-
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  public String getCustomer() {
-    return customer;
-  }
-
-  public void setCustomer(String customer) {
-    this.customer = customer;
-  }
-
-  public Long getDate() {
-    return date;
-  }
-
-  public void setDate(Long date) {
-    this.date = date;
-  }
-
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  public Discount getDiscount() {
-    return discount;
-  }
-
-  public void setDiscount(Discount discount) {
-    this.discount = discount;
-  }
-
-  public Long getDueDate() {
-    return dueDate;
-  }
-
-  public void setDueDate(Long dueDate) {
-    this.dueDate = dueDate;
-  }
-
-  public Long getEndingBalance() {
-    return endingBalance;
-  }
-
-  public void setEndingBalance(Long endingBalance) {
-    this.endingBalance = endingBalance;
-  }
-
-  public Boolean getForgiven() {
-    return forgiven;
-  }
-
-  public void setForgiven(Boolean forgiven) {
-    this.forgiven = forgiven;
-  }
-
-  public InvoiceLineItemCollection getLines() {
-    return lines;
-  }
-
-  public Boolean getLivemode() {
-    return livemode;
-  }
-
-  public void setLivemode(Boolean livemode) {
-    this.livemode = livemode;
-  }
-
-  public Map<String, String> getMetadata() {
-    return metadata;
-  }
-
-  public void setMetadata(Map<String, String> metadata) {
-    this.metadata = metadata;
-  }
-
-  public Long getNextPaymentAttempt() {
-    return nextPaymentAttempt;
-  }
-
-  public void setNextPaymentAttempt(Long nextPaymentAttempt) {
-    this.nextPaymentAttempt = nextPaymentAttempt;
-  }
-
-  public String getNumber() {
-    return number;
-  }
-
-  public void setNumber(String number) {
-    this.number = number;
-  }
-
-  public Boolean getPaid() {
-    return paid;
-  }
-
-  public void setPaid(Boolean paid) {
-    this.paid = paid;
-  }
-
-  public Long getPeriodEnd() {
-    return periodEnd;
-  }
-
-  public void setPeriodEnd(Long periodEnd) {
-    this.periodEnd = periodEnd;
-  }
-
-  public Long getPeriodStart() {
-    return periodStart;
-  }
-
-  public void setPeriodStart(Long periodStart) {
-    this.periodStart = periodStart;
-  }
-
-  public String getReceiptNumber() {
-    return receiptNumber;
-  }
-
-  public void setReceiptNumber(String receiptNumber) {
-    this.receiptNumber = receiptNumber;
-  }
-
-  public Long getStartingBalance() {
-    return startingBalance;
-  }
-
-  public void setStartingBalance(Long startingBalance) {
-    this.startingBalance = startingBalance;
-  }
-
-  public String getStatementDescriptor() {
-    return statementDescriptor;
-  }
-
-  public void setStatementDescriptor(String statementDescriptor) {
-    this.statementDescriptor = statementDescriptor;
-  }
-
+  // <editor-fold desc="subscription">
   public String getSubscription() {
     return (this.subscription != null) ? this.subscription.getId() : null;
   }
@@ -299,54 +90,7 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
   public void setSubscriptionObject(Subscription subscription) {
     this.subscription = new ExpandableField<Subscription>(subscription.getId(), subscription);
   }
-
-  public Long getSubscriptionProrationDate() {
-    return subscriptionProrationDate;
-  }
-
-  public void setSubscriptionProrationDate(Long subscriptionProrationDate) {
-    this.subscriptionProrationDate = subscriptionProrationDate;
-  }
-
-  public Long getSubtotal() {
-    return subtotal;
-  }
-
-  public void setSubtotal(Long subtotal) {
-    this.subtotal = subtotal;
-  }
-
-  public Long getTax() {
-    return tax;
-  }
-
-  public void setTax(Long tax) {
-    this.tax = tax;
-  }
-
-  public Double getTaxPercent() {
-    return taxPercent;
-  }
-
-  public void setTaxPercent(Double taxPercent) {
-    this.taxPercent = taxPercent;
-  }
-
-  public Long getTotal() {
-    return total;
-  }
-
-  public void setTotal(Long total) {
-    this.total = total;
-  }
-
-  public Long getWebhooksDeliveredAt() {
-    return webhooksDeliveredAt;
-  }
-
-  public void setWebhooksDeliveredAt(Long webhooksDeliveredAt) {
-    this.webhooksDeliveredAt = webhooksDeliveredAt;
-  }
+  // </editor-fold>
 
   public static Invoice retrieve(String id) throws AuthenticationException,
       InvalidRequestException, APIConnectionException, CardException,

--- a/src/main/java/com/stripe/model/InvoiceItem.java
+++ b/src/main/java/com/stripe/model/InvoiceItem.java
@@ -10,63 +10,39 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class InvoiceItem extends APIResource implements MetadataStore<InvoiceItem>, HasId {
   String id;
   String object;
   Long amount;
   String currency;
-  ExpandableField<Customer> customer;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Customer> customer;
   Long date;
   String description;
   Boolean discountable;
-  ExpandableField<Invoice> invoice;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Invoice> invoice;
   Boolean livemode;
   Map<String, String> metadata;
   InvoiceLineItemPeriod period;
   Plan plan;
   Boolean proration;
   Integer quantity;
-  ExpandableField<Subscription> subscription;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Subscription> subscription;
 
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public Long getAmount() {
-    return amount;
-  }
-
-  public void setAmount(Long amount) {
-    this.amount = amount;
-  }
-
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
+  // <editor-fold desc="customer">
   public String getCustomer() {
     return (this.customer != null) ? this.customer.getId() : null;
   }
 
   public void setCustomer(String customerID) {
     this.customer = setExpandableFieldID(customerID, this.customer);
-
   }
 
   public Customer getCustomerObject() {
@@ -76,38 +52,15 @@ public class InvoiceItem extends APIResource implements MetadataStore<InvoiceIte
   public void setCustomerObject(Customer c) {
     this.customer = new ExpandableField<Customer>(c.getId(), c);
   }
+  // </editor-fold>
 
-  public Long getDate() {
-    return date;
-  }
-
-  public void setDate(Long date) {
-    this.date = date;
-  }
-
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  public Boolean getDiscountable() {
-    return discountable;
-  }
-
-  public void setDiscountable(Boolean discountable) {
-    this.discountable = discountable;
-  }
-
+  // <editor-fold desc="invoice">
   public String getInvoice() {
     return (this.invoice != null) ? this.invoice.getId() : null;
   }
 
   public void setInvoice(String invoiceID) {
     this.invoice = setExpandableFieldID(invoiceID, this.invoice);
-
   }
 
   public Invoice getInvoiceObject() {
@@ -117,55 +70,9 @@ public class InvoiceItem extends APIResource implements MetadataStore<InvoiceIte
   public void setInvoiceObject(Invoice invoice) {
     this.invoice = new ExpandableField<Invoice>(invoice.getId(), invoice);
   }
+  // </editor-fold>
 
-  public Boolean getLivemode() {
-    return livemode;
-  }
-
-  public void setLivemode(Boolean livemode) {
-    this.livemode = livemode;
-  }
-
-  public Map<String, String> getMetadata() {
-    return metadata;
-  }
-
-  public void setMetadata(Map<String, String> metadata) {
-    this.metadata = metadata;
-  }
-
-  public InvoiceLineItemPeriod getPeriod() {
-    return period;
-  }
-
-  public void setPeriod(InvoiceLineItemPeriod period) {
-    this.period = period;
-  }
-
-  public Plan getPlan() {
-    return plan;
-  }
-
-  public void setPlan(Plan plan) {
-    this.plan = plan;
-  }
-
-  public Boolean getProration() {
-    return proration;
-  }
-
-  public void setProration(Boolean proration) {
-    this.proration = proration;
-  }
-
-  public Integer getQuantity() {
-    return quantity;
-  }
-
-  public void setQuantity(Integer quantity) {
-    this.quantity = quantity;
-  }
-
+  // <editor-fold desc="subscription">
   public String getSubscription() {
     return (this.subscription != null) ? this.subscription.getId() : null;
   }
@@ -181,6 +88,7 @@ public class InvoiceItem extends APIResource implements MetadataStore<InvoiceIte
   public void setSubscriptionObject(Subscription subscription) {
     this.subscription = new ExpandableField<Subscription>(subscription.getId(), subscription);
   }
+  // </editor-fold>
 
   public static InvoiceItem create(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,

--- a/src/main/java/com/stripe/model/InvoiceLineItem.java
+++ b/src/main/java/com/stripe/model/InvoiceLineItem.java
@@ -2,6 +2,13 @@ package com.stripe.model;
 
 import java.util.Map;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class InvoiceLineItem extends StripeObject implements HasId {
   String id;
   String object;
@@ -17,64 +24,4 @@ public class InvoiceLineItem extends StripeObject implements HasId {
   Integer quantity;
   String subscription;
   String type;
-
-  public String getId() {
-    return this.id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public Long getAmount() {
-    return this.amount;
-  }
-
-  public String getCurrency() {
-    return this.currency;
-  }
-
-  public String getDescription() {
-    return this.description;
-  }
-
-  public Boolean getDiscountable() {
-    return this.discountable;
-  }
-
-  public Boolean getLivemode() {
-    return this.livemode;
-  }
-
-  public Map<String, String> getMetadata() {
-    return this.metadata;
-  }
-
-  public InvoiceLineItemPeriod getPeriod() {
-    return this.period;
-  }
-
-  public Plan getPlan() {
-    return this.plan;
-  }
-
-  public Boolean getProration() {
-    return this.proration;
-  }
-
-  public Integer getQuantity() {
-    return this.quantity;
-  }
-
-  public String getSubscription() {
-    return this.subscription;
-  }
-
-  public String getType() {
-    return this.type;
-  }
 }

--- a/src/main/java/com/stripe/model/InvoiceLineItemPeriod.java
+++ b/src/main/java/com/stripe/model/InvoiceLineItemPeriod.java
@@ -1,22 +1,13 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class InvoiceLineItemPeriod extends StripeObject {
   Long end;
   Long start;
-
-  public Long getEnd() {
-    return end;
-  }
-
-  public void setEnd(Long end) {
-    this.end = end;
-  }
-
-  public Long getStart() {
-    return start;
-  }
-
-  public void setStart(Long start) {
-    this.start = start;
-  }
 }

--- a/src/main/java/com/stripe/model/IssuerFraudRecord.java
+++ b/src/main/java/com/stripe/model/IssuerFraudRecord.java
@@ -10,31 +10,22 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class IssuerFraudRecord extends APIResource implements HasId {
   String id;
   String object;
-  ExpandableField<Charge> charge;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Charge> charge;
   Long created;
   String fraudType;
   Boolean livemode;
   Long postDate;
-
-  @Override
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
 
   public String getCharge() {
     return (this.charge != null) ? this.charge.getId() : null;
@@ -50,38 +41,6 @@ public class IssuerFraudRecord extends APIResource implements HasId {
 
   public void setChargeObject(Charge c) {
     this.charge = new ExpandableField<Charge>(c.getId(), c);
-  }
-
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
-  public String getFraudType() {
-    return fraudType;
-  }
-
-  public void setFraudType(String fraudType) {
-    this.fraudType = fraudType;
-  }
-
-  public Boolean getLivemode() {
-    return livemode;
-  }
-
-  public void setLivemode(Boolean livemode) {
-    this.livemode = livemode;
-  }
-
-  public Long getPostDate() {
-    return postDate;
-  }
-
-  public void setPostDate(Long postDate) {
-    this.postDate = postDate;
   }
 
   public static IssuerFraudRecord retrieve(String id)
@@ -117,5 +76,4 @@ public class IssuerFraudRecord extends APIResource implements HasId {
         classURL(IssuerFraudRecord.class), params, IssuerFraudRecordCollection.class, options
     );
   }
-
 }

--- a/src/main/java/com/stripe/model/LegalEntity.java
+++ b/src/main/java/com/stripe/model/LegalEntity.java
@@ -4,6 +4,13 @@ import com.google.gson.annotations.SerializedName;
 
 import java.util.List;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class LegalEntity extends StripeObject {
   List<Owner> additionalOwners;
   Address address;
@@ -14,208 +21,37 @@ public class LegalEntity extends StripeObject {
   String lastName;
   Address personalAddress;
   Boolean personalIdNumberProvided;
-  @SerializedName("ssn_last_4_provided")
-  Boolean ssnLast4Provided;
+  @SerializedName("ssn_last_4_provided") Boolean ssnLast4Provided;
   String type;
   Verification verification;
 
-  public List<Owner> getAdditionalOwners() {
-    return additionalOwners;
-  }
-
-  public Address getAddress() {
-    return address;
-  }
-
-  public String getBusinessName() {
-    return businessName;
-  }
-
-  public Boolean getBusinessTaxIdProvided() {
-    return businessTaxIdProvided;
-  }
-
-  public void setBusinessTaxIdProvided(Boolean businessTaxIdProvided) {
-    this.businessTaxIdProvided = businessTaxIdProvided;
-  }
-
-  public DateOfBirth getDob() {
-    return dob;
-  }
-
-  public String getFirstName() {
-    return firstName;
-  }
-
-  public String getLastName() {
-    return lastName;
-  }
-
-  public Address getPersonalAddress() {
-    return personalAddress;
-  }
-
-  public Boolean getPersonalIdNumberProvided() {
-    return personalIdNumberProvided;
-  }
-
-  public void setPersonalIdNumberProvided(Boolean personalIdNumberProvided) {
-    this.personalIdNumberProvided = personalIdNumberProvided;
-  }
-
-  public Boolean getSsnLast4Provided() {
-    return ssnLast4Provided;
-  }
-
-  public void setSsnLast4Provided(Boolean ssnLast4Provided) {
-    this.ssnLast4Provided = ssnLast4Provided;
-  }
-
-  public String getType() {
-    return type;
-  }
-
-  public Verification getVerification() {
-    return verification;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-
-    LegalEntity le = (LegalEntity) o;
-    return equals(additionalOwners, le.additionalOwners)
-        && equals(address, le.address)
-        && equals(businessName, le.businessName)
-        && equals(dob, le.dob)
-        && equals(firstName, le.firstName)
-        && equals(lastName, le.lastName)
-        && equals(personalAddress, le.personalAddress)
-        && equals(personalIdNumberProvided, le.personalIdNumberProvided)
-        && equals(ssnLast4Provided, le.ssnLast4Provided)
-        && equals(type, le.type)
-        && equals(verification, le.verification);
-  }
-
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
   public static class DateOfBirth extends StripeObject {
     Integer day;
     Integer month;
     Integer year;
-
-    public Integer getDay() {
-      return day;
-    }
-
-    public Integer getMonth() {
-      return month;
-    }
-
-    public Integer getYear() {
-      return year;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-
-      DateOfBirth dob = (DateOfBirth) o;
-      return equals(day, dob.day)
-          && equals(month, dob.month)
-          && equals(year, dob.year);
-    }
   }
 
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
   public static class Verification extends StripeObject {
     String details;
     String detailsCode;
     String document;
     String status;
-
-    public String getDetails() {
-      return details;
-    }
-
-    public String getDetailsCode() {
-      return detailsCode;
-    }
-
-    public String getDocument() {
-      return document;
-    }
-
-    public String getStatus() {
-      return status;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-
-      Verification verification = (Verification) o;
-      return equals(details, verification.details)
-          && equals(detailsCode, verification.detailsCode)
-          && equals(document, verification.document)
-          && equals(status, verification.status);
-    }
   }
 
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
   public static class Owner extends StripeObject {
     Address address;
     DateOfBirth dob;
     String firstName;
     String lastName;
     Verification verification;
-
-    public Address getAddress() {
-      return address;
-    }
-
-    public DateOfBirth getDob() {
-      return dob;
-    }
-
-    public String getFirstName() {
-      return firstName;
-    }
-
-    public String getLastName() {
-      return lastName;
-    }
-
-    public Verification getVerification() {
-      return verification;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-
-      Owner owner = (Owner) o;
-      return equals(address, owner.address)
-          && equals(dob, owner.dob)
-          && equals(firstName, owner.firstName)
-          && equals(lastName, owner.lastName)
-          && equals(verification, owner.verification);
-    }
   }
 }

--- a/src/main/java/com/stripe/model/LoginLink.java
+++ b/src/main/java/com/stripe/model/LoginLink.java
@@ -2,6 +2,13 @@ package com.stripe.model;
 
 import com.stripe.net.APIResource;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class LoginLink extends APIResource implements HasId {
   String object;
   Long created;
@@ -10,29 +17,5 @@ public class LoginLink extends APIResource implements HasId {
   public String getId() {
     throw new UnsupportedOperationException(
         "Login links are ephemeral and do not have an identifier");
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
-  public String getUrl() {
-    return url;
-  }
-
-  public void setUrl(String url) {
-    this.url = url;
   }
 }

--- a/src/main/java/com/stripe/model/Money.java
+++ b/src/main/java/com/stripe/model/Money.java
@@ -1,86 +1,24 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class Money extends StripeObject {
   Long amount;
   String currency;
   SourceTypes sourceTypes;
 
-  public Long getAmount() {
-    return amount;
-  }
-
-  public void setAmount(Long amount) {
-    this.amount = amount;
-  }
-
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  public SourceTypes getSourceTypes() {
-    return sourceTypes;
-  }
-
-  public void setSourceTypes(SourceTypes sourceTypes) {
-    this.sourceTypes = sourceTypes;
-  }
-
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
   public static class SourceTypes extends StripeObject {
     Long alipayAccount;
     Long bankAccount;
     Long bitcoinReceiver;
     Long card;
-
-    public Long getAlipayAccount() {
-      return alipayAccount;
-    }
-
-    public void setAlipayAccount(Long alipayAccount) {
-      this.alipayAccount = alipayAccount;
-    }
-
-    public Long getBankAccount() {
-      return bankAccount;
-    }
-
-    public void setBankAccount(Long bankAccount) {
-      this.bankAccount = bankAccount;
-    }
-
-    public Long getBitcoinReceiver() {
-      return bitcoinReceiver;
-    }
-
-    public void setBitcoinReceiver(Long bitcoinReceiver) {
-      this.bitcoinReceiver = bitcoinReceiver;
-    }
-
-    public Long getCard() {
-      return card;
-    }
-
-    public void setCard(Long card) {
-      this.card = card;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-
-      SourceTypes st = (SourceTypes) o;
-      return equals(alipayAccount, st.alipayAccount)
-          && equals(bankAccount, st.bankAccount)
-          && equals(bitcoinReceiver, st.bitcoinReceiver)
-          && equals(card, st.card);
-    }
   }
 }

--- a/src/main/java/com/stripe/model/NextRecurringCharge.java
+++ b/src/main/java/com/stripe/model/NextRecurringCharge.java
@@ -1,22 +1,13 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class NextRecurringCharge extends StripeObject {
   Long amount;
   String date;
-
-  public Long getAmount() {
-    return amount;
-  }
-
-  public void setAmount(Long amount) {
-    this.amount = amount;
-  }
-
-  public String getDate() {
-    return date;
-  }
-
-  public void setDate(String date) {
-    this.date = date;
-  }
 }

--- a/src/main/java/com/stripe/model/Order.java
+++ b/src/main/java/com/stripe/model/Order.java
@@ -11,6 +11,14 @@ import com.stripe.net.RequestOptions;
 import java.util.List;
 import java.util.Map;
 
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class Order extends APIResource implements HasId, MetadataStore<Order> {
   String id;
   String object;
@@ -18,10 +26,10 @@ public class Order extends APIResource implements HasId, MetadataStore<Order> {
   Long amountReturned;
   String application;
   Long applicationFee;
-  ExpandableField<Charge> charge;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Charge> charge;
   Long created;
   String currency;
-  ExpandableField<Customer> customer;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Customer> customer;
   String email;
   String externalCouponCode;
   List<OrderItem> items;
@@ -36,61 +44,13 @@ public class Order extends APIResource implements HasId, MetadataStore<Order> {
   Long updated;
   String upstreamId;
 
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public Long getAmount() {
-    return amount;
-  }
-
-  public void setAmount(Long amount) {
-    this.amount = amount;
-  }
-
-  public Long getAmountReturned() {
-    return amountReturned;
-  }
-
-  public void setAmountReturned(Long amountReturned) {
-    this.amountReturned = amountReturned;
-  }
-
-  public String getApplication() {
-    return application;
-  }
-
-  public void setApplication(String application) {
-    this.application = application;
-  }
-
-  public Long getApplicationFee() {
-    return applicationFee;
-  }
-
-  public void setApplicationFee(Long applicationFee) {
-    this.applicationFee = applicationFee;
-  }
-
+  // <editor-fold desc="charge">
   public String getCharge() {
     return (this.charge != null) ? this.charge.getId() : null;
   }
 
   public void setCharge(String chargeID) {
     this.charge = setExpandableFieldID(chargeID, this.charge);
-
   }
 
   public Charge getChargeObject() {
@@ -100,23 +60,9 @@ public class Order extends APIResource implements HasId, MetadataStore<Order> {
   public void setChargeObject(Charge charge) {
     this.charge = new ExpandableField<Charge>(charge.getId(), charge);
   }
+  // </editor-fold>
 
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
+  // <editor-fold desc="customer">
   public String getCustomer() {
     return (this.customer != null) ? this.customer.getId() : null;
   }
@@ -132,110 +78,7 @@ public class Order extends APIResource implements HasId, MetadataStore<Order> {
   public void setCustomerObject(Customer customer) {
     this.customer = new ExpandableField<Customer>(customer.getId(), customer);
   }
-
-  public String getEmail() {
-    return email;
-  }
-
-  public void setEmail(String email) {
-    this.email = email;
-  }
-
-  public String getExternalCouponCode() {
-    return externalCouponCode;
-  }
-
-  public void setExternalCouponCode(String externalCouponCode) {
-    this.externalCouponCode = externalCouponCode;
-  }
-
-  public List<OrderItem> getItems() {
-    return items;
-  }
-
-  public void setItems(List<OrderItem> items) {
-    this.items = items;
-  }
-
-  public Boolean getLivemode() {
-    return livemode;
-  }
-
-  public void setLivemode(Boolean livemode) {
-    this.livemode = livemode;
-  }
-
-  public Map<String, String> getMetadata() {
-    return metadata;
-  }
-
-  public void setMetadata(Map<String, String> metadata) {
-    this.metadata = metadata;
-  }
-
-  public OrderReturnCollection getReturns() {
-    return returns;
-  }
-
-  public void setReturns(OrderReturnCollection returns) {
-    this.returns = returns;
-  }
-
-  public String getSelectedShippingMethod() {
-    return selectedShippingMethod;
-  }
-
-  public void setSelectedShippingMethod(String selectedShippingMethod) {
-    this.selectedShippingMethod = selectedShippingMethod;
-  }
-
-  public ShippingDetails getShipping() {
-    return shipping;
-  }
-
-  public void setShipping(ShippingDetails shipping) {
-    this.shipping = shipping;
-  }
-
-  public List<ShippingMethod> getShippingMethods() {
-    return shippingMethods;
-  }
-
-  public void setShippingMethods(List<ShippingMethod> shippingMethods) {
-    this.shippingMethods = shippingMethods;
-  }
-
-  public String getStatus() {
-    return status;
-  }
-
-  public void setStatus(String status) {
-    this.status = status;
-  }
-
-  public StatusTransitions getStatusTransitions() {
-    return statusTransitions;
-  }
-
-  public void setStatusTransitions(StatusTransitions statusTransitions) {
-    this.statusTransitions = statusTransitions;
-  }
-
-  public Long getUpdated() {
-    return updated;
-  }
-
-  public void setUpdated(Long updated) {
-    this.updated = updated;
-  }
-
-  public String getUpstreamId() {
-    return upstreamId;
-  }
-
-  public void setUpstreamId(String upstreamId) {
-    this.upstreamId = upstreamId;
-  }
+  // </editor-fold>
 
   public static Order create(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,

--- a/src/main/java/com/stripe/model/OrderItem.java
+++ b/src/main/java/com/stripe/model/OrderItem.java
@@ -2,47 +2,24 @@ package com.stripe.model;
 
 import com.stripe.net.APIResource;
 
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class OrderItem extends APIResource {
   String object;
   Long amount;
   String currency;
   String description;
-  ExpandableField<HasId> parent;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<HasId> parent;
   Integer quantity;
   String type;
 
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public Long getAmount() {
-    return amount;
-  }
-
-  public void setAmount(Long amount) {
-    this.amount = amount;
-  }
-
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
+  // <editor-fold desc="parent">
   public String getParent() {
     return (this.parent != null) ? this.parent.getId() : null;
   }
@@ -62,20 +39,5 @@ public class OrderItem extends APIResource {
   public <O extends HasId> O getParentObjectAs() {
     return (this.parent != null) ? (O) this.parent.getExpanded() : null;
   }
-
-  public Integer getQuantity() {
-    return quantity;
-  }
-
-  public void setQuantity(Integer quantity) {
-    this.quantity = quantity;
-  }
-
-  public String getType() {
-    return type;
-  }
-
-  public void setType(String type) {
-    this.type = type;
-  }
+  // </editor-fold>
 }

--- a/src/main/java/com/stripe/model/OrderReturn.java
+++ b/src/main/java/com/stripe/model/OrderReturn.java
@@ -11,6 +11,14 @@ import com.stripe.net.RequestOptions;
 import java.util.List;
 import java.util.Map;
 
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class OrderReturn extends APIResource implements HasId {
   String id;
   String object;
@@ -19,65 +27,10 @@ public class OrderReturn extends APIResource implements HasId {
   String currency;
   List<OrderItem> items;
   Boolean livemode;
-  ExpandableField<Order> order;
-  ExpandableField<Refund> refund;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Order> order;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Refund> refund;
 
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public Long getAmount() {
-    return amount;
-  }
-
-  public void setAmount(Long amount) {
-    this.amount = amount;
-  }
-
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  public List<OrderItem> getItems() {
-    return items;
-  }
-
-  public void setItems(List<OrderItem> items) {
-    this.items = items;
-  }
-
-  public Boolean getLivemode() {
-    return livemode;
-  }
-
-  public void setLivemode(Boolean livemode) {
-    this.livemode = livemode;
-  }
-
+  // <editor-fold desc="order">
   public String getOrder() {
     return (this.order != null) ? this.order.getId() : null;
   }
@@ -93,7 +46,9 @@ public class OrderReturn extends APIResource implements HasId {
   public void setOrderObject(Order order) {
     this.order = new ExpandableField<Order>(order.getId(), order);
   }
+  // </editor-fold>
 
+  // <editor-fold desc="refund">
   public String getRefund() {
     return (this.refund != null) ? this.refund.getId() : null;
   }
@@ -109,6 +64,7 @@ public class OrderReturn extends APIResource implements HasId {
   public void setRefundObject(Refund refund) {
     this.refund = new ExpandableField<Refund>(refund.getId(), refund);
   }
+  // </editor-fold>
 
   public static OrderReturn retrieve(String id)
       throws AuthenticationException, InvalidRequestException,

--- a/src/main/java/com/stripe/model/PackageDimensions.java
+++ b/src/main/java/com/stripe/model/PackageDimensions.java
@@ -1,40 +1,15 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class PackageDimensions extends StripeObject {
   Double height;
   Double length;
   Double weight;
   Double width;
-
-  public Double getHeight() {
-    return height;
-  }
-
-  public void setHeight(Double height) {
-    this.height = height;
-  }
-
-  public Double getLength() {
-    return length;
-  }
-
-  public void setLength(Double length) {
-    this.length = length;
-  }
-
-  public Double getWeight() {
-    return weight;
-  }
-
-  public void setWeight(Double weight) {
-    this.weight = weight;
-  }
-
-  public Double getWidth() {
-    return width;
-  }
-
-  public void setWidth(Double width) {
-    this.width = width;
-  }
 }

--- a/src/main/java/com/stripe/model/Payout.java
+++ b/src/main/java/com/stripe/model/Payout.java
@@ -10,17 +10,27 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class Payout extends APIResource implements MetadataStore<Payout>, HasId {
   String id;
   String object;
   Long amount;
   Long arrivalDate;
   Boolean automatic;
-  ExpandableField<BalanceTransaction> balanceTransaction;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+      ExpandableField<BalanceTransaction> balanceTransaction;
   Long created;
   String currency;
-  ExpandableField<ExternalAccount> destination;
-  ExpandableField<BalanceTransaction> failureBalanceTransaction;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<ExternalAccount> destination;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+      ExpandableField<BalanceTransaction> failureBalanceTransaction;
   String failureCode;
   String failureMessage;
   Boolean livemode;
@@ -31,46 +41,7 @@ public class Payout extends APIResource implements MetadataStore<Payout>, HasId 
   String status;
   String type;
 
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public Long getAmount() {
-    return amount;
-  }
-
-  public void setAmount(Long amount) {
-    this.amount = amount;
-  }
-
-  public Long getArrivalDate() {
-    return arrivalDate;
-  }
-
-  public void setArrivalDate(Long arrivalDate) {
-    this.arrivalDate = arrivalDate;
-  }
-
-  public Boolean getAutomatic() {
-    return automatic;
-  }
-
-  public void setAutomatic(Boolean automatic) {
-    this.automatic = automatic;
-  }
-
+  // <editor-fold desc="balanceTransaction">
   public String getBalanceTransaction() {
     return (this.balanceTransaction != null) ? this.balanceTransaction.getId() : null;
   }
@@ -86,23 +57,9 @@ public class Payout extends APIResource implements MetadataStore<Payout>, HasId 
   public void setBalanceTransactionObject(BalanceTransaction c) {
     this.balanceTransaction = new ExpandableField<BalanceTransaction>(c.getId(), c);
   }
+  // </editor-fold>
 
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
+  // <editor-fold desc="destination">
   public String getDestination() {
     return (this.destination != null) ? this.destination.getId() : null;
   }
@@ -118,7 +75,9 @@ public class Payout extends APIResource implements MetadataStore<Payout>, HasId 
   public void setDestinationObject(ExternalAccount c) {
     this.destination = new ExpandableField<ExternalAccount>(c.getId(), c);
   }
+  // </editor-fold>
 
+  // <editor-fold desc="failureBalanceTransaction">
   public String getFailureBalanceTransaction() {
     return (this.failureBalanceTransaction != null) ? this.failureBalanceTransaction.getId()
         : null;
@@ -137,78 +96,7 @@ public class Payout extends APIResource implements MetadataStore<Payout>, HasId 
   public void setFailureBalanceTransactionObject(BalanceTransaction c) {
     this.failureBalanceTransaction = new ExpandableField<BalanceTransaction>(c.getId(), c);
   }
-
-  public String getFailureCode() {
-    return failureCode;
-  }
-
-  public void setFailureCode(String failureCode) {
-    this.failureCode = failureCode;
-  }
-
-  public String getFailureMessage() {
-    return failureMessage;
-  }
-
-  public void setFailureMessage(String failureMessage) {
-    this.failureMessage = failureMessage;
-  }
-
-  public Boolean getLivemode() {
-    return livemode;
-  }
-
-  public void setLivemode(Boolean livemode) {
-    this.livemode = livemode;
-  }
-
-  public Map<String, String> getMetadata() {
-    return metadata;
-  }
-
-  public void setMetadata(Map<String, String> metadata) {
-    this.metadata = metadata;
-  }
-
-  public String getMethod() {
-    return method;
-  }
-
-  public void setMethod(String method) {
-    this.method = method;
-  }
-
-  public String getSourceType() {
-    return sourceType;
-  }
-
-  public void setSourceType(String sourceType) {
-    this.sourceType = sourceType;
-  }
-
-  public String getStatementDescriptor() {
-    return statementDescriptor;
-  }
-
-  public void setStatementDescriptor(String statementDescriptor) {
-    this.statementDescriptor = statementDescriptor;
-  }
-
-  public String getStatus() {
-    return status;
-  }
-
-  public void setStatus(String status) {
-    this.status = status;
-  }
-
-  public String getType() {
-    return type;
-  }
-
-  public void setType(String type) {
-    this.type = type;
-  }
+  // </editor-fold>
 
   public Payout cancel()
       throws AuthenticationException, InvalidRequestException,

--- a/src/main/java/com/stripe/model/Plan.java
+++ b/src/main/java/com/stripe/model/Plan.java
@@ -11,6 +11,14 @@ import com.stripe.net.RequestOptions;
 import java.util.List;
 import java.util.Map;
 
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
   String id;
   String object;
@@ -23,109 +31,55 @@ public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
   Boolean livemode;
   Map<String, String> metadata;
   String nickname;
-  ExpandableField<Product> product;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Product> product;
   List<PlanTier> tiers;
   String tiersMode;
   PlanTransformUsage transformUsage;
   String usageType;
 
-  @Deprecated
-  String statementDescription;
+  /**
+   * The {@code name} attribute.
+   *
+   * @return the {@code name} attribute
+   * @deprecated Prefer using the {@code getProduct().getName()} method instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2018-02-05">API version 2018-02-05</a>
+   */
   @Deprecated
   String name;
+
+  /**
+   * The {@code statement_description} attribute.
+   *
+   * @return the {@code statement_description} attribute
+   * @deprecated Prefer using the {@code getProduct().getStatementDescriptor()} method instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2014-12-17">API version 2014-12-17</a>
+   * @see <a href="https://stripe.com/docs/upgrades#2018-02-05">API version 2018-02-05</a>
+   */
   @Deprecated
-  Integer trialPeriodDays;
+  String statementDescription;
+
+  /**
+   * The {@code statement_descriptor} attribute.
+   *
+   * @return the {@code statement_descriptor} attribute
+   * @deprecated Prefer using the {@code getProduct().getStatementDescriptor()} method instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2018-02-05">API version 2018-02-05</a>
+   */
   @Deprecated
   String statementDescriptor;
 
-  public String getId() {
-    return id;
-  }
+  /**
+   * The {@code trial_period_days} attribute.
+   *
+   * @return the {@code trial_period_days} attribute
+   * @deprecated Prefer using the {@link Subscription#create} method with the {@code trial_end}
+   *     parameter instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2018-02-05">API version 2018-02-05</a>
+   */
+  @Deprecated
+  Integer trialPeriodDays;
 
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public Long getAmount() {
-    return amount;
-  }
-
-  public void setAmount(Long amount) {
-    this.amount = amount;
-  }
-
-  public String getBillingScheme() {
-    return billingScheme;
-  }
-
-  public void setBillingScheme(String billingScheme) {
-    this.billingScheme = billingScheme;
-  }
-
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  public String getInterval() {
-    return interval;
-  }
-
-  public void setInterval(String interval) {
-    this.interval = interval;
-  }
-
-  public Integer getIntervalCount() {
-    return intervalCount;
-  }
-
-  public void setIntervalCount(Integer intervalCount) {
-    this.intervalCount = intervalCount;
-  }
-
-  public Boolean getLivemode() {
-    return livemode;
-  }
-
-  public void setLivemode(Boolean livemode) {
-    this.livemode = livemode;
-  }
-
-  public Map<String, String> getMetadata() {
-    return metadata;
-  }
-
-  public void setMetadata(Map<String, String> metadata) {
-    this.metadata = metadata;
-  }
-
-  public String getNickname() {
-    return nickname;
-  }
-
-  public void setNickname(String nickname) {
-    this.nickname = nickname;
-  }
-
+  // <editor-fold desc="product">
   public String getProduct() {
     return (this.product != null) ? this.product.getId() : null;
   }
@@ -141,70 +95,7 @@ public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
   public void setProductObject(Product product) {
     this.product = new ExpandableField<Product>(product.getId(), product);
   }
-
-  /**
-   * Returns the {@code name} attribute.
-   *
-   * @return the {@code name} attribute
-   * @deprecated Prefer using the {@code getProduct().getName()} method instead.
-   * @see <a href="https://stripe.com/docs/upgrades#2018-02-05">API version 2018-02-05</a>
-   */
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  /**
-   * Returns the {@code statement_descriptor} attribute.
-   *
-   * @return the {@code statement_descriptor} attribute
-   * @deprecated Prefer using the {@code getProduct().getStatementDescriptor()} method instead.
-   * @see <a href="https://stripe.com/docs/upgrades#2018-02-05">API version 2018-02-05</a>
-   */
-  public String getStatementDescriptor() {
-    return statementDescriptor;
-  }
-
-  public void setStatementDescriptor(String statementDescriptor) {
-    this.statementDescriptor = statementDescriptor;
-  }
-
-  /**
-   * Returns the {@code trial_period_days} attribute.
-   *
-   * @return the {@code trial_period_days} attribute
-   * @deprecated Prefer using the {@link Subscription#create} method with the {@code trial_end}
-   *     parameter instead.
-   * @see <a href="https://stripe.com/docs/upgrades#2018-02-05">API version 2018-02-05</a>
-   */
-  public Integer getTrialPeriodDays() {
-    return trialPeriodDays;
-  }
-
-  public void setTrialPeriodDays(Integer trialPeriodDays) {
-    this.trialPeriodDays = trialPeriodDays;
-  }
-
-  /**
-   * Returns the {@code statement_description} attribute.
-   *
-   * @return the {@code statement_description} attribute
-   * @deprecated Prefer using the {@code getProduct().getStatementDescriptor()} method instead.
-   * @see <a href="https://stripe.com/docs/upgrades#2014-12-17">API version 2014-12-17</a>
-   * @see <a href="https://stripe.com/docs/upgrades#2018-02-05">API version 2018-02-05</a>
-   */
-  @Deprecated
-  public String getStatementDescription() {
-    return statementDescription;
-  }
-
-  @Deprecated
-  public void setStatementDescription(String statementDescription) {
-    this.statementDescription = statementDescription;
-  }
+  // </editor-fold>
 
   public List<PlanTier> getTiers() {
     return tiers;

--- a/src/main/java/com/stripe/model/Product.java
+++ b/src/main/java/com/stripe/model/Product.java
@@ -11,6 +11,14 @@ import com.stripe.net.RequestOptions;
 import java.util.List;
 import java.util.Map;
 
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class Product extends APIResource implements HasId, MetadataStore<Product> {
   String id;
   String object;
@@ -30,152 +38,9 @@ public class Product extends APIResource implements HasId, MetadataStore<Product
   String statementDescriptor;
   String type;
   Long updated;
-  String url;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) String url;
 
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public Boolean getActive() {
-    return active;
-  }
-
-  public void setActive(Boolean active) {
-    this.active = active;
-  }
-
-  public List<String> getAttributes() {
-    return attributes;
-  }
-
-  public void setAttributes(List<String> attributes) {
-    this.attributes = attributes;
-  }
-
-  public String getCaption() {
-    return caption;
-  }
-
-  public void setCaption(String caption) {
-    this.caption = caption;
-  }
-
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
-  public List<String> getDeactivateOn() {
-    return deactivateOn;
-  }
-
-  public void setDeactivateOn(List<String> deactivateOn) {
-    this.deactivateOn = deactivateOn;
-  }
-
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  public List<String> getImages() {
-    return images;
-  }
-
-  public void setImages(List<String> images) {
-    this.images = images;
-  }
-
-  public Boolean getLivemode() {
-    return livemode;
-  }
-
-  public void setLivemode(Boolean livemode) {
-    this.livemode = livemode;
-  }
-
-  public Map<String, String> getMetadata() {
-    return metadata;
-  }
-
-  public void setMetadata(Map<String, String> metadata) {
-    this.metadata = metadata;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public PackageDimensions getPackageDimensions() {
-    return packageDimensions;
-  }
-
-  public void setPackageDimensions(PackageDimensions packageDimensions) {
-    this.packageDimensions = packageDimensions;
-  }
-
-  public Boolean getShippable() {
-    return shippable;
-  }
-
-  public void setShippable(Boolean shippable) {
-    this.shippable = shippable;
-  }
-
-  public SKUCollection getSkus() {
-    return skus;
-  }
-
-  public void setSkus(SKUCollection skus) {
-    this.skus = skus;
-  }
-
-  public Long getUpdated() {
-    return updated;
-  }
-
-  public void setUpdated(Long updated) {
-    this.updated = updated;
-  }
-
-  public String getStatementDescriptor() {
-    return statementDescriptor;
-  }
-
-  public void setStatementDescriptor(String statementDescriptor) {
-    this.statementDescriptor = statementDescriptor;
-  }
-
-  public String getType() {
-    return type;
-  }
-
-  public void setType(String type) {
-    this.type = type;
-  }
-
+  // <editor-fold desc="url">
   public String getURL() {
     return url;
   }
@@ -183,6 +48,7 @@ public class Product extends APIResource implements HasId, MetadataStore<Product
   public void setURL(String url) {
     this.url = url;
   }
+  // </editor-fold>
 
   public static Product create(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,

--- a/src/main/java/com/stripe/model/Recipient.java
+++ b/src/main/java/com/stripe/model/Recipient.java
@@ -11,59 +11,32 @@ import com.stripe.net.RequestOptions;
 import java.util.HashMap;
 import java.util.Map;
 
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class Recipient extends APIResource implements MetadataStore<Recipient>, HasId {
   String id;
   String object;
   BankAccount activeAccount;
   RecipientCardCollection cards;
   Long created;
-  ExpandableField<Card> defaultCard;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Card> defaultCard;
   Boolean deleted;
   String description;
   String email;
   Boolean livemode;
   Map<String, String> metadata;
-  ExpandableField<Account> migratedTo;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Account> migratedTo;
   String name;
   String type;
   Boolean verified;
 
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public BankAccount getActiveAccount() {
-    return activeAccount;
-  }
-
-  public void setActiveAccount(BankAccount activeAccount) {
-    this.activeAccount = activeAccount;
-  }
-
-  public RecipientCardCollection getCards() {
-    return cards;
-  }
-
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
+  // <editor-fold desc="defaultCard">
   public String getDefaultCard() {
     return (this.defaultCard != null) ? this.defaultCard.getId() : null;
   }
@@ -79,43 +52,9 @@ public class Recipient extends APIResource implements MetadataStore<Recipient>, 
   public void setDefaultCardObject(Card c) {
     this.defaultCard = new ExpandableField<Card>(c.getId(), c);
   }
+  // </editor-fold>
 
-  public Boolean getDeleted() {
-    return deleted;
-  }
-
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  public String getEmail() {
-    return email;
-  }
-
-  public void setEmail(String email) {
-    this.email = email;
-  }
-
-  public Boolean getLivemode() {
-    return livemode;
-  }
-
-  public void setLivemode(Boolean livemode) {
-    this.livemode = livemode;
-  }
-
-  public Map<String, String> getMetadata() {
-    return metadata;
-  }
-
-  public void setMetadata(Map<String, String> metadata) {
-    this.metadata = metadata;
-  }
-
+  // <editor-fold desc="migratedTo">
   public String getMigratedTo() {
     return (this.migratedTo != null) ? this.migratedTo.getId() : null;
   }
@@ -131,30 +70,7 @@ public class Recipient extends APIResource implements MetadataStore<Recipient>, 
   public void setMigratedToObject(Account c) {
     this.migratedTo = new ExpandableField<Account>(c.getId(), c);
   }
-
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public String getType() {
-    return type;
-  }
-
-  public void setType(String type) {
-    this.type = type;
-  }
-
-  public Boolean getVerified() {
-    return verified;
-  }
-
-  public void setVerified(Boolean verified) {
-    this.verified = verified;
-  }
+  // </editor-fold>
 
   public static Recipient create(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,

--- a/src/main/java/com/stripe/model/Refund.java
+++ b/src/main/java/com/stripe/model/Refund.java
@@ -10,12 +10,21 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class Refund extends APIResource implements MetadataStore<Charge>, HasId {
   String id;
   String object;
   Long amount;
-  ExpandableField<BalanceTransaction> balanceTransaction;
-  ExpandableField<Charge> charge;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+      ExpandableField<BalanceTransaction> balanceTransaction;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Charge> charge;
   Long created;
   String currency;
   String description;
@@ -24,30 +33,7 @@ public class Refund extends APIResource implements MetadataStore<Charge>, HasId 
   String receiptNumber;
   String status;
 
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public Long getAmount() {
-    return amount;
-  }
-
-  public void setAmount(Long amount) {
-    this.amount = amount;
-  }
-
+  // <editor-fold desc="balanceTransaction">
   public String getBalanceTransaction() {
     return (this.balanceTransaction != null) ? this.balanceTransaction.getId() : null;
   }
@@ -63,7 +49,9 @@ public class Refund extends APIResource implements MetadataStore<Charge>, HasId 
   public void setBalanceTransactionObject(BalanceTransaction c) {
     this.balanceTransaction = new ExpandableField<BalanceTransaction>(c.getId(), c);
   }
+  // </editor-fold>
 
+  // <editor-fold desc="charge">
   public String getCharge() {
     return (this.charge != null) ? this.charge.getId() : null;
   }
@@ -79,62 +67,7 @@ public class Refund extends APIResource implements MetadataStore<Charge>, HasId 
   public void setChargeObject(Charge c) {
     this.charge = new ExpandableField<Charge>(c.getId(), c);
   }
-
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  public Map<String, String> getMetadata() {
-    return metadata;
-  }
-
-  public void setMetadata(Map<String, String> metadata) {
-    this.metadata = metadata;
-  }
-
-  public String getReason() {
-    return reason;
-  }
-
-  public void setReason(String reason) {
-    this.reason = reason;
-  }
-
-  public String getReceiptNumber() {
-    return receiptNumber;
-  }
-
-  public void setReceiptNumber(String receiptNumber) {
-    this.receiptNumber = receiptNumber;
-  }
-
-  public String getStatus() {
-    return status;
-  }
-
-  public void setStatus(String status) {
-    this.status = status;
-  }
+  // </editor-fold>
 
   public Refund update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,

--- a/src/main/java/com/stripe/model/Reversal.java
+++ b/src/main/java/com/stripe/model/Reversal.java
@@ -10,36 +10,26 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class Reversal extends APIResource implements MetadataStore<Transfer>, HasId {
   String id;
   String object;
   Long amount;
-  ExpandableField<BalanceTransaction> balanceTransaction;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+      ExpandableField<BalanceTransaction> balanceTransaction;
   Long created;
   String currency;
   Map<String, String> metadata;
-  ExpandableField<Transfer> transfer;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Transfer> transfer;
 
-  public String getId() {
-    return id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public Long getAmount() {
-    return amount;
-  }
-
-  public void setAmount(Long amount) {
-    this.amount = amount;
-  }
-
+  // <editor-fold desc="balanceTransaction">
   public String getBalanceTransaction() {
     return (this.balanceTransaction != null) ? this.balanceTransaction.getId() : null;
   }
@@ -55,31 +45,9 @@ public class Reversal extends APIResource implements MetadataStore<Transfer>, Ha
   public void setBalanceTransactionObject(BalanceTransaction c) {
     this.balanceTransaction = new ExpandableField<BalanceTransaction>(c.getId(), c);
   }
+  // </editor-fold>
 
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  public Map<String, String> getMetadata() {
-    return metadata;
-  }
-
-  public void setMetadata(Map<String, String> metadata) {
-    this.metadata = metadata;
-  }
-
+  // <editor-fold desc="transfer">
   public String getTransfer() {
     return (this.transfer != null) ? this.transfer.getId() : null;
   }
@@ -95,6 +63,7 @@ public class Reversal extends APIResource implements MetadataStore<Transfer>, Ha
   public void setTransferObject(Transfer c) {
     this.transfer = new ExpandableField<Transfer>(c.getId(), c);
   }
+  // </editor-fold>
 
   public Reversal update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,

--- a/src/main/java/com/stripe/model/Review.java
+++ b/src/main/java/com/stripe/model/Review.java
@@ -1,5 +1,12 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class Review extends StripeObject implements HasId {
   String id;
   String object;
@@ -8,60 +15,4 @@ public class Review extends StripeObject implements HasId {
   Boolean livemode;
   Boolean open;
   String reason;
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public String getCharge() {
-    return this.charge;
-  }
-
-  public void setCharge(String charge) {
-    this.charge = charge;
-  }
-
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
-  public Boolean getLivemode() {
-    return livemode;
-  }
-
-  public void setLivemode(Boolean livemode) {
-    this.livemode = livemode;
-  }
-
-  public Boolean getOpen() {
-    return open;
-  }
-
-  public void setOpen(Boolean open) {
-    this.open = open;
-  }
-
-  public String getReason() {
-    return reason;
-  }
-
-  public void setReason(String reason) {
-    this.reason = reason;
-  }
 }

--- a/src/main/java/com/stripe/model/SKU.java
+++ b/src/main/java/com/stripe/model/SKU.java
@@ -10,6 +10,14 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class SKU extends APIResource implements HasId, MetadataStore<SKU> {
   String id;
   String object;
@@ -23,105 +31,10 @@ public class SKU extends APIResource implements HasId, MetadataStore<SKU> {
   Map<String, String> metadata;
   PackageDimensions packageDimensions;
   Integer price;
-  ExpandableField<Product> product;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Product> product;
   Long updated;
 
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public Boolean getActive() {
-    return active;
-  }
-
-  public void setActive(Boolean active) {
-    this.active = active;
-  }
-
-  public Map<String, String> getAttributes() {
-    return attributes;
-  }
-
-  public void setAttributes(Map<String, String> attributes) {
-    this.attributes = attributes;
-  }
-
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  public String getImage() {
-    return image;
-  }
-
-  public void setImage(String image) {
-    this.image = image;
-  }
-
-  public Inventory getInventory() {
-    return inventory;
-  }
-
-  public void setInventory(Inventory inventory) {
-    this.inventory = inventory;
-  }
-
-  public Boolean getLivemode() {
-    return livemode;
-  }
-
-  public void setLivemode(Boolean livemode) {
-    this.livemode = livemode;
-  }
-
-  public Map<String, String> getMetadata() {
-    return metadata;
-  }
-
-  public void setMetadata(Map<String, String> metadata) {
-    this.metadata = metadata;
-  }
-
-  public PackageDimensions getPackageDimensions() {
-    return packageDimensions;
-  }
-
-  public void setPackageDimensions(PackageDimensions packageDimensions) {
-    this.packageDimensions = packageDimensions;
-  }
-
-  public Integer getPrice() {
-    return price;
-  }
-
-  public void setPrice(Integer price) {
-    this.price = price;
-  }
-
+  // <editor-fold desc="product">
   public String getProduct() {
     return (this.product != null) ? this.product.getId() : null;
   }
@@ -138,14 +51,7 @@ public class SKU extends APIResource implements HasId, MetadataStore<SKU> {
   public void setProductObject(Product product) {
     this.product = new ExpandableField<Product>(product.getId(), product);
   }
-
-  public Long getUpdated() {
-    return updated;
-  }
-
-  public void setUpdated(Long updated) {
-    this.updated = updated;
-  }
+  // </editor-fold>
 
   public static SKU create(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,

--- a/src/main/java/com/stripe/model/ShippingDetails.java
+++ b/src/main/java/com/stripe/model/ShippingDetails.java
@@ -1,59 +1,14 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public final class ShippingDetails extends StripeObject {
   protected Address address;
   protected String name;
   protected String phone;
-
-  public Address getAddress() {
-    return address;
-  }
-
-  public void setAddress(Address address) {
-    this.address = address;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public String getPhone() {
-    return phone;
-  }
-
-  public void setPhone(String phone) {
-    this.phone = phone;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-
-    ShippingDetails that = (ShippingDetails) o;
-
-    if (address != null ? !address.equals(that.address) : that.address != null) {
-      return false;
-    }
-    if (name != null ? !name.equals(that.name) : that.name != null) {
-      return false;
-    }
-    return phone != null ? phone.equals(that.phone) : that.phone == null;
-  }
-
-  @Override
-  public int hashCode() {
-    int result = address != null ? address.hashCode() : 0;
-    result = 31 * result + (name != null ? name.hashCode() : 0);
-    result = 31 * result + (phone != null ? phone.hashCode() : 0);
-    return result;
-  }
 }

--- a/src/main/java/com/stripe/model/ShippingMethod.java
+++ b/src/main/java/com/stripe/model/ShippingMethod.java
@@ -1,40 +1,15 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class ShippingMethod extends StripeObject {
   String id;
   Long amount;
   String currency;
   String description;
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public Long getAmount() {
-    return amount;
-  }
-
-  public void setAmount(Long amount) {
-    this.amount = amount;
-  }
-
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
 }

--- a/src/main/java/com/stripe/model/Source.java
+++ b/src/main/java/com/stripe/model/Source.java
@@ -9,6 +9,13 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = true)
 public class Source extends ExternalAccount implements HasSourceTypeData {
   Long amount;
   String clientSecret;
@@ -27,128 +34,6 @@ public class Source extends ExternalAccount implements HasSourceTypeData {
 
   // Type-specific properties
   Map<String, String> typeData;
-
-  public Long getAmount() {
-    return amount;
-  }
-
-  public void setAmount(Long amount) {
-    this.amount = amount;
-  }
-
-  public String getClientSecret() {
-    return clientSecret;
-  }
-
-  public void setClientSecret(String clientSecret) {
-    this.clientSecret = clientSecret;
-  }
-
-  public SourceCodeVerificationFlow getCodeVerification() {
-    return codeVerification;
-  }
-
-  public void setCodeVerification(SourceCodeVerificationFlow codeVerification) {
-    this.codeVerification = codeVerification;
-  }
-
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  public String getFlow() {
-    return flow;
-  }
-
-  public void setFlow(String flow) {
-    this.flow = flow;
-  }
-
-  public Boolean getLivemode() {
-    return livemode;
-  }
-
-  public void setLivemode(Boolean livemode) {
-    this.livemode = livemode;
-  }
-
-  public SourceOwner getOwner() {
-    return owner;
-  }
-
-  public void setOwner(SourceOwner owner) {
-    this.owner = owner;
-  }
-
-  public SourceReceiverFlow getReceiver() {
-    return receiver;
-  }
-
-  public void setReceiver(SourceReceiverFlow receiver) {
-    this.receiver = receiver;
-  }
-
-  public SourceRedirectFlow getRedirect() {
-    return redirect;
-  }
-
-  public void setRedirect(SourceRedirectFlow redirect) {
-    this.redirect = redirect;
-  }
-
-  public String getStatementDescriptor() {
-    return statementDescriptor;
-  }
-
-  public void setStatementDescriptor(String statementDescriptor) {
-    this.statementDescriptor = statementDescriptor;
-  }
-
-  public String getStatus() {
-    return status;
-  }
-
-  public void setStatus(String status) {
-    this.status = status;
-  }
-
-  public String getUsage() {
-    return usage;
-  }
-
-  public void setUsage(String usage) {
-    this.usage = usage;
-  }
-
-  public String getType() {
-    return type;
-  }
-
-  public void setType(String type) {
-    this.type = type;
-  }
-
-  // Type-specific getters/setters
-
-  public Map<String, String> getTypeData() {
-    return typeData;
-  }
-
-  public void setTypeData(Map<String, String> typeData) {
-    this.typeData = typeData;
-  }
 
   // APIResource methods
 

--- a/src/main/java/com/stripe/model/SourceCodeVerificationFlow.java
+++ b/src/main/java/com/stripe/model/SourceCodeVerificationFlow.java
@@ -1,22 +1,13 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public final class SourceCodeVerificationFlow extends StripeObject {
   Integer attemptsRemaining;
   String status;
-
-  public Integer getAttemptsRemaining() {
-    return attemptsRemaining;
-  }
-
-  public void setAttemptsRemaining(Integer attemptsRemaining) {
-    this.attemptsRemaining = attemptsRemaining;
-  }
-
-  public String getStatus() {
-    return status;
-  }
-
-  public void setStatus(String status) {
-    this.status = status;
-  }
 }

--- a/src/main/java/com/stripe/model/SourceMandateNotification.java
+++ b/src/main/java/com/stripe/model/SourceMandateNotification.java
@@ -4,6 +4,13 @@ import com.stripe.net.APIResource;
 
 import java.util.Map;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class SourceMandateNotification extends APIResource implements HasId, HasSourceTypeData {
   String id;
   String object;
@@ -17,86 +24,4 @@ public class SourceMandateNotification extends APIResource implements HasId, Has
 
   // Type-specific properties
   Map<String, String> typeData;
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public Long getAmount() {
-    return amount;
-  }
-
-  public void setAmount(Long amount) {
-    this.amount = amount;
-  }
-
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
-  public Boolean getLivemode() {
-    return livemode;
-  }
-
-  public void setLivemode(Boolean livemode) {
-    this.livemode = livemode;
-  }
-
-  public String getReason() {
-    return reason;
-  }
-
-  public void setReason(String reason) {
-    this.reason = reason;
-  }
-
-  public Source getSource() {
-    return source;
-  }
-
-  public void setSource(Source source) {
-    this.source = source;
-  }
-
-  public String getStatus() {
-    return status;
-  }
-
-  public void setStatus(String status) {
-    this.status = status;
-  }
-
-  public String getType() {
-    return type;
-  }
-
-  public void setType(String type) {
-    this.type = type;
-  }
-
-  // Type-specific getters/setters
-
-  public Map<String, String> getTypeData() {
-    return typeData;
-  }
-
-  public void setTypeData(Map<String, String> typeData) {
-    this.typeData = typeData;
-  }
 }

--- a/src/main/java/com/stripe/model/SourceOwner.java
+++ b/src/main/java/com/stripe/model/SourceOwner.java
@@ -1,5 +1,12 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public final class SourceOwner extends StripeObject {
   protected Address address;
   protected Address verifiedAddress;
@@ -9,68 +16,4 @@ public final class SourceOwner extends StripeObject {
   protected String verifiedPhone;
   protected String email;
   protected String verifiedEmail;
-
-  public Address getAddress() {
-    return address;
-  }
-
-  public void setAddress(Address address) {
-    this.address = address;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public String getPhone() {
-    return phone;
-  }
-
-  public void setPhone(String phone) {
-    this.phone = phone;
-  }
-
-  public String getEmail() {
-    return email;
-  }
-
-  public void setEmail(String email) {
-    this.email = email;
-  }
-
-  public Address getVerifiedAddress() {
-    return address;
-  }
-
-  public void setVerifiedAddress(Address address) {
-    this.verifiedAddress = address;
-  }
-
-  public String getVerifiedName() {
-    return name;
-  }
-
-  public void setVerifiedName(String name) {
-    this.verifiedName = name;
-  }
-
-  public String getVerifiedPhone() {
-    return phone;
-  }
-
-  public void setVerifiedPhone(String phone) {
-    this.verifiedPhone = phone;
-  }
-
-  public String getVerifiedEmail() {
-    return email;
-  }
-
-  public void setVerifiedEmail(String email) {
-    this.verifiedEmail = email;
-  }
 }

--- a/src/main/java/com/stripe/model/SourceReceiverFlow.java
+++ b/src/main/java/com/stripe/model/SourceReceiverFlow.java
@@ -1,5 +1,12 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public final class SourceReceiverFlow extends StripeObject {
   String refundAttributesStatus;
   String refundAttributesMethod;
@@ -7,52 +14,4 @@ public final class SourceReceiverFlow extends StripeObject {
   Long amountReturned;
   Long amountCharged;
   String address;
-
-  public String getRefundAttributesStatus() {
-    return refundAttributesStatus;
-  }
-
-  public void setRefundAttributesStatus(String refundAttributesStatus) {
-    this.refundAttributesStatus = refundAttributesStatus;
-  }
-
-  public String getRefundAttributesMethod() {
-    return refundAttributesMethod;
-  }
-
-  public void setRefundAttributesMethod(String refundAttributesMethod) {
-    this.refundAttributesMethod = refundAttributesMethod;
-  }
-
-  public Long getAmountReceived() {
-    return amountReceived;
-  }
-
-  public void setAmountReceived(Long amountReceived) {
-    this.amountReceived = amountReceived;
-  }
-
-  public Long getAmountReturned() {
-    return amountReturned;
-  }
-
-  public void setAmountReturned(Long amountReturned) {
-    this.amountReturned = amountReturned;
-  }
-
-  public Long getAmountCharged() {
-    return amountCharged;
-  }
-
-  public void setAmountCharged(Long amountCharged) {
-    this.amountCharged = amountCharged;
-  }
-
-  public String getAddress() {
-    return address;
-  }
-
-  public void setAddress(String address) {
-    this.address = address;
-  }
 }

--- a/src/main/java/com/stripe/model/SourceRedirectFlow.java
+++ b/src/main/java/com/stripe/model/SourceRedirectFlow.java
@@ -1,19 +1,20 @@
 package com.stripe.model;
 
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public final class SourceRedirectFlow extends StripeObject {
   String failureReason;
-  String returnUrl;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) String returnUrl;
   String status;
-  String url;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) String url;
 
-  public String getFailureReason() {
-    return failureReason;
-  }
-
-  public void setFailureReason(String failureReason) {
-    this.failureReason = failureReason;
-  }
-
+  // <editor-fold desc="returnUrl">
   public String getReturnURL() {
     return returnUrl;
   }
@@ -21,15 +22,9 @@ public final class SourceRedirectFlow extends StripeObject {
   public void setReturnURL(String returnUrl) {
     this.returnUrl = returnUrl;
   }
+  // </editor-fold>
 
-  public String getStatus() {
-    return status;
-  }
-
-  public void setStatus(String status) {
-    this.status = status;
-  }
-
+  // <editor-fold desc="url">
   public String getURL() {
     return url;
   }
@@ -37,4 +32,5 @@ public final class SourceRedirectFlow extends StripeObject {
   public void setURL(String url) {
     this.url = url;
   }
+  // </editor-fold>
 }

--- a/src/main/java/com/stripe/model/SourceTransaction.java
+++ b/src/main/java/com/stripe/model/SourceTransaction.java
@@ -4,6 +4,13 @@ import com.stripe.net.APIResource;
 
 import java.util.Map;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class SourceTransaction extends APIResource implements HasId, HasSourceTypeData {
   String id;
   String object;
@@ -17,86 +24,4 @@ public class SourceTransaction extends APIResource implements HasId, HasSourceTy
 
   // Type-specific properties
   Map<String, String> typeData;
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public Long getAmount() {
-    return amount;
-  }
-
-  public void setAmount(Long amount) {
-    this.amount = amount;
-  }
-
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  public String getCustomerData() {
-    return customerData;
-  }
-
-  public void setCustomerData(String customerData) {
-    this.customerData = customerData;
-  }
-
-  public Boolean getLivemode() {
-    return livemode;
-  }
-
-  public void setLivemode(Boolean livemode) {
-    this.livemode = livemode;
-  }
-
-  public String getSource() {
-    return source;
-  }
-
-  public void setSource(String source) {
-    this.source = source;
-  }
-
-  public String getType() {
-    return type;
-  }
-
-  public void setType(String type) {
-    this.type = type;
-  }
-
-  // Type-specific getters/setters
-
-  public Map<String, String> getTypeData() {
-    return typeData;
-  }
-
-  public void setTypeData(Map<String, String> typeData) {
-    this.typeData = typeData;
-  }
 }

--- a/src/main/java/com/stripe/model/StatusTransitions.java
+++ b/src/main/java/com/stripe/model/StatusTransitions.java
@@ -2,41 +2,16 @@ package com.stripe.model;
 
 import com.stripe.net.APIResource;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class StatusTransitions extends APIResource {
   Long canceled;
   Long fulfiled;
   Long paid;
   Long returned;
-
-  public Long getCanceled() {
-    return canceled;
-  }
-
-  public void setCanceled(Long canceled) {
-    this.canceled = canceled;
-  }
-
-  public Long getFulfiled() {
-    return fulfiled;
-  }
-
-  public void setFulfiled(Long fulfiled) {
-    this.fulfiled = fulfiled;
-  }
-
-  public Long getPaid() {
-    return paid;
-  }
-
-  public void setPaid(Long paid) {
-    this.paid = paid;
-  }
-
-  public Long getReturned() {
-    return returned;
-  }
-
-  public void setReturned(Long returned) {
-    this.returned = returned;
-  }
 }

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -10,7 +10,14 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class Subscription extends APIResource implements MetadataStore<Subscription>, HasId {
   String id;
   String object;
@@ -22,11 +29,11 @@ public class Subscription extends APIResource implements MetadataStore<Subscript
   Long created;
   Long currentPeriodEnd;
   Long currentPeriodStart;
-  ExpandableField<Customer> customer;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Customer> customer;
   Integer daysUntilDue;
   Discount discount;
   Long endedAt;
-  SubscriptionItemCollection items;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) SubscriptionItemCollection items;
   Map<String, String> metadata;
   Plan plan;
   Integer quantity;
@@ -36,86 +43,7 @@ public class Subscription extends APIResource implements MetadataStore<Subscript
   Long trialEnd;
   Long trialStart;
 
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public Double getApplicationFeePercent() {
-    return applicationFeePercent;
-  }
-
-  public void setApplicationFeePercent(Double applicationFeePercent) {
-    this.applicationFeePercent = applicationFeePercent;
-  }
-
-  public String getBilling() {
-    return billing;
-  }
-
-  public void setBilling(String billing) {
-    this.billing = billing;
-  }
-
-  public Long getBillingCycleAnchor() {
-    return billingCycleAnchor;
-  }
-
-  public void setBillingCycleAnchor(Long billingCycleAnchor) {
-    this.billingCycleAnchor = billingCycleAnchor;
-  }
-
-  public Boolean getCancelAtPeriodEnd() {
-    return cancelAtPeriodEnd;
-  }
-
-  public void setCancelAtPeriodEnd(Boolean cancelAtPeriodEnd) {
-    this.cancelAtPeriodEnd = cancelAtPeriodEnd;
-  }
-
-  public Long getCanceledAt() {
-    return canceledAt;
-  }
-
-  public void setCanceledAt(Long canceledAt) {
-    this.canceledAt = canceledAt;
-  }
-
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
-  public Long getCurrentPeriodEnd() {
-    return currentPeriodEnd;
-  }
-
-  public void setCurrentPeriodEnd(Long currentPeriodEnd) {
-    this.currentPeriodEnd = currentPeriodEnd;
-  }
-
-  public Long getCurrentPeriodStart() {
-    return currentPeriodStart;
-  }
-
-  public void setCurrentPeriodStart(Long currentPeriodStart) {
-    this.currentPeriodStart = currentPeriodStart;
-  }
-
+  // <editor-fold desc="customer">
   public String getCustomer() {
     return (this.customer != null) ? this.customer.getId() : null;
   }
@@ -131,95 +59,9 @@ public class Subscription extends APIResource implements MetadataStore<Subscript
   public void setCustomerObject(Customer c) {
     this.customer = new ExpandableField<Customer>(c.getId(), c);
   }
+  // </editor-fold>
 
-  public Integer getDaysUntilDue() {
-    return daysUntilDue;
-  }
-
-  public void setDaysUntilDue(Integer daysUntilDue) {
-    this.daysUntilDue = daysUntilDue;
-  }
-
-  public Discount getDiscount() {
-    return discount;
-  }
-
-  public void setDiscount(Discount discount) {
-    this.discount = discount;
-  }
-
-  public Long getEndedAt() {
-    return endedAt;
-  }
-
-  public void setEndedAt(Long endedAt) {
-    this.endedAt = endedAt;
-  }
-
-  public Map<String, String> getMetadata() {
-    return metadata;
-  }
-
-  public void setMetadata(Map<String, String> metadata) {
-    this.metadata = metadata;
-  }
-
-  public Plan getPlan() {
-    return plan;
-  }
-
-  public void setPlan(Plan plan) {
-    this.plan = plan;
-  }
-
-  public Integer getQuantity() {
-    return quantity;
-  }
-
-  public void setQuantity(Integer quantity) {
-    this.quantity = quantity;
-  }
-
-  public Long getStart() {
-    return start;
-  }
-
-  public void setStart(Long start) {
-    this.start = start;
-  }
-
-  public String getStatus() {
-    return status;
-  }
-
-  public void setStatus(String status) {
-    this.status = status;
-  }
-
-  public Double getTaxPercent() {
-    return taxPercent;
-  }
-
-  public void setTaxPercent(Double taxPercent) {
-    this.taxPercent = taxPercent;
-  }
-
-  public Long getTrialEnd() {
-    return trialEnd;
-  }
-
-  public void setTrialEnd(Long trialEnd) {
-    this.trialEnd = trialEnd;
-  }
-
-  public Long getTrialStart() {
-    return trialStart;
-  }
-
-  public void setTrialStart(Long trialStart) {
-    this.trialStart = trialStart;
-  }
-
+  // <editor-fold desc="items">
   public SubscriptionItemCollection getSubscriptionItems() {
     return items;
   }
@@ -227,6 +69,7 @@ public class Subscription extends APIResource implements MetadataStore<Subscript
   public void setSubscriptionItems(SubscriptionItemCollection items) {
     this.items = items;
   }
+  // </editor-fold>
 
   @Deprecated
   public static SubscriptionCollection all(Map<String, Object> params)

--- a/src/main/java/com/stripe/model/SubscriptionItem.java
+++ b/src/main/java/com/stripe/model/SubscriptionItem.java
@@ -10,53 +10,20 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class SubscriptionItem extends APIResource implements HasId {
   String id;
   String object;
   Long created;
   Plan plan;
   Integer quantity;
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
-  public Plan getPlan() {
-    return plan;
-  }
-
-  public void setPlan(Plan plan) {
-    this.plan = plan;
-  }
-
-  public Integer getQuantity() {
-    return quantity;
-  }
-
-  public void setQuantity(Integer quantity) {
-    this.quantity = quantity;
-  }
 
   public static SubscriptionItem create(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,

--- a/src/main/java/com/stripe/model/Summary.java
+++ b/src/main/java/com/stripe/model/Summary.java
@@ -1,5 +1,12 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class Summary extends StripeObject {
   Integer adjustmentCount;
   Long adjustmentGross;
@@ -12,92 +19,4 @@ public class Summary extends StripeObject {
   Long refundGross;
   Integer validationCount;
   Long validationFees;
-
-  public Integer getAdjustmentCount() {
-    return adjustmentCount;
-  }
-
-  public void setAdjustmentCount(Integer adjustmentCount) {
-    this.adjustmentCount = adjustmentCount;
-  }
-
-  public Long getAdjustmentGross() {
-    return adjustmentGross;
-  }
-
-  public void setAdjustmentGross(Long adjustmentGross) {
-    this.adjustmentGross = adjustmentGross;
-  }
-
-  public Integer getChargeCount() {
-    return chargeCount;
-  }
-
-  public void setChargeCount(Integer chargeCount) {
-    this.chargeCount = chargeCount;
-  }
-
-  public Long getChargeFees() {
-    return chargeFees;
-  }
-
-  public void setChargeFees(Long chargeFees) {
-    this.chargeFees = chargeFees;
-  }
-
-  public Long getChargeGross() {
-    return chargeGross;
-  }
-
-  public void setChargeGross(Long chargeGross) {
-    this.chargeGross = chargeGross;
-  }
-
-  public Long getNet() {
-    return net;
-  }
-
-  public void setNet(Long net) {
-    this.net = net;
-  }
-
-  public Integer getRefundCount() {
-    return refundCount;
-  }
-
-  public void setRefundCount(Integer refundCount) {
-    this.refundCount = refundCount;
-  }
-
-  public Long getRefundFees() {
-    return refundFees;
-  }
-
-  public void setRefundFees(Long refundFees) {
-    this.refundFees = refundFees;
-  }
-
-  public Long getRefundGross() {
-    return refundGross;
-  }
-
-  public void setRefundGross(Long refundGross) {
-    this.refundGross = refundGross;
-  }
-
-  public Integer getValidationCount() {
-    return validationCount;
-  }
-
-  public void setValidationCount(Integer validationCount) {
-    this.validationCount = validationCount;
-  }
-
-  public Long getValidationFees() {
-    return validationFees;
-  }
-
-  public void setValidationFees(Long validationFees) {
-    this.validationFees = validationFees;
-  }
 }

--- a/src/main/java/com/stripe/model/ThreeDSecure.java
+++ b/src/main/java/com/stripe/model/ThreeDSecure.java
@@ -13,6 +13,14 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class ThreeDSecure extends APIResource implements HasId {
   String id;
   String object;
@@ -22,89 +30,8 @@ public class ThreeDSecure extends APIResource implements HasId {
   Long created;
   String currency;
   Boolean livemode;
-  @SerializedName("redirect_url")
-  String redirectURL;
+  @SerializedName("redirect_url") String redirectURL;
   String status;
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public Long getAmount() {
-    return amount;
-  }
-
-  public void setAmount(Long amount) {
-    this.amount = amount;
-  }
-
-  public Boolean getAuthenticated() {
-    return authenticated;
-  }
-
-  public void setAuthenticated(Boolean authenticated) {
-    this.authenticated = authenticated;
-  }
-
-  public Card getCard() {
-    return card;
-  }
-
-  public void setCard(Card card) {
-    this.card = card;
-  }
-
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  public Boolean getLivemode() {
-    return livemode;
-  }
-
-  public void setLivemode(Boolean livemode) {
-    this.livemode = livemode;
-  }
-
-  public String getRedirectURL() {
-    return redirectURL;
-  }
-
-  public void setRedirectURL(String redirectURL) {
-    this.redirectURL = redirectURL;
-  }
-
-  public String getStatus() {
-    return status;
-  }
-
-  public void setStatus(String status) {
-    this.status = status;
-  }
 
   public static ThreeDSecure create(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,

--- a/src/main/java/com/stripe/model/Token.java
+++ b/src/main/java/com/stripe/model/Token.java
@@ -10,6 +10,13 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class Token extends APIResource implements HasId {
   String id;
   String object;
@@ -23,102 +30,6 @@ public class Token extends APIResource implements HasId {
   Boolean livemode;
   String type;
   Boolean used;
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public Long getAmount() {
-    return amount;
-  }
-
-  public void setAmount(Long amount) {
-    this.amount = amount;
-  }
-
-  public BankAccount getBankAccount() {
-    return bankAccount;
-  }
-
-  public void setBankAccount(BankAccount bankAccount) {
-    this.bankAccount = bankAccount;
-  }
-
-  public Card getCard() {
-    return card;
-  }
-
-  public void setCard(Card card) {
-    this.card = card;
-  }
-
-  public String getClientIp() {
-    return clientIp;
-  }
-
-  public void setClientIp(String clientIp) {
-    this.clientIp = clientIp;
-  }
-
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  public String getEmail() {
-    return email;
-  }
-
-  public void setEmail(String email) {
-    this.email = email;
-  }
-
-  public Boolean getLivemode() {
-    return livemode;
-  }
-
-  public void setLivemode(Boolean livemode) {
-    this.livemode = livemode;
-  }
-
-  public String getType() {
-    return type;
-  }
-
-  public void setType(String type) {
-    this.type = type;
-  }
-
-  public Boolean getUsed() {
-    return used;
-  }
-
-  public void setUsed(Boolean used) {
-    this.used = used;
-  }
 
   public static Token create(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,

--- a/src/main/java/com/stripe/model/Topup.java
+++ b/src/main/java/com/stripe/model/Topup.java
@@ -10,11 +10,20 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class Topup extends APIResource implements MetadataStore<Topup>, HasId {
   String id;
   String object;
   Integer amount;
-  ExpandableField<BalanceTransaction> balanceTransaction;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+      ExpandableField<BalanceTransaction> balanceTransaction;
   Long created;
   String currency;
   String description;
@@ -27,31 +36,7 @@ public class Topup extends APIResource implements MetadataStore<Topup>, HasId {
   String statementDescriptor;
   String status;
 
-  @Override
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public Integer getAmount() {
-    return amount;
-  }
-
-  public void setAmount(Integer amount) {
-    this.amount = amount;
-  }
-
+  // <editor-fold desc="balanceTransaction">
   public String getBalanceTransaction() {
     return (this.balanceTransaction != null) ? this.balanceTransaction.getId() : null;
   }
@@ -67,95 +52,7 @@ public class Topup extends APIResource implements MetadataStore<Topup>, HasId {
   public void setBalanceTransactionObject(BalanceTransaction c) {
     this.balanceTransaction = new ExpandableField<BalanceTransaction>(c.getId(), c);
   }
-
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  public Long getExpectedAvailabilityDate() {
-    return expectedAvailabilityDate;
-  }
-
-  public void setExpectedAvailabilityDate(Long expectedAvailabilityDate) {
-    this.expectedAvailabilityDate = expectedAvailabilityDate;
-  }
-
-  public String getFailureCode() {
-    return failureCode;
-  }
-
-  public void setFailureCode(String failureCode) {
-    this.failureCode = failureCode;
-  }
-
-  public String getFailureMessage() {
-    return failureMessage;
-  }
-
-  public void setFailureMessage(String failureMessage) {
-    this.failureMessage = failureMessage;
-  }
-
-  public Boolean getLivemode() {
-    return livemode;
-  }
-
-  public void setLivemode(Boolean livemode) {
-    this.livemode = livemode;
-  }
-
-  @Override
-  public Map<String, String> getMetadata() {
-    return metadata;
-  }
-
-  public void setMetadata(Map<String, String> metadata) {
-    this.metadata = metadata;
-  }
-
-  public Source getSource() {
-    return source;
-  }
-
-  public void setSource(Source source) {
-    this.source = source;
-  }
-
-  public String getStatementDescriptor() {
-    return statementDescriptor;
-  }
-
-  public void setStatementDescriptor(String statementDescriptor) {
-    this.statementDescriptor = statementDescriptor;
-  }
-
-  public String getStatus() {
-    return status;
-  }
-
-  public void setStatus(String status) {
-    this.status = status;
-  }
+  // </editor-fold>
 
   public static Topup create(Map<String, Object> params)
           throws AuthenticationException, InvalidRequestException,

--- a/src/main/java/com/stripe/model/Transfer.java
+++ b/src/main/java/com/stripe/model/Transfer.java
@@ -11,86 +11,86 @@ import com.stripe.net.RequestOptions;
 import java.util.List;
 import java.util.Map;
 
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class Transfer extends APIResource implements MetadataStore<Transfer>, HasId {
   String id;
   String object;
   Long amount;
   Long amountReversed;
   String applicationFee;
-  ExpandableField<BalanceTransaction> balanceTransaction;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+      ExpandableField<BalanceTransaction> balanceTransaction;
   BankAccount bankAccount;
   Long created;
   String currency;
   Long date;
   String description;
-  ExpandableField<Account> destination;
-  ExpandableField<Charge> destinationPayment;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Account> destination;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Charge> destinationPayment;
   String failureCode;
   String failureMessage;
   Boolean livemode;
   Map<String, String> metadata;
-  TransferReversalCollection reversals;
+  @Getter(AccessLevel.NONE) TransferReversalCollection reversals;
   Boolean reversed;
-  ExpandableField<Charge> sourceTransaction;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Charge> sourceTransaction;
   String sourceType;
   String statementDescriptor;
   String status;
   String transferGroup;
   String type;
 
+  /**
+   * The {@code account} attribute.
+   *
+   * @return the {@code account} attribute
+   * @deprecated Prefer using the {@link #bankAccount} attribute instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2014-05-19">API version 2014-05-19</a>
+   */
   @Deprecated
   BankAccount account;
+
+  /**
+   * The {@code other_transfers} attribute.
+   *
+   * @return the {@code other_transfers} attribute
+   * @deprecated Prefer using the {@link BalanceTransaction#list} method instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2014-08-04">API version 2014-08-04</a>
+   */
   @Deprecated
   List<String> otherTransfers;
+
   @Deprecated
   String recipient;
+
+  /**
+   * The {@code statement_description} attribute.
+   *
+   * @return the {@code statement_description} attribute
+   * @deprecated Prefer using the {@link #statementDescriptor} attribute instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2014-12-17">API version 2014-12-17</a>
+   */
   @Deprecated
   String statementDescription;
+
+  /**
+   * The {@code summary} attribute.
+   *
+   * @return the {@code summary} attribute
+   * @deprecated Prefer using the {@link BalanceTransaction#list} method instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2014-08-04">API version 2014-08-04</a>
+   */
   @Deprecated
   Summary summary;
 
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public Long getAmount() {
-    return amount;
-  }
-
-  public void setAmount(Long amount) {
-    this.amount = amount;
-  }
-
-  public Long getAmountReversed() {
-    return amountReversed;
-  }
-
-  public void setAmountReversed(Long amountReversed) {
-    this.amountReversed = amountReversed;
-  }
-
-  @Deprecated
-  public String getApplicationFee() {
-    return applicationFee;
-  }
-
-  @Deprecated
-  public void setApplicationFee(String applicationFee) {
-    this.applicationFee = applicationFee;
-  }
-
+  // <editor-fold desc="balanceTransaction">
   public String getBalanceTransaction() {
     return (this.balanceTransaction != null) ? this.balanceTransaction.getId() : null;
   }
@@ -106,51 +106,9 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
   public void setBalanceTransactionObject(BalanceTransaction c) {
     this.balanceTransaction = new ExpandableField<BalanceTransaction>(c.getId(), c);
   }
+  // </editor-fold>
 
-  @Deprecated
-  public BankAccount getBankAccount() {
-    return bankAccount;
-  }
-
-  @Deprecated
-  public void setBankAccount(BankAccount bankAccount) {
-    this.bankAccount = bankAccount;
-  }
-
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  public Long getDate() {
-    return date;
-  }
-
-  public void setDate(Long date) {
-    this.date = date;
-  }
-
-  @Deprecated
-  public String getDescription() {
-    return description;
-  }
-
-  @Deprecated
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
+  // <editor-fold desc="destination">
   public String getDestination() {
     return (this.destination != null) ? this.destination.getId() : null;
   }
@@ -166,7 +124,9 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
   public void setDestinationObject(Account c) {
     this.destination = new ExpandableField<Account>(c.getId(), c);
   }
+  // </editor-fold>
 
+  // <editor-fold desc="destinationPayment">
   public String getDestinationPayment() {
     return (this.destinationPayment != null) ? this.destinationPayment.getId() : null;
   }
@@ -183,42 +143,7 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
     this.destinationPayment
         = new ExpandableField<Charge>(destinationPayment.getId(), destinationPayment);
   }
-
-  @Deprecated
-  public String getFailureCode() {
-    return failureCode;
-  }
-
-  @Deprecated
-  public void setFailureCode(String failureCode) {
-    this.failureCode = failureCode;
-  }
-
-  @Deprecated
-  public String getFailureMessage() {
-    return failureMessage;
-  }
-
-  @Deprecated
-  public void setFailureMessage(String failureMessage) {
-    this.failureMessage = failureMessage;
-  }
-
-  public Boolean getLivemode() {
-    return livemode;
-  }
-
-  public void setLivemode(Boolean livemode) {
-    this.livemode = livemode;
-  }
-
-  public Map<String, String> getMetadata() {
-    return metadata;
-  }
-
-  public void setMetadata(Map<String, String> metadata) {
-    this.metadata = metadata;
-  }
+  // </editor-fold>
 
   /**
    * Returns the {@code reversals} list.
@@ -232,14 +157,7 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
     return reversals;
   }
 
-  public Boolean getReversed() {
-    return reversed;
-  }
-
-  public void setReversed(Boolean reversed) {
-    this.reversed = reversed;
-  }
-
+  // <editor-fold desc="sourceTransaction">
   public String getSourceTransaction() {
     return (this.sourceTransaction != null) ? this.sourceTransaction.getId() : null;
   }
@@ -257,128 +175,7 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
     this.sourceTransaction
         = new ExpandableField<Charge>(sourceTransaction.getId(), sourceTransaction);
   }
-
-  public String getSourceType() {
-    return sourceType;
-  }
-
-  public void setSourceType(String sourceType) {
-    this.sourceType = sourceType;
-  }
-
-  public String getStatementDescriptor() {
-    return statementDescriptor;
-  }
-
-  public void setStatementDescriptor(String statementDescriptor) {
-    this.statementDescriptor = statementDescriptor;
-  }
-
-  @Deprecated
-  public String getStatus() {
-    return status;
-  }
-
-  @Deprecated
-  public void setStatus(String status) {
-    this.status = status;
-  }
-
-  public String getTransferGroup() {
-    return this.transferGroup;
-  }
-
-  public void setTransferGroup(String transferGroup) {
-    this.transferGroup = transferGroup;
-  }
-
-  @Deprecated
-  public String getType() {
-    return type;
-  }
-
-  @Deprecated
-  public void setType(String type) {
-    this.type = type;
-  }
-
-  /**
-   * Returns the {@code account} attribute.
-   *
-   * @return the {@code account} attribute
-   * @deprecated Prefer using the {@code bank_account} attribute instead.
-   * @see <a href="https://stripe.com/docs/upgrades#2014-05-19">API version 2014-05-19</a>
-   */
-  @Deprecated
-  public BankAccount getAccount() {
-    return account;
-  }
-
-  @Deprecated
-  public void setAccount(BankAccount account) {
-    this.account = account;
-  }
-
-  /**
-   * Returns the {@code other_transfers} attribute.
-   *
-   * @return the {@code other_transfers} attribute
-   * @deprecated Prefer using the {@link BalanceTransaction#list} method instead.
-   * @see <a href="https://stripe.com/docs/upgrades#2014-08-04">API version 2014-08-04</a>
-   */
-  @Deprecated
-  public List<String> getOtherTransfers() {
-    return otherTransfers;
-  }
-
-  @Deprecated
-  public void setOtherTransfers(List<String> otherTransfers) {
-    this.otherTransfers = otherTransfers;
-  }
-
-  @Deprecated
-  public String getRecipient() {
-    return recipient;
-  }
-
-  @Deprecated
-  public void setRecipient(String recipient) {
-    this.recipient = recipient;
-  }
-
-  /**
-   * Returns the {@code statement_description} attribute.
-   *
-   * @return the {@code statement_description} attribute
-   * @deprecated Prefer using the {@code statement_descriptor} attribute instead.
-   * @see <a href="https://stripe.com/docs/upgrades#2014-12-17">API version 2014-12-17</a>
-   */
-  @Deprecated
-  public String getStatementDescription() {
-    return statementDescription;
-  }
-
-  @Deprecated
-  public void setStatementDescription(String statementDescription) {
-    this.statementDescription = statementDescription;
-  }
-
-  /**
-   * Returns the {@code summary} attribute.
-   *
-   * @return the {@code summary} attribute
-   * @deprecated Prefer using the {@link BalanceTransaction#list} method instead.
-   * @see <a href="https://stripe.com/docs/upgrades#2014-08-04">API version 2014-08-04</a>
-   */
-  @Deprecated
-  public Summary getSummary() {
-    return summary;
-  }
-
-  @Deprecated
-  public void setSummary(Summary summary) {
-    this.summary = summary;
-  }
+  // </editor-fold>
 
   public static Transfer create(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
@@ -426,12 +223,6 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
         options);
   }
 
-  /**
-   * Returns the {@code summary} attribute.
-   *
-   * @return the {@code summary} attribute
-   * @deprecated Prefer using the {@code transfers.getReversals().create(params)} method instead.
-   */
   @Deprecated
   public Transfer cancel()
       throws AuthenticationException, InvalidRequestException,

--- a/src/main/java/com/stripe/model/TransferTransaction.java
+++ b/src/main/java/com/stripe/model/TransferTransaction.java
@@ -1,5 +1,12 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class TransferTransaction extends StripeObject implements HasId {
   String id;
   String object;
@@ -9,68 +16,4 @@ public class TransferTransaction extends StripeObject implements HasId {
   Long created;
   String description;
   Long fee;
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public Long getAmount() {
-    return amount;
-  }
-
-  public void setAmount(Long amount) {
-    this.amount = amount;
-  }
-
-  public Long getNet() {
-    return net;
-  }
-
-  public void setNet(Long net) {
-    this.net = net;
-  }
-
-  public String getType() {
-    return type;
-  }
-
-  public void setType(String type) {
-    this.type = type;
-  }
-
-  public Long getCreated() {
-    return created;
-  }
-
-  public void setCreated(Long created) {
-    this.created = created;
-  }
-
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  public Long getFee() {
-    return fee;
-  }
-
-  public void setFee(Long fee) {
-    this.fee = fee;
-  }
 }

--- a/src/main/java/com/stripe/model/UsageRecord.java
+++ b/src/main/java/com/stripe/model/UsageRecord.java
@@ -11,6 +11,13 @@ import com.stripe.net.RequestOptions;
 import java.util.HashMap;
 import java.util.Map;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class UsageRecord extends APIResource implements HasId {
   String id;
   String object;
@@ -18,55 +25,6 @@ public class UsageRecord extends APIResource implements HasId {
   Long quantity;
   String subscriptionItem;
   Long timestamp;
-
-  @Override
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getObject() {
-    return object;
-  }
-
-  public void setObject(String object) {
-    this.object = object;
-  }
-
-  public Boolean getLivemode() {
-    return livemode;
-  }
-
-  public void setLivemode(Boolean livemode) {
-    this.livemode = livemode;
-  }
-
-  public Long getQuantity() {
-    return quantity;
-  }
-
-  public void setQuantity(Long quantity) {
-    this.quantity = quantity;
-  }
-
-  public String getSubscriptionItem() {
-    return subscriptionItem;
-  }
-
-  public void setSubscriptionItem(String subscriptionItem) {
-    this.subscriptionItem = subscriptionItem;
-  }
-
-  public Long getTimestamp() {
-    return timestamp;
-  }
-
-  public void setTimestamp(Long timestamp) {
-    this.timestamp = timestamp;
-  }
 
   /**
    * Create a new usage record associated with a subscription item.

--- a/src/main/java/com/stripe/model/VerificationFields.java
+++ b/src/main/java/com/stripe/model/VerificationFields.java
@@ -1,43 +1,15 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+@Getter
+@Setter
+@Accessors(chain = true)
+@EqualsAndHashCode(callSuper = false)
 public final class VerificationFields extends StripeObject {
   protected VerificationFieldsDetails individual;
   protected VerificationFieldsDetails company;
-
-  public VerificationFieldsDetails getIndividual() {
-    return individual;
-  }
-
-  public VerificationFields setIndividual(VerificationFieldsDetails individual) {
-    this.individual = individual;
-    return this;
-  }
-
-  public VerificationFieldsDetails getCompany() {
-    return company;
-  }
-
-  public VerificationFields setCompany(VerificationFieldsDetails company) {
-    this.company = company;
-    return this;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-
-    VerificationFields verificationFields = (VerificationFields) o;
-
-    if (individual != null ? !individual.equals(verificationFields.individual)
-        : verificationFields.individual != null) {
-      return false;
-    }
-    return company != null ? company.equals(verificationFields.company)
-        : verificationFields.company == null;
-  }
 }

--- a/src/main/java/com/stripe/model/VerificationFieldsDetails.java
+++ b/src/main/java/com/stripe/model/VerificationFieldsDetails.java
@@ -2,44 +2,16 @@ package com.stripe.model;
 
 import java.util.List;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+@Getter
+@Setter
+@Accessors(chain = true)
+@EqualsAndHashCode(callSuper = false)
 public final class VerificationFieldsDetails extends StripeObject {
   protected List<String> additional;
   protected List<String> minimum;
-
-  public List<String> getAdditional() {
-    return additional;
-  }
-
-  public VerificationFieldsDetails setAdditional(List<String> additional) {
-    this.additional = additional;
-    return this;
-  }
-
-  public List<String> getMinimum() {
-    return minimum;
-  }
-
-  public VerificationFieldsDetails setMinimum(List<String> minimum) {
-    this.additional = minimum;
-    return this;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-
-    VerificationFieldsDetails verificationFieldsDetails = (VerificationFieldsDetails) o;
-
-    if (additional != null ? !additional.equals(verificationFieldsDetails.additional)
-        : verificationFieldsDetails.additional != null) {
-      return false;
-    }
-    return minimum != null ? minimum.equals(verificationFieldsDetails.minimum)
-        : verificationFieldsDetails.minimum == null;
-  }
 }

--- a/src/main/java/com/stripe/model/oauth/DeauthorizedAccount.java
+++ b/src/main/java/com/stripe/model/oauth/DeauthorizedAccount.java
@@ -2,14 +2,13 @@ package com.stripe.model.oauth;
 
 import com.stripe.model.StripeObject;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class DeauthorizedAccount extends StripeObject {
   String stripeUserId;
-
-  public String getStripeUserId() {
-    return stripeUserId;
-  }
-
-  public void setStripeUserId(String stripeUserId) {
-    this.stripeUserId = stripeUserId;
-  }
 }

--- a/src/main/java/com/stripe/model/oauth/TokenResponse.java
+++ b/src/main/java/com/stripe/model/oauth/TokenResponse.java
@@ -2,32 +2,15 @@ package com.stripe.model.oauth;
 
 import com.stripe.model.StripeObject;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class TokenResponse extends StripeObject {
   Boolean livemode;
   String scope;
   String stripeUserId;
-
-  public Boolean getLivemode() {
-    return livemode;
-  }
-
-  public void setLivemode(Boolean livemode) {
-    this.livemode = livemode;
-  }
-
-  public String getScope() {
-    return scope;
-  }
-
-  public void setScope(String scope) {
-    this.scope = scope;
-  }
-
-  public String getStripeUserId() {
-    return stripeUserId;
-  }
-
-  public void setStripeUserId(String stripeUserId) {
-    this.stripeUserId = stripeUserId;
-  }
 }


### PR DESCRIPTION
cc @stripe/api-libraries 

This is a proposal to make use of [Project Lombok](https://github.com/rzwitserloot/lombok) and particularly its [`@Getter` / `@Setter`](https://projectlombok.org/features/GetterSetter.html) and [`@EqualsAndHashCode`](https://projectlombok.org/features/EqualsAndHashCode.html) annotations to reduce the amount of boilerplate code.

This PR removes about 6,000 lines of code, while adding some functionality as some of the classes currently lacks some setters or `equals()` / `hashCode()` methods.

This is obviously a non-trivial change, and I don't suggest it be merged as is, but I think it's an interesting improvement worth exploring.
