### PR TITLE
Make charge dispute expandable

### DIFF
--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -26,7 +26,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
 	ExpandableField<Customer> customer;
 	String description;
 	ExpandableField<Account> destination;
-	Dispute dispute;
+	ExpandableField<Dispute> dispute;
 	String failureCode;
 	String failureMessage;
 	FraudDetails fraudDetails;
@@ -232,12 +232,26 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
 		this.destination = new ExpandableField<Account>(c.getId(), c);
 	}
 
-	public Dispute getDispute() {
-		return dispute;
+	public String getDispute() {
+		if (dispute == null) {
+			return null;
+		}
+		return dispute.getId();
 	}
 
-	public void setDispute(Dispute dispute) {
-		this.dispute = dispute;
+	public void setDispute(String dispute) {
+		this.dispute = setExpandableFieldID(dispute, this.dispute);
+	}
+
+	public Dispute getDisputeObject() {
+		if (dispute == null) {
+			return null;
+		}
+		return this.dispute.getExpanded();
+	}
+
+	public void setDisputeObject(Dispute dispute) {
+		this.dispute = new ExpandableField<Dispute>(dispute.getId(), dispute);
 	}
 
 	public String getFailureCode() {

--- a/src/test/java/com/stripe/functional/DisputeTest.java
+++ b/src/test/java/com/stripe/functional/DisputeTest.java
@@ -34,14 +34,17 @@ public class DisputeTest extends BaseStripeFunctionalTest {
         // This test relies on the server asynchronously marking the charge as disputed.
         // TODO: find a more reliable way to do this instead of sleeping
         Thread.sleep(10000);
-        return Charge.retrieve(charge.getId());
+
+        Map<String, Object> retrieveParams = new HashMap<String, Object>();
+		retrieveParams.put("expand[]", "dispute");
+        return Charge.retrieve(charge.getId(), retrieveParams, null);
     }
 
     @Test
     public void testDisputedCharge() throws StripeException, InterruptedException {
         int chargeValueCents = 100;
         Charge disputedCharge = createDisputedCharge(chargeValueCents);
-        Dispute dispute = disputedCharge.getDispute();
+        Dispute dispute = disputedCharge.getDisputeObject();
         assertNotNull(dispute);
         assertFalse(dispute.getIsChargeRefundable());
         assertEquals(1, dispute.getBalanceTransactions().size());
@@ -52,7 +55,7 @@ public class DisputeTest extends BaseStripeFunctionalTest {
     public void testRetrieveDispute() throws StripeException, InterruptedException {
         int chargeValueCents = 100;
         Charge disputedCharge = createDisputedCharge(chargeValueCents);
-        Dispute dispute = disputedCharge.getDispute();
+        Dispute dispute = disputedCharge.getDisputeObject();
         Dispute retrievedDispute = Dispute.retrieve(dispute.getId());
         assertEquals(dispute.getId(), retrievedDispute.getId());
     }
@@ -62,7 +65,7 @@ public class DisputeTest extends BaseStripeFunctionalTest {
         int chargeValueCents = 100;
         Charge disputedCharge = createDisputedCharge(chargeValueCents);
 
-        Dispute initialDispute = disputedCharge.getDispute();
+        Dispute initialDispute = disputedCharge.getDisputeObject();
         EvidenceSubObject emptyEvidence = new EvidenceSubObject();
         assertEquals(emptyEvidence, initialDispute.getEvidenceSubObject());
         assertEquals(new HashMap<String, String>(), initialDispute.getMetadata());
@@ -101,7 +104,7 @@ public class DisputeTest extends BaseStripeFunctionalTest {
     public void testCloseDispute() throws StripeException, InterruptedException {
         int chargeValueCents = 100;
         Charge disputedCharge = createDisputedCharge(chargeValueCents);
-        Dispute dispute = disputedCharge.getDispute();
+        Dispute dispute = disputedCharge.getDisputeObject();
         assertEquals("needs_response", dispute.getStatus());
 
         Dispute closedDispute = dispute.close();
@@ -174,7 +177,7 @@ public class DisputeTest extends BaseStripeFunctionalTest {
         int chargeValueCents = 100;
         Charge disputedCharge = createDisputedCharge(chargeValueCents);
 
-        Dispute initialDispute = disputedCharge.getDispute();
+        Dispute initialDispute = disputedCharge.getDisputeObject();
         assertNull(initialDispute.getEvidence());
         EvidenceSubObject emptyEvidence = new EvidenceSubObject();
         assertEquals(emptyEvidence, initialDispute.getEvidenceSubObject());
@@ -210,7 +213,7 @@ public class DisputeTest extends BaseStripeFunctionalTest {
         Charge disputedCharge = createDisputedCharge(chargeValueCents);
 
         String myEvidence = "Here's evidence showing this charge is legitimate.";
-        Dispute initialDispute = disputedCharge.getDispute();
+        Dispute initialDispute = disputedCharge.getDisputeObject();
         assertNull(initialDispute.getEvidence());
         assertNull(initialDispute.getEvidenceSubObject());
         Map<String, Object> disputeParams = ImmutableMap.<String, Object>of("evidence", myEvidence);


### PR DESCRIPTION
Charge disputes are no longer expanded by default in newer API versions.
Here we make that an expandable field, and fix functional tests that
depend on it to leverage that.

This is a breaking change.

r? @ob-stripe 