### PR TITLE
Added support for network_reason_code to the Dispute object

### DIFF
--- a/src/main/java/com/stripe/model/Dispute.java
+++ b/src/main/java/com/stripe/model/Dispute.java
@@ -25,6 +25,7 @@ public class Dispute extends APIResource implements HasId {
 	Map<String, String> metadata;
 	String reason;
 	String status;
+	String networkReasonCode; // Not part of the public API.
 
 	/** 8/2014: Legacy (now use balanceTransactions) -- https://stripe.com/docs/upgrades#2014-08-20 */
 	@Deprecated
@@ -136,6 +137,17 @@ public class Dispute extends APIResource implements HasId {
 
 	public void setStatus(String status) {
 		this.status = status;
+	}
+
+	public String getNetworkReasonCode() {
+		return networkReasonCode;
+	}
+
+	/**
+	 * This method is not part of the public API and for internal use only.
+	 */
+	public void setNetworkReasonCode(String networkReasonCode) {
+		this.networkReasonCode = networkReasonCode;
 	}
 
 	/**


### PR DESCRIPTION
This property is not part of the public API and for internal use only.

r? @brandur-stripe 