### PR TITLE
Peg the test suite's API version

### DIFF
--- a/src/test/java/com/stripe/BaseStripeFunctionalTest.java
+++ b/src/test/java/com/stripe/BaseStripeFunctionalTest.java
@@ -72,8 +72,13 @@ public class BaseStripeFunctionalTest {
     @BeforeClass
     public static void setUp() {
         Stripe.apiKey = "tGN0bIwXnHdwOa85VABjPdSn8nWY7G7I"; // stripe public
+
+        // Peg the API version so that it can be varied independently of the
+        // one set on the test account.
+        Stripe.apiVersion = "2017-02-14";
+
         // test key
-        supportedRequestOptions = RequestOptions.builder().setStripeVersion("2015-02-16").build();
+        supportedRequestOptions = RequestOptions.builder().build();
 
         defaultCardParams.put("number", "4242424242424242");
         defaultCardParams.put("exp_month", 12);

--- a/src/test/java/com/stripe/BaseStripeFunctionalTest.java
+++ b/src/test/java/com/stripe/BaseStripeFunctionalTest.java
@@ -78,7 +78,7 @@ public class BaseStripeFunctionalTest {
         Stripe.apiVersion = "2017-02-14";
 
         // test key
-        supportedRequestOptions = RequestOptions.builder().build();
+        supportedRequestOptions = RequestOptions.builder().setStripeVersion(Stripe.apiVersion).build();
 
         defaultCardParams.put("number", "4242424242424242");
         defaultCardParams.put("exp_month", 12);

--- a/src/test/java/com/stripe/functional/ChargeTest.java
+++ b/src/test/java/com/stripe/functional/ChargeTest.java
@@ -1,6 +1,7 @@
 package com.stripe.functional;
 
 import com.google.common.collect.ImmutableMap;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import com.stripe.Stripe;
 import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
@@ -170,8 +171,11 @@ public class ChargeTest extends BaseStripeFunctionalTest {
 		invalidChargeParams.put("card", invalidCardParams);
 		Charge charge = Charge.create(invalidChargeParams, supportedRequestOptions);
 		assertEquals(charge.getPaid(), true);
-		assertEquals(charge.getCard().getAddressZipCheck(), "fail");
-		assertEquals(charge.getCard().getAddressLine1Check(), "pass");
+
+		assertThat(charge.getSource(), instanceOf(Card.class));
+		Card card = (Card)charge.getSource();
+		assertEquals(card.getAddressZipCheck(), "fail");
+		assertEquals(card.getAddressLine1Check(), "pass");
 	}
 
 	@Test
@@ -188,8 +192,11 @@ public class ChargeTest extends BaseStripeFunctionalTest {
 		invalidChargeParams.put("card", invalidCardParams);
 		Charge charge = Charge.create(invalidChargeParams, supportedRequestOptions);
 		assertEquals(charge.getPaid(), true);
-		assertEquals(charge.getCard().getAddressZipCheck(), "pass");
-		assertEquals(charge.getCard().getAddressLine1Check(), "fail");
+
+		assertThat(charge.getSource(), instanceOf(Card.class));
+		Card card = (Card)charge.getSource();
+		assertEquals(card.getAddressZipCheck(), "pass");
+		assertEquals(card.getAddressLine1Check(), "fail");
 	}
 
 	// ChargeCollection Tests:

--- a/src/test/java/com/stripe/functional/DisputeTest.java
+++ b/src/test/java/com/stripe/functional/DisputeTest.java
@@ -37,7 +37,7 @@ public class DisputeTest extends BaseStripeFunctionalTest {
         Thread.sleep(10000);
 
         Map<String, Object> retrieveParams = new HashMap<String, Object>();
-		retrieveParams.put("expand[]", "dispute");
+        retrieveParams.put("expand[]", "dispute");
         return Charge.retrieve(charge.getId(), retrieveParams, options);
     }
 
@@ -209,7 +209,7 @@ public class DisputeTest extends BaseStripeFunctionalTest {
 
     @Test
     public void testSubmitOldStyleEvidence() throws StripeException, InterruptedException {
-		RequestOptions options = RequestOptions.builder().setStripeVersion("2014-11-20").build();
+        RequestOptions options = RequestOptions.builder().setStripeVersion("2014-11-20").build();
 
         int chargeValueCents = 100;
         //Stripe.apiVersion = "2014-11-20";

--- a/src/test/java/com/stripe/functional/DisputeTest.java
+++ b/src/test/java/com/stripe/functional/DisputeTest.java
@@ -205,22 +205,4 @@ public class DisputeTest extends BaseStripeFunctionalTest {
         assertNotNull(evidenceDetails);
         assertEquals(1, evidenceDetails.getSubmissionCount().intValue());
     }
-
-    @Test
-    public void testSubmitOldStyleEvidence() throws StripeException, InterruptedException {
-        int chargeValueCents = 100;
-        Stripe.apiVersion = "2014-11-20";
-        Charge disputedCharge = createDisputedCharge(chargeValueCents);
-
-        String myEvidence = "Here's evidence showing this charge is legitimate.";
-        Dispute initialDispute = disputedCharge.getDisputeObject();
-        assertNull(initialDispute.getEvidence());
-        assertNull(initialDispute.getEvidenceSubObject());
-        Map<String, Object> disputeParams = ImmutableMap.<String, Object>of("evidence", myEvidence);
-
-        Dispute updatedDispute = disputedCharge.updateDispute(disputeParams);
-        assertNotNull(updatedDispute);
-        assertEquals(myEvidence, updatedDispute.getEvidence());
-        assertNull(updatedDispute.getEvidenceSubObject());
-    }
 }


### PR DESCRIPTION
Pegs the test suite's API version so that we can upgrade it
independently of the account's implicit version. It's also to check how
much breaks when we move to a relatively modern version of the API.

See also https://github.com/stripe/stripe-php/pull/337 and https://github.com/stripe/stripe-python/pull/298.