### PR TITLE
Balance transaction deserialization with support for expandable source objects

### DIFF
--- a/src/main/java/com/stripe/model/BalanceTransaction.java
+++ b/src/main/java/com/stripe/model/BalanceTransaction.java
@@ -1,5 +1,8 @@
 package com.stripe.model;
 
+import java.util.List;
+import java.util.Map;
+
 import com.stripe.Stripe;
 import com.stripe.exception.APIConnectionException;
 import com.stripe.exception.APIException;
@@ -8,9 +11,6 @@ import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
 import com.stripe.net.APIResource;
 import com.stripe.net.RequestOptions;
-
-import java.util.List;
-import java.util.Map;
 
 public class BalanceTransaction extends APIResource implements HasId {
 	String id;
@@ -26,7 +26,11 @@ public class BalanceTransaction extends APIResource implements HasId {
 	String source;
 	String status;
 	String type;
-
+	
+	transient Charge sourceCharge;
+	transient Transfer sourceTransfer;
+	transient Refund sourceRefund;
+	
 	@Deprecated
 	TransferCollection sourcedTransfers;
 
@@ -146,6 +150,30 @@ public class BalanceTransaction extends APIResource implements HasId {
 	public void setType(String type) {
 		this.type = type;
 	}
+	
+	public Charge getSourceCharge() {
+		return sourceCharge;
+	}
+
+	public void setSourceCharge(Charge sourceCharge) {
+		this.sourceCharge = sourceCharge;
+	}
+
+	public Transfer getSourceTransfer() {
+		return sourceTransfer;
+	}
+
+	public void setSourceTransfer(Transfer sourceTransfer) {
+		this.sourceTransfer = sourceTransfer;
+	}
+
+	public Refund getSourceRefund() {
+		return sourceRefund;
+	}
+
+	public void setSourceRefund(Refund sourceRefund) {
+		this.sourceRefund = sourceRefund;
+	}
 
 	public static BalanceTransaction retrieve(String id) throws AuthenticationException,
 			InvalidRequestException, APIConnectionException, CardException,
@@ -200,4 +228,5 @@ public class BalanceTransaction extends APIResource implements HasId {
 			APIConnectionException, CardException, APIException {
 		return list(params, options);
 	}
+	
 }

--- a/src/main/java/com/stripe/model/BalanceTransaction.java
+++ b/src/main/java/com/stripe/model/BalanceTransaction.java
@@ -27,9 +27,7 @@ public class BalanceTransaction extends APIResource implements HasId {
 	String status;
 	String type;
 	
-	transient Charge sourceCharge;
-	transient Transfer sourceTransfer;
-	transient Refund sourceRefund;
+	transient HasId sourceObject;
 	
 	@Deprecated
 	TransferCollection sourcedTransfers;
@@ -151,30 +149,15 @@ public class BalanceTransaction extends APIResource implements HasId {
 		this.type = type;
 	}
 	
-	public Charge getSourceCharge() {
-		return sourceCharge;
+	public void setSourceObject(HasId sourceObject) {
+		this.sourceObject = sourceObject;
 	}
 
-	public void setSourceCharge(Charge sourceCharge) {
-		this.sourceCharge = sourceCharge;
+	@SuppressWarnings("unchecked")
+	public <O> O getSourceObject() {
+		return (O) sourceObject;
 	}
-
-	public Transfer getSourceTransfer() {
-		return sourceTransfer;
-	}
-
-	public void setSourceTransfer(Transfer sourceTransfer) {
-		this.sourceTransfer = sourceTransfer;
-	}
-
-	public Refund getSourceRefund() {
-		return sourceRefund;
-	}
-
-	public void setSourceRefund(Refund sourceRefund) {
-		this.sourceRefund = sourceRefund;
-	}
-
+		
 	public static BalanceTransaction retrieve(String id) throws AuthenticationException,
 			InvalidRequestException, APIConnectionException, CardException,
 			APIException {

--- a/src/main/java/com/stripe/model/BalanceTransaction.java
+++ b/src/main/java/com/stripe/model/BalanceTransaction.java
@@ -23,11 +23,9 @@ public class BalanceTransaction extends APIResource implements HasId {
 	Long fee;
 	List<Fee> feeDetails;
 	Integer net;
-	String source;
+	ExpandableField<HasId> source;
 	String status;
 	String type;
-	
-	transient HasId sourceObject;
 	
 	@Deprecated
 	TransferCollection sourcedTransfers;
@@ -112,14 +110,6 @@ public class BalanceTransaction extends APIResource implements HasId {
 		this.net = net;
 	}
 
-	public String getSource() {
-		return source;
-	}
-
-	public void setSource(String source) {
-		this.source = source;
-	}
-
 	/**
 	 * @deprecated
 	 * Recent API versions no longer return this field (https://stripe.com/docs/upgrades#2017-01-27).
@@ -149,15 +139,35 @@ public class BalanceTransaction extends APIResource implements HasId {
 		this.type = type;
 	}
 	
-	public void setSourceObject(HasId sourceObject) {
-		this.sourceObject = sourceObject;
+	public String getSource() {
+		if (this.source == null) {
+			return null;
+		}
+		return this.source.getId();
 	}
 
-	@SuppressWarnings("unchecked")
-	public <O> O getSourceObject() {
-		return (O) sourceObject;
+	public void setSource(String sourceID) {
+		this.source = setExpandableFieldID(sourceID, this.source);
 	}
-		
+	
+	public HasId getSourceObject() {
+		if (this.source == null) {
+			return null;
+		}
+		return this.source.getExpanded();
+	}
+
+	public void setSourceObject(HasId o) {
+		this.source = new ExpandableField<HasId>(o.getId(), o);
+	}
+
+	public <O extends HasId> O getSourceObjectAs() {
+		if (this.source == null) {
+			return null;
+		}
+		return (O) this.source.getExpanded();
+ 	}
+	
 	public static BalanceTransaction retrieve(String id) throws AuthenticationException,
 			InvalidRequestException, APIConnectionException, CardException,
 			APIException {

--- a/src/main/java/com/stripe/model/BalanceTransactionDeserializer.java
+++ b/src/main/java/com/stripe/model/BalanceTransactionDeserializer.java
@@ -50,17 +50,19 @@ public class BalanceTransactionDeserializer implements JsonDeserializer<BalanceT
 			sourceId = sourceIdEl != null ? sourceIdEl.getAsString() : null;
 			JsonElement val = sourceJsonObject.get("object");
 			if (val != null) {
+				Class<? extends HasId> sourceObjClass = null;
 				if ("charge".equals(val.getAsString())) {
-					Charge charge = context.deserialize(source, Charge.class);
-					balanceTransaction.setSourceCharge(charge);
+					sourceObjClass = Charge.class;
 				} else if ("transfer".equals(val.getAsString())) {
-					Transfer transfer = context.deserialize(source, Transfer.class);
-					balanceTransaction.setSourceTransfer(transfer);
+					sourceObjClass = Transfer.class;
 				} else if ("refund".equals(val.getAsString())) {
-					Refund refund = context.deserialize(source, Refund.class);
-					balanceTransaction.setSourceRefund(refund);
+					sourceObjClass = Refund.class;
 				}
 				// TODO support other source types (?)
+				if (sourceObjClass != null) {
+					HasId sourceObj = context.deserialize(source, sourceObjClass);
+					balanceTransaction.setSourceObject(sourceObj);
+				}
 			}
 		} else if (!source.isJsonNull()) {
 			throw new JsonParseException("Source field on a balance transaction was a non-primitive, non-object type.");

--- a/src/main/java/com/stripe/model/BalanceTransactionDeserializer.java
+++ b/src/main/java/com/stripe/model/BalanceTransactionDeserializer.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2003-2010 SPORTSVITE, LLC. All Rights Reserved.
+ *
+ * This software is the confidential and proprietary information of
+ * SPORTSVITE, LLC and certain third parties ("Confidential Information").
+ * You shall not disclose such Confidential Information and shall
+ * use it only in accordance with the terms of the license agreement
+ * you entered into with SPORTSVITE, LLC.
+ *
+ * SPORTSVITE, LLC MAKES NO REPRESENTATIONS OR WARRANTIES ABOUT THE SUITABILITY OF
+ * THE SOFTWARE, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
+ * OR NON-INFRINGEMENT. SPORTSVITE, LLC SHALL NOT BE LIABLE FOR ANY DAMAGES
+ * SUFFERED BY LICENSEE AS A RESULT OF USING, MODIFYING OR DISTRIBUTING
+ * THIS SOFTWARE OR ITS DERIVATIVES.
+ */
+package com.stripe.model;
+
+import java.lang.reflect.Type;
+
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+
+/**
+ * @author kion
+ */
+public class BalanceTransactionDeserializer implements JsonDeserializer<BalanceTransaction> {
+
+	@Override
+	public BalanceTransaction deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+		Gson gson = new GsonBuilder()
+				.setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+				.create();
+		
+		if (json.isJsonNull()) {
+			return null;
+		}
+
+		if (!json.isJsonObject()) {
+			throw new JsonParseException("BalanceTransaction type was not an object, which is problematic.");
+		}
+		
+		JsonObject btAsJsonObject = json.getAsJsonObject();
+
+		JsonElement source = btAsJsonObject.get("source");
+		
+		btAsJsonObject.remove("source");
+
+		BalanceTransaction balanceTransaction = gson.fromJson(json, typeOfT);
+		
+		String sourceId = null;
+
+		if (source.isJsonPrimitive()) {
+			JsonPrimitive sourceJsonPrimitive = source.getAsJsonPrimitive();
+			if (!sourceJsonPrimitive.isString()) {
+				throw new JsonParseException("Source field on a balance transaction was a primitive non-string type.");
+			}
+			sourceId = sourceJsonPrimitive.getAsString();
+		} else if (source.isJsonObject()) {
+			JsonObject sourceJsonObject = source.getAsJsonObject();
+			JsonElement sourceIdEl = sourceJsonObject.get("id");
+			sourceId = sourceIdEl != null ? sourceIdEl.getAsString() : null;
+			JsonElement val = sourceJsonObject.get("object");
+			if (val != null) {
+				if ("charge".equals(val.getAsString())) {
+					Charge charge = context.deserialize(source, Charge.class);
+					balanceTransaction.setSourceCharge(charge);
+				} else if ("transfer".equals(val.getAsString())) {
+					Transfer transfer = context.deserialize(source, Transfer.class);
+					balanceTransaction.setSourceTransfer(transfer);
+				} else if ("refund".equals(val.getAsString())) {
+					Refund refund = context.deserialize(source, Refund.class);
+					balanceTransaction.setSourceRefund(refund);
+				}
+				// TODO support other source types (?)
+			}
+		} else if (!source.isJsonNull()) {
+			throw new JsonParseException("Source field on a balance transaction was a non-primitive, non-object type.");
+		}
+		
+		balanceTransaction.setSource(sourceId);
+
+		return balanceTransaction;
+	}
+
+}

--- a/src/main/java/com/stripe/model/BalanceTransactionDeserializer.java
+++ b/src/main/java/com/stripe/model/BalanceTransactionDeserializer.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2003-2010 SPORTSVITE, LLC. All Rights Reserved.
- *
- * This software is the confidential and proprietary information of
- * SPORTSVITE, LLC and certain third parties ("Confidential Information").
- * You shall not disclose such Confidential Information and shall
- * use it only in accordance with the terms of the license agreement
- * you entered into with SPORTSVITE, LLC.
- *
- * SPORTSVITE, LLC MAKES NO REPRESENTATIONS OR WARRANTIES ABOUT THE SUITABILITY OF
- * THE SOFTWARE, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
- * OR NON-INFRINGEMENT. SPORTSVITE, LLC SHALL NOT BE LIABLE FOR ANY DAMAGES
- * SUFFERED BY LICENSEE AS A RESULT OF USING, MODIFYING OR DISTRIBUTING
- * THIS SOFTWARE OR ITS DERIVATIVES.
- */
 package com.stripe.model;
 
 import java.lang.reflect.Type;
@@ -28,9 +12,6 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonPrimitive;
 
-/**
- * @author kion
- */
 public class BalanceTransactionDeserializer implements JsonDeserializer<BalanceTransaction> {
 
 	@Override

--- a/src/main/java/com/stripe/model/DisputeDataDeserializer.java
+++ b/src/main/java/com/stripe/model/DisputeDataDeserializer.java
@@ -1,5 +1,7 @@
 package com.stripe.model;
 
+import java.lang.reflect.Type;
+
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -10,12 +12,11 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonPrimitive;
 
-import java.lang.reflect.Type;
-
 public class DisputeDataDeserializer implements JsonDeserializer<Dispute> {
 	public Dispute deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
 		Gson gson = new GsonBuilder()
 				.setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+				.registerTypeAdapter(ExpandableField.class, new ExpandableFieldDeserializer())
 				.create();
 		if (json.isJsonNull()) {
 			return null;

--- a/src/main/java/com/stripe/net/APIResource.java
+++ b/src/main/java/com/stripe/net/APIResource.java
@@ -1,5 +1,9 @@
 package com.stripe.net;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.Map;
+
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -9,6 +13,8 @@ import com.stripe.exception.APIException;
 import com.stripe.exception.AuthenticationException;
 import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
+import com.stripe.model.BalanceTransaction;
+import com.stripe.model.BalanceTransactionDeserializer;
 import com.stripe.model.ChargeRefundCollection;
 import com.stripe.model.ChargeRefundCollectionDeserializer;
 import com.stripe.model.Dispute;
@@ -28,10 +34,6 @@ import com.stripe.model.StripeObject;
 import com.stripe.model.StripeRawJsonObject;
 import com.stripe.model.StripeRawJsonObjectDeserializer;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.util.Map;
-
 public abstract class APIResource extends StripeObject {
 	private static StripeResponseGetter stripeResponseGetter = new LiveStripeResponseGetter();
 
@@ -45,6 +47,7 @@ public abstract class APIResource extends StripeObject {
 			.registerTypeAdapter(ChargeRefundCollection.class, new ChargeRefundCollectionDeserializer())
 			.registerTypeAdapter(FeeRefundCollection.class, new FeeRefundCollectionDeserializer())
 			.registerTypeAdapter(StripeRawJsonObject.class, new StripeRawJsonObjectDeserializer())
+			.registerTypeAdapter(BalanceTransaction.class, new BalanceTransactionDeserializer())
 			.registerTypeAdapter(Dispute.class, new DisputeDataDeserializer())
 			.registerTypeAdapter(Source.class, new SourceDeserializer())
 			.registerTypeAdapter(ExpandableField.class, new ExpandableFieldDeserializer())


### PR DESCRIPTION
# The Task

Implement balance transactions view with metadata (e.g. customer name, payment summary) rendered for records of type "charge". To make it clear, `Charge` objects we create are populated with metadata we need to store. This task is only about extracting that metadata from balance transaction records corresponding to charges.

Note: I'm aware balance transactions do not support metadata, but according to API docs, "source" object on balance transaction is expandable and is capable of returning full nested structure of corresponding charge, transfer, etc.

# The Problem

If "data.source" expansion is requested, returned JSON data structure looks correct - it does contain nested objects.

However, stripe-java unfortunately does not support this currently.

Consider the following API call:

`Map<String, Object> params = new HashMap<String, Object>();`
`params.put("expand", Arrays.asList(new String[]{ "data.source.metadata" }));`
`BalanceTransactionCollection transactions = BalanceTransaction.list(params);`

It worked perfectly without "expand" param set (but obviously didn't contain the nested objects we needed to get), but as long as param is set, it fails with the following exception:

> com.google.gson.JsonSyntaxException: java.lang.IllegalStateException: Expected a string but was BEGIN_OBJECT at line 15 column 18 path $.data[0].source

This happens when execution flow reaches the following line within `LiveStripeResponseGetter._request` method:

`T resource = APIResource.GSON.fromJson(rBody, clazz);`

Obviously Gson fails to properly deserialize balance transaction JSON structure that has nested source object, b/c `BalanceTransaction.source` is defined as `String`. 

To make it clear, I'm aware that stripe-java has support for expandable fields, but the challenge there is that just changing "source" type on `BalanceTransaction` from `String` to `ExpandableField<...>` wouldn't work b/c nested "source" objects within returned JSON might have *different types* (i.e. some are charges, others are transfers, adjustments, etc), while `ExpandableField` requires single generic type (`<? extends HasId>`).

# The Solution

Note: I tried to solve this in a different way initially - see pull request https://github.com/stripe/stripe-java/pull/361 - , which worked just fine with JSON structures returned by end-point requests, but was incompatible with incoming JSON structures for webhooks (was throwing exception on `APIResource.GSON.fromJson(jsonBody, Event.class)` call); this new solution supports both and looks a bit more elegant too.

Here's a list of changes I made to solve the problem:

- added a bunch of transient properties for various possible nested "source" object types (e.g. “sourceCharge", “sourceTransfer", etc.) to `BalanceTransaction` class (I only added a few, might need to support more in the future) which would be populated based on the type of corresponding "source" object (others would remain null); so, for example, if nested "source" object was of type "charge", you'd be able to call `balanceTransaction.getSourceCharge()` to get populated `Charge` instance
- implemented new `BalanceTransactionDeserializer` class that supports nested "source" objects deserialization for balance transactions and registered it within `APIResource.GSON` (i.e. mapped it to `BalanceTransaction` class via `GsonBuilder`)

I only needed support for nested "charge" objects, but also added support for "transfer" and "refund" ones - for the sake of having an example of how to extend that logic to support more nested object types, if needed.

**NOTE**: I did these changes on separate branch - **balance-transaction-deserializer** - which is based on v3.11.0 of code-base b/c that's the version we use in production currently (i.e. version our code-base is currently integrated with); changes are pretty straightforward though and shouldn't be hard to merge into master branch (GitHub indicates there are no conflicts).

**IMPORTANT**: as far as I can tell, these are non-breaking changes that should be safe to merge in - they should not break any existing code that uses stripe-java, i.e. if someone calls `balanceTransaction.getSource()` in their code, they would still be getting String ID, while those who need full nested source object would rather call one of the new methods for the appropriate "source" object type, e.g. `balanceTransaction.getSourceCharge()` to get nested `Charge` object; `BalanceTransactionDeserializer ` only handles nested "source" object for balance transaction if one is present and only handles types it knows how to handle - in all other cases it does nothing besides of setting "source" object ID (which it always does, of course), so it won't throw exceptions in case no/new/unknown "source" objects are present in JSON data returned by API end-points; and, finally, just FYI: `BalanceTransactionTest` still passes without issues (I did not do any changes to it).