### PR TITLE
Add invoicing parameters to Subscription and Invoice

### DIFF
--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -17,6 +17,7 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
 	Long applicationFee;
 	Integer attemptCount;
 	Boolean attempted;
+	String billing;
 	ExpandableField<Charge> charge;
 	Boolean closed;
 	Long created;
@@ -25,12 +26,14 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
 	Long date;
 	String description;
 	Discount discount;
+	Long dueDate;
 	Long endingBalance;
 	Boolean forgiven;
 	InvoiceLineItemCollection lines;
 	Boolean livemode;
 	Map<String, String> metadata;
 	Long nextPaymentAttempt;
+	String number;
 	Boolean paid;
 	Long periodEnd;
 	Long periodStart;
@@ -91,6 +94,14 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
 
 	public void setAttempted(Boolean attempted) {
 		this.attempted = attempted;
+	}
+
+	public String getBilling() {
+		return billing;
+	}
+
+	public void setBilling(String billing) {
+		this.billing = billing;
 	}
 
 	public String getCharge() {
@@ -171,6 +182,14 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
 		this.discount = discount;
 	}
 
+	public Long getDueDate() {
+		return dueDate;
+	}
+
+	public void setDueDate(Long dueDate) {
+		this.dueDate = dueDate;
+	}
+
 	public Long getEndingBalance() {
 		return endingBalance;
 	}
@@ -213,6 +232,14 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
 
 	public void setNextPaymentAttempt(Long nextPaymentAttempt) {
 		this.nextPaymentAttempt = nextPaymentAttempt;
+	}
+
+	public String getNumber() {
+		return number;
+	}
+
+	public void setNumber(String number) {
+		this.number = number;
 	}
 
 	public Boolean getPaid() {

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -15,12 +15,14 @@ public class Subscription extends APIResource implements MetadataStore<Subscript
 	String id;
 	String object;
 	Double applicationFeePercent;
+	String billing;
 	Boolean cancelAtPeriodEnd;
 	Long canceledAt;
 	Long created;
 	Long currentPeriodEnd;
 	Long currentPeriodStart;
 	String customer;
+	Integer daysUntilDue;
 	Discount discount;
 	Long endedAt;
 	SubscriptionItemCollection items;
@@ -55,6 +57,14 @@ public class Subscription extends APIResource implements MetadataStore<Subscript
 
 	public void setApplicationFeePercent(Double applicationFeePercent) {
 		this.applicationFeePercent = applicationFeePercent;
+	}
+
+	public String getBilling() {
+		return billing;
+	}
+
+	public void setBilling(String billing) {
+		this.billing = billing;
 	}
 
 	public Boolean getCancelAtPeriodEnd() {
@@ -103,6 +113,14 @@ public class Subscription extends APIResource implements MetadataStore<Subscript
 
 	public void setCustomer(String customer) {
 		this.customer = customer;
+	}
+
+	public Integer getDaysUntilDue() {
+		return daysUntilDue;
+	}
+
+	public void setDaysUntilDue(Integer daysUntilDue) {
+		this.daysUntilDue = daysUntilDue;
 	}
 
 	public Discount getDiscount() {

--- a/src/test/java/com/stripe/functional/SubscriptionTest.java
+++ b/src/test/java/com/stripe/functional/SubscriptionTest.java
@@ -192,4 +192,26 @@ public class SubscriptionTest extends BaseStripeFunctionalTest {
         Customer customer = Customer.create(defaultCustomerParams);
         testMetadata(customer.createSubscription(getSubscriptionParams()));
     }
+
+    @Test
+    public void testInvoicingSubscription() throws StripeException {
+        Plan plan = Plan.create(getUniquePlanParams());
+        defaultCustomerParams.put("email", "test@stripe.com");
+        Customer customer = Customer.create(defaultCustomerParams);
+
+        Map<String, Object> subscriptionParams = new HashMap<String, Object>();
+        subscriptionParams.put("plan", plan.getId());
+        subscriptionParams.put("billing", "send_invoice");
+        subscriptionParams.put("days_until_due", 30);
+        subscriptionParams.put("customer", customer.getId());
+        Subscription sub = Subscription.create(subscriptionParams);
+        assertEquals(plan.getId(), sub.getPlan().getId());
+        assertEquals("send_invoice", sub.getBilling());
+        assertEquals((Integer) 30, sub.getDaysUntilDue());
+
+        Map<String, Object> updateParams = new HashMap<String, Object>();
+        updateParams.put("days_until_due", 10);
+        Subscription subUpdated = sub.update(updateParams);
+        assertEquals((Integer) 10, subUpdated.getDaysUntilDue());
+    }
 }


### PR DESCRIPTION
This PR adds and tests new invoicing related parameters:
Subscription model: billing, days_until_due
Invoice model: billing, due_date, number

I don't believe any changes need to be made for what parameters are accepted in function calls.
