### PR TITLE
Removes unused params from Account.delete() method

### DIFF
--- a/src/main/java/com/stripe/model/Account.java
+++ b/src/main/java/com/stripe/model/Account.java
@@ -303,6 +303,18 @@ public class Account extends APIResource implements HasId, MetadataStore<Account
 		return request(RequestMethod.POST, instanceURL(Account.class, this.id), params, Account.class, options);
 	}
 
+	public DeletedAccount delete()
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return delete((RequestOptions) null);
+	}
+
+	public DeletedAccount delete(RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return delete(null, (RequestOptions) null);
+	}
+
 	public DeletedAccount delete(Map<String, Object> params)
 			throws AuthenticationException, InvalidRequestException,
 			APIConnectionException, CardException, APIException {

--- a/src/test/java/com/stripe/model/AccountTest.java
+++ b/src/test/java/com/stripe/model/AccountTest.java
@@ -158,4 +158,18 @@ public class AccountTest extends BaseStripeTest {
 		verifyPost(ExternalAccount.class, "https://api.stripe.com/v1/accounts/acct_1032D82eZvKYlo2C/external_accounts", params);
 		verifyNoMoreInteractions(networkMock);
 	}
+
+	@Test
+	public void testAccountDelete() throws StripeException, IOException {
+		String json = resource("account.json");
+		stubNetwork(Account.class, json);
+		Account acc = Account.retrieve("acct_1032D82eZvKYlo2C");
+		verifyGet(Account.class, "https://api.stripe.com/v1/accounts/acct_1032D82eZvKYlo2C");
+
+		stubNetwork(DeletedAccount.class, "{\"id\": \"acct_1032D82eZvKYlo2C\", \"deleted\": \"true\"}");
+		acc.delete();
+		verifyDelete(DeletedAccount.class, "https://api.stripe.com/v1/accounts/acct_1032D82eZvKYlo2C");
+
+		verifyNoMoreInteractions(networkMock);
+	}
 }


### PR DESCRIPTION
r? @brandur-stripe
cc @stripe/api-libraries @remi-stripe

This PR fixes the `Account.delete()` method to not accept any parameters, since they're unneeded (the API doesn't accept any parameters for this request anyway, and the Java example in the [API reference](https://stripe.com/docs/api/java#delete_account) doesn't pass any either).

It also adds a test for the method.
