### PR TITLE
Adds toJson() method

### DIFF
--- a/src/main/java/com/stripe/model/Account.java
+++ b/src/main/java/com/stripe/model/Account.java
@@ -10,6 +10,7 @@ import com.stripe.net.RequestOptions;
 
 public class Account extends APIResource implements HasId, MetadataStore<Account> {
 	String id;
+	String object;
 	String businessLogo;
 	String businessName;
 	String businessPrimaryColor;
@@ -45,6 +46,14 @@ public class Account extends APIResource implements HasId, MetadataStore<Account
 
 	public String getId() {
 		return id;
+	}
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
 	}
 
 	public String getBusinessLogo()

--- a/src/main/java/com/stripe/model/ApplePayDomain.java
+++ b/src/main/java/com/stripe/model/ApplePayDomain.java
@@ -13,6 +13,7 @@ import java.util.Map;
 
 public class ApplePayDomain extends APIResource implements HasId {
 	String id;
+	String object;
 	Long created;
 	String domainName;
 	Boolean livemode;
@@ -23,6 +24,14 @@ public class ApplePayDomain extends APIResource implements HasId {
 
 	public void setId(String id) {
 		this.id = id;
+	}
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
 	}
 
 	public Long getCreated() {

--- a/src/main/java/com/stripe/model/ApplicationFee.java
+++ b/src/main/java/com/stripe/model/ApplicationFee.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 public class ApplicationFee extends APIResource implements HasId {
 	String id;
+	String object;
 	String account;
 	Long amount;
 	Long amountRefunded;
@@ -34,6 +35,14 @@ public class ApplicationFee extends APIResource implements HasId {
 
 	public void setId(String id) {
 		this.id = id;
+	}
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
 	}
 
 	public String getAccount() {

--- a/src/main/java/com/stripe/model/Balance.java
+++ b/src/main/java/com/stripe/model/Balance.java
@@ -11,9 +11,18 @@ import com.stripe.net.RequestOptions;
 import java.util.List;
 
 public class Balance extends APIResource {
+	String object;
 	List<Money> available;
 	Boolean livemode;
 	List<Money> pending;
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
+	}
 
 	public List<Money> getAvailable() {
 		return available;

--- a/src/main/java/com/stripe/model/BalanceTransaction.java
+++ b/src/main/java/com/stripe/model/BalanceTransaction.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 public class BalanceTransaction extends APIResource implements HasId {
 	String id;
+	String object;
 	Long amount;
 	Long availableOn;
 	Long created;
@@ -33,6 +34,14 @@ public class BalanceTransaction extends APIResource implements HasId {
 
 	public void setId(String id) {
 		this.id = id;
+	}
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
 	}
 
 	public Long getAmount() {

--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -14,6 +14,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
 	public static final String FRAUD_DETAILS = "fraud_details";
 
 	String id;
+	String object;
 	Long amount;
 	Long amountRefunded;
 	ExpandableField<Application> application;
@@ -61,6 +62,14 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
 
 	public void setId(String id) {
 		this.id = id;
+	}
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
 	}
 
 	public Long getAmount() {

--- a/src/main/java/com/stripe/model/CountrySpec.java
+++ b/src/main/java/com/stripe/model/CountrySpec.java
@@ -13,6 +13,7 @@ import java.util.Map;
 
 public class CountrySpec extends APIResource implements HasId {
 	String id;
+	String object;
 	String defaultCurrency;
 	Map<String, List<String>> supportedBankAccountCurrencies;
 	List<String> supportedPaymentCurrencies;
@@ -25,6 +26,14 @@ public class CountrySpec extends APIResource implements HasId {
 
 	public void setId(String id) {
 		this.id = id;
+	}
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
 	}
 
 	public String getDefaultCurrency() {

--- a/src/main/java/com/stripe/model/Coupon.java
+++ b/src/main/java/com/stripe/model/Coupon.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 public class Coupon extends APIResource implements MetadataStore<Coupon>, HasId {
 	String id;
+	String object;
 	Long amountOff;
 	Long created;
 	String currency;
@@ -31,6 +32,14 @@ public class Coupon extends APIResource implements MetadataStore<Coupon>, HasId 
 
 	public void setId(String id) {
 		this.id = id;
+	}
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
 	}
 
 	public Long getAmountOff() {

--- a/src/main/java/com/stripe/model/Customer.java
+++ b/src/main/java/com/stripe/model/Customer.java
@@ -13,6 +13,7 @@ import java.util.Map;
 
 public class Customer extends APIResource implements MetadataStore<Customer>, HasId {
 	String id;
+	String object;
 	Long accountBalance;
 	String businessVatId;
 	Long created;
@@ -46,6 +47,14 @@ public class Customer extends APIResource implements MetadataStore<Customer>, Ha
 
 	public void setId(String id) {
 		this.id = id;
+	}
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
 	}
 
 	public Long getAccountBalance() {

--- a/src/main/java/com/stripe/model/Discount.java
+++ b/src/main/java/com/stripe/model/Discount.java
@@ -3,6 +3,7 @@ package com.stripe.model;
 
 public class Discount extends StripeObject {
 	String id;
+	String object;
 	Coupon coupon;
 	String customer;
 	Long end;
@@ -15,6 +16,14 @@ public class Discount extends StripeObject {
 
 	public void setId(String id) {
 		this.id = id;
+	}
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
 	}
 
 	public Coupon getCoupon() {

--- a/src/main/java/com/stripe/model/Dispute.java
+++ b/src/main/java/com/stripe/model/Dispute.java
@@ -13,6 +13,7 @@ import java.util.Map;
 
 public class Dispute extends APIResource implements HasId {
 	String id;
+	String object;
 	Long amount;
 	List<BalanceTransaction> balanceTransactions;
 	String charge;
@@ -43,6 +44,14 @@ public class Dispute extends APIResource implements HasId {
 
 	public void setId(String id) {
 		this.id = id;
+	}
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
 	}
 
 	public Long getAmount() {

--- a/src/main/java/com/stripe/model/Event.java
+++ b/src/main/java/com/stripe/model/Event.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 public class Event extends APIResource implements HasId {
 	String id;
+	String object;
 	String apiVersion;
 	Long created;
 	EventData data;
@@ -27,6 +28,14 @@ public class Event extends APIResource implements HasId {
 
 	public void setId(String id) {
 		this.id = id;
+	}
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
 	}
 
 	public String getApiVersion() {

--- a/src/main/java/com/stripe/model/FeeRefund.java
+++ b/src/main/java/com/stripe/model/FeeRefund.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 public class FeeRefund extends APIResource implements MetadataStore<ApplicationFee>, HasId {
 	String id;
+	String object;
 	Long amount;
 	String balanceTransaction;
 	String currency;
@@ -21,6 +22,14 @@ public class FeeRefund extends APIResource implements MetadataStore<ApplicationF
 
 	public String getId() {
 		return id;
+	}
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
 	}
 
 	public Long getAmount() {

--- a/src/main/java/com/stripe/model/FileUpload.java
+++ b/src/main/java/com/stripe/model/FileUpload.java
@@ -13,6 +13,7 @@ import java.util.Map;
 
 public class FileUpload extends APIResource implements HasId {
 	String id;
+	String object;
 	Long created;
 	String purpose;
 	Long size;
@@ -25,6 +26,14 @@ public class FileUpload extends APIResource implements HasId {
 
 	public void setId(String id) {
 		this.id = id;
+	}
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
 	}
 
 	public Long getCreated() {

--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 public class Invoice extends APIResource implements MetadataStore<Invoice>, HasId {
 	String id;
+	String object;
 	Long amountDue;
 	Long applicationFee;
 	Integer attemptCount;
@@ -50,6 +51,14 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
 
 	public void setId(String id) {
 		this.id = id;
+	}
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
 	}
 
 	public Long getAmountDue() {

--- a/src/main/java/com/stripe/model/InvoiceItem.java
+++ b/src/main/java/com/stripe/model/InvoiceItem.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 public class InvoiceItem extends APIResource implements MetadataStore<InvoiceItem>, HasId {
 	String id;
+	String object;
 	Long amount;
 	String currency;
 	String customer;
@@ -33,6 +34,14 @@ public class InvoiceItem extends APIResource implements MetadataStore<InvoiceIte
 
 	public void setId(String id) {
 		this.id = id;
+	}
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
 	}
 
 	public Long getAmount() {

--- a/src/main/java/com/stripe/model/InvoiceLineItem.java
+++ b/src/main/java/com/stripe/model/InvoiceLineItem.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 public class InvoiceLineItem extends StripeObject implements HasId {
 	String id;
+	String object;
 	Long amount;
 	String currency;
 	String description;
@@ -19,6 +20,14 @@ public class InvoiceLineItem extends StripeObject implements HasId {
 
 	public String getId() {
 		return this.id;
+	}
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
 	}
 
 	public Long getAmount() {

--- a/src/main/java/com/stripe/model/Order.java
+++ b/src/main/java/com/stripe/model/Order.java
@@ -13,6 +13,7 @@ import com.stripe.net.RequestOptions;
 
 public class Order extends APIResource implements HasId, MetadataStore<Order> {
 	String id;
+	String object;
 	Long amount;
 	String application;
 	Long applicationFee;
@@ -38,6 +39,14 @@ public class Order extends APIResource implements HasId, MetadataStore<Order> {
 
 	public void setId(String id) {
 		this.id = id;
+	}
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
 	}
 
 	public Long getAmount() {

--- a/src/main/java/com/stripe/model/OrderItem.java
+++ b/src/main/java/com/stripe/model/OrderItem.java
@@ -1,12 +1,21 @@
 package com.stripe.model;
 
 public class OrderItem extends StripeObject {
+	String object;
 	Long amount;
 	String currency;
 	String description;
 	String parent;
 	Integer quantity;
 	String type;
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
+	}
 
 	public Long getAmount() {
 		return amount;

--- a/src/main/java/com/stripe/model/OrderReturn.java
+++ b/src/main/java/com/stripe/model/OrderReturn.java
@@ -13,6 +13,7 @@ import com.stripe.net.RequestOptions;
 
 public class OrderReturn extends APIResource implements HasId {
 	String id;
+	String object;
 	Long amount;
 	Long created;
 	String currency;
@@ -27,6 +28,14 @@ public class OrderReturn extends APIResource implements HasId {
 
 	public void setId(String id) {
 		this.id = id;
+	}
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
 	}
 
 	public Long getAmount() {

--- a/src/main/java/com/stripe/model/Plan.java
+++ b/src/main/java/com/stripe/model/Plan.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
 	String id;
+	String object;
 	Long amount;
 	Long created;
 	String currency;
@@ -32,6 +33,14 @@ public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
 
 	public void setId(String id) {
 		this.id = id;
+	}
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
 	}
 
 	public Long getAmount() {

--- a/src/main/java/com/stripe/model/Product.java
+++ b/src/main/java/com/stripe/model/Product.java
@@ -13,6 +13,7 @@ import com.stripe.net.RequestOptions;
 
 public class Product extends APIResource implements HasId, MetadataStore<Product> {
 	String id;
+	String object;
 	Boolean active;
 	List<String> attributes;
 	String caption;
@@ -35,6 +36,14 @@ public class Product extends APIResource implements HasId, MetadataStore<Product
 
 	public void setId(String id) {
 		this.id = id;
+	}
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
 	}
 
 	public Boolean getActive() {

--- a/src/main/java/com/stripe/model/Recipient.java
+++ b/src/main/java/com/stripe/model/Recipient.java
@@ -13,6 +13,7 @@ import java.util.Map;
 
 public class Recipient extends APIResource implements MetadataStore<Recipient>, HasId {
 	String id;
+	String object;
 	BankAccount activeAccount;
 	RecipientCardCollection cards;
 	Long created;
@@ -33,6 +34,14 @@ public class Recipient extends APIResource implements MetadataStore<Recipient>, 
 
 	public void setId(String id) {
 		this.id = id;
+	}
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
 	}
 
 	public BankAccount getActiveAccount() {

--- a/src/main/java/com/stripe/model/Refund.java
+++ b/src/main/java/com/stripe/model/Refund.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 public class Refund extends APIResource implements MetadataStore<Charge>, HasId {
 	String id;
+	String object;
 	Long amount;
 	String balanceTransaction;
 	String charge;
@@ -29,6 +30,14 @@ public class Refund extends APIResource implements MetadataStore<Charge>, HasId 
 
 	public void setId(String id) {
 		this.id = id;
+	}
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
 	}
 
 	public Long getAmount() {

--- a/src/main/java/com/stripe/model/Reversal.java
+++ b/src/main/java/com/stripe/model/Reversal.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 public class Reversal extends APIResource implements MetadataStore<Transfer>, HasId {
 	String id;
+	String object;
 	Long amount;
 	String balanceTransaction;
 	Long created;
@@ -21,6 +22,14 @@ public class Reversal extends APIResource implements MetadataStore<Transfer>, Ha
 
 	public String getId() {
 		return id;
+	}
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
 	}
 
 	public Long getAmount() {

--- a/src/main/java/com/stripe/model/Review.java
+++ b/src/main/java/com/stripe/model/Review.java
@@ -2,6 +2,7 @@ package com.stripe.model;
 
 public class Review extends StripeObject implements HasId {
 	String id;
+	String object;
 	String charge;
 	Long created;
 	Boolean livemode;
@@ -14,6 +15,14 @@ public class Review extends StripeObject implements HasId {
 
 	public void setId(String id) {
 		this.id = id;
+	}
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
 	}
 
 	public String getCharge() {

--- a/src/main/java/com/stripe/model/SKU.java
+++ b/src/main/java/com/stripe/model/SKU.java
@@ -13,6 +13,7 @@ import com.stripe.net.RequestOptions;
 
 public class SKU extends APIResource implements HasId, MetadataStore<SKU> {
 	String id;
+	String object;
 	Boolean active;
 	Map<String, String> attributes;
 	Long created;
@@ -32,6 +33,14 @@ public class SKU extends APIResource implements HasId, MetadataStore<SKU> {
 
 	public void setId(String id) {
 		this.id = id;
+	}
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
 	}
 
 	public Boolean getActive() {

--- a/src/main/java/com/stripe/model/StripeObject.java
+++ b/src/main/java/com/stripe/model/StripeObject.java
@@ -24,6 +24,10 @@ public abstract class StripeObject {
 			PRETTY_PRINT_GSON.toJson(this));
 	}
 
+	public String toJson() {
+		return PRETTY_PRINT_GSON.toJson(this);
+	}
+
 	private Object getIdString() {
 		try {
 			Field idField = this.getClass().getDeclaredField("id");

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -13,6 +13,7 @@ import java.util.Map;
 
 public class Subscription extends APIResource implements MetadataStore<Subscription>, HasId {
 	String id;
+	String object;
 	Double applicationFeePercent;
 	Boolean cancelAtPeriodEnd;
 	Long canceledAt;
@@ -38,6 +39,14 @@ public class Subscription extends APIResource implements MetadataStore<Subscript
 
 	public void setId(String id) {
 		this.id = id;
+	}
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
 	}
 
 	public Double getApplicationFeePercent() {

--- a/src/main/java/com/stripe/model/SubscriptionItem.java
+++ b/src/main/java/com/stripe/model/SubscriptionItem.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 public class SubscriptionItem extends APIResource implements HasId {
 	String id;
+	String object;
 	Long created;
 	Plan plan;
 	Integer quantity;
@@ -24,6 +25,14 @@ public class SubscriptionItem extends APIResource implements HasId {
 
 	public void setId(String id) {
 		this.id = id;
+	}
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
 	}
 
 	public Long getCreated() {

--- a/src/main/java/com/stripe/model/ThreeDSecure.java
+++ b/src/main/java/com/stripe/model/ThreeDSecure.java
@@ -15,6 +15,7 @@ import java.util.Map;
 
 public class ThreeDSecure extends APIResource implements HasId {
 	String id;
+	String object;
 	Long amount;
 	Boolean authenticated;
 	Card card;
@@ -31,6 +32,14 @@ public class ThreeDSecure extends APIResource implements HasId {
 
 	public void setId(String id) {
 		this.id = id;
+	}
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
 	}
 
 	public Long getAmount() {

--- a/src/main/java/com/stripe/model/Token.java
+++ b/src/main/java/com/stripe/model/Token.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 public class Token extends APIResource implements HasId {
 	String id;
+	String object;
 	Long amount;
 	BankAccount bankAccount;
 	Card card;
@@ -29,6 +30,14 @@ public class Token extends APIResource implements HasId {
 
 	public void setId(String id) {
 		this.id = id;
+	}
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
 	}
 
 	public Long getAmount() {

--- a/src/main/java/com/stripe/model/Transfer.java
+++ b/src/main/java/com/stripe/model/Transfer.java
@@ -13,6 +13,7 @@ import java.util.Map;
 
 public class Transfer extends APIResource implements MetadataStore<Transfer>, HasId {
 	String id;
+	String object;
 	Long amount;
 	Long amountReversed;
 	String applicationFee;
@@ -53,6 +54,14 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
 
 	public void setId(String id) {
 		this.id = id;
+	}
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
 	}
 
 	public Long getAmount() {

--- a/src/main/java/com/stripe/model/TransferTransaction.java
+++ b/src/main/java/com/stripe/model/TransferTransaction.java
@@ -2,6 +2,7 @@ package com.stripe.model;
 
 public class TransferTransaction extends StripeObject implements HasId {
 	String id;
+	String object;
 	Long amount;
 	Long net;
 	String type;
@@ -15,6 +16,14 @@ public class TransferTransaction extends StripeObject implements HasId {
 
 	public void setId(String id) {
 		this.id = id;
+	}
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
 	}
 
 	public Long getAmount() {

--- a/src/test/java/com/stripe/model/EventTest.java
+++ b/src/test/java/com/stripe/model/EventTest.java
@@ -21,4 +21,21 @@ public class EventTest extends BaseStripeTest {
 
 		assertEquals(account.getEmail(), "test@stripe.com");
 	}
+
+	@Test
+	public void serializesToJson() throws IOException {
+		String json = resource("account_event.json");
+		Event event = StripeObject.PRETTY_PRINT_GSON.fromJson(json, Event.class);
+
+		Event reserializedEvent = StripeObject.PRETTY_PRINT_GSON.fromJson(event.toJson(), Event.class);
+
+		assertEquals(reserializedEvent.getId(), event.getId());
+		assertEquals(reserializedEvent.getObject(), event.getObject());
+		assertEquals(reserializedEvent.getApiVersion(), event.getApiVersion());
+		assertEquals(reserializedEvent.getCreated(), event.getCreated());
+		assertEquals(reserializedEvent.getLivemode(), event.getLivemode());
+		assertEquals(reserializedEvent.getRequest(), event.getRequest());
+		assertEquals(reserializedEvent.getType(), event.getType());
+		assertEquals(reserializedEvent.getUserId(), event.getUserId());
+	}
 }


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @remi-stripe 

This PR adds a `toJson()` method to `StripeObject` which returns the JSON serialization of the object, without the extra fluff included in `toString()`.

It also adds the `object` property to all first-order API resource models, which was previously missing (it could be deduced from the model class, but it was missing from the JSON output).

Serializing objects is useful for interacting with our iOS SDK, which expects some specific endpoints (cf. [here](https://stripe.com/docs/mobile/ios/standard#prepare-your-api)).

The test is pretty 😞 , but the JSON serialization does not guarantee key order (making it hard to compare it to the original JSON dump used to create the instance), and our models don't have `equals` operators that only compare property values.
