### PR TITLE
Introduce delete variant without arguments

### DIFF
--- a/src/main/java/com/stripe/model/Account.java
+++ b/src/main/java/com/stripe/model/Account.java
@@ -294,6 +294,12 @@ public class Account extends APIResource implements HasId, MetadataStore<Account
 		return request(RequestMethod.POST, instanceURL(Account.class, this.id), params, Account.class, options);
 	}
 
+	public DeletedAccount delete()
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return delete(null, (RequestOptions) null);
+	}
+
 	public DeletedAccount delete(Map<String, Object> params)
 			throws AuthenticationException, InvalidRequestException,
 			APIConnectionException, CardException, APIException {


### PR DESCRIPTION
Many other models have delete variants that don't require any
parameters, and we indeed reference a currently non-existent
parameterless variant for account's delete in our API documentation.

This patch adds this missing method.

Fixes #312.

r? @andrewnelder Would you mind taking a look at this one? Thanks!
