### PR TITLE
Make `rule` under charge outcome expandable

### DIFF
--- a/src/main/java/com/stripe/model/ChargeOutcome.java
+++ b/src/main/java/com/stripe/model/ChargeOutcome.java
@@ -1,12 +1,14 @@
 package com.stripe.model;
 
-public class ChargeOutcome extends StripeObject {
+import com.stripe.net.APIResource;
+
+public class ChargeOutcome extends APIResource {
 	protected String networkStatus;
 	protected String reason;
 	protected String riskLevel;
+	protected ExpandableField<ChargeOutcomeRule> rule;
 	protected String sellerMessage;
 	protected String type;
-	protected ChargeOutcomeRule rule;
 
 	public String getNetworkStatus() {
 		return networkStatus;
@@ -28,8 +30,26 @@ public class ChargeOutcome extends StripeObject {
 		return type;
 	}
 
+	@Deprecated
 	public ChargeOutcomeRule getRule() {
-		return rule;
+		if (this.rule == null) {
+			return null;
+		}
+		return this.rule.getExpanded();
+	}
+
+	public String getRuleId() {
+		if (this.rule == null) {
+			return null;
+		}
+		return this.rule.getId();
+	}
+
+	public ChargeOutcomeRule getRuleObject() {
+		if (this.rule == null) {
+			return null;
+		}
+		return this.rule.getExpanded();
 	}
 
 	public void setNetworkStatus(String networkStatus) {
@@ -52,7 +72,16 @@ public class ChargeOutcome extends StripeObject {
 		this.type = type;
 	}
 
+	@Deprecated
 	public void setRule(ChargeOutcomeRule rule) {
-		this.rule = rule;
+		this.rule = new ExpandableField<ChargeOutcomeRule>(rule.getId(), rule);
+	}
+
+	public void setRuleId(String ruleId) {
+		this.rule = setExpandableFieldID(ruleId, this.rule);
+	}
+
+	public void setRuleObject(ChargeOutcomeRule rule) {
+		this.rule = new ExpandableField<ChargeOutcomeRule>(rule.getId(), rule);
 	}
 }

--- a/src/main/java/com/stripe/model/ChargeOutcomeRule.java
+++ b/src/main/java/com/stripe/model/ChargeOutcomeRule.java
@@ -1,11 +1,16 @@
 package com.stripe.model;
 
-public class ChargeOutcomeRule extends StripeObject {
+public class ChargeOutcomeRule extends StripeObject implements HasId {
 	protected String action;
+	protected String id;
 	protected String predicate;
 
 	public String getAction() {
 		return action;
+	}
+
+	public String getId() {
+		return id;
 	}
 
 	public String getPredicate() {
@@ -14,6 +19,10 @@ public class ChargeOutcomeRule extends StripeObject {
 
 	public void setAction(String action) {
 		this.action = action;
+	}
+
+	public void setId(String id) {
+		this.id = id;
 	}
 
 	public void setPredicate(String predicate) {

--- a/src/test/java/com/stripe/model/ChargeOutcomeTest.java
+++ b/src/test/java/com/stripe/model/ChargeOutcomeTest.java
@@ -19,21 +19,30 @@ public class ChargeOutcomeTest extends BaseStripeTest {
 		assertEquals("approved_by_network", outcome.getNetworkStatus());
 		assertEquals("normal", outcome.getRiskLevel());
 		assertEquals(null, outcome.getReason());
+		assertEquals(null, outcome.getRule());
+		assertEquals("ssr_199IRC2eZvKYlo2CPfFd4CB6", outcome.getRuleId());
 		assertEquals("Payment complete.", outcome.getSellerMessage());
 		assertEquals("authorized", outcome.getType());
 	}
 
 	public void testDeserializeWithRule() throws StripeException, IOException {
-		String json = resource("charge_outcome_with_rule.json");
+		String json = resource("charge_outcome_expansions.json");
 		ChargeOutcome outcome = APIResource.GSON.fromJson(json, ChargeOutcome.class);
 
 		assertEquals("approved_by_network", outcome.getNetworkStatus());
 		assertEquals("elevated", outcome.getRiskLevel());
 		assertEquals("elevated_risk_level", outcome.getReason());
+		assertEquals("ssr_199IRC2eZvKYlo2CPfFd4CB6", outcome.getRuleId());
 		assertEquals("Stripe evaluated this charge as having elevated risk, and placed it in your manual review queue.", outcome.getSellerMessage());
 		assertEquals("manual_review", outcome.getType());
 
-		ChargeOutcomeRule rule = outcome.getRule();
+		ChargeOutcomeRule rule = outcome.getRuleObject();
+		assertEquals("manual_review", rule.getAction());
+		assertEquals("ssr_199IRC2eZvKYlo2CPfFd4CB6", rule.getId());
+		assertEquals(":risk_level: = 'elevated'", rule.getPredicate());
+
+		// Deprecated usage, but should still work.
+		rule = outcome.getRule();
 		assertEquals("manual_review", rule.getAction());
 		assertEquals(":risk_level: = 'elevated'", rule.getPredicate());
 	}

--- a/src/test/resources/com/stripe/model/charge_outcome.json
+++ b/src/test/resources/com/stripe/model/charge_outcome.json
@@ -2,6 +2,7 @@
     "network_status": "approved_by_network",
     "reason": null,
     "risk_level": "normal",
+    "rule": "ssr_199IRC2eZvKYlo2CPfFd4CB6",
     "seller_message": "Payment complete.",
     "type": "authorized"
 }

--- a/src/test/resources/com/stripe/model/charge_outcome_expansions.json
+++ b/src/test/resources/com/stripe/model/charge_outcome_expansions.json
@@ -4,6 +4,7 @@
     "risk_level": "elevated",
     "rule": {
         "action": "manual_review",
+        "id": "ssr_199IRC2eZvKYlo2CPfFd4CB6",
         "predicate": ":risk_level: = 'elevated'"
     },
     "seller_message": "Stripe evaluated this charge as having elevated risk, and placed it in your manual review queue.",


### PR DESCRIPTION
Adds accessors for an expandable `rule` under charge outcome now that
this field is now collapsed by default. We also start assigning
`ChargeOutcomeRule` and ID with `HasId`.

I changed the tests around a little bit to make them a little more
consistent with how we test expansions elsewhere in the suite.

Fixes #355.

r? @anelder-stripe