### PR TITLE
Add support for login_links on the Account resource

### DIFF
--- a/src/main/java/com/stripe/model/Account.java
+++ b/src/main/java/com/stripe/model/Account.java
@@ -23,6 +23,7 @@ public class Account extends APIResource implements HasId, MetadataStore<Account
 	String defaultCurrency;
 	Boolean detailsSubmitted;
 	String displayName;
+	LoginLinkCollection loginLinks;
 	String email;
 	ExternalAccountCollection externalAccounts;
 	Keys keys;
@@ -41,6 +42,7 @@ public class Account extends APIResource implements HasId, MetadataStore<Account
 	AccountTosAcceptance tosAcceptance;
 	AccountTransferSchedule transferSchedule;
 	Boolean transfersEnabled;
+	String type;
 	Verification verification;
 
 	@Deprecated
@@ -117,6 +119,10 @@ public class Account extends APIResource implements HasId, MetadataStore<Account
 		return displayName;
 	}
 
+	public LoginLinkCollection getLoginLinks() {
+		return loginLinks;
+	}
+
 	public String getEmail() {
 		return email;
 	}
@@ -135,6 +141,11 @@ public class Account extends APIResource implements HasId, MetadataStore<Account
 		return legalEntity;
 	}
 
+	/**
+	 * @deprecated
+	 * Use getType() instead.
+	 */
+	@Deprecated
 	public Boolean getManaged()
 	{
 		return managed;
@@ -210,6 +221,14 @@ public class Account extends APIResource implements HasId, MetadataStore<Account
 
 	public Boolean getTransfersEnabled() {
 		return transfersEnabled;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
 	}
 
 	public Verification getVerification() {

--- a/src/main/java/com/stripe/model/LoginLink.java
+++ b/src/main/java/com/stripe/model/LoginLink.java
@@ -1,0 +1,45 @@
+package com.stripe.model;
+
+import com.stripe.exception.APIConnectionException;
+import com.stripe.exception.APIException;
+import com.stripe.exception.AuthenticationException;
+import com.stripe.exception.CardException;
+import com.stripe.exception.InvalidRequestException;
+import com.stripe.net.APIResource;
+import com.stripe.net.RequestOptions;
+
+import java.util.Map;
+
+public class LoginLink extends APIResource implements HasId {
+	String object;
+	Long created;
+	String url;
+
+	public String getId() {
+		throw new UnsupportedOperationException("Login links are ephemeral and do not have an identifier");
+	}
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
+	}
+
+	public Long getCreated() {
+		return created;
+	}
+
+	public void setCreated(Long created) {
+		this.created = created;
+	}
+
+	public String getUrl() {
+		return url;
+	}
+
+	public void setUrl(String url) {
+		this.url = url;
+	}
+}

--- a/src/main/java/com/stripe/model/LoginLinkCollection.java
+++ b/src/main/java/com/stripe/model/LoginLinkCollection.java
@@ -1,0 +1,27 @@
+package com.stripe.model;
+
+import com.stripe.Stripe;
+import com.stripe.exception.APIConnectionException;
+import com.stripe.exception.APIException;
+import com.stripe.exception.AuthenticationException;
+import com.stripe.exception.CardException;
+import com.stripe.exception.InvalidRequestException;
+import com.stripe.net.APIResource;
+import com.stripe.net.RequestOptions;
+
+import java.util.Map;
+
+public class LoginLinkCollection extends StripeCollection<LoginLink> {
+	public LoginLink create()
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create((RequestOptions) null);
+	}
+
+	public LoginLink create(RequestOptions options) throws AuthenticationException,
+			InvalidRequestException, APIConnectionException, CardException,
+			APIException {
+		String url = String.format("%s%s", Stripe.getApiBase(), this.getURL());
+		return APIResource.request(APIResource.RequestMethod.POST, url, null, LoginLink.class, options);
+	}
+}

--- a/src/test/java/com/stripe/model/AccountTest.java
+++ b/src/test/java/com/stripe/model/AccountTest.java
@@ -178,4 +178,17 @@ public class AccountTest extends BaseStripeTest {
 
 		verifyNoMoreInteractions(networkMock);
 	}
+
+	@Test
+	public void testAccountCreateLoginLink() throws StripeException, IOException {
+		String json = resource("account_express.json");
+		stubNetwork(Account.class, json);
+		Account acc = Account.retrieve("acct_EXPRESS");
+		verifyGet(Account.class, "https://api.stripe.com/v1/accounts/acct_EXPRESS");
+
+		String json_link = resource("login_link.json");
+		stubNetwork(LoginLink.class, json_link);
+		LoginLink link = acc.getLoginLinks().create();
+		verifyPost(LoginLink.class, "https://api.stripe.com/v1/accounts/acct_EXPRESS/login_links", (RequestOptions) null);
+	}
 }

--- a/src/test/resources/com/stripe/model/account_express.json
+++ b/src/test/resources/com/stripe/model/account_express.json
@@ -1,0 +1,12 @@
+{
+    "id": "acct_EXPRESS",
+    "country": "US",
+    "login_links": {
+        "object": "list",
+        "url": "/v1/accounts/acct_EXPRESS/login_links",
+        "has_more": false,
+        "data": []
+    },
+    "object": "account",
+    "type": "custom"
+}

--- a/src/test/resources/com/stripe/model/login_link.json
+++ b/src/test/resources/com/stripe/model/login_link.json
@@ -1,0 +1,5 @@
+{
+    "created": 1493820886,
+    "object": "login_link",
+    "url": "https://connect.stripe.com/express/URL"
+}


### PR DESCRIPTION
This adds support for creating a login_link on an Account. Also adds support for the new `type` property/parameter on the Account resource instead of `managed`

r? @brandur 