### PR TITLE
Added support for expandable balance transaction source object

### DIFF
--- a/src/main/java/com/stripe/model/BalanceTransaction.java
+++ b/src/main/java/com/stripe/model/BalanceTransaction.java
@@ -1,5 +1,8 @@
 package com.stripe.model;
 
+import java.util.List;
+import java.util.Map;
+
 import com.stripe.Stripe;
 import com.stripe.exception.APIConnectionException;
 import com.stripe.exception.APIException;
@@ -8,9 +11,6 @@ import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
 import com.stripe.net.APIResource;
 import com.stripe.net.RequestOptions;
-
-import java.util.List;
-import java.util.Map;
 
 public class BalanceTransaction extends APIResource implements HasId {
 	String id;
@@ -23,7 +23,7 @@ public class BalanceTransaction extends APIResource implements HasId {
 	Long fee;
 	List<Fee> feeDetails;
 	Integer net;
-	String source;
+	ExpandableField<BalanceTransactionSourceObject> source;
 	String status;
 	String type;
 
@@ -109,12 +109,16 @@ public class BalanceTransaction extends APIResource implements HasId {
 	public void setNet(Integer net) {
 		this.net = net;
 	}
-
+	
 	public String getSource() {
+		return source != null ? source.getId() : null;
+	}
+
+	public ExpandableField<BalanceTransactionSourceObject> getSourceObject() {
 		return source;
 	}
 
-	public void setSource(String source) {
+	public void setSource(ExpandableField<BalanceTransactionSourceObject> source) {
 		this.source = source;
 	}
 

--- a/src/main/java/com/stripe/model/BalanceTransactionSourceObject.java
+++ b/src/main/java/com/stripe/model/BalanceTransactionSourceObject.java
@@ -1,0 +1,48 @@
+package com.stripe.model;
+
+public class BalanceTransactionSourceObject extends StripeObject implements HasId {
+	
+	String id;
+	
+	transient Charge charge;
+	
+	transient Transfer transfer;
+	
+	transient Refund refund;
+	
+	// TODO support other expandable properties/types (?)
+
+	@Override
+	public String getId() {
+		return id;
+	}
+	
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public Charge getCharge() {
+		return charge;
+	}
+
+	public void setCharge(Charge charge) {
+		this.charge = charge;
+	}
+
+	public Transfer getTransfer() {
+		return transfer;
+	}
+
+	public void setTransfer(Transfer transfer) {
+		this.transfer = transfer;
+	}
+
+	public Refund getRefund() {
+		return refund;
+	}
+
+	public void setRefund(Refund refund) {
+		this.refund = refund;
+	}
+
+}

--- a/src/main/java/com/stripe/model/ExpandableFieldDeserializer.java
+++ b/src/main/java/com/stripe/model/ExpandableFieldDeserializer.java
@@ -1,9 +1,14 @@
 package com.stripe.model;
 
-import com.google.gson.*;
-
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
 
 public class ExpandableFieldDeserializer implements JsonDeserializer<ExpandableField> {
 	public ExpandableField deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
@@ -34,7 +39,31 @@ public class ExpandableFieldDeserializer implements JsonDeserializer<ExpandableF
 			// We need to get the type inside the generic ExpandableField to make sure fromJson correctly serializes
 			// the JsonObject:
 			Type clazz = ((ParameterizedType) typeOfT).getActualTypeArguments()[0];
-			expandableField = new ExpandableField(id, (HasId)context.deserialize(json, clazz));
+			HasId hasIdObj = (HasId) context.deserialize(json, clazz);
+			// =======================================================
+			// BEGIN :: Handle type specific expandable properties
+			// =======================================================
+			if (hasIdObj instanceof BalanceTransactionSourceObject) {
+				JsonElement val = fieldAsJsonObject.get("object");
+				if (val != null) {
+					if ("charge".equals(val.getAsString())) {
+						Charge charge = context.deserialize(json, Charge.class);
+						((BalanceTransactionSourceObject) hasIdObj).setCharge(charge);
+					} else if ("transfer".equals(val.getAsString())) {
+						Transfer transfer = context.deserialize(json, Transfer.class);
+						((BalanceTransactionSourceObject) hasIdObj).setTransfer(transfer);
+					} else if ("refund".equals(val.getAsString())) {
+						Refund refund = context.deserialize(json, Refund.class);
+						((BalanceTransactionSourceObject) hasIdObj).setRefund(refund);
+					}
+				}
+			}
+			// =======================================================
+			// TODO support other expandable properties/types (?)
+			// =======================================================
+			// END :: Handle type specific expandable properties
+			// =======================================================
+			expandableField = new ExpandableField(id, hasIdObj);
 			return expandableField;
 		}
 


### PR DESCRIPTION
# The Task

Implement balance transactions view with metadata (e.g. customer name, payment summary) rendered for records of type "charge". To make it clear, `Charge` objects we create are populated with metadata we need to store. This task is only about extracting that metadata from balance transaction records corresponding to charges.

Note: I know balance transactions do not support metadata, but according to API docs, "source" object on balance transaction is expandable and is capable of returning full nested structure of corresponding charge, transfer, etc.

# The Problem

If "data.source" expansion is requested, returned JSON data structure looks correct - it does contain nested objects.

However, stripe-java unfortunately does not support this currently.

Consider the following API call:

`Map<String, Object> params = new HashMap<String, Object>();`
`params.put("expand", Arrays.asList(new String[]{ "data.source.metadata" }));`
`BalanceTransactionCollection transactions = BalanceTransaction.list(params);`

It worked perfectly without "expand" param set (but obviously didn't contain the nested objects we needed to get), but as long as param is set, it fails with the following exception:

> com.google.gson.JsonSyntaxException: java.lang.IllegalStateException: Expected a string but was BEGIN_OBJECT at line 15 column 18 path $.data[0].source

This happens when execution flow reaches the following line within `LiveStripeResponseGetter._request` method:

`T resource = APIResource.GSON.fromJson(rBody, clazz);`

Obviously Gson fails to properly deserialize JSON structure that has nested source objects, b/c `BalanceTransaction.source` is defined as `String`. 

To make it clear, I'm aware that stripe-java already has support for expandable fields in general. It's this specific scenario that is not supported.

I also realize there's a challenge there: just changing "source" type on `BalanceTransaction` from `String` to `ExpandableField<...>` wouldn't be sufficient b/c nested "source" objects within returned JSON have *different types* (i.e. some are charges, others are transfers, adjustments, etc), while `ExpandableField` requires single generic type (`<? extends HasId>`).

# The Solution

So, I'm not sure how elegant this solution is (I'm not very familiar with stripe-java code-base, it's my very first contribution to it), but the way I solved the problem was as follows:

- added `BalanceTransactionSourceObject` class (extends `StripeObject`, implements `HasId`) to provide wrapper for various balance transaction source object types; it has properties like "charge", "transfer", etc. (I only added few, might need to support more in the future) which would be populated based on type of corresponding source object (others would remain null); so, for example, if nested source object was of type "charge", you'd be able to call `balanceTransaction.getSourceObject().getCharge()` to get populated `Charge` instance
- changed `BalanceTransaction.source` type from `String` to `ExpandableField<BalanceTransactionSourceObject>` and add `getSource()` and `getSourceObject()` methods to it, which work the same way as other similar methods within other model classes (i.e. `getSource()` returns `String` ID of nested object if it's not null, while `getSourceObject()` returns populated nested object itself, i.e. instance of `BalanceTransactionSourceObject`)
- added support for nested "source" objects deserialization based on their type to `ExpandableFieldDeserializer` class - see section of the code commented with _"Handle type specific expandable properties"_ 

I only needed support for nested "charge" objects, but also added support for "transfer" and "refund" ones - for the sake of having an example of how to extend that logic to support more nested object types, if needed.

**NOTE**: I did these changes on separate branch - **exp-balance-trx-source-obj** - which is based on v3.11.0 of code-base b/c that's the version we use in production currently (i.e. version our code-base is currently integrated with); changes are pretty straightforward though and shouldn't be hard to get merged into master branch too, I believe.

**IMPORTANT**: these are non-breaking changes that are safe to merge in - they would not break any existing code that uses stripe-java API, i.e. if someone uses `balanceTransaction.getSource()` they would still be getting String ID, while those who need full nested object would rather call new `balanceTransaction.getSourceObject()` method; `ExpandableFieldDeserializer` only handles types it knows how to handle - in all other cases it simply does nothing (ignores nested object and makes no attempt to deserialize it), so it won't throw exceptions in case new/unknown "source" objects are present in JSON data returned by API end-points; and, finally, just FYI: `BalanceTransactionTest` still passes with no issues (I did not do any changes to it).