### PR TITLE
Configurable connect and read timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,29 @@ public class StripeExample {
 
 See the project's [functional tests](https://github.com/stripe/stripe-java/blob/master/src/test/java/com/stripe/functional/) for more examples.
 
+### Configuring Timeouts
+
+Connect and read timeouts can be configured globally:
+
+```java
+Stripe.setConnectTimeout(30 * 1000); // in milliseconds
+Stripe.setReadTimeout(80 * 1000);
+```
+
+Or on a finer grain level using `RequestOptions`:
+
+```java
+RequestOptions options = RequestOptions.builder()
+    .setConnectTimeout(30 * 1000) // in milliseconds
+    .setReadTimeout(80 * 1000)
+    .build();
+Charge.create(params, options);
+```
+
+Please take care to set conservative read timeouts. Some API requests can take
+some time, and a short timeout increases the likelihood of a problem within our
+servers.
+
 ## Testing
 
 You must have Maven installed. To run the tests:
@@ -94,3 +117,7 @@ unit and functional tests. For example:
     mvn test -D test=com.stripe.model.AccountTest
     mvn test -D test=com.stripe.functional.ChargeTest
     mvn test -D test=com.stripe.functional.ChargeTest#testChargeCreate
+
+<!--
+# vim: set tw=79:
+-->

--- a/src/main/java/com/stripe/Stripe.java
+++ b/src/main/java/com/stripe/Stripe.java
@@ -4,11 +4,21 @@ import java.net.PasswordAuthentication;
 import java.net.Proxy;
 
 public abstract class Stripe {
+	private final static int DEFAULT_CONNECT_TIMEOUT = 30 * 1000;
+	private final static int DEFAULT_READ_TIMEOUT = 80 * 1000;
+
 	public static final String UPLOAD_API_BASE = "https://uploads.stripe.com";
 	public static final String LIVE_API_BASE = "https://api.stripe.com";
 	public static final String VERSION = "4.4.0";
+
 	public static volatile String apiKey;
 	public static volatile String apiVersion;
+
+	// Note that URLConnection reserves the value of 0 to mean "infinite
+	// timeout", so we use -1 here to represent an unset value which should
+	// fall back to a default.
+	private static volatile int connectTimeout = -1;
+	private static volatile int readTimeout = -1;
 
 	private static volatile String apiBase = LIVE_API_BASE;
 	private static volatile Proxy connectionProxy = null;
@@ -38,6 +48,44 @@ public abstract class Stripe {
 
 	public static Proxy getConnectionProxy() {
 		return connectionProxy;
+	}
+	
+	public static int getConnectTimeout() {
+		if (connectTimeout == -1) {
+			return DEFAULT_CONNECT_TIMEOUT;
+		}
+	    return connectTimeout;
+	}
+
+	/**
+	 * Sets the timeout value that will be used for making new connections to
+	 * the Stripe API (in milliseconds).
+	 *
+	 * @param timeout timeout value in milliseconds
+	 */
+	public static void setConnectTimeout(final int timeout) {
+		connectTimeout = timeout;
+	}
+	
+	public static int getReadTimeout() {
+		if (readTimeout == -1) {
+			return DEFAULT_READ_TIMEOUT;
+		}
+	    return readTimeout;
+	}
+
+	/**
+	 * Sets the timeout value that will be used when reading data from an
+	 * established connection to the Stripe API (in milliseconds).
+	 *
+	 * Note that this value should be set conservatively because some API
+	 * requests can take time and a short timeout increases the likelihood of
+	 * causing a problem in the backend.
+	 *
+	 * @param timeout timeout value in milliseconds
+	 */
+	public static void setReadTimeout(final int timeout) {
+		readTimeout = timeout;
 	}
 
 	/**

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -149,8 +149,8 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 		} else {
 			conn = (HttpURLConnection) stripeURL.openConnection();
 		}
-		conn.setConnectTimeout(30 * 1000);
-		conn.setReadTimeout(80 * 1000);
+		conn.setConnectTimeout(options.getConnectTimeout());
+		conn.setReadTimeout(options.getReadTimeout());
 		conn.setUseCaches(false);
 		for (Map.Entry<String, String> header : getHeaders(options).entrySet()) {
 			conn.setRequestProperty(header.getKey(), header.getValue());

--- a/src/main/java/com/stripe/net/RequestOptions.java
+++ b/src/main/java/com/stripe/net/RequestOptions.java
@@ -3,20 +3,29 @@ package com.stripe.net;
 import com.stripe.Stripe;
 
 public class RequestOptions {
+	
+	private final static int DEFAULT_CONNECT_TIMEOUT = 30 * 1000;    	
+	
+	private final static int DEFAULT_READ_TIMEOUT = 80 * 1000;
+    
 	public static RequestOptions getDefault() {
-		return new RequestOptions(Stripe.apiKey, Stripe.apiVersion, null, null);
+		return new RequestOptions(Stripe.apiKey, Stripe.apiVersion, null, null, DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT);
 	}
 
 	private final String apiKey;
 	private final String stripeVersion;
 	private final String idempotencyKey;
 	private final String stripeAccount;
+	private final int connectTimeout;
+	private final int readTimeout;
 
-	private RequestOptions(String apiKey, String stripeVersion, String idempotencyKey, String stripeAccount) {
+	private RequestOptions(String apiKey, String stripeVersion, String idempotencyKey, String stripeAccount, int connectTimeout, int readTimeout) {
 		this.apiKey = apiKey;
 		this.stripeVersion = stripeVersion;
 		this.idempotencyKey = idempotencyKey;
 		this.stripeAccount = stripeAccount;
+		this.connectTimeout = connectTimeout;
+		this.readTimeout = readTimeout;
 	}
 
 	public String getApiKey() {
@@ -33,6 +42,14 @@ public class RequestOptions {
 
 	public String getStripeAccount() {
 		return stripeAccount;
+	}
+	
+	public int getReadTimeout() {
+	    return readTimeout;
+	}
+	
+	public int getConnectTimeout() {
+	    return connectTimeout;
 	}
 
 	@Override
@@ -51,6 +68,14 @@ public class RequestOptions {
 		if (stripeVersion != null ? !stripeVersion.equals(that.stripeVersion) : that.stripeVersion != null) {
 			return false;
 		}
+		
+		if (connectTimeout != that.connectTimeout) {
+			return false;
+		}
+		
+		if (readTimeout != that.readTimeout) {
+			return false;
+		}
 
 		return true;
 	}
@@ -60,6 +85,8 @@ public class RequestOptions {
 		int result = apiKey != null ? apiKey.hashCode() : 0;
 		result = 31 * result + (stripeVersion != null ? stripeVersion.hashCode() : 0);
 		result = 31 * result + (idempotencyKey != null ? idempotencyKey.hashCode() : 0);
+		result = 31 * result + readTimeout;
+		result = 31 * result + connectTimeout;
 		return result;
 	}
 
@@ -76,6 +103,8 @@ public class RequestOptions {
 		private String stripeVersion;
 		private String idempotencyKey;
 		private String stripeAccount;
+		private int connectTimeout;
+		private int readTimeout;
 
 		public RequestOptionsBuilder() {
 			this.apiKey = Stripe.apiKey;
@@ -110,6 +139,24 @@ public class RequestOptions {
 			this.idempotencyKey = idempotencyKey;
 			return this;
 		}
+		
+		public RequestOptionsBuilder setConnectTimeout(int connectTimeout) {
+		    this.connectTimeout = connectTimeout;
+		    return this;
+		}
+		
+		public RequestOptionsBuilder setReadTimeout(int readTimeout) {
+		    this.readTimeout = readTimeout;
+		    return this;
+		}
+		
+		public int getConnectTimeout() {
+		    return connectTimeout;
+		}
+		
+		public int getReadTimeout() {
+		    return readTimeout;
+		}
 
 		public RequestOptionsBuilder clearIdempotencyKey() {
 			this.idempotencyKey = null;
@@ -138,7 +185,9 @@ public class RequestOptions {
 				normalizeApiKey(this.apiKey),
 				normalizeStripeVersion(this.stripeVersion),
 				normalizeIdempotencyKey(this.idempotencyKey),
-				normalizeStripeAccount(this.stripeAccount));
+				normalizeStripeAccount(this.stripeAccount),
+				connectTimeout,
+				readTimeout);
 		}
 	}
 

--- a/src/main/java/com/stripe/net/RequestOptions.java
+++ b/src/main/java/com/stripe/net/RequestOptions.java
@@ -3,13 +3,8 @@ package com.stripe.net;
 import com.stripe.Stripe;
 
 public class RequestOptions {
-	
-	private final static int DEFAULT_CONNECT_TIMEOUT = 30 * 1000;    	
-	
-	private final static int DEFAULT_READ_TIMEOUT = 80 * 1000;
-    
 	public static RequestOptions getDefault() {
-		return new RequestOptions(Stripe.apiKey, Stripe.apiVersion, null, null, DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT);
+		return new RequestOptions(Stripe.apiKey, Stripe.apiVersion, null, null, Stripe.getConnectTimeout(), Stripe.getReadTimeout());
 	}
 
 	private final String apiKey;
@@ -140,22 +135,38 @@ public class RequestOptions {
 			return this;
 		}
 		
-		public RequestOptionsBuilder setConnectTimeout(int connectTimeout) {
-		    this.connectTimeout = connectTimeout;
-		    return this;
-		}
-		
-		public RequestOptionsBuilder setReadTimeout(int readTimeout) {
-		    this.readTimeout = readTimeout;
-		    return this;
-		}
-		
 		public int getConnectTimeout() {
 		    return connectTimeout;
 		}
 		
+		/**
+		 * Sets the timeout value that will be used for making new connections to
+		 * the Stripe API (in milliseconds).
+		 *
+		 * @param timeout timeout value in milliseconds
+		 */
+		public RequestOptionsBuilder setConnectTimeout(int timeout) {
+		    this.connectTimeout = timeout;
+		    return this;
+		}
+		
 		public int getReadTimeout() {
 		    return readTimeout;
+		}
+		
+		/**
+		 * Sets the timeout value that will be used when reading data from an
+		 * established connection to the Stripe API (in milliseconds).
+		 *
+		 * Note that this value should be set conservatively because some API
+		 * requests can take time and a short timeout increases the likelihood
+		 * of causing a problem in the backend.
+		 *
+		 * @param timeout timeout value in milliseconds
+		 */
+		public RequestOptionsBuilder setReadTimeout(int timeout) {
+		    this.readTimeout = timeout;
+		    return this;
 		}
 
 		public RequestOptionsBuilder clearIdempotencyKey() {

--- a/src/test/java/com/stripe/functional/TimeoutTest.java
+++ b/src/test/java/com/stripe/functional/TimeoutTest.java
@@ -1,0 +1,23 @@
+package com.stripe.functional;
+
+import org.junit.Test;
+
+import com.stripe.BaseStripeFunctionalTest;
+import com.stripe.exception.APIConnectionException;
+import com.stripe.exception.StripeException;
+import com.stripe.model.Token;
+import com.stripe.net.RequestOptions;
+
+public class TimeoutTest extends BaseStripeFunctionalTest {
+	
+	@Test(expected=APIConnectionException.class)
+	public void testReadTimeoutIsConsidered() throws StripeException {
+		
+		int tooShortTimeoutInMillis = 1;
+		RequestOptions options = RequestOptions.builder()
+				.setReadTimeout(tooShortTimeoutInMillis)
+				.build();
+		Token.create(defaultTokenParams, options);
+	}
+
+}


### PR DESCRIPTION
Continues the work by @agori in #366 to add configurable connect and read timeouts on both the top-level `Stripe` class and on `RequestOptions` for finer grainer configurability.