### PR TITLE
Add `three_d_secure` accessors on Card model

### DIFF
--- a/src/main/java/com/stripe/model/Card.java
+++ b/src/main/java/com/stripe/model/Card.java
@@ -34,6 +34,7 @@ public class Card extends ExternalAccount {
 	String name;
 	String recipient;
 	String status;
+	ThreeDSecure threeDSecure;
 	String tokenizationMethod;
 
 	// Please note that these field are for internal use only and are not typically returned
@@ -227,6 +228,14 @@ public class Card extends ExternalAccount {
 
 	public void setStatus(String status) {
 		this.status = status;
+	}
+
+	public ThreeDSecure getThreeDSecure() {
+		return threeDSecure;
+	}
+
+	public void setThreeDSecure(ThreeDSecure threeDSecure) {
+		this.threeDSecure = threeDSecure;
 	}
 
 	public String getTokenizationMethod() {

--- a/src/test/java/com/stripe/model/CardTest.java
+++ b/src/test/java/com/stripe/model/CardTest.java
@@ -1,0 +1,27 @@
+package com.stripe.model;
+
+import com.stripe.BaseStripeTest;
+import com.stripe.exception.StripeException;
+import com.stripe.net.APIResource;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CardTest extends BaseStripeTest {
+	Card card;
+
+	@Before
+	public void deserialize() throws IOException {
+		String json = resource("card.json");
+		card = APIResource.GSON.fromJson(json, Card.class);
+	}
+
+	@Test
+	public void testDeserialize() throws IOException {
+		assertEquals("bypassed", card.getThreeDSecure().getStatus());
+	}
+}

--- a/src/test/resources/com/stripe/model/card.json
+++ b/src/test/resources/com/stripe/model/card.json
@@ -1,0 +1,41 @@
+{
+  "account": "",
+  "address_city": "",
+  "address_country": "",
+  "address_line1": "",
+  "address_line1_check": "",
+  "address_line2": "",
+  "address_state": "",
+  "address_zip": "",
+  "address_zip_check": "",
+  "available_payout_methods": [
+  ],
+  "brand": "Visa",
+  "country": "",
+  "currency": "",
+  "customer": "",
+  "cvc_check": "",
+  "default_for_currency": false,
+  "description": "",
+  "dynamic_last4": "",
+  "emv_auth_data": "",
+  "estimated_availability": "",
+  "exp_month": 8,
+  "exp_year": 2018,
+  "fingerprint": "",
+  "funding": "unknown",
+  "google_reference": "",
+  "id": "card_19tLKYDSlTMT26Mkl7bixGYc",
+  "iin": "",
+  "issuer": "",
+  "last4": "4242",
+  "metadata": {
+  },
+  "name": "",
+  "object": "card",
+  "recipient": "",
+  "three_d_secure": {
+    "status": "bypassed"
+  },
+  "tokenization_method": ""
+}


### PR DESCRIPTION
Adds missing `three_d_secure` accessors on the Card mode. They're supposed to have been there for a while now, and it's just an oversight that they're currently missing.

Fixes #371.

[1] https://stripe.com/docs/api#card_object-three_d_secure

r? @ob-stripe 