### PR TITLE
Remove raw PANs from our test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,7 @@ public class StripeExample {
         Map<String, Object> chargeMap = new HashMap<String, Object>();
         chargeMap.put("amount", 100);
         chargeMap.put("currency", "usd");
-        Map<String, Object> cardMap = new HashMap<String, Object>();
-        cardMap.put("number", "4242424242424242");
-        cardMap.put("exp_month", 12);
-        cardMap.put("exp_year", 2020);
-        chargeMap.put("card", cardMap);
+        chargeMap.put("source", "tok_visa"); // obtained via Stripe.js
         try {
             Charge charge = Charge.create(chargeMap, requestOptions);
             System.out.println(charge);

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ public class StripeExample {
         Map<String, Object> chargeMap = new HashMap<String, Object>();
         chargeMap.put("amount", 100);
         chargeMap.put("currency", "usd");
-        chargeMap.put("source", "tok_visa"); // obtained via Stripe.js
+        chargeMap.put("source", "tok_1234"); // obtained via Stripe.js
         try {
             Charge charge = Charge.create(chargeMap, requestOptions);
             System.out.println(charge);

--- a/src/test/java/com/stripe/BaseStripeFunctionalTest.java
+++ b/src/test/java/com/stripe/BaseStripeFunctionalTest.java
@@ -17,15 +17,11 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class BaseStripeFunctionalTest {
-    public static Map<String, Object> defaultCardParams = new HashMap<String, Object>();
-    public static Map<String, Object> defaultSourceParams = new HashMap<String, Object>();
-    public static Map<String, Object> defaultDebitCardParams = new HashMap<String, Object>();
     public static Map<String, Object> defaultChargeParams = new HashMap<String, Object>();
     public static Map<String, Object> defaultCustomerParams = new HashMap<String, Object>();
     public static Map<String, Object> defaultPlanParams = new HashMap<String, Object>();
     public static Map<String, Object> defaultCouponParams = new HashMap<String, Object>();
     public static Map<String, Object> defaultTokenParams = new HashMap<String, Object>();
-    public static Map<String, Object> defaultDebitTokenParams = new HashMap<String, Object>();
     public static Map<String, Object> defaultBankAccountParams = new HashMap<String, Object>();
     public static Map<String, Object> defaultRecipientParams = new HashMap<String, Object>();
     public static Map<String, Object> defaultBitcoinReceiverParams = new HashMap<String, Object>();
@@ -80,41 +76,11 @@ public class BaseStripeFunctionalTest {
         // test key
         supportedRequestOptions = RequestOptions.builder().setStripeVersion(Stripe.apiVersion).build();
 
-        defaultCardParams.put("number", "4242424242424242");
-        defaultCardParams.put("exp_month", 12);
-        defaultCardParams.put("exp_year", getYear());
-        defaultCardParams.put("cvc", "123");
-        defaultCardParams.put("name", "J Bindings Cardholder");
-        defaultCardParams.put("address_line1", "140 2nd Street");
-        defaultCardParams.put("address_line2", "4th Floor");
-        defaultCardParams.put("address_city", "San Francisco");
-        defaultCardParams.put("address_zip", "94105");
-        defaultCardParams.put("address_state", "CA");
-        defaultCardParams.put("address_country", "USA");
-
-        defaultSourceParams = new HashMap<String, Object>(defaultCardParams);
-        defaultSourceParams.put("object", "card");
-
-        defaultDebitCardParams.put("number", "4000056655665556");
-        defaultDebitCardParams.put("exp_month", 12);
-        defaultDebitCardParams.put("exp_year", getYear());
-        defaultDebitCardParams.put("cvc", "123");
-        defaultDebitCardParams.put("name", "J Bindings Debitholder");
-        defaultDebitCardParams.put("address_line1", "140 2nd Street");
-        defaultDebitCardParams.put("address_line2", "4th Floor");
-        defaultDebitCardParams.put("address_city", "San Francisco");
-        defaultDebitCardParams.put("address_zip", "94105");
-        defaultDebitCardParams.put("address_state", "CA");
-        defaultDebitCardParams.put("address_country", "USA");
-
         defaultChargeParams.put("amount", 100);
         defaultChargeParams.put("currency", "usd");
-        defaultChargeParams.put("card", defaultCardParams);
+        defaultChargeParams.put("source", "tok_visa");
 
-        defaultTokenParams.put("card", defaultCardParams);
-        defaultDebitTokenParams.put("card", defaultDebitCardParams);
-
-        defaultCustomerParams.put("card", defaultCardParams);
+        defaultCustomerParams.put("source", "tok_visa");
         defaultCustomerParams.put("description", "J Bindings Customer");
 
         defaultPlanParams.put("amount", 100);
@@ -136,7 +102,7 @@ public class BaseStripeFunctionalTest {
         defaultRecipientParams.put("type", "individual");
         defaultRecipientParams.put("tax_id", "000000000");
         defaultRecipientParams.put("bank_account", defaultBankAccountParams);
-        defaultRecipientParams.put("card", defaultDebitCardParams);
+        defaultRecipientParams.put("card", "tok_visa_debit");
 
         defaultBitcoinReceiverParams.put("amount", 100);
         defaultBitcoinReceiverParams.put("currency", "usd");

--- a/src/test/java/com/stripe/functional/CardTest.java
+++ b/src/test/java/com/stripe/functional/CardTest.java
@@ -13,7 +13,7 @@ public class CardTest extends BaseStripeFunctionalTest {
     public void testCardMetadata() throws StripeException {
         Customer customer = Customer.create(defaultCustomerParams);
         Map<String, Object> creationParams = new HashMap<String, Object>();
-        creationParams.put("card", defaultCardParams);
+        creationParams.put("source", "tok_visa");
         testMetadata(customer.createCard(creationParams));
     }
 }

--- a/src/test/java/com/stripe/functional/ChargeTest.java
+++ b/src/test/java/com/stripe/functional/ChargeTest.java
@@ -84,7 +84,7 @@ public class ChargeTest extends BaseStripeFunctionalTest {
 		assertNotNull(retrievedCharge.getSource());
 		assertEquals("card", retrievedCharge.getSource().getObject());
 		Card card = (Card) retrievedCharge.getSource();
-		assertEquals(defaultCardParams.get("address_city"), card.getAddressCity());
+		assertEquals("4242", card.getLast4());
 		//BT Checks:
 		assertNotNull(retrievedCharge.getBalanceTransaction());
 		assertNull(retrievedCharge.getBalanceTransactionObject());
@@ -140,7 +140,7 @@ public class ChargeTest extends BaseStripeFunctionalTest {
 		invalidCardParams.put("number", "4242424242424241");
 		invalidCardParams.put("exp_month", 12);
 		invalidCardParams.put("exp_year", getYear());
-		invalidChargeParams.put("card", invalidCardParams);
+		invalidChargeParams.put("source", invalidCardParams);
 		Charge.create(invalidChargeParams);
 	}
 
@@ -149,10 +149,7 @@ public class ChargeTest extends BaseStripeFunctionalTest {
 		Map<String, Object> declinedChargeParams = new HashMap<String, Object>();
 		declinedChargeParams.putAll(defaultChargeParams);
 		Map<String, Object> declinedCardParams = new HashMap<String, Object>();
-		declinedCardParams.put("number", "4000000000000002");
-		declinedCardParams.put("exp_month", 12);
-		declinedCardParams.put("exp_year", getYear());
-		declinedChargeParams.put("card", declinedCardParams);
+		declinedChargeParams.put("source", "tok_chargeDeclined");
 
 		try {
 			Charge.create(declinedChargeParams);
@@ -168,20 +165,13 @@ public class ChargeTest extends BaseStripeFunctionalTest {
 		Map<String, Object> invalidChargeParams = new HashMap<String, Object>();
 		invalidChargeParams.putAll(defaultChargeParams);
 		Map<String, Object> invalidCardParams = new HashMap<String, Object>();
-		// See https://stripe.com/docs/testing
-		invalidCardParams.put("number", "4000000000000036");
-		invalidCardParams.put("address_zip", "94024");
-		invalidCardParams.put("address_line1", "42 Foo Street");
-		invalidCardParams.put("exp_month", 12);
-		invalidCardParams.put("exp_year", getYear());
-		invalidChargeParams.put("card", invalidCardParams);
+		invalidChargeParams.put("source", "tok_avsZipFail");
 		Charge charge = Charge.create(invalidChargeParams, supportedRequestOptions);
 		assertEquals(charge.getPaid(), true);
 
 		assertThat(charge.getSource(), instanceOf(Card.class));
 		Card card = (Card)charge.getSource();
 		assertEquals(card.getAddressZipCheck(), "fail");
-		assertEquals(card.getAddressLine1Check(), "pass");
 	}
 
 	@Test
@@ -189,19 +179,12 @@ public class ChargeTest extends BaseStripeFunctionalTest {
 		Map<String, Object> invalidChargeParams = new HashMap<String, Object>();
 		invalidChargeParams.putAll(defaultChargeParams);
 		Map<String, Object> invalidCardParams = new HashMap<String, Object>();
-		// See https://stripe.com/docs/testing
-		invalidCardParams.put("number", "4000000000000028");
-		invalidCardParams.put("address_zip", "94024");
-		invalidCardParams.put("address_line1", "42 Foo Street");
-		invalidCardParams.put("exp_month", 12);
-		invalidCardParams.put("exp_year", getYear());
-		invalidChargeParams.put("card", invalidCardParams);
+		invalidChargeParams.put("source", "tok_avsLine1Fail");
 		Charge charge = Charge.create(invalidChargeParams, supportedRequestOptions);
 		assertEquals(charge.getPaid(), true);
 
 		assertThat(charge.getSource(), instanceOf(Card.class));
 		Card card = (Card)charge.getSource();
-		assertEquals(card.getAddressZipCheck(), "pass");
 		assertEquals(card.getAddressLine1Check(), "fail");
 	}
 
@@ -267,7 +250,7 @@ public class ChargeTest extends BaseStripeFunctionalTest {
 		invalidCardParams.put("number", "4242424242424241");
 		invalidCardParams.put("exp_month", 12);
 		invalidCardParams.put("exp_year", getYear());
-		invalidChargeParams.put("card", invalidCardParams);
+		invalidChargeParams.put("source", invalidCardParams);
 		Charge.create(invalidChargeParams, Stripe.apiKey);
 	}
 

--- a/src/test/java/com/stripe/functional/ChargeTest.java
+++ b/src/test/java/com/stripe/functional/ChargeTest.java
@@ -137,7 +137,7 @@ public class ChargeTest extends BaseStripeFunctionalTest {
 		Map<String, Object> invalidChargeParams = new HashMap<String, Object>();
 		invalidChargeParams.putAll(defaultChargeParams);
 		Map<String, Object> invalidCardParams = new HashMap<String, Object>();
-		invalidCardParams.put("number", "4242424242424241");
+		invalidCardParams.put("number", "4242424242424241"); // No magic token for invalid card number
 		invalidCardParams.put("exp_month", 12);
 		invalidCardParams.put("exp_year", getYear());
 		invalidChargeParams.put("source", invalidCardParams);
@@ -247,7 +247,7 @@ public class ChargeTest extends BaseStripeFunctionalTest {
 		Map<String, Object> invalidChargeParams = new HashMap<String, Object>();
 		invalidChargeParams.putAll(defaultChargeParams);
 		Map<String, Object> invalidCardParams = new HashMap<String, Object>();
-		invalidCardParams.put("number", "4242424242424241");
+		invalidCardParams.put("number", "4242424242424241"); // No magic token for invalid card number
 		invalidCardParams.put("exp_month", 12);
 		invalidCardParams.put("exp_year", getYear());
 		invalidChargeParams.put("source", invalidCardParams);

--- a/src/test/java/com/stripe/functional/CountrySpecTest.java
+++ b/src/test/java/com/stripe/functional/CountrySpecTest.java
@@ -16,15 +16,7 @@ import static org.junit.Assert.assertNotSame;
 public class CountrySpecTest extends BaseStripeFunctionalTest {
     @Test
     public void testChargeCreationSourceAsCard() throws StripeException {
-        Map<String, Object> chargeParams = new HashMap<String, Object>();
-        chargeParams.put("amount", 100);
-        chargeParams.put("currency", "usd");
-        Map<String, Object> cardMap = new HashMap<String, Object>();
-        cardMap.put("number", "4242424242424242");
-        cardMap.put("exp_month", 12);
-        cardMap.put("exp_year", getYear());
-        chargeParams.put("card", cardMap);
-        Charge charge = Charge.create(chargeParams);
+        Charge charge = Charge.create(defaultChargeParams);
 
         assertTrue(charge.getSource() instanceof Card);
         assertNotNull(charge.getSource().getId());

--- a/src/test/java/com/stripe/functional/CustomerTest.java
+++ b/src/test/java/com/stripe/functional/CustomerTest.java
@@ -147,7 +147,7 @@ public class CustomerTest extends BaseStripeFunctionalTest {
     @Test
     public void testCustomerCreateWithSource() throws StripeException {
         HashMap<String, Object> customerCreationParams = new HashMap<String, Object>();
-        customerCreationParams.put("source", defaultSourceParams);
+        customerCreationParams.put("source", "tok_visa");
         Customer customer = Customer.create(customerCreationParams);
         assertNotNull(customer);
         assertNotNull(customer.getId());
@@ -156,18 +156,6 @@ public class CustomerTest extends BaseStripeFunctionalTest {
         assertNotNull(customer.getDefaultSource());
         ExternalAccount card = customer.getSources().retrieve(customer.getDefaultSource());
         assertEquals(card.getId(), customer.getDefaultSource());
-    }
-
-    @Test
-    public void testCustomerCreateSourceWithCardHash() throws StripeException {
-        Customer customer = Customer.create(new HashMap<String, Object>());
-        ExternalAccountCollection customerSources = customer.getSources();
-        HashMap<String, Object> createParams = new HashMap<String, Object>();
-        createParams.put("source", defaultSourceParams);
-        ExternalAccount paymentSource = customerSources.create(createParams);
-        assertNotNull(paymentSource);
-        assertNotNull(paymentSource.getId());
-        assert(paymentSource instanceof Card);
     }
 
     @Test
@@ -213,11 +201,9 @@ public class CustomerTest extends BaseStripeFunctionalTest {
         String originalDefaultSource = createdCustomer.getDefaultSource();
 
         Map<String, Object> creationParams = new HashMap<String, Object>();
-        creationParams.put("card", defaultCardParams);
+        creationParams.put("source", "tok_visa");
         ExternalAccount addedCard = createdCustomer.getSources().create(creationParams);
-
-        Token token = Token.create(defaultTokenParams);
-        createdCustomer.createCard(token.getId());
+        createdCustomer.createCard("tok_visa");
 
         Customer updatedCustomer = Customer.retrieve(createdCustomer.getId(), supportedRequestOptions);
         assertEquals(3, updatedCustomer.getSources().getData().size());
@@ -238,7 +224,7 @@ public class CustomerTest extends BaseStripeFunctionalTest {
         Customer createdCustomer = Customer.create(defaultCustomerParams, supportedRequestOptions);
 
         Map<String, Object> creationParams = new HashMap<String, Object>();
-        creationParams.put("card", defaultCardParams);
+        creationParams.put("source", "tok_visa");
         ExternalAccount addedCard = createdCustomer.getSources().create(creationParams);
 
         assertEquals(createdCustomer.getId(), addedCard.getCustomer());
@@ -263,7 +249,7 @@ public class CustomerTest extends BaseStripeFunctionalTest {
     public void testCustomerCardDelete() throws StripeException {
         Customer customer = Customer.create(defaultCustomerParams, supportedRequestOptions);
         Map<String, Object> creationParams = new HashMap<String, Object>();
-        creationParams.put("card", defaultCardParams);
+        creationParams.put("source", "tok_visa");
         customer.createCard(creationParams);
 
         ExternalAccount card = customer.getSources().getData().get(0);
@@ -286,8 +272,7 @@ public class CustomerTest extends BaseStripeFunctionalTest {
         creationParams.put("bank_account", defaultBankAccountParams);
         BankAccount addedBankAccount = createdCustomer.createBankAccount(creationParams);
 
-        Token token = Token.create(defaultTokenParams);
-        createdCustomer.createCard(token.getId());
+        createdCustomer.createCard("tok_visa");
 
         Customer updatedCustomer = Customer.retrieve(createdCustomer.getId(), supportedRequestOptions);
         assertEquals((Integer) updatedCustomer.getSources().getData().size(), (Integer) 3);

--- a/src/test/java/com/stripe/functional/DisputeTest.java
+++ b/src/test/java/com/stripe/functional/DisputeTest.java
@@ -25,11 +25,7 @@ public class DisputeTest extends BaseStripeFunctionalTest {
         Map<String, Object> chargeParams = new HashMap<String, Object>();
         chargeParams.putAll(defaultChargeParams);
         chargeParams.put("amount", chargeValueCents);
-        Map<String, Object> testModeDisputeCardParams = new HashMap<String, Object>();
-        testModeDisputeCardParams.put("number", "4000000000000259");
-        testModeDisputeCardParams.put("exp_month", 12);
-        testModeDisputeCardParams.put("exp_year", getYear());
-        chargeParams.put("source", testModeDisputeCardParams);
+        chargeParams.put("source", "tok_createDispute");
         Charge charge = Charge.create(chargeParams, options);
 
         // This test relies on the server asynchronously marking the charge as disputed.

--- a/src/test/java/com/stripe/functional/DisputeTest.java
+++ b/src/test/java/com/stripe/functional/DisputeTest.java
@@ -29,7 +29,7 @@ public class DisputeTest extends BaseStripeFunctionalTest {
         testModeDisputeCardParams.put("number", "4000000000000259");
         testModeDisputeCardParams.put("exp_month", 12);
         testModeDisputeCardParams.put("exp_year", getYear());
-        chargeParams.put("card", testModeDisputeCardParams);
+        chargeParams.put("source", testModeDisputeCardParams);
         Charge charge = Charge.create(chargeParams, options);
 
         // This test relies on the server asynchronously marking the charge as disputed.

--- a/src/test/java/com/stripe/functional/RecipientTest.java
+++ b/src/test/java/com/stripe/functional/RecipientTest.java
@@ -54,11 +54,10 @@ public class RecipientTest extends BaseStripeFunctionalTest {
         String originalDefaultCard = createdRecipient.getDefaultCard();
 
         Map<String, Object> creationParams = new HashMap<String, Object>();
-        creationParams.put("card", defaultDebitCardParams);
+        creationParams.put("card", "tok_visa_debit");
         Card addedCard = createdRecipient.createCard(creationParams);
 
-        Token token = Token.create(defaultDebitTokenParams);
-        createdRecipient.createCard(token.getId());
+        createdRecipient.createCard("tok_visa_debit");
 
         Recipient updatedRecipient = Recipient.retrieve(createdRecipient.getId());
         assertEquals((Integer) 3, (Integer) updatedRecipient.getCards().getData().size());
@@ -88,7 +87,7 @@ public class RecipientTest extends BaseStripeFunctionalTest {
     public void testRecipientCardDelete() throws StripeException {
         Recipient recipient = Recipient.create(defaultRecipientParams);
         Map<String, Object> creationParams = new HashMap<String, Object>();
-        creationParams.put("card", defaultDebitCardParams);
+        creationParams.put("card", "tok_visa_debit");
         recipient.createCard(creationParams);
 
         Card card = recipient.getCards().getData().get(0);

--- a/src/test/java/com/stripe/functional/RelayTest.java
+++ b/src/test/java/com/stripe/functional/RelayTest.java
@@ -158,7 +158,7 @@ public class RelayTest extends BaseStripeFunctionalTest {
         Order updated = retrieved.update(ImmutableMap.<String,Object>of("metadata", ImmutableMap.of("foo", "bar")), relayRequestOptions);
         assertEquals("bar", updated.getMetadata().get("foo"));
 
-        Order paid = updated.pay(ImmutableMap.<String,Object>of("source", defaultSourceParams), relayRequestOptions);
+        Order paid = updated.pay(ImmutableMap.<String,Object>of("source", "tok_visa"), relayRequestOptions);
         assertEquals("paid", paid.getStatus());
 
         OrderReturn returned = paid.returnOrder(null, relayRequestOptions);

--- a/src/test/java/com/stripe/functional/TokenTest.java
+++ b/src/test/java/com/stripe/functional/TokenTest.java
@@ -15,22 +15,34 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class TokenTest extends BaseStripeFunctionalTest {
+    private Map<String, Object> getTokenParams() {
+        Map<String, Object> tokenParams = new HashMap<String, Object>();
+        Map<String, Object> cardParams = new HashMap<String, Object>();
+        cardParams.put("number", "4242424242424242");
+        cardParams.put("exp_month", 12);
+        cardParams.put("exp_year", getYear());
+        cardParams.put("cvc", "123");
+        tokenParams.put("card", cardParams);
+
+        return tokenParams;
+    }
+
     @Test
     public void testTokenCreate() throws StripeException {
-        Token token = Token.create(defaultTokenParams);
+        Token token = Token.create(getTokenParams());
         assertFalse(token.getUsed());
     }
 
     @Test
     public void testTokenRetrieve() throws StripeException {
-        Token createdToken = Token.create(defaultTokenParams);
+        Token createdToken = Token.create(getTokenParams());
         Token retrievedToken = Token.retrieve(createdToken.getId());
         assertEquals(createdToken.getId(), retrievedToken.getId());
     }
 
     @Test
     public void testTokenUse() throws StripeException {
-        Token createdToken = Token.create(defaultTokenParams);
+        Token createdToken = Token.create(getTokenParams());
         Map<String, Object> chargeWithTokenParams = new HashMap<String, Object>();
         chargeWithTokenParams.put("amount", 199);
         chargeWithTokenParams.put("currency", "usd");
@@ -42,13 +54,13 @@ public class TokenTest extends BaseStripeFunctionalTest {
 
     @Test
     public void testTokenCreatePerCallAPIKey() throws StripeException {
-        Token token = Token.create(defaultTokenParams, Stripe.apiKey);
+        Token token = Token.create(getTokenParams(), Stripe.apiKey);
         assertFalse(token.getUsed());
     }
 
     @Test
     public void testTokenRetrievePerCallAPIKey() throws StripeException {
-        Token createdToken = Token.create(defaultTokenParams, Stripe.apiKey);
+        Token createdToken = Token.create(getTokenParams(), Stripe.apiKey);
         Token retrievedToken = Token.retrieve(createdToken.getId(),
                 Stripe.apiKey);
         assertEquals(createdToken.getId(), retrievedToken.getId());
@@ -56,7 +68,7 @@ public class TokenTest extends BaseStripeFunctionalTest {
 
     @Test
     public void testTokenUsePerCallAPIKey() throws StripeException {
-        Token createdToken = Token.create(defaultTokenParams, Stripe.apiKey);
+        Token createdToken = Token.create(getTokenParams(), Stripe.apiKey);
         Map<String, Object> chargeWithTokenParams = new HashMap<String, Object>();
         chargeWithTokenParams.put("amount", 199);
         chargeWithTokenParams.put("currency", "usd");

--- a/src/test/java/com/stripe/functional/TokenTest.java
+++ b/src/test/java/com/stripe/functional/TokenTest.java
@@ -18,7 +18,7 @@ public class TokenTest extends BaseStripeFunctionalTest {
     private Map<String, Object> getTokenParams() {
         Map<String, Object> tokenParams = new HashMap<String, Object>();
         Map<String, Object> cardParams = new HashMap<String, Object>();
-        cardParams.put("number", "4242424242424242");
+        cardParams.put("number", "4242424242424242"); // Test token creation so needs PAN.
         cardParams.put("exp_month", 12);
         cardParams.put("exp_year", getYear());
         cardParams.put("cvc", "123");


### PR DESCRIPTION
This PR aims to use the new test tokens such as `tok_visa` instead or hardcoding raw PANs in the test suite.

Left a reference to the dispute test card as there's no token for it yet. Also revamped the Token resource test suite to reference the PAN there. No test token for invalid card number so left that one too.

r? @brandur-stripe 