### PR TITLE
Add support for multiplan subscriptions

### DIFF
--- a/src/main/java/com/stripe/model/DeletedSubscriptionItem.java
+++ b/src/main/java/com/stripe/model/DeletedSubscriptionItem.java
@@ -1,0 +1,23 @@
+package com.stripe.model;
+
+
+public class DeletedSubscriptionItem extends StripeObject implements DeletedStripeObject {
+  String id;
+  Boolean deleted;
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public Boolean getDeleted() {
+    return deleted;
+  }
+
+  public void setDeleted(Boolean deleted) {
+    this.deleted = deleted;
+  }
+}

--- a/src/main/java/com/stripe/model/DeletedSubscriptionItem.java
+++ b/src/main/java/com/stripe/model/DeletedSubscriptionItem.java
@@ -2,22 +2,22 @@ package com.stripe.model;
 
 
 public class DeletedSubscriptionItem extends StripeObject implements DeletedStripeObject {
-  String id;
-  Boolean deleted;
+	String id;
+	Boolean deleted;
 
-  public String getId() {
-    return id;
-  }
+	public String getId() {
+		return id;
+	}
 
-  public void setId(String id) {
-    this.id = id;
-  }
+	public void setId(String id) {
+		this.id = id;
+	}
 
-  public Boolean getDeleted() {
-    return deleted;
-  }
+	public Boolean getDeleted() {
+		return deleted;
+	}
 
-  public void setDeleted(Boolean deleted) {
-    this.deleted = deleted;
-  }
+	public void setDeleted(Boolean deleted) {
+		this.deleted = deleted;
+	}
 }

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -22,6 +22,7 @@ public class Subscription extends APIResource implements MetadataStore<Subscript
 	String customer;
 	Discount discount;
 	Long endedAt;
+	SubscriptionItemCollection items;
 	Map<String, String> metadata;
 	Plan plan;
 	Integer quantity;
@@ -173,6 +174,14 @@ public class Subscription extends APIResource implements MetadataStore<Subscript
 
 	public void setTrialStart(Long trialStart) {
 		this.trialStart = trialStart;
+	}
+
+	public SubscriptionItemCollection getSubscriptionItems() {
+		return items;
+	}
+
+	public void setSubscriptionItems(SubscriptionItemCollection items) {
+		this.items = items;
 	}
 
 	@Deprecated

--- a/src/main/java/com/stripe/model/SubscriptionItem.java
+++ b/src/main/java/com/stripe/model/SubscriptionItem.java
@@ -13,102 +13,102 @@ import java.util.List;
 
 
 public class SubscriptionItem extends APIResource implements HasId {
-  String id;
-  Long created;
-  Plan plan;
-  Integer quantity;
+	String id;
+	Long created;
+	Plan plan;
+	Integer quantity;
 
-  public String getId() {
-    return id;
-  }
+	public String getId() {
+		return id;
+	}
 
-  public void setId(String id) {
-    this.id = id;
-  }
+	public void setId(String id) {
+		this.id = id;
+	}
 
-  public Long getCreated() {
-    return created;
-  }
+	public Long getCreated() {
+		return created;
+	}
 
-  public void setCreated(Long created) {
-    this.created = created;
-  }
+	public void setCreated(Long created) {
+		this.created = created;
+	}
 
-  public Plan getPlan() {
-    return plan;
-  }
+	public Plan getPlan() {
+		return plan;
+	}
 
-  public void setPlan(Plan plan) {
-    this.plan = plan;
-  }
+	public void setPlan(Plan plan) {
+		this.plan = plan;
+	}
 
-  public Integer getQuantity() {
-    return quantity;
-  }
+	public Integer getQuantity() {
+		return quantity;
+	}
 
-  public void setQuantity(Integer quantity) {
-    this.quantity = quantity;
-  }
+	public void setQuantity(Integer quantity) {
+		this.quantity = quantity;
+	}
 
-  public static SubscriptionItem create(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return create(params, (RequestOptions) null);
-  }
+	public static SubscriptionItem create(Map<String, Object> params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params, (RequestOptions) null);
+	}
 
-  public static SubscriptionItem create(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return request(RequestMethod.POST, classURL(SubscriptionItem.class), params, SubscriptionItem.class, options);
-  }
+	public static SubscriptionItem create(Map<String, Object> params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return request(RequestMethod.POST, classURL(SubscriptionItem.class), params, SubscriptionItem.class, options);
+	}
 
-  public static SubscriptionItemCollection list(Map<String, Object> params)
-      throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    return list(params, (RequestOptions) null);
-  }
+	public static SubscriptionItemCollection list(Map<String, Object> params)
+			throws AuthenticationException,
+			InvalidRequestException, APIConnectionException, CardException,
+			APIException {
+		return list(params, (RequestOptions) null);
+	}
 
-  public static SubscriptionItemCollection list(Map<String, Object> params,
-      RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    return requestCollection(classURL(SubscriptionItem.class), params, SubscriptionItemCollection.class, options);
-  }
+	public static SubscriptionItemCollection list(Map<String, Object> params,
+			RequestOptions options) throws AuthenticationException,
+			InvalidRequestException, APIConnectionException, CardException,
+			APIException {
+		return requestCollection(classURL(SubscriptionItem.class), params, SubscriptionItemCollection.class, options);
+	}
 
-  public static SubscriptionItem retrieve(String id) throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    return retrieve(id, (RequestOptions) null);
-  }
+	public static SubscriptionItem retrieve(String id) throws AuthenticationException,
+			InvalidRequestException, APIConnectionException, CardException,
+			APIException {
+		return retrieve(id, (RequestOptions) null);
+	}
 
-  public static SubscriptionItem retrieve(String id, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return request(RequestMethod.GET, instanceURL(SubscriptionItem.class, id), null, SubscriptionItem.class, options);
-  }
+	public static SubscriptionItem retrieve(String id, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return request(RequestMethod.GET, instanceURL(SubscriptionItem.class, id), null, SubscriptionItem.class, options);
+	}
 
-  public SubscriptionItem update(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return update(params, (RequestOptions) null);
-  }
+	public SubscriptionItem update(Map<String, Object> params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params, (RequestOptions) null);
+	}
 
-  public SubscriptionItem update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return request(RequestMethod.POST, instanceURL(SubscriptionItem.class, id), params, SubscriptionItem.class, options);
-  }
+	public SubscriptionItem update(Map<String, Object> params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return request(RequestMethod.POST, instanceURL(SubscriptionItem.class, id), params, SubscriptionItem.class, options);
+	}
 
-  public DeletedSubscriptionItem delete() throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    return delete((RequestOptions) null);
-  }
+	public DeletedSubscriptionItem delete() throws AuthenticationException,
+			InvalidRequestException, APIConnectionException, CardException,
+			APIException {
+		return delete((RequestOptions) null);
+	}
 
-  public DeletedSubscriptionItem delete(RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    return request(RequestMethod.DELETE, instanceURL(SubscriptionItem.class, id), null, DeletedSubscriptionItem.class, options);
-  }
+	public DeletedSubscriptionItem delete(RequestOptions options) throws AuthenticationException,
+			InvalidRequestException, APIConnectionException, CardException,
+			APIException {
+		return request(RequestMethod.DELETE, instanceURL(SubscriptionItem.class, id), null, DeletedSubscriptionItem.class, options);
+	}
 }

--- a/src/main/java/com/stripe/model/SubscriptionItem.java
+++ b/src/main/java/com/stripe/model/SubscriptionItem.java
@@ -1,0 +1,114 @@
+package com.stripe.model;
+
+import com.stripe.exception.APIConnectionException;
+import com.stripe.exception.APIException;
+import com.stripe.exception.AuthenticationException;
+import com.stripe.exception.CardException;
+import com.stripe.exception.InvalidRequestException;
+import com.stripe.net.APIResource;
+import com.stripe.net.RequestOptions;
+
+import java.util.Map;
+import java.util.List;
+
+
+public class SubscriptionItem extends APIResource implements HasId {
+  String id;
+  Long created;
+  Plan plan;
+  Integer quantity;
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public Long getCreated() {
+    return created;
+  }
+
+  public void setCreated(Long created) {
+    this.created = created;
+  }
+
+  public Plan getPlan() {
+    return plan;
+  }
+
+  public void setPlan(Plan plan) {
+    this.plan = plan;
+  }
+
+  public Integer getQuantity() {
+    return quantity;
+  }
+
+  public void setQuantity(Integer quantity) {
+    this.quantity = quantity;
+  }
+
+  public static SubscriptionItem create(Map<String, Object> params)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return create(params, (RequestOptions) null);
+  }
+
+  public static SubscriptionItem create(Map<String, Object> params, RequestOptions options)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return request(RequestMethod.POST, classURL(SubscriptionItem.class), params, SubscriptionItem.class, options);
+  }
+
+  public static SubscriptionItemCollection list(Map<String, Object> params)
+      throws AuthenticationException,
+      InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    return list(params, (RequestOptions) null);
+  }
+
+  public static SubscriptionItemCollection list(Map<String, Object> params,
+      RequestOptions options) throws AuthenticationException,
+      InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    return requestCollection(classURL(SubscriptionItem.class), params, SubscriptionItemCollection.class, options);
+  }
+
+  public static SubscriptionItem retrieve(String id) throws AuthenticationException,
+      InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    return retrieve(id, (RequestOptions) null);
+  }
+
+  public static SubscriptionItem retrieve(String id, RequestOptions options)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return request(RequestMethod.GET, instanceURL(SubscriptionItem.class, id), null, SubscriptionItem.class, options);
+  }
+
+  public SubscriptionItem update(Map<String, Object> params)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return update(params, (RequestOptions) null);
+  }
+
+  public SubscriptionItem update(Map<String, Object> params, RequestOptions options)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return request(RequestMethod.POST, instanceURL(SubscriptionItem.class, id), params, SubscriptionItem.class, options);
+  }
+
+  public DeletedSubscriptionItem delete() throws AuthenticationException,
+      InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    return delete((RequestOptions) null);
+  }
+
+  public DeletedSubscriptionItem delete(RequestOptions options) throws AuthenticationException,
+      InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    return request(RequestMethod.DELETE, instanceURL(SubscriptionItem.class, id), null, DeletedSubscriptionItem.class, options);
+  }
+}

--- a/src/main/java/com/stripe/model/SubscriptionItemCollection.java
+++ b/src/main/java/com/stripe/model/SubscriptionItemCollection.java
@@ -1,0 +1,4 @@
+package com.stripe.model;
+
+public class SubscriptionItemCollection extends StripeCollection<SubscriptionItem> {
+}

--- a/src/main/java/com/stripe/net/APIResource.java
+++ b/src/main/java/com/stripe/net/APIResource.java
@@ -66,6 +66,8 @@ public abstract class APIResource extends StripeObject {
 			return "three_d_secure";
 		} else if (className.equals("applepaydomain")) {
 			return "apple_pay_domain";
+		} else if (className.equals("subscriptionitem")) {
+			return "subscription_item";
 		} else {
 			return className;
 		}

--- a/src/test/java/com/stripe/StripeTest.java
+++ b/src/test/java/com/stripe/StripeTest.java
@@ -1297,64 +1297,64 @@ public class StripeTest {
 		assertEquals(sub.getId(), customer.getSubscriptions().getData().get(0).getId());
 	}
 
-  @Test
-  public void testSubscriptionItemCreate() throws StripeException {
-	Customer customer = Customer.create(defaultCustomerParams);
-	Subscription subscription = createDefaultSubscription(customer);
-	SubscriptionItem subscriptionItem = createDefaultSubscriptionItem(subscription);
+	@Test
+	public void testSubscriptionItemCreate() throws StripeException {
+		Customer customer = Customer.create(defaultCustomerParams);
+		Subscription subscription = createDefaultSubscription(customer);
+		SubscriptionItem subscriptionItem = createDefaultSubscriptionItem(subscription);
 
-	assertEquals(subscriptionItem.getPlan().getName(), "J Bindings Plan");
-  }
+		assertEquals(subscriptionItem.getPlan().getName(), "J Bindings Plan");
+	}
 
-  @Test
-  public void testSubscriptionItemRetrieve() throws StripeException {
-	Customer customer = Customer.create(defaultCustomerParams);
-	Subscription subscription = createDefaultSubscription(customer);
-	SubscriptionItem subscriptionItem = createDefaultSubscriptionItem(subscription);
+	@Test
+	public void testSubscriptionItemRetrieve() throws StripeException {
+		Customer customer = Customer.create(defaultCustomerParams);
+		Subscription subscription = createDefaultSubscription(customer);
+		SubscriptionItem subscriptionItem = createDefaultSubscriptionItem(subscription);
 
-	SubscriptionItem retrievedSubscriptionItem = SubscriptionItem
-		.retrieve(subscriptionItem.getId());
-	assertEquals(subscriptionItem.getId(), retrievedSubscriptionItem.getId());
-  }
+		SubscriptionItem retrievedSubscriptionItem = SubscriptionItem
+			.retrieve(subscriptionItem.getId());
+		assertEquals(subscriptionItem.getId(), retrievedSubscriptionItem.getId());
+	}
 
-  @Test
-  public void testSubscriptionItemList() throws StripeException {
-	Customer customer = Customer.create(defaultCustomerParams);
-	Subscription subscription = createDefaultSubscription(customer);
-	SubscriptionItem subscriptionItem = createDefaultSubscriptionItem(subscription);
+	@Test
+	public void testSubscriptionItemList() throws StripeException {
+		Customer customer = Customer.create(defaultCustomerParams);
+		Subscription subscription = createDefaultSubscription(customer);
+		SubscriptionItem subscriptionItem = createDefaultSubscriptionItem(subscription);
 
-	Map<String, Object> listParams = new HashMap<String, Object>();
-	listParams.put("subscription", subscription.getId());
-	SubscriptionItemCollection subscriptionItems = SubscriptionItem.list(listParams);
-	List<SubscriptionItem> subscriptionItemsData = subscriptionItems.getData();
-	assertEquals(subscriptionItemsData.size(), 2);
-  }
+		Map<String, Object> listParams = new HashMap<String, Object>();
+		listParams.put("subscription", subscription.getId());
+		SubscriptionItemCollection subscriptionItems = SubscriptionItem.list(listParams);
+		List<SubscriptionItem> subscriptionItemsData = subscriptionItems.getData();
+		assertEquals(subscriptionItemsData.size(), 2);
+	}
 
-  @Test
-  public void testSubscriptionItemUpdate() throws StripeException {
-	Customer customer = Customer.create(defaultCustomerParams);
-	Subscription subscription = createDefaultSubscription(customer);
-	SubscriptionItem subscriptionItem = createDefaultSubscriptionItem(subscription);
+	@Test
+	public void testSubscriptionItemUpdate() throws StripeException {
+		Customer customer = Customer.create(defaultCustomerParams);
+		Subscription subscription = createDefaultSubscription(customer);
+		SubscriptionItem subscriptionItem = createDefaultSubscriptionItem(subscription);
 
-	Map<String, Object> updateParams = new HashMap<String, Object>();
-	updateParams.put("quantity", 4);
-	updateParams.put("subscription", subscription.getId());
+		Map<String, Object> updateParams = new HashMap<String, Object>();
+		updateParams.put("quantity", 4);
+		updateParams.put("subscription", subscription.getId());
 
-	SubscriptionItem updatedSubscriptionItem =
-		subscriptionItem.update(updateParams);
-	assertTrue(updatedSubscriptionItem.getQuantity() == 4);
-  }
+		SubscriptionItem updatedSubscriptionItem =
+			subscriptionItem.update(updateParams);
+		assertTrue(updatedSubscriptionItem.getQuantity() == 4);
+	}
 
-  @Test
-  public void testSubscriptionItemDelete() throws StripeException {
-	Customer customer = Customer.create(defaultCustomerParams);
-	Subscription subscription = createDefaultSubscription(customer);
-	SubscriptionItem subscriptionItem = createDefaultSubscriptionItem(subscription);
+	@Test
+	public void testSubscriptionItemDelete() throws StripeException {
+		Customer customer = Customer.create(defaultCustomerParams);
+		Subscription subscription = createDefaultSubscription(customer);
+		SubscriptionItem subscriptionItem = createDefaultSubscriptionItem(subscription);
 
-	DeletedSubscriptionItem deletedSubscriptionItem = subscriptionItem.delete();
-	assertTrue(deletedSubscriptionItem.getDeleted());
-	assertEquals(deletedSubscriptionItem.getId(), subscriptionItem.getId());
-  }
+		DeletedSubscriptionItem deletedSubscriptionItem = subscriptionItem.delete();
+		assertTrue(deletedSubscriptionItem.getDeleted());
+		assertEquals(deletedSubscriptionItem.getId(), subscriptionItem.getId());
+	}
 
 	@Test
 	public void testInvoiceItemCreate() throws StripeException {

--- a/src/test/java/com/stripe/StripeTest.java
+++ b/src/test/java/com/stripe/StripeTest.java
@@ -119,9 +119,9 @@ public class StripeTest {
 
 	static String getYear() {
 		Date date = new Date(); //Get current date
-  		Calendar calendar = new GregorianCalendar();
-  		calendar.setTime(date);
-   		return calendar.get(Calendar.YEAR) + 1 +"";
+		Calendar calendar = new GregorianCalendar();
+		calendar.setTime(date);
+		return calendar.get(Calendar.YEAR) + 1 +"";
 	}
 
 
@@ -182,9 +182,9 @@ public class StripeTest {
 		HashMap<String, Object> items = new HashMap<String, Object>();
 		HashMap<String, Object> item = new HashMap<String, Object>();
 
-    item.put("plan", plan.getId());
-    item.put("quantity", 1);
-    items.put("0", item);
+		item.put("plan", plan.getId());
+		item.put("quantity", 1);
+		items.put("0", item);
 
 		subCreateParams.put("items", items);
 		subCreateParams.put("customer", customer.getId());
@@ -1297,63 +1297,63 @@ public class StripeTest {
 		assertEquals(sub.getId(), customer.getSubscriptions().getData().get(0).getId());
 	}
 
-	@Test
+  @Test
   public void testSubscriptionItemCreate() throws StripeException {
-    Customer customer = Customer.create(defaultCustomerParams);
-    Subscription subscription = createDefaultSubscription(customer);
-    SubscriptionItem subscriptionItem = createDefaultSubscriptionItem(subscription);
+	Customer customer = Customer.create(defaultCustomerParams);
+	Subscription subscription = createDefaultSubscription(customer);
+	SubscriptionItem subscriptionItem = createDefaultSubscriptionItem(subscription);
 
-    assertEquals(subscriptionItem.getPlan().getName(), "J Bindings Plan");
+	assertEquals(subscriptionItem.getPlan().getName(), "J Bindings Plan");
   }
 
   @Test
   public void testSubscriptionItemRetrieve() throws StripeException {
-    Customer customer = Customer.create(defaultCustomerParams);
-    Subscription subscription = createDefaultSubscription(customer);
-    SubscriptionItem subscriptionItem = createDefaultSubscriptionItem(subscription);
+	Customer customer = Customer.create(defaultCustomerParams);
+	Subscription subscription = createDefaultSubscription(customer);
+	SubscriptionItem subscriptionItem = createDefaultSubscriptionItem(subscription);
 
-    SubscriptionItem retrievedSubscriptionItem = SubscriptionItem
-        .retrieve(subscriptionItem.getId());
-    assertEquals(subscriptionItem.getId(), retrievedSubscriptionItem.getId());
+	SubscriptionItem retrievedSubscriptionItem = SubscriptionItem
+		.retrieve(subscriptionItem.getId());
+	assertEquals(subscriptionItem.getId(), retrievedSubscriptionItem.getId());
   }
 
   @Test
   public void testSubscriptionItemList() throws StripeException {
-    Customer customer = Customer.create(defaultCustomerParams);
-    Subscription subscription = createDefaultSubscription(customer);
-    SubscriptionItem subscriptionItem = createDefaultSubscriptionItem(subscription);
+	Customer customer = Customer.create(defaultCustomerParams);
+	Subscription subscription = createDefaultSubscription(customer);
+	SubscriptionItem subscriptionItem = createDefaultSubscriptionItem(subscription);
 
-    Map<String, Object> listParams = new HashMap<String, Object>();
-    listParams.put("subscription", subscription.getId());
-    SubscriptionItemCollection subscriptionItems = SubscriptionItem.list(listParams);
-    List<SubscriptionItem> subscriptionItemsData = subscriptionItems.getData();
-    assertEquals(subscriptionItemsData.size(), 2);
+	Map<String, Object> listParams = new HashMap<String, Object>();
+	listParams.put("subscription", subscription.getId());
+	SubscriptionItemCollection subscriptionItems = SubscriptionItem.list(listParams);
+	List<SubscriptionItem> subscriptionItemsData = subscriptionItems.getData();
+	assertEquals(subscriptionItemsData.size(), 2);
   }
 
   @Test
   public void testSubscriptionItemUpdate() throws StripeException {
-    Customer customer = Customer.create(defaultCustomerParams);
-    Subscription subscription = createDefaultSubscription(customer);
-    SubscriptionItem subscriptionItem = createDefaultSubscriptionItem(subscription);
+	Customer customer = Customer.create(defaultCustomerParams);
+	Subscription subscription = createDefaultSubscription(customer);
+	SubscriptionItem subscriptionItem = createDefaultSubscriptionItem(subscription);
 
-    Map<String, Object> updateParams = new HashMap<String, Object>();
-    updateParams.put("quantity", 4);
-    updateParams.put("subscription", subscription.getId());
+	Map<String, Object> updateParams = new HashMap<String, Object>();
+	updateParams.put("quantity", 4);
+	updateParams.put("subscription", subscription.getId());
 
-    SubscriptionItem updatedSubscriptionItem =
-        subscriptionItem.update(updateParams);
-    assertTrue(updatedSubscriptionItem.getQuantity() == 4);
+	SubscriptionItem updatedSubscriptionItem =
+		subscriptionItem.update(updateParams);
+	assertTrue(updatedSubscriptionItem.getQuantity() == 4);
   }
 
   @Test
   public void testSubscriptionItemDelete() throws StripeException {
-    Customer customer = Customer.create(defaultCustomerParams);
-    Subscription subscription = createDefaultSubscription(customer);
-    SubscriptionItem subscriptionItem = createDefaultSubscriptionItem(subscription);
+	Customer customer = Customer.create(defaultCustomerParams);
+	Subscription subscription = createDefaultSubscription(customer);
+	SubscriptionItem subscriptionItem = createDefaultSubscriptionItem(subscription);
 
-    DeletedSubscriptionItem deletedSubscriptionItem = subscriptionItem.delete();
-    assertTrue(deletedSubscriptionItem.getDeleted());
-    assertEquals(deletedSubscriptionItem.getId(), subscriptionItem.getId());
+	DeletedSubscriptionItem deletedSubscriptionItem = subscriptionItem.delete();
+	assertTrue(deletedSubscriptionItem.getDeleted());
+	assertEquals(deletedSubscriptionItem.getId(), subscriptionItem.getId());
   }
 
 	@Test

--- a/src/test/java/com/stripe/StripeTest.java
+++ b/src/test/java/com/stripe/StripeTest.java
@@ -1338,7 +1338,6 @@ public class StripeTest {
 
 		Map<String, Object> updateParams = new HashMap<String, Object>();
 		updateParams.put("quantity", 4);
-		updateParams.put("subscription", subscription.getId());
 
 		SubscriptionItem updatedSubscriptionItem =
 			subscriptionItem.update(updateParams);

--- a/src/test/java/com/stripe/StripeTest.java
+++ b/src/test/java/com/stripe/StripeTest.java
@@ -40,6 +40,7 @@ import com.stripe.model.DeletedPlan;
 import com.stripe.model.DeletedProduct;
 import com.stripe.model.DeletedRecipient;
 import com.stripe.model.DeletedSKU;
+import com.stripe.model.DeletedSubscriptionItem;
 import com.stripe.model.Dispute;
 import com.stripe.model.Event;
 import com.stripe.model.EvidenceDetails;
@@ -63,6 +64,8 @@ import com.stripe.model.Source;
 import com.stripe.model.SKU;
 import com.stripe.model.ShippingDetails;
 import com.stripe.model.Subscription;
+import com.stripe.model.SubscriptionItem;
+import com.stripe.model.SubscriptionItemCollection;
 import com.stripe.model.Token;
 import com.stripe.model.Transfer;
 import com.stripe.model.VerificationFields;
@@ -170,6 +173,31 @@ public class StripeTest {
 		Map<String, Object> params = new HashMap<String, Object>();
 		params.put("domain_name", "jackshack.website");
 		return params;
+	}
+
+	static Subscription createDefaultSubscription(Customer customer)
+			throws StripeException {
+		Plan plan = Plan.create(getUniquePlanParams());
+		Map<String, Object> subCreateParams = new HashMap<String, Object>();
+		HashMap<String, Object> items = new HashMap<String, Object>();
+		HashMap<String, Object> item = new HashMap<String, Object>();
+
+    item.put("plan", plan.getId());
+    item.put("quantity", 1);
+    items.put("0", item);
+
+		subCreateParams.put("items", items);
+		subCreateParams.put("customer", customer.getId());
+		return Subscription.create(subCreateParams);
+	}
+
+	static SubscriptionItem createDefaultSubscriptionItem(Subscription subscription)
+			throws StripeException {
+		Plan plan = Plan.create(getUniquePlanParams());
+		Map<String, Object> subItemParams = new HashMap<String, Object>();
+		subItemParams.put("plan", plan.getId());
+		subItemParams.put("subscription", subscription.getId());
+		return SubscriptionItem.create(subItemParams);
 	}
 
 	static InvoiceItem createDefaultInvoiceItem(Customer customer)
@@ -1268,6 +1296,65 @@ public class StripeTest {
 		assertEquals(1, customer.getSubscriptions().getData().size());
 		assertEquals(sub.getId(), customer.getSubscriptions().getData().get(0).getId());
 	}
+
+	@Test
+  public void testSubscriptionItemCreate() throws StripeException {
+    Customer customer = Customer.create(defaultCustomerParams);
+    Subscription subscription = createDefaultSubscription(customer);
+    SubscriptionItem subscriptionItem = createDefaultSubscriptionItem(subscription);
+
+    assertEquals(subscriptionItem.getPlan().getName(), "J Bindings Plan");
+  }
+
+  @Test
+  public void testSubscriptionItemRetrieve() throws StripeException {
+    Customer customer = Customer.create(defaultCustomerParams);
+    Subscription subscription = createDefaultSubscription(customer);
+    SubscriptionItem subscriptionItem = createDefaultSubscriptionItem(subscription);
+
+    SubscriptionItem retrievedSubscriptionItem = SubscriptionItem
+        .retrieve(subscriptionItem.getId());
+    assertEquals(subscriptionItem.getId(), retrievedSubscriptionItem.getId());
+  }
+
+  @Test
+  public void testSubscriptionItemList() throws StripeException {
+    Customer customer = Customer.create(defaultCustomerParams);
+    Subscription subscription = createDefaultSubscription(customer);
+    SubscriptionItem subscriptionItem = createDefaultSubscriptionItem(subscription);
+
+    Map<String, Object> listParams = new HashMap<String, Object>();
+    listParams.put("subscription", subscription.getId());
+    SubscriptionItemCollection subscriptionItems = SubscriptionItem.list(listParams);
+    List<SubscriptionItem> subscriptionItemsData = subscriptionItems.getData();
+    assertEquals(subscriptionItemsData.size(), 2);
+  }
+
+  @Test
+  public void testSubscriptionItemUpdate() throws StripeException {
+    Customer customer = Customer.create(defaultCustomerParams);
+    Subscription subscription = createDefaultSubscription(customer);
+    SubscriptionItem subscriptionItem = createDefaultSubscriptionItem(subscription);
+
+    Map<String, Object> updateParams = new HashMap<String, Object>();
+    updateParams.put("quantity", 4);
+    updateParams.put("subscription", subscription.getId());
+
+    SubscriptionItem updatedSubscriptionItem =
+        subscriptionItem.update(updateParams);
+    assertTrue(updatedSubscriptionItem.getQuantity() == 4);
+  }
+
+  @Test
+  public void testSubscriptionItemDelete() throws StripeException {
+    Customer customer = Customer.create(defaultCustomerParams);
+    Subscription subscription = createDefaultSubscription(customer);
+    SubscriptionItem subscriptionItem = createDefaultSubscriptionItem(subscription);
+
+    DeletedSubscriptionItem deletedSubscriptionItem = subscriptionItem.delete();
+    assertTrue(deletedSubscriptionItem.getDeleted());
+    assertEquals(deletedSubscriptionItem.getId(), subscriptionItem.getId());
+  }
 
 	@Test
 	public void testInvoiceItemCreate() throws StripeException {

--- a/src/test/java/com/stripe/model/InvoiceTest.java
+++ b/src/test/java/com/stripe/model/InvoiceTest.java
@@ -18,44 +18,44 @@ import static org.mockito.Mockito.*;
 
 public class InvoiceTest extends BaseStripeTest {
 
-  @Before
-  public void mockStripeResponseGetter() {
-    APIResource.setStripeResponseGetter(networkMock);
-  }
+	@Before
+	public void mockStripeResponseGetter() {
+		APIResource.setStripeResponseGetter(networkMock);
+	}
 
-  @After
-  public void unmockStripeResponseGetter() {
-    /* This needs to be done because tests aren't isolated in Java */
-    APIResource.setStripeResponseGetter(new LiveStripeResponseGetter());
-  }
+	@After
+	public void unmockStripeResponseGetter() {
+		/* This needs to be done because tests aren't isolated in Java */
+		APIResource.setStripeResponseGetter(new LiveStripeResponseGetter());
+	}
 
-  @Test
-  public void testUpcoming() throws StripeException {
-    Map<String, Object> params = new HashMap<String, Object>();
-    List<HashMap<String, Object>> items = new ArrayList<HashMap<String, Object>>();
+	@Test
+	public void testUpcoming() throws StripeException {
+		Map<String, Object> params = new HashMap<String, Object>();
+		List<HashMap<String, Object>> items = new ArrayList<HashMap<String, Object>>();
 
-    HashMap<String, Object> itemA = new HashMap<String, Object>();
-    itemA.put("id", "si_kjnkk893jslo");
-    itemA.put("quantity", 3);
+		HashMap<String, Object> itemA = new HashMap<String, Object>();
+		itemA.put("id", "si_kjnkk893jslo");
+		itemA.put("quantity", 3);
 
-    HashMap<String, Object> itemB = new HashMap<String, Object>();
-    itemB.put("id", "si_kmmkjkjl123x8");
-    itemB.put("deleted", true);
+		HashMap<String, Object> itemB = new HashMap<String, Object>();
+		itemB.put("id", "si_kmmkjkjl123x8");
+		itemB.put("deleted", true);
 
-    HashMap<String, Object> itemC = new HashMap<String, Object>();
-    itemC.put("plan", "silver");
-    itemC.put("quantity", 1);
+		HashMap<String, Object> itemC = new HashMap<String, Object>();
+		itemC.put("plan", "silver");
+		itemC.put("quantity", 1);
 
-    items.add(itemA);
-    items.add(itemB);
-    items.add(itemC);
+		items.add(itemA);
+		items.add(itemB);
+		items.add(itemC);
 
-    params.put("subscription_items", items);
-    params.put("subscription", "sub_8OgUootyH2faMz");
-    params.put("customer", "cus_8OgDDsZEwoTscq");
-    Invoice.upcoming(params);
+		params.put("subscription_items", items);
+		params.put("subscription", "sub_8OgUootyH2faMz");
+		params.put("customer", "cus_8OgDDsZEwoTscq");
+		Invoice.upcoming(params);
 
-    verifyGet(Invoice.class, "https://api.stripe.com/v1/invoices/upcoming", params);
-    verifyNoMoreInteractions(networkMock);
-  }
+		verifyGet(Invoice.class, "https://api.stripe.com/v1/invoices/upcoming", params);
+		verifyNoMoreInteractions(networkMock);
+	}
 }

--- a/src/test/java/com/stripe/model/InvoiceTest.java
+++ b/src/test/java/com/stripe/model/InvoiceTest.java
@@ -1,0 +1,61 @@
+package com.stripe.model;
+
+import com.stripe.BaseStripeTest;
+import com.stripe.exception.StripeException;
+import com.stripe.model.Invoice;
+import com.stripe.net.APIResource;
+import com.stripe.net.LiveStripeResponseGetter;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.Map;
+import java.util.HashMap;
+import java.util.List;
+import java.util.ArrayList;
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+
+public class InvoiceTest extends BaseStripeTest {
+
+  @Before
+  public void mockStripeResponseGetter() {
+    APIResource.setStripeResponseGetter(networkMock);
+  }
+
+  @After
+  public void unmockStripeResponseGetter() {
+    /* This needs to be done because tests aren't isolated in Java */
+    APIResource.setStripeResponseGetter(new LiveStripeResponseGetter());
+  }
+
+  @Test
+  public void testUpcoming() throws StripeException {
+    Map<String, Object> params = new HashMap<String, Object>();
+    List<HashMap<String, Object>> items = new ArrayList<HashMap<String, Object>>();
+
+    HashMap<String, Object> itemA = new HashMap<String, Object>();
+    itemA.put("id", "si_kjnkk893jslo");
+    itemA.put("quantity", 3);
+
+    HashMap<String, Object> itemB = new HashMap<String, Object>();
+    itemB.put("id", "si_kmmkjkjl123x8");
+    itemB.put("deleted", true);
+
+    HashMap<String, Object> itemC = new HashMap<String, Object>();
+    itemC.put("plan", "silver");
+    itemC.put("quantity", 1);
+
+    items.add(itemA);
+    items.add(itemB);
+    items.add(itemC);
+
+    params.put("subscription_items", items);
+    params.put("subscription", "sub_8OgUootyH2faMz");
+    params.put("customer", "cus_8OgDDsZEwoTscq");
+    Invoice.upcoming(params);
+
+    verifyGet(Invoice.class, "https://api.stripe.com/v1/invoices/upcoming", params);
+    verifyNoMoreInteractions(networkMock);
+  }
+}

--- a/src/test/java/com/stripe/model/SubscriptionItemTest.java
+++ b/src/test/java/com/stripe/model/SubscriptionItemTest.java
@@ -16,72 +16,72 @@ import static org.mockito.Mockito.*;
 
 public class SubscriptionItemTest extends BaseStripeTest {
 
-  @Before
-  public void mockStripeResponseGetter() {
-    APIResource.setStripeResponseGetter(networkMock);
-  }
+	@Before
+	public void mockStripeResponseGetter() {
+		APIResource.setStripeResponseGetter(networkMock);
+	}
 
-  @After
-  public void unmockStripeResponseGetter() {
-    /* This needs to be done because tests aren't isolated in Java */
-    APIResource.setStripeResponseGetter(new LiveStripeResponseGetter());
-  }
+	@After
+	public void unmockStripeResponseGetter() {
+		/* This needs to be done because tests aren't isolated in Java */
+		APIResource.setStripeResponseGetter(new LiveStripeResponseGetter());
+	}
 
-  @Test
-  public void testRetrieve() throws StripeException {
-    SubscriptionItem.retrieve("test_item");
+	@Test
+	public void testRetrieve() throws StripeException {
+		SubscriptionItem.retrieve("test_item");
 
-    verifyGet(SubscriptionItem.class, "https://api.stripe.com/v1/subscription_items/test_item");
-    verifyNoMoreInteractions(networkMock);
-  }
+		verifyGet(SubscriptionItem.class, "https://api.stripe.com/v1/subscription_items/test_item");
+		verifyNoMoreInteractions(networkMock);
+	}
 
-  @Test
-  public void testList() throws StripeException {
-    HashMap<String, Object> params = new HashMap<String, Object>();
-    params.put("limit", 3);
-    params.put("subscription", "test_sub");
+	@Test
+	public void testList() throws StripeException {
+		HashMap<String, Object> params = new HashMap<String, Object>();
+		params.put("limit", 3);
+		params.put("subscription", "test_sub");
 
-    SubscriptionItem.list(params);
+		SubscriptionItem.list(params);
 
-    verifyGet(SubscriptionItemCollection.class, "https://api.stripe.com/v1/subscription_items", params);
-    verifyNoMoreInteractions(networkMock);
-  }
+		verifyGet(SubscriptionItemCollection.class, "https://api.stripe.com/v1/subscription_items", params);
+		verifyNoMoreInteractions(networkMock);
+	}
 
-  @Test
-  public void testUpdate() throws StripeException {
-    SubscriptionItem item = new SubscriptionItem();
-    item.setId("test_item");
+	@Test
+	public void testUpdate() throws StripeException {
+		SubscriptionItem item = new SubscriptionItem();
+		item.setId("test_item");
 
-    HashMap<String, Object> params = new HashMap<String, Object>();
-    params.put("plan", "gold");
+		HashMap<String, Object> params = new HashMap<String, Object>();
+		params.put("plan", "gold");
 
-    item.update(params);
+		item.update(params);
 
-    verifyPost(SubscriptionItem.class, "https://api.stripe.com/v1/subscription_items/test_item", params);
-    verifyNoMoreInteractions(networkMock);
-  }
+		verifyPost(SubscriptionItem.class, "https://api.stripe.com/v1/subscription_items/test_item", params);
+		verifyNoMoreInteractions(networkMock);
+	}
 
-  @Test
-  public void testCreate() throws StripeException {
-    HashMap<String, Object> params = new HashMap<String, Object>();
-    params.put("subscription", "sub_8OgUootyH2faMz");
-    params.put("plan", "gold");
-    params.put("quantity", 2);
+	@Test
+	public void testCreate() throws StripeException {
+		HashMap<String, Object> params = new HashMap<String, Object>();
+		params.put("subscription", "sub_8OgUootyH2faMz");
+		params.put("plan", "gold");
+		params.put("quantity", 2);
 
-    SubscriptionItem item = SubscriptionItem.create(params);
+		SubscriptionItem item = SubscriptionItem.create(params);
 
-    verifyPost(SubscriptionItem.class, "https://api.stripe.com/v1/subscription_items", params);
-    verifyNoMoreInteractions(networkMock);
-  }
+		verifyPost(SubscriptionItem.class, "https://api.stripe.com/v1/subscription_items", params);
+		verifyNoMoreInteractions(networkMock);
+	}
 
-  @Test
-  public void testDelete() throws StripeException {
-    SubscriptionItem item = new SubscriptionItem();
-    item.setId("test_item");
+	@Test
+	public void testDelete() throws StripeException {
+		SubscriptionItem item = new SubscriptionItem();
+		item.setId("test_item");
 
-    item.delete();
+		item.delete();
 
-    verifyDelete(DeletedSubscriptionItem.class, "https://api.stripe.com/v1/subscription_items/test_item");
-    verifyNoMoreInteractions(networkMock);
-  }
+		verifyDelete(DeletedSubscriptionItem.class, "https://api.stripe.com/v1/subscription_items/test_item");
+		verifyNoMoreInteractions(networkMock);
+	}
 }

--- a/src/test/java/com/stripe/model/SubscriptionItemTest.java
+++ b/src/test/java/com/stripe/model/SubscriptionItemTest.java
@@ -1,0 +1,87 @@
+package com.stripe.model;
+
+import com.stripe.BaseStripeTest;
+import com.stripe.exception.StripeException;
+import com.stripe.model.SubscriptionItem;
+import com.stripe.net.APIResource;
+import com.stripe.net.LiveStripeResponseGetter;
+import org.junit.After;
+import org.junit.Before;
+import junit.framework.Assert;
+
+import java.util.HashMap;
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+
+public class SubscriptionItemTest extends BaseStripeTest {
+
+  @Before
+  public void mockStripeResponseGetter() {
+    APIResource.setStripeResponseGetter(networkMock);
+  }
+
+  @After
+  public void unmockStripeResponseGetter() {
+    /* This needs to be done because tests aren't isolated in Java */
+    APIResource.setStripeResponseGetter(new LiveStripeResponseGetter());
+  }
+
+  @Test
+  public void testRetrieve() throws StripeException {
+    SubscriptionItem.retrieve("test_item");
+
+    verifyGet(SubscriptionItem.class, "https://api.stripe.com/v1/subscription_items/test_item");
+    verifyNoMoreInteractions(networkMock);
+  }
+
+  @Test
+  public void testList() throws StripeException {
+    HashMap<String, Object> params = new HashMap<String, Object>();
+    params.put("limit", 3);
+    params.put("subscription", "test_sub");
+
+    SubscriptionItem.list(params);
+
+    verifyGet(SubscriptionItemCollection.class, "https://api.stripe.com/v1/subscription_items", params);
+    verifyNoMoreInteractions(networkMock);
+  }
+
+  @Test
+  public void testUpdate() throws StripeException {
+    SubscriptionItem item = new SubscriptionItem();
+    item.setId("test_item");
+
+    HashMap<String, Object> params = new HashMap<String, Object>();
+    params.put("plan", "gold");
+
+    item.update(params);
+
+    verifyPost(SubscriptionItem.class, "https://api.stripe.com/v1/subscription_items/test_item", params);
+    verifyNoMoreInteractions(networkMock);
+  }
+
+  @Test
+  public void testCreate() throws StripeException {
+    HashMap<String, Object> params = new HashMap<String, Object>();
+    params.put("subscription", "sub_8OgUootyH2faMz");
+    params.put("plan", "gold");
+    params.put("quantity", 2);
+
+    SubscriptionItem item = SubscriptionItem.create(params);
+
+    verifyPost(SubscriptionItem.class, "https://api.stripe.com/v1/subscription_items", params);
+    verifyNoMoreInteractions(networkMock);
+  }
+
+  @Test
+  public void testDelete() throws StripeException {
+    SubscriptionItem item = new SubscriptionItem();
+    item.setId("test_item");
+
+    item.delete();
+
+    verifyDelete(DeletedSubscriptionItem.class, "https://api.stripe.com/v1/subscription_items/test_item");
+    verifyNoMoreInteractions(networkMock);
+  }
+}

--- a/src/test/java/com/stripe/model/SubscriptionTest.java
+++ b/src/test/java/com/stripe/model/SubscriptionTest.java
@@ -10,7 +10,10 @@ import org.junit.After;
 import org.junit.Before;
 import junit.framework.Assert;
 
+import java.util.Map;
 import java.util.HashMap;
+import java.util.List;
+import java.util.ArrayList;
 import org.junit.Test;
 
 import static org.mockito.Mockito.*;
@@ -64,10 +67,62 @@ public class SubscriptionTest extends BaseStripeTest {
   }
 
   @Test
+  public void testUpdateWithItems() throws StripeException {
+    Subscription subscription = new Subscription();
+    subscription.setId("test_sub");
+
+    HashMap<String, Object> params = new HashMap<String, Object>();
+    List<HashMap<String, Object>> items = new ArrayList<HashMap<String, Object>>();
+
+    HashMap<String, Object> itemA = new HashMap<String, Object>();
+    itemA.put("plan", "gold");
+    itemA.put("quantity", 1);
+
+    HashMap<String, Object> itemB = new HashMap<String, Object>();
+    itemB.put("plan", "silver");
+    itemB.put("quantity", 2);
+
+    items.add(itemA);
+    items.add(itemB);
+
+    params.put("items", items);
+
+    subscription.update(params);
+
+    verifyPost(Subscription.class, "https://api.stripe.com/v1/subscriptions/test_sub", params);
+    verifyNoMoreInteractions(networkMock);
+  }
+
+  @Test
   public void testCreate() throws StripeException {
     HashMap<String, Object> params = new HashMap<String, Object>();
     params.put("customer", "test_cus");
     params.put("plan", "gold");
+
+    Subscription subscription = Subscription.create(params);
+
+    verifyPost(Subscription.class, "https://api.stripe.com/v1/subscriptions", params);
+    verifyNoMoreInteractions(networkMock);
+  }
+
+  @Test
+  public void testCreateWithItems() throws StripeException {
+    Map<String, Object> params = new HashMap<String, Object>();
+    List<HashMap<String, Object>> items = new ArrayList<HashMap<String, Object>>();
+
+    HashMap<String, Object> itemA = new HashMap<String, Object>();
+    itemA.put("plan", "gold");
+    itemA.put("quantity", 1);
+
+    HashMap<String, Object> itemB = new HashMap<String, Object>();
+    itemB.put("plan", "silver");
+    itemB.put("quantity", 2);
+
+    items.add(itemA);
+    items.add(itemB);
+
+    params.put("customer", "test_cus");
+    params.put("items", items);
 
     Subscription subscription = Subscription.create(params);
 

--- a/src/test/java/com/stripe/model/SubscriptionTest.java
+++ b/src/test/java/com/stripe/model/SubscriptionTest.java
@@ -20,140 +20,140 @@ import static org.mockito.Mockito.*;
 
 public class SubscriptionTest extends BaseStripeTest {
 
-  @Before
-  public void mockStripeResponseGetter() {
-    APIResource.setStripeResponseGetter(networkMock);
-  }
+	@Before
+	public void mockStripeResponseGetter() {
+		APIResource.setStripeResponseGetter(networkMock);
+	}
 
-  @After
-  public void unmockStripeResponseGetter() {
-    /* This needs to be done because tests aren't isolated in Java */
-    APIResource.setStripeResponseGetter(new LiveStripeResponseGetter());
-  }
+	@After
+	public void unmockStripeResponseGetter() {
+		/* This needs to be done because tests aren't isolated in Java */
+		APIResource.setStripeResponseGetter(new LiveStripeResponseGetter());
+	}
 
-  @Test
-  public void testRetrieve() throws StripeException {
-    Subscription.retrieve("test_sub");
+	@Test
+	public void testRetrieve() throws StripeException {
+		Subscription.retrieve("test_sub");
 
-    verifyGet(Subscription.class, "https://api.stripe.com/v1/subscriptions/test_sub");
-    verifyNoMoreInteractions(networkMock);
-  }
+		verifyGet(Subscription.class, "https://api.stripe.com/v1/subscriptions/test_sub");
+		verifyNoMoreInteractions(networkMock);
+	}
 
-  @Test
-  public void testAll() throws StripeException {
-    HashMap<String, Object> params = new HashMap<String, Object>();
-    params.put("limit", 3);
-    params.put("customer", "test_cus");
-    params.put("plan", "gold");
+	@Test
+	public void testAll() throws StripeException {
+		HashMap<String, Object> params = new HashMap<String, Object>();
+		params.put("limit", 3);
+		params.put("customer", "test_cus");
+		params.put("plan", "gold");
 
-    Subscription.all(params);
+		Subscription.all(params);
 
-    verifyGet(SubscriptionCollection.class, "https://api.stripe.com/v1/subscriptions", params);
-    verifyNoMoreInteractions(networkMock);
-  }
+		verifyGet(SubscriptionCollection.class, "https://api.stripe.com/v1/subscriptions", params);
+		verifyNoMoreInteractions(networkMock);
+	}
 
-  @Test
-  public void testUpdate() throws StripeException {
-    Subscription subscription = new Subscription();
-    subscription.setId("test_sub");
+	@Test
+	public void testUpdate() throws StripeException {
+		Subscription subscription = new Subscription();
+		subscription.setId("test_sub");
 
-    HashMap<String, Object> params = new HashMap<String, Object>();
-    params.put("plan", "gold");
+		HashMap<String, Object> params = new HashMap<String, Object>();
+		params.put("plan", "gold");
 
-    subscription.update(params);
+		subscription.update(params);
 
-    verifyPost(Subscription.class, "https://api.stripe.com/v1/subscriptions/test_sub", params);
-    verifyNoMoreInteractions(networkMock);
-  }
+		verifyPost(Subscription.class, "https://api.stripe.com/v1/subscriptions/test_sub", params);
+		verifyNoMoreInteractions(networkMock);
+	}
 
-  @Test
-  public void testUpdateWithItems() throws StripeException {
-    Subscription subscription = new Subscription();
-    subscription.setId("test_sub");
+	@Test
+	public void testUpdateWithItems() throws StripeException {
+		Subscription subscription = new Subscription();
+		subscription.setId("test_sub");
 
-    HashMap<String, Object> params = new HashMap<String, Object>();
-    List<HashMap<String, Object>> items = new ArrayList<HashMap<String, Object>>();
+		HashMap<String, Object> params = new HashMap<String, Object>();
+		List<HashMap<String, Object>> items = new ArrayList<HashMap<String, Object>>();
 
-    HashMap<String, Object> itemA = new HashMap<String, Object>();
-    itemA.put("plan", "gold");
-    itemA.put("quantity", 1);
+		HashMap<String, Object> itemA = new HashMap<String, Object>();
+		itemA.put("plan", "gold");
+		itemA.put("quantity", 1);
 
-    HashMap<String, Object> itemB = new HashMap<String, Object>();
-    itemB.put("plan", "silver");
-    itemB.put("quantity", 2);
+		HashMap<String, Object> itemB = new HashMap<String, Object>();
+		itemB.put("plan", "silver");
+		itemB.put("quantity", 2);
 
-    items.add(itemA);
-    items.add(itemB);
+		items.add(itemA);
+		items.add(itemB);
 
-    params.put("items", items);
+		params.put("items", items);
 
-    subscription.update(params);
+		subscription.update(params);
 
-    verifyPost(Subscription.class, "https://api.stripe.com/v1/subscriptions/test_sub", params);
-    verifyNoMoreInteractions(networkMock);
-  }
+		verifyPost(Subscription.class, "https://api.stripe.com/v1/subscriptions/test_sub", params);
+		verifyNoMoreInteractions(networkMock);
+	}
 
-  @Test
-  public void testCreate() throws StripeException {
-    HashMap<String, Object> params = new HashMap<String, Object>();
-    params.put("customer", "test_cus");
-    params.put("plan", "gold");
+	@Test
+	public void testCreate() throws StripeException {
+		HashMap<String, Object> params = new HashMap<String, Object>();
+		params.put("customer", "test_cus");
+		params.put("plan", "gold");
 
-    Subscription subscription = Subscription.create(params);
+		Subscription subscription = Subscription.create(params);
 
-    verifyPost(Subscription.class, "https://api.stripe.com/v1/subscriptions", params);
-    verifyNoMoreInteractions(networkMock);
-  }
+		verifyPost(Subscription.class, "https://api.stripe.com/v1/subscriptions", params);
+		verifyNoMoreInteractions(networkMock);
+	}
 
-  @Test
-  public void testCreateWithItems() throws StripeException {
-    Map<String, Object> params = new HashMap<String, Object>();
-    List<HashMap<String, Object>> items = new ArrayList<HashMap<String, Object>>();
+	@Test
+	public void testCreateWithItems() throws StripeException {
+		Map<String, Object> params = new HashMap<String, Object>();
+		List<HashMap<String, Object>> items = new ArrayList<HashMap<String, Object>>();
 
-    HashMap<String, Object> itemA = new HashMap<String, Object>();
-    itemA.put("plan", "gold");
-    itemA.put("quantity", 1);
+		HashMap<String, Object> itemA = new HashMap<String, Object>();
+		itemA.put("plan", "gold");
+		itemA.put("quantity", 1);
 
-    HashMap<String, Object> itemB = new HashMap<String, Object>();
-    itemB.put("plan", "silver");
-    itemB.put("quantity", 2);
+		HashMap<String, Object> itemB = new HashMap<String, Object>();
+		itemB.put("plan", "silver");
+		itemB.put("quantity", 2);
 
-    items.add(itemA);
-    items.add(itemB);
+		items.add(itemA);
+		items.add(itemB);
 
-    params.put("customer", "test_cus");
-    params.put("items", items);
+		params.put("customer", "test_cus");
+		params.put("items", items);
 
-    Subscription subscription = Subscription.create(params);
+		Subscription subscription = Subscription.create(params);
 
-    verifyPost(Subscription.class, "https://api.stripe.com/v1/subscriptions", params);
-    verifyNoMoreInteractions(networkMock);
-  }
+		verifyPost(Subscription.class, "https://api.stripe.com/v1/subscriptions", params);
+		verifyNoMoreInteractions(networkMock);
+	}
 
-  @Test
-  public void testCancel() throws StripeException {
-    Subscription subscription = new Subscription();
-    subscription.setId("test_sub");
+	@Test
+	public void testCancel() throws StripeException {
+		Subscription subscription = new Subscription();
+		subscription.setId("test_sub");
 
-    subscription.cancel(null);
+		subscription.cancel(null);
 
-    verifyDelete(Subscription.class, "https://api.stripe.com/v1/subscriptions/test_sub");
-    verifyNoMoreInteractions(networkMock);
-  }
+		verifyDelete(Subscription.class, "https://api.stripe.com/v1/subscriptions/test_sub");
+		verifyNoMoreInteractions(networkMock);
+	}
 
-  @Test
-  public void testSetDeleteDiscount() throws StripeException {
-    Subscription subscription = new Subscription();
-    subscription.setId("test_sub");
+	@Test
+	public void testSetDeleteDiscount() throws StripeException {
+		Subscription subscription = new Subscription();
+		subscription.setId("test_sub");
 
-    Discount discount = new Discount();
-    discount.setId("test_dis");
-    subscription.setDiscount(discount);
-    Assert.assertEquals("test_dis", subscription.getDiscount().id);
+		Discount discount = new Discount();
+		discount.setId("test_dis");
+		subscription.setDiscount(discount);
+		Assert.assertEquals("test_dis", subscription.getDiscount().id);
 
-    subscription.deleteDiscount();
+		subscription.deleteDiscount();
 
-    verifyDelete(Discount.class, "https://api.stripe.com/v1/subscriptions/test_sub/discount");
-    verifyNoMoreInteractions(networkMock);
-  }
+		verifyDelete(Discount.class, "https://api.stripe.com/v1/subscriptions/test_sub/discount");
+		verifyNoMoreInteractions(networkMock);
+	}
 }


### PR DESCRIPTION
This PR adds bindings support for subscriptions with multiple items:

- Adds SubscriptionItem object and tests

- Add tests to verify passing in items arrays into invoice creation, subscription update, and subscription create
