### PR TITLE
Transfer Transactions should use requestCollection

### DIFF
--- a/src/main/java/com/stripe/model/Transfer.java
+++ b/src/main/java/com/stripe/model/Transfer.java
@@ -442,7 +442,7 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
 			Map<String, Object> params, RequestOptions options)
 			throws AuthenticationException, InvalidRequestException,
 			APIConnectionException, CardException, APIException {
-		return request(RequestMethod.GET, String.format("%s/transactions",
-						instanceURL(Transfer.class, this.getId())), params, TransferTransactionCollection.class, options);
+		String url = String.format("%s%s", instanceURL(Transfer.class, this.getId()), "/transactions");
+		return requestCollection(url, params, TransferTransactionCollection.class, options);
 	}
 }

--- a/src/test/java/com/stripe/StripeTest.java
+++ b/src/test/java/com/stripe/StripeTest.java
@@ -68,6 +68,7 @@ import com.stripe.model.SubscriptionItem;
 import com.stripe.model.SubscriptionItemCollection;
 import com.stripe.model.Token;
 import com.stripe.model.Transfer;
+import com.stripe.model.TransferTransactionCollection;
 import com.stripe.model.VerificationFields;
 
 import com.stripe.net.RequestOptions;
@@ -1594,6 +1595,17 @@ public class StripeTest {
 		listParams.put("count", 1);
 		List<Transfer> transfers = Transfer.all(listParams).getData();
 		assertEquals(transfers.size(), 1);
+	}
+
+	@Test
+	public void testTransferTransactions() throws StripeException {
+		Map<String, Object> transferParams = getTransferParams();
+		Transfer transfer = Transfer.create(transferParams);
+		HashMap<String, Object> params = new HashMap<String, Object>();
+		TransferTransactionCollection transactions = transfer.transactions(params, supportedRequestOptions);
+		// Test that requestOptions and requestParams are the same in returned transactions:
+		assertEquals(supportedRequestOptions, transactions.getRequestOptions());
+		assertEquals(params, transactions.getRequestParams());
 	}
 
 	@Test


### PR DESCRIPTION
`Transfer.transactions` was using `APIResource.request` instead of `APIResource.requestCollection`, which meant that the returned `TransferTransactionCollection` didn't have `requestOptions` or `requestParams`. (https://github.com/stripe/stripe-java/blob/master/src/main/java/com/stripe/net/APIResource.java#L163)

These are needed if we want to make subsequent calls to get the next page of data in the collection.

r? @brandur 