### PR TITLE
Added support for the new Payout object

### DIFF
--- a/src/main/java/com/stripe/model/EventDataDeserializer.java
+++ b/src/main/java/com/stripe/model/EventDataDeserializer.java
@@ -44,6 +44,7 @@ public class EventDataDeserializer implements JsonDeserializer<EventData> {
 		objectMap.put("order", Order.class);
 		objectMap.put("order_item", OrderItem.class);
 		objectMap.put("order_return", OrderReturn.class);
+		objectMap.put("payout", Payout.class);
 		objectMap.put("plan", Plan.class);
 		objectMap.put("product", Product.class);
 		objectMap.put("refund", Refund.class);

--- a/src/main/java/com/stripe/model/Payout.java
+++ b/src/main/java/com/stripe/model/Payout.java
@@ -1,0 +1,237 @@
+package com.stripe.model;
+
+import com.stripe.exception.APIConnectionException;
+import com.stripe.exception.APIException;
+import com.stripe.exception.AuthenticationException;
+import com.stripe.exception.CardException;
+import com.stripe.exception.InvalidRequestException;
+import com.stripe.net.APIResource;
+import com.stripe.net.RequestOptions;
+
+import java.util.List;
+import java.util.Map;
+
+public class Payout extends APIResource implements MetadataStore<Payout>, HasId {
+	String id;
+	String object;
+	Long amount;
+	Long arrivalDate;
+	String balanceTransaction;
+	Long created;
+	String currency;
+	String destination;
+	String failureBalanceTransaction;
+	String failureCode;
+	String failureMessage;
+	Boolean livemode;
+	Map<String, String> metadata;
+	String method;
+	String sourceType;
+	String statementDescriptor;
+	String status;
+	String type;
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
+	}
+
+	public Long getAmount() {
+		return amount;
+	}
+
+	public void setAmount(Long amount) {
+		this.amount = amount;
+	}
+
+	public Long getArrivalDate() {
+		return arrivalDate;
+	}
+
+	public void setArrivalDate(Long arrivalDate) {
+		this.arrivalDate = arrivalDate;
+	}
+
+	public String getBalanceTransaction() {
+		return balanceTransaction;
+	}
+
+	public void setBalanceTransaction(String balanceTransaction) {
+		this.balanceTransaction = balanceTransaction;
+	}
+
+	public Long getCreated() {
+		return created;
+	}
+
+	public void setCreated(Long created) {
+		this.created = created;
+	}
+
+	public String getCurrency() {
+		return currency;
+	}
+
+	public void setCurrency(String currency) {
+		this.currency = currency;
+	}
+
+	public String getDestination() {
+		return destination;
+	}
+
+	public void setDestination(String destination) {
+		this.destination = destination;
+	}
+
+	public String getFailureBalanceTransaction() {
+		return failureBalanceTransaction;
+	}
+
+	public void setFailureBalanceTransaction(String failureBalanceTransaction) {
+		this.failureBalanceTransaction = failureBalanceTransaction;
+	}
+
+	public String getFailureCode() {
+		return failureCode;
+	}
+
+	public void setFailureCode(String failureCode) {
+		this.failureCode = failureCode;
+	}
+
+	public String getFailureMessage() {
+		return failureMessage;
+	}
+
+	public void setFailureMessage(String failureMessage) {
+		this.failureMessage = failureMessage;
+	}
+
+	public Boolean getLivemode() {
+		return livemode;
+	}
+
+	public void setLivemode(Boolean livemode) {
+		this.livemode = livemode;
+	}
+
+	public Map<String, String> getMetadata() {
+		return metadata;
+	}
+
+	public void setMetadata(Map<String, String> metadata) {
+		this.metadata = metadata;
+	}
+
+	public String getMethod() {
+		return method;
+	}
+
+	public void setMethod(String method) {
+		this.method = method;
+	}
+
+	public String getSourceType() {
+		return sourceType;
+	}
+
+	public void setSourceType(String sourceType) {
+		this.sourceType = sourceType;
+	}
+
+	public String getStatementDescriptor() {
+		return statementDescriptor;
+	}
+
+	public void setStatementDescriptor(String statementDescriptor) {
+		this.statementDescriptor = statementDescriptor;
+	}
+
+	public String getStatus() {
+		return status;
+	}
+
+	public void setStatus(String status) {
+		this.status = status;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	public Payout cancel()
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return cancel((RequestOptions) null);
+	}
+
+	public Payout cancel(RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return request(RequestMethod.POST, instanceURL(Payout.class, this.id) + "/cancel", null, Payout.class, options);
+	}
+
+	public static Payout create(Map<String, Object> params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params, (RequestOptions) null);
+	}
+
+	public static Payout create(Map<String, Object> params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return request(RequestMethod.POST, classURL(Payout.class), params, Payout.class, options);
+	}
+
+	public static PayoutCollection list(Map<String, Object> params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return list(params, (RequestOptions) null);
+	}
+
+	public static PayoutCollection list(Map<String, Object> params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException, APIConnectionException,
+			CardException, APIException {
+		return requestCollection(classURL(Payout.class), params, PayoutCollection.class, options);
+	}
+
+	public static Payout retrieve(String id) throws AuthenticationException,
+			InvalidRequestException, APIConnectionException, CardException,
+			APIException {
+		return retrieve(id, (RequestOptions) null);
+	}
+
+	public static Payout retrieve(String id, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return request(RequestMethod.GET, instanceURL(Payout.class, id), null, Payout.class, options);
+	}
+
+	public Payout update(Map<String, Object> params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params, (RequestOptions) null);
+	}
+
+	public Payout update(Map<String, Object> params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return request(RequestMethod.POST, instanceURL(Payout.class, this.id), params, Payout.class, options);
+	}
+}

--- a/src/main/java/com/stripe/model/PayoutCollection.java
+++ b/src/main/java/com/stripe/model/PayoutCollection.java
@@ -1,0 +1,4 @@
+package com.stripe.model;
+
+public class PayoutCollection extends StripeCollection<Payout> {
+}

--- a/src/main/java/com/stripe/model/Transfer.java
+++ b/src/main/java/com/stripe/model/Transfer.java
@@ -81,10 +81,12 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
 		this.amountReversed = amountReversed;
 	}
 
+	@Deprecated
 	public String getApplicationFee() {
 		return applicationFee;
 	}
 
+	@Deprecated
 	public void setApplicationFee(String applicationFee) {
 		this.applicationFee = applicationFee;
 	}
@@ -97,10 +99,12 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
 		this.balanceTransaction = balanceTransaction;
 	}
 
+	@Deprecated
 	public BankAccount getBankAccount() {
 		return bankAccount;
 	}
 
+	@Deprecated
 	public void setBankAccount(BankAccount bankAccount) {
 		this.bankAccount = bankAccount;
 	}
@@ -129,10 +133,12 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
 		this.date = date;
 	}
 
+	@Deprecated
 	public String getDescription() {
 		return description;
 	}
 
+	@Deprecated
 	public void setDescription(String description) {
 		this.description = description;
 	}
@@ -153,18 +159,22 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
 		this.destinationPayment = destinationPayment;
 	}
 
+	@Deprecated
 	public String getFailureCode() {
 		return failureCode;
 	}
 
+	@Deprecated
 	public void setFailureCode(String failureCode) {
 		this.failureCode = failureCode;
 	}
 
+	@Deprecated
 	public String getFailureMessage() {
 		return failureMessage;
 	}
 
+	@Deprecated
 	public void setFailureMessage(String failureMessage) {
 		this.failureMessage = failureMessage;
 	}
@@ -200,10 +210,12 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
 		this.reversed = reversed;
 	}
 
+	@Deprecated
 	public String getSourceTransaction() {
 		return sourceTransaction;
 	}
 
+	@Deprecated
 	public void setSourceTransaction(String sourceTransaction) {
 		this.sourceTransaction = sourceTransaction;
 	}
@@ -224,10 +236,12 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
 		this.statementDescriptor = statementDescriptor;
 	}
 
+	@Deprecated
 	public String getStatus() {
 		return status;
 	}
 
+	@Deprecated
 	public void setStatus(String status) {
 		this.status = status;
 	}
@@ -240,10 +254,12 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
 		this.transferGroup = transferGroup;
 	}
 
+	@Deprecated
 	public String getType() {
 		return type;
 	}
 
+	@Deprecated
 	public void setType(String type) {
 		this.type = type;
 	}

--- a/src/test/java/com/stripe/BaseStripeFunctionalTest.java
+++ b/src/test/java/com/stripe/BaseStripeFunctionalTest.java
@@ -75,7 +75,7 @@ public class BaseStripeFunctionalTest {
 
         // Peg the API version so that it can be varied independently of the
         // one set on the test account.
-        Stripe.apiVersion = "2017-02-14";
+        Stripe.apiVersion = "2017-04-06";
 
         // test key
         supportedRequestOptions = RequestOptions.builder().setStripeVersion(Stripe.apiVersion).build();

--- a/src/test/java/com/stripe/functional/ChargeTest.java
+++ b/src/test/java/com/stripe/functional/ChargeTest.java
@@ -26,14 +26,20 @@ public class ChargeTest extends BaseStripeFunctionalTest {
 	}
 
 	@Test
-	public void testChargeCreateExpandBalanceTransaction() throws StripeException {
-		String[] expand = new String[]{"balance_transaction"};
-		Map<String, Object> params = defaultChargeParams;
-		params.put("expand[]", "balance_transaction");
-		Charge createdCharge = Charge.create(params);
-		assertFalse(createdCharge.getRefunded());
-		//Check expanded BT
-		assertEquals(createdCharge.getBalanceTransactionObject().getId(), createdCharge.getBalanceTransaction());
+	public void testChargeExpandBalanceTransaction() throws StripeException {
+		Map<String, Object> createParams = defaultChargeParams;
+		createParams.put("expand[]", "balance_transaction");
+		Charge createdCharge = Charge.create(createParams);
+
+		assertEquals(createdCharge.getBalanceTransactionObject().getId(),
+			createdCharge.getBalanceTransaction());
+
+		Map<String, Object> retrieveParams = new HashMap<String, Object>();
+		retrieveParams.put("expand[]", "balance_transaction");
+		Charge retrievedCharge = Charge.retrieve(createdCharge.getId(), retrieveParams, null);
+
+		assertEquals(retrievedCharge.getBalanceTransactionObject().getId(),
+			retrievedCharge.getBalanceTransaction());
 	}
 
 	@Test
@@ -206,18 +212,6 @@ public class ChargeTest extends BaseStripeFunctionalTest {
 		listParams.put("count", 1);
 		List<Charge> charges = Charge.all(listParams).getData();
 		assertEquals(charges.size(), 1);
-	}
-
-	@Test
-	public void testChargeListExpandBalanceTransaction() throws StripeException {
-		Map<String, Object> listParams = new HashMap<String, Object>();
-		listParams.put("count", 1);
-		listParams.put("expand[]", "data.balance_transaction");
-		List<Charge> charges = Charge.list(listParams).getData();
-		assertEquals(charges.size(), 1);
-		//Check expanded BT
-		Charge c = charges.get(0);
-		assertEquals(c.getBalanceTransactionObject().getId(), c.getBalanceTransaction());
 	}
 
 	@Test

--- a/src/test/java/com/stripe/functional/TransferTest.java
+++ b/src/test/java/com/stripe/functional/TransferTest.java
@@ -40,8 +40,9 @@ public class TransferTest extends BaseStripeFunctionalTest {
 
     @Test
     public void testTransferCreate() throws StripeException {
-        Transfer createdTransfer = Transfer.create(getTransferParams());
-        assertEquals("paid", createdTransfer.getStatus());
+        Map<String, Object> transferParams = getTransferParams();
+        Transfer createdTransfer = Transfer.create(transferParams);
+        assertEquals(transferParams.get("destination"), createdTransfer.getDestination());
     }
 
     @Test

--- a/src/test/java/com/stripe/model/PayoutTest.java
+++ b/src/test/java/com/stripe/model/PayoutTest.java
@@ -1,0 +1,91 @@
+package com.stripe.model;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import com.stripe.BaseStripeTest;
+import com.stripe.exception.StripeException;
+import com.stripe.net.APIResource;
+import com.stripe.net.LiveStripeResponseGetter;
+import com.stripe.net.RequestOptions;
+import com.stripe.net.RequestOptions.RequestOptionsBuilder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class PayoutTest extends BaseStripeTest {
+    @Before
+    public void mockStripeResponseGetter() {
+        APIResource.setStripeResponseGetter(networkMock);
+    }
+
+    @After
+    public void unmockStripeResponseGetter() {
+        /* This needs to be done because tests aren't isolated in Java */
+        APIResource.setStripeResponseGetter(new LiveStripeResponseGetter());
+    }
+
+    @Test
+    public void testDeserialize() throws StripeException, IOException {
+        String json = resource("payout.json");
+        Payout payout = APIResource.GSON.fromJson(json, Payout.class);
+
+        assertEquals("po_123456789ABCD", payout.getId());
+        assertEquals(10000L, (long) payout.getAmount());
+        assertEquals(1487116449L, (long) payout.getArrivalDate());
+        assertEquals("txn_123456789ABCD", payout.getBalanceTransaction());
+        assertEquals("usd", payout.getCurrency());
+        assertEquals("ba_123456789ABCD", payout.getDestination());
+        assertEquals("standard", payout.getMethod());
+        assertEquals("card", payout.getSourceType());
+        assertEquals("paid", payout.getStatus());
+        assertEquals("bank_account", payout.getType());
+    }
+
+    @Test
+    public void testCancel() throws StripeException {
+        Payout payout = new Payout();
+        payout.setId("po_test_cancel");
+        payout.cancel();
+
+        verifyPost(Payout.class, "https://api.stripe.com/v1/payouts/po_test_cancel/cancel");
+        verifyNoMoreInteractions(networkMock);
+    }
+
+    @Test
+    public void testCreate() throws StripeException {
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("amount", "10000");
+        params.put("currency", "usd");
+
+        Payout payout = Payout.create(params);
+
+        verifyPost(Payout.class, "https://api.stripe.com/v1/payouts", params);
+        verifyNoMoreInteractions(networkMock);
+    }
+
+    @Test
+    public void testRetrieve() throws StripeException {
+        Payout payout = Payout.retrieve("po_test_retrieve");
+
+        verifyGet(Payout.class, "https://api.stripe.com/v1/payouts/po_test_retrieve");
+        verifyNoMoreInteractions(networkMock);
+    }
+
+    @Test
+    public void testList() throws StripeException {
+        HashMap<String, Object> params = new HashMap<String, Object>();
+        params.put("limit", 3);
+
+        Payout.list(params);
+
+        verifyGet(PayoutCollection.class, "https://api.stripe.com/v1/payouts", params);
+        verifyNoMoreInteractions(networkMock);
+    }
+}

--- a/src/test/resources/com/stripe/model/payout.json
+++ b/src/test/resources/com/stripe/model/payout.json
@@ -1,0 +1,20 @@
+{
+  "id": "po_123456789ABCD",
+  "object": "payout",
+  "amount": 10000,
+  "arrival_date": 1487116449,
+  "balance_transaction": "txn_123456789ABCD",
+  "cancellation_balance_transaction": null,
+  "created": 1487116449,
+  "currency": "usd",
+  "destination": "ba_123456789ABCD",
+  "failure_code": null,
+  "failure_message": null,
+  "livemode": false,
+  "metadata": {},
+  "method": "standard",
+  "source_type": "card",
+  "statement_descriptor": null,
+  "status": "paid",
+  "type": "bank_account"
+}


### PR DESCRIPTION
The Transfer object used to represent all movements of funds in Stripe. It split in two concepts:
- Transfer: this describes the movement of funds between Stripe accounts and is specific to Stripe Connect.
- Payout: this describes the movement of funds from a Stripe account to a bank account, debit card or any future payout method.

This change is behind an API version so old API versions would still use the Transfer object for everything while new API version would see the split.

This applies beyond the new object as some properties/methods are removed from Transfer and other properties are renamed on other objects.