### PR TITLE
Adds support for verify source endpoint

### DIFF
--- a/src/main/java/com/stripe/model/Source.java
+++ b/src/main/java/com/stripe/model/Source.java
@@ -192,11 +192,7 @@ public class Source extends ExternalAccount {
 	public Source verify(Map<String, Object> params, RequestOptions options)
 			throws AuthenticationException, InvalidRequestException,
 			APIConnectionException, CardException, APIException {
-		if (this.getCustomer() != null) {
-			return request(RequestMethod.POST, String.format("%s/verify", this.getSourceInstanceURL()), params, Source.class, options);
-		} else {
-			throw new InvalidRequestException("Only customer sources can be verified in this manner.", null, null, null, null);
-		}
+		return request(RequestMethod.POST, String.format("%s/verify", this.getSourceInstanceURL()), params, Source.class, options);
 	}
 
 	@Override

--- a/src/test/java/com/stripe/model/SourceTest.java
+++ b/src/test/java/com/stripe/model/SourceTest.java
@@ -1,0 +1,73 @@
+package com.stripe.model;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+
+import com.stripe.BaseStripeTest;
+import com.stripe.exception.StripeException;
+import com.stripe.net.APIResource;
+import com.stripe.net.LiveStripeResponseGetter;
+import com.stripe.net.RequestOptions;
+import com.stripe.net.RequestOptions.RequestOptionsBuilder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class SourceTest extends BaseStripeTest {
+  @Before
+  public void mockStripeResponseGetter() {
+    APIResource.setStripeResponseGetter(networkMock);
+  }
+
+  @After
+  public void unmockStripeResponseGetter() {
+    /* This needs to be done because tests aren't isolated in Java */
+    APIResource.setStripeResponseGetter(new LiveStripeResponseGetter());
+  }
+
+  @Test
+  public void testCreate() throws StripeException {
+    HashMap<String, Object> ownerParams = new HashMap<String, Object>();
+    ownerParams.put("email", "jenny.rosen@example.com");
+
+    HashMap<String, Object> params = new HashMap<String, Object>();
+    params.put("type", "bitcoin");
+    params.put("amount", 1000);
+    params.put("currency", "usd");
+    params.put("owner", ownerParams);
+
+    Source src = Source.create(params);
+
+    verifyPost(Source.class, "https://api.stripe.com/v1/sources", params);
+  }
+
+  @Test
+  public void testRetrieve() throws StripeException {
+    Source src = Source.retrieve("src_foo");
+
+    verifyGet(Source.class, "https://api.stripe.com/v1/sources/src_foo");
+    verifyNoMoreInteractions(networkMock);
+  }
+
+  @Test
+  public void testVerify() throws StripeException, IOException {
+    stubNetwork(Source.class, resource("source_ach_debit.json"));
+    Source src = Source.retrieve("src_19LGIDKCFFPkgtRhhqvVrz6T");
+    verifyGet(Source.class, "https://api.stripe.com/v1/sources/src_19LGIDKCFFPkgtRhhqvVrz6T");
+
+    Map params = new HashMap<String, Object>();
+    Integer[] values = {32, 45};
+    params.put("values", values);
+    src.verify(params);
+    verifyPost(
+        Source.class,
+        "https://api.stripe.com/v1/sources/src_19LGIDKCFFPkgtRhhqvVrz6T/verify",
+        params
+    );
+  }
+}

--- a/src/test/resources/com/stripe/model/source_ach_debit.json
+++ b/src/test/resources/com/stripe/model/source_ach_debit.json
@@ -1,0 +1,35 @@
+{
+  "id": "src_19LGIDKCFFPkgtRhhqvVrz6T",
+  "object": "source",
+  "ach_debit": {
+    "country": "US",
+    "fingerprint": "yY5BWKwnW98uydOa",
+    "last4": 6789,
+    "routing_number": 110000000,
+    "type": "individual"
+  },
+  "amount": null,
+  "client_secret": "src_client_secret_mtpQ6fRQdFszxs9ZNfjq2ecA",
+  "created": 1480443925,
+  "currency": "usd",
+  "flow": "verification",
+  "livemode": false,
+  "metadata": {},
+  "owner": {
+    "address": null,
+    "email": null,
+    "name": "Stripey McStripe",
+    "phone": null,
+    "verified_address": null,
+    "verified_email": null,
+    "verified_name": null,
+    "verified_phone": null
+  },
+  "status": "pending",
+  "type": "ach_debit",
+  "usage": "reusable",
+  "verification": {
+    "attempts_remaining": 10,
+    "status": "pending"
+  }
+}


### PR DESCRIPTION
r? @will-stripe
cc @stripe/api-libraries @stan-stripe

This PR adds support for the /verify endpoint for sources, for use with ACH debit and other source types that require a verification. I also added tests for sources.
