### PR TITLE
Add `account` under the event model

### DIFF
--- a/src/main/java/com/stripe/model/Event.java
+++ b/src/main/java/com/stripe/model/Event.java
@@ -13,6 +13,7 @@ import java.util.Map;
 public class Event extends APIResource implements HasId {
 	String id;
 	String object;
+	String account;
 	String apiVersion;
 	Long created;
 	EventData data;
@@ -36,6 +37,14 @@ public class Event extends APIResource implements HasId {
 
 	public void setObject(String object) {
 		this.object = object;
+	}
+
+	public String getAccount() {
+		return account;
+	}
+
+	public void setAccount(String account) {
+		this.account = account;
 	}
 
 	public String getApiVersion() {
@@ -94,10 +103,14 @@ public class Event extends APIResource implements HasId {
 		this.type = name;
 	}
 
+	/** Legacy; use `getAccount` instead (https://stripe.com/docs/upgrades#2017-05-25) */
+	@Deprecated
 	public String getUserId() {
 		return userId;
 	}
 
+	/** Legacy; use `setAccount` instead (https://stripe.com/docs/upgrades#2017-05-25) */
+	@Deprecated
 	public void setUserId(String userId) {
 		this.userId = userId;
 	}

--- a/src/test/java/com/stripe/model/EventTest.java
+++ b/src/test/java/com/stripe/model/EventTest.java
@@ -31,11 +31,11 @@ public class EventTest extends BaseStripeTest {
 
 		assertEquals(reserializedEvent.getId(), event.getId());
 		assertEquals(reserializedEvent.getObject(), event.getObject());
+		assertEquals(reserializedEvent.getAccount(), event.getAccount());
 		assertEquals(reserializedEvent.getApiVersion(), event.getApiVersion());
 		assertEquals(reserializedEvent.getCreated(), event.getCreated());
 		assertEquals(reserializedEvent.getLivemode(), event.getLivemode());
 		assertEquals(reserializedEvent.getRequest(), event.getRequest());
 		assertEquals(reserializedEvent.getType(), event.getType());
-		assertEquals(reserializedEvent.getUserId(), event.getUserId());
 	}
 }

--- a/src/test/resources/com/stripe/model/account_event.json
+++ b/src/test/resources/com/stripe/model/account_event.json
@@ -4,6 +4,7 @@
   "id":"evt_00000000000000",
   "type":"account.updated",
   "object":"event",
+  "acccount":"acct_00000000000000",
   "data":{
     "object":{
       "id":"vuJEYvcYMexPckSv0bsIJYJBPTK82lWJ_00000000000000",


### PR DESCRIPTION
The `user_id` field is being renamed to `account`. I've left the `user_id` accessors in here for backwards compatibility.

r? @remi-stripe 