### PR TITLE
allow to set connection and read timeout per request.

### DIFF
--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -149,7 +149,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 		} else {
 			conn = (HttpURLConnection) stripeURL.openConnection();
 		}
-		conn.setConnectTimeout(options.getConnectionTimeout());
+		conn.setConnectTimeout(options.getConnectTimeout());
 		conn.setReadTimeout(options.getReadTimeout());
 		conn.setUseCaches(false);
 		for (Map.Entry<String, String> header : getHeaders(options).entrySet()) {

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -149,8 +149,8 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 		} else {
 			conn = (HttpURLConnection) stripeURL.openConnection();
 		}
-		conn.setConnectTimeout(30 * 1000);
-		conn.setReadTimeout(80 * 1000);
+		conn.setConnectTimeout(options.getConnectionTimeout());
+		conn.setReadTimeout(options.getReadTimeout());
 		conn.setUseCaches(false);
 		for (Map.Entry<String, String> header : getHeaders(options).entrySet()) {
 			conn.setRequestProperty(header.getKey(), header.getValue());

--- a/src/main/java/com/stripe/net/RequestOptions.java
+++ b/src/main/java/com/stripe/net/RequestOptions.java
@@ -3,8 +3,13 @@ package com.stripe.net;
 import com.stripe.Stripe;
 
 public class RequestOptions {
+	
+	private final static int DEFAULT_CONNECTION_TIMEOUT = 30 * 1000;    	
+	
+	private final static int DEFAULT_READ_TIMEOUT = 80 * 1000;
+    
 	public static RequestOptions getDefault() {
-		return new RequestOptions(Stripe.apiKey, Stripe.apiVersion, null, null, 30 * 1000, 80 * 1000);
+		return new RequestOptions(Stripe.apiKey, Stripe.apiVersion, null, null, DEFAULT_CONNECTION_TIMEOUT, DEFAULT_READ_TIMEOUT);
 	}
 
 	private final String apiKey;

--- a/src/main/java/com/stripe/net/RequestOptions.java
+++ b/src/main/java/com/stripe/net/RequestOptions.java
@@ -4,19 +4,23 @@ import com.stripe.Stripe;
 
 public class RequestOptions {
 	public static RequestOptions getDefault() {
-		return new RequestOptions(Stripe.apiKey, Stripe.apiVersion, null, null);
+		return new RequestOptions(Stripe.apiKey, Stripe.apiVersion, null, null, 30 * 1000, 80 * 1000);
 	}
 
 	private final String apiKey;
 	private final String stripeVersion;
 	private final String idempotencyKey;
 	private final String stripeAccount;
+	private final int connectionTimeout;
+	private final int readTimeout;
 
-	private RequestOptions(String apiKey, String stripeVersion, String idempotencyKey, String stripeAccount) {
+	private RequestOptions(String apiKey, String stripeVersion, String idempotencyKey, String stripeAccount, int connectionTimeout, int readTimeout) {
 		this.apiKey = apiKey;
 		this.stripeVersion = stripeVersion;
 		this.idempotencyKey = idempotencyKey;
 		this.stripeAccount = stripeAccount;
+		this.connectionTimeout = connectionTimeout;
+		this.readTimeout = readTimeout;
 	}
 
 	public String getApiKey() {
@@ -33,6 +37,14 @@ public class RequestOptions {
 
 	public String getStripeAccount() {
 		return stripeAccount;
+	}
+	
+	public int getReadTimeout() {
+	    return readTimeout;
+	}
+	
+	public int getConnectionTimeout() {
+	    return connectionTimeout;
 	}
 
 	@Override
@@ -51,6 +63,14 @@ public class RequestOptions {
 		if (stripeVersion != null ? !stripeVersion.equals(that.stripeVersion) : that.stripeVersion != null) {
 			return false;
 		}
+		
+		if (connectionTimeout != that.connectionTimeout) {
+			return false;
+		}
+		
+		if (readTimeout != that.readTimeout) {
+			return false;
+		}
 
 		return true;
 	}
@@ -60,6 +80,8 @@ public class RequestOptions {
 		int result = apiKey != null ? apiKey.hashCode() : 0;
 		result = 31 * result + (stripeVersion != null ? stripeVersion.hashCode() : 0);
 		result = 31 * result + (idempotencyKey != null ? idempotencyKey.hashCode() : 0);
+		result = 31 * result + readTimeout;
+		result = 31 * result + connectionTimeout;
 		return result;
 	}
 
@@ -76,6 +98,8 @@ public class RequestOptions {
 		private String stripeVersion;
 		private String idempotencyKey;
 		private String stripeAccount;
+		private int connectionTimeout;
+		private int readTimeout;
 
 		public RequestOptionsBuilder() {
 			this.apiKey = Stripe.apiKey;
@@ -110,6 +134,24 @@ public class RequestOptions {
 			this.idempotencyKey = idempotencyKey;
 			return this;
 		}
+		
+		public RequestOptionsBuilder setConnectionTimeout(int connectionTimeout) {
+		    this.connectionTimeout = connectionTimeout;
+		    return this;
+		}
+		
+		public RequestOptionsBuilder setReadTimeout(int readTimeout) {
+		    this.readTimeout = readTimeout;
+		    return this;
+		}
+		
+		public int getConnectionTimeout() {
+		    return connectionTimeout;
+		}
+		
+		public int getReadTimeout() {
+		    return readTimeout;
+		}
 
 		public RequestOptionsBuilder clearIdempotencyKey() {
 			this.idempotencyKey = null;
@@ -138,7 +180,9 @@ public class RequestOptions {
 				normalizeApiKey(this.apiKey),
 				normalizeStripeVersion(this.stripeVersion),
 				normalizeIdempotencyKey(this.idempotencyKey),
-				normalizeStripeAccount(this.stripeAccount));
+				normalizeStripeAccount(this.stripeAccount),
+				connectionTimeout,
+				readTimeout);
 		}
 	}
 

--- a/src/main/java/com/stripe/net/RequestOptions.java
+++ b/src/main/java/com/stripe/net/RequestOptions.java
@@ -16,15 +16,15 @@ public class RequestOptions {
 	private final String stripeVersion;
 	private final String idempotencyKey;
 	private final String stripeAccount;
-	private final int connectionTimeout;
+	private final int connectTimeout;
 	private final int readTimeout;
 
-	private RequestOptions(String apiKey, String stripeVersion, String idempotencyKey, String stripeAccount, int connectionTimeout, int readTimeout) {
+	private RequestOptions(String apiKey, String stripeVersion, String idempotencyKey, String stripeAccount, int connectTimeout, int readTimeout) {
 		this.apiKey = apiKey;
 		this.stripeVersion = stripeVersion;
 		this.idempotencyKey = idempotencyKey;
 		this.stripeAccount = stripeAccount;
-		this.connectionTimeout = connectionTimeout;
+		this.connectTimeout = connectTimeout;
 		this.readTimeout = readTimeout;
 	}
 
@@ -48,8 +48,8 @@ public class RequestOptions {
 	    return readTimeout;
 	}
 	
-	public int getConnectionTimeout() {
-	    return connectionTimeout;
+	public int getConnectTimeout() {
+	    return connectTimeout;
 	}
 
 	@Override
@@ -69,7 +69,7 @@ public class RequestOptions {
 			return false;
 		}
 		
-		if (connectionTimeout != that.connectionTimeout) {
+		if (connectTimeout != that.connectTimeout) {
 			return false;
 		}
 		
@@ -86,7 +86,7 @@ public class RequestOptions {
 		result = 31 * result + (stripeVersion != null ? stripeVersion.hashCode() : 0);
 		result = 31 * result + (idempotencyKey != null ? idempotencyKey.hashCode() : 0);
 		result = 31 * result + readTimeout;
-		result = 31 * result + connectionTimeout;
+		result = 31 * result + connectTimeout;
 		return result;
 	}
 
@@ -103,7 +103,7 @@ public class RequestOptions {
 		private String stripeVersion;
 		private String idempotencyKey;
 		private String stripeAccount;
-		private int connectionTimeout;
+		private int connectTimeout;
 		private int readTimeout;
 
 		public RequestOptionsBuilder() {
@@ -140,8 +140,8 @@ public class RequestOptions {
 			return this;
 		}
 		
-		public RequestOptionsBuilder setConnectionTimeout(int connectionTimeout) {
-		    this.connectionTimeout = connectionTimeout;
+		public RequestOptionsBuilder setConnectTimeout(int connectTimeout) {
+		    this.connectTimeout = connectTimeout;
 		    return this;
 		}
 		
@@ -150,8 +150,8 @@ public class RequestOptions {
 		    return this;
 		}
 		
-		public int getConnectionTimeout() {
-		    return connectionTimeout;
+		public int getConnectTimeout() {
+		    return connectTimeout;
 		}
 		
 		public int getReadTimeout() {
@@ -186,7 +186,7 @@ public class RequestOptions {
 				normalizeStripeVersion(this.stripeVersion),
 				normalizeIdempotencyKey(this.idempotencyKey),
 				normalizeStripeAccount(this.stripeAccount),
-				connectionTimeout,
+				connectTimeout,
 				readTimeout);
 		}
 	}

--- a/src/main/java/com/stripe/net/RequestOptions.java
+++ b/src/main/java/com/stripe/net/RequestOptions.java
@@ -4,12 +4,12 @@ import com.stripe.Stripe;
 
 public class RequestOptions {
 	
-	private final static int DEFAULT_CONNECTION_TIMEOUT = 30 * 1000;    	
+	private final static int DEFAULT_CONNECT_TIMEOUT = 30 * 1000;    	
 	
 	private final static int DEFAULT_READ_TIMEOUT = 80 * 1000;
     
 	public static RequestOptions getDefault() {
-		return new RequestOptions(Stripe.apiKey, Stripe.apiVersion, null, null, DEFAULT_CONNECTION_TIMEOUT, DEFAULT_READ_TIMEOUT);
+		return new RequestOptions(Stripe.apiKey, Stripe.apiVersion, null, null, DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT);
 	}
 
 	private final String apiKey;

--- a/src/test/java/com/stripe/functional/TimeoutTest.java
+++ b/src/test/java/com/stripe/functional/TimeoutTest.java
@@ -11,16 +11,8 @@ import com.stripe.net.RequestOptions;
 public class TimeoutTest extends BaseStripeFunctionalTest {
 	
 	@Test(expected=APIConnectionException.class)
-	public void testConnectionTimeoutIsConsidered() throws StripeException {
-		int tooShortTimeoutInMillis = 1;
-		RequestOptions options = RequestOptions.builder()
-				.setConnectionTimeout(tooShortTimeoutInMillis)
-				.build();
-		Token.create(defaultTokenParams, options);
-	}
-	
-	@Test(expected=APIConnectionException.class)
 	public void testReadTimeoutIsConsidered() throws StripeException {
+		
 		int tooShortTimeoutInMillis = 1;
 		RequestOptions options = RequestOptions.builder()
 				.setReadTimeout(tooShortTimeoutInMillis)

--- a/src/test/java/com/stripe/functional/TimeoutTest.java
+++ b/src/test/java/com/stripe/functional/TimeoutTest.java
@@ -1,0 +1,31 @@
+package com.stripe.functional;
+
+import org.junit.Test;
+
+import com.stripe.BaseStripeFunctionalTest;
+import com.stripe.exception.APIConnectionException;
+import com.stripe.exception.StripeException;
+import com.stripe.model.Token;
+import com.stripe.net.RequestOptions;
+
+public class TimeoutTest extends BaseStripeFunctionalTest {
+	
+	@Test(expected=APIConnectionException.class)
+	public void testConnectionTimeoutIsConsidered() throws StripeException {
+		int tooShortTimeoutInMillis = 1;
+		RequestOptions options = RequestOptions.builder()
+				.setConnectionTimeout(tooShortTimeoutInMillis)
+				.build();
+		Token.create(defaultTokenParams, options);
+	}
+	
+	@Test(expected=APIConnectionException.class)
+	public void testReadTimeoutIsConsidered() throws StripeException {
+		int tooShortTimeoutInMillis = 1;
+		RequestOptions options = RequestOptions.builder()
+				.setReadTimeout(tooShortTimeoutInMillis)
+				.build();
+		Token.create(defaultTokenParams, options);
+	}
+
+}


### PR DESCRIPTION
It's important to be able to set a reasonable timeout for http connections. If production server has a network problem or Stripe serve is down, a reasonable timeout could prevent the calling thread from being blocked for huge amount of time. 

Timeout values were previously hard coded in LiveStripeResponseGetter, and the values were frankly quite high (30 seconds for connection and 80 for reads).

Example:

```
RequestOptions options = RequestOptions.builder()
    .setConnectionTimeout(2000)
    .setReadTimeout(5000)
    .build()

Customer.create(params, options);

```
