### PR TITLE
Removed sourced_transfers from balance transaction

### DIFF
--- a/src/main/java/com/stripe/model/BalanceTransaction.java
+++ b/src/main/java/com/stripe/model/BalanceTransaction.java
@@ -24,9 +24,11 @@ public class BalanceTransaction extends APIResource implements HasId {
 	List<Fee> feeDetails;
 	Integer net;
 	String source;
-	TransferCollection sourcedTransfers;
 	String status;
 	String type;
+
+	@Deprecated
+	TransferCollection sourcedTransfers;
 
 	public String getId() {
 		return id;
@@ -116,6 +118,7 @@ public class BalanceTransaction extends APIResource implements HasId {
 		this.source = source;
 	}
 
+	@Deprecated
 	public TransferCollection getSourcedTransfers() {
 		if (sourcedTransfers != null && sourcedTransfers.getURL() == null && getSource() != null) {
 			sourcedTransfers.setURL(String.format("/v1/transfers?source_transaction=%s", getSource()));


### PR DESCRIPTION
Removed sourced_transfers from balance transaction resource because that field has been deprecated in new versions of the API.
