### PR TITLE
Add event request object

### DIFF
--- a/src/main/java/com/stripe/model/Event.java
+++ b/src/main/java/com/stripe/model/Event.java
@@ -18,7 +18,7 @@ public class Event extends APIResource implements HasId {
 	EventData data;
 	Boolean livemode;
 	Integer pendingWebhooks;
-	String request;
+	EventRequest request;
 	String type;
 	String userId;
 
@@ -78,11 +78,11 @@ public class Event extends APIResource implements HasId {
 		this.pendingWebhooks = pendingWebhooks;
 	}
 
-	public String getRequest() {
+	public EventRequest getRequest() {
 		return request;
 	}
 
-	public void setRequest(String request) {
+	public void setRequest(EventRequest request) {
 		this.request = request;
 	}
 

--- a/src/main/java/com/stripe/model/EventRequest.java
+++ b/src/main/java/com/stripe/model/EventRequest.java
@@ -1,0 +1,22 @@
+package com.stripe.model;
+
+public class EventRequest extends StripeObject {
+	String id;
+	String idempotencyKey;
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getIdempotencyKey() {
+		return idempotencyKey;
+	}
+
+	public void setIdempotencyKey(String idempotencyKey) {
+		this.idempotencyKey = idempotencyKey;
+	}
+}

--- a/src/main/java/com/stripe/model/EventRequestDeserializer.java
+++ b/src/main/java/com/stripe/model/EventRequestDeserializer.java
@@ -1,0 +1,34 @@
+package com.stripe.model;
+
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.reflect.TypeToken;
+
+import java.lang.reflect.Type;
+import java.util.List;
+
+public class EventRequestDeserializer implements JsonDeserializer<EventRequest> {
+
+	public EventRequest deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+		throws JsonParseException {
+		Gson gson = new GsonBuilder()
+			.setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+			.create();
+
+		// API versions 2017-05-25 and earlier render `request` as a string
+		// instead of a JSON object
+		if (json.isJsonPrimitive()) {
+			EventRequest request = new EventRequest();
+			request.setId(json.getAsString());
+			return request;
+		}
+		else {
+			return gson.fromJson(json, typeOfT);
+		}
+	}
+}

--- a/src/main/java/com/stripe/model/StripeObject.java
+++ b/src/main/java/com/stripe/model/StripeObject.java
@@ -13,6 +13,7 @@ public abstract class StripeObject {
 		serializeNulls().
 		setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).
 		registerTypeAdapter(EventData.class, new EventDataDeserializer()).
+		registerTypeAdapter(EventRequest.class, new EventRequestDeserializer()).
 		create();
 
 	@Override public String toString() {

--- a/src/main/java/com/stripe/net/APIResource.java
+++ b/src/main/java/com/stripe/net/APIResource.java
@@ -15,6 +15,8 @@ import com.stripe.model.Dispute;
 import com.stripe.model.DisputeDataDeserializer;
 import com.stripe.model.EventData;
 import com.stripe.model.EventDataDeserializer;
+import com.stripe.model.EventRequest;
+import com.stripe.model.EventRequestDeserializer;
 import com.stripe.model.ExpandableField;
 import com.stripe.model.ExpandableFieldDeserializer;
 import com.stripe.model.ExternalAccountTypeAdapterFactory;
@@ -42,6 +44,7 @@ public abstract class APIResource extends StripeObject {
 	public static final Gson GSON = new GsonBuilder()
 			.setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
 			.registerTypeAdapter(EventData.class, new EventDataDeserializer())
+			.registerTypeAdapter(EventRequest.class, new EventRequestDeserializer())
 			.registerTypeAdapter(ChargeRefundCollection.class, new ChargeRefundCollectionDeserializer())
 			.registerTypeAdapter(FeeRefundCollection.class, new FeeRefundCollectionDeserializer())
 			.registerTypeAdapter(StripeRawJsonObject.class, new StripeRawJsonObjectDeserializer())

--- a/src/test/java/com/stripe/model/EventTest.java
+++ b/src/test/java/com/stripe/model/EventTest.java
@@ -39,4 +39,11 @@ public class EventTest extends BaseStripeTest {
 		assertEquals(reserializedEvent.getType(), event.getType());
 		assertEquals(reserializedEvent.getUserId(), event.getUserId());
 	}
+
+	@Test
+	public void supportsOldRequest() throws IOException {
+		String json = resource("event_old_request.json");
+		Event event = StripeObject.PRETTY_PRINT_GSON.fromJson(json, Event.class);
+		assertEquals(event.getRequest().getId(), "req_Ait4gLD2CQhStB");
+	}
 }

--- a/src/test/java/com/stripe/model/EventTest.java
+++ b/src/test/java/com/stripe/model/EventTest.java
@@ -34,7 +34,8 @@ public class EventTest extends BaseStripeTest {
 		assertEquals(reserializedEvent.getApiVersion(), event.getApiVersion());
 		assertEquals(reserializedEvent.getCreated(), event.getCreated());
 		assertEquals(reserializedEvent.getLivemode(), event.getLivemode());
-		assertEquals(reserializedEvent.getRequest(), event.getRequest());
+		assertEquals(reserializedEvent.getRequest().getId(), event.getRequest().getId());
+		assertEquals(reserializedEvent.getRequest().getIdempotencyKey(), event.getRequest().getIdempotencyKey());
 		assertEquals(reserializedEvent.getType(), event.getType());
 		assertEquals(reserializedEvent.getUserId(), event.getUserId());
 	}

--- a/src/test/resources/com/stripe/model/account_event.json
+++ b/src/test/resources/com/stripe/model/account_event.json
@@ -20,5 +20,9 @@
     "previous_attributes":{
       "details_submitted":false
     }
+  },
+  "request":{
+    "id":"req_Ait4gLD2CQhStB",
+    "idempotency_key":"01b3f64f-4e49-4959-8947-4a95acc82d18"
   }
 }

--- a/src/test/resources/com/stripe/model/event_old_request.json
+++ b/src/test/resources/com/stripe/model/event_old_request.json
@@ -1,0 +1,10 @@
+{
+  "created":1326853478,
+  "livemode":false,
+  "id":"evt_00000000000000",
+  "type":"account.updated",
+  "object":"event",
+  "data":{
+  },
+  "request":"req_Ait4gLD2CQhStB"
+}


### PR DESCRIPTION
Event's `request` field has changed from being a string to being an object that contains a request ID and an idempotency key.

I don't think there's an easy way of making this backwards compatible, and since it's probably not in all that common of use, I've just changed the type completely here.

r? @remi-stripe ~~One thing I noticed while testing is that if you load an event from an old API version (before the type changed) with this code, you get a GSON error because it's expecting an object instead of a string. I don't really like that if a user upgrades this SDK and is still on an old API version, that could throw an error. The right answer is probably to lock stripe-java to a version like we do for stripe-go, but I'm not sure I want to shave that yak right now. Any thoughts on a better way to handle this?~~