### PR TITLE
Add support for ephemeral keys

### DIFF
--- a/src/main/java/com/stripe/model/EphemeralKey.java
+++ b/src/main/java/com/stripe/model/EphemeralKey.java
@@ -20,7 +20,7 @@ public class EphemeralKey extends APIResource implements HasId {
 	Boolean livemode;
 	String secret;
 	List<AssociatedObject> associatedObjects;
-    transient JsonObject rawJson;
+	transient JsonObject rawJson;
 
 	public String getId() {
 		return id;
@@ -95,7 +95,7 @@ public class EphemeralKey extends APIResource implements HasId {
 	public EphemeralKey delete()
 			throws AuthenticationException, InvalidRequestException,
 			APIConnectionException, CardException, APIException {
-        return delete((RequestOptions) null);
+		return delete((RequestOptions) null);
 	}
 
 	public EphemeralKey delete(RequestOptions options)

--- a/src/main/java/com/stripe/model/EphemeralKey.java
+++ b/src/main/java/com/stripe/model/EphemeralKey.java
@@ -89,6 +89,10 @@ public class EphemeralKey extends APIResource implements HasId {
 	public static EphemeralKey create(Map<String, Object> params, RequestOptions options)
 			throws AuthenticationException, InvalidRequestException,
 			APIConnectionException, CardException, APIException {
+		if (options.getStripeVersion() == null) {
+			throw new IllegalArgumentException("stripeVersion must be specified in RequestOptions");
+		}
+
 		return request(RequestMethod.POST, classURL(EphemeralKey.class), params, EphemeralKey.class, options);
 	}
 

--- a/src/main/java/com/stripe/model/EphemeralKey.java
+++ b/src/main/java/com/stripe/model/EphemeralKey.java
@@ -1,0 +1,76 @@
+package com.stripe.model;
+
+import com.stripe.exception.APIConnectionException;
+import com.stripe.exception.APIException;
+import com.stripe.exception.AuthenticationException;
+import com.stripe.exception.CardException;
+import com.stripe.exception.InvalidRequestException;
+import com.stripe.net.APIResource;
+import com.stripe.net.RequestOptions;
+
+import java.util.List;
+import java.util.Map;
+
+public class EphemeralKey extends APIResource implements HasId {
+	String id;
+	String object;
+	Long created;
+	Long expires;
+	Boolean livemode;
+	String secret;
+	List<AssociatedObject> associatedObjects;
+
+	public String getId() {
+		return id;
+	}
+
+	public String getObject() {
+		return object;
+	}
+
+	public Long getCreated() {
+		return created;
+	}
+
+	public Long getExpires() {
+		return expires;
+	}
+
+	public Boolean getLivemode() {
+		return livemode;
+	}
+
+	public String getSecret() {
+		return secret;
+	}
+
+	public List<AssociatedObject> getAssociatedObjects() {
+		return associatedObjects;
+	}
+
+	public static EphemeralKey create(Map<String, Object> params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return request(RequestMethod.POST, classURL(EphemeralKey.class), params, EphemeralKey.class, options);
+	}
+
+    // TODO: DeletedEphemeralKey?
+	public EphemeralKey delete(RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return request(RequestMethod.DELETE, instanceURL(EphemeralKey.class, this.id), null, EphemeralKey.class, options);
+	}
+
+	public static class AssociatedObject extends StripeObject {
+		String type;
+		String id;
+
+		public String getType() {
+			return type;
+		}
+
+		public String getId() {
+			return id;
+		}
+	}
+}

--- a/src/main/java/com/stripe/model/EphemeralKey.java
+++ b/src/main/java/com/stripe/model/EphemeralKey.java
@@ -1,6 +1,5 @@
 package com.stripe.model;
 
-import com.google.gson.JsonObject;
 import com.stripe.exception.APIConnectionException;
 import com.stripe.exception.APIException;
 import com.stripe.exception.AuthenticationException;
@@ -19,8 +18,8 @@ public class EphemeralKey extends APIResource implements HasId {
 	Long expires;
 	Boolean livemode;
 	String secret;
-	List<AssociatedObject> associatedObjects;
-	transient JsonObject rawJson;
+	List<EphemeralKeyAssociatedObject> associatedObjects;
+	transient String rawJson;
 
 	public String getId() {
 		return id;
@@ -70,19 +69,19 @@ public class EphemeralKey extends APIResource implements HasId {
 		this.secret = secret;
 	}
 
-	public List<AssociatedObject> getAssociatedObjects() {
+	public List<EphemeralKeyAssociatedObject> getAssociatedObjects() {
 		return associatedObjects;
 	}
 
-	public void setAssociatedObjects(List<AssociatedObject> associatedObjects) {
+	public void setAssociatedObjects(List<EphemeralKeyAssociatedObject> associatedObjects) {
 		this.associatedObjects = associatedObjects;
 	}
 
-	public JsonObject getRawJson() {
+	public String getRawJson() {
 		return rawJson;
 	}
 
-	public void setRawJson(JsonObject rawJson) {
+	public void setRawJson(String rawJson) {
 		this.rawJson = rawJson;
 	}
 
@@ -106,26 +105,5 @@ public class EphemeralKey extends APIResource implements HasId {
 			throws AuthenticationException, InvalidRequestException,
 			APIConnectionException, CardException, APIException {
 		return request(RequestMethod.DELETE, instanceURL(EphemeralKey.class, this.id), null, EphemeralKey.class, options);
-	}
-
-	public static class AssociatedObject extends StripeObject {
-		String type;
-		String id;
-
-		public String getType() {
-			return type;
-		}
-
-		public void setType(String type) {
-			this.type = type;
-		}
-
-		public String getId() {
-			return id;
-		}
-
-		public void setId(String id) {
-			this.id = id;
-		}
 	}
 }

--- a/src/main/java/com/stripe/model/EphemeralKey.java
+++ b/src/main/java/com/stripe/model/EphemeralKey.java
@@ -1,5 +1,6 @@
 package com.stripe.model;
 
+import com.google.gson.JsonObject;
 import com.stripe.exception.APIConnectionException;
 import com.stripe.exception.APIException;
 import com.stripe.exception.AuthenticationException;
@@ -19,33 +20,70 @@ public class EphemeralKey extends APIResource implements HasId {
 	Boolean livemode;
 	String secret;
 	List<AssociatedObject> associatedObjects;
+    transient JsonObject rawJson;
 
 	public String getId() {
 		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
 	}
 
 	public String getObject() {
 		return object;
 	}
 
+	public void setObject(String object) {
+		this.object = object;
+	}
+
 	public Long getCreated() {
 		return created;
+	}
+
+	public void setCreated(Long created) {
+		this.created = created;
 	}
 
 	public Long getExpires() {
 		return expires;
 	}
 
+	public void setExpires(Long expires) {
+		this.expires = expires;
+	}
+
 	public Boolean getLivemode() {
 		return livemode;
+	}
+
+	public void setLivemode(Boolean livemode) {
+		this.livemode = livemode;
 	}
 
 	public String getSecret() {
 		return secret;
 	}
 
+	public void setSecret(String secret) {
+		this.secret = secret;
+	}
+
 	public List<AssociatedObject> getAssociatedObjects() {
 		return associatedObjects;
+	}
+
+	public void setAssociatedObjects(List<AssociatedObject> associatedObjects) {
+		this.associatedObjects = associatedObjects;
+	}
+
+	public JsonObject getRawJson() {
+		return rawJson;
+	}
+
+	public void setRawJson(JsonObject rawJson) {
+		this.rawJson = rawJson;
 	}
 
 	public static EphemeralKey create(Map<String, Object> params, RequestOptions options)
@@ -54,7 +92,12 @@ public class EphemeralKey extends APIResource implements HasId {
 		return request(RequestMethod.POST, classURL(EphemeralKey.class), params, EphemeralKey.class, options);
 	}
 
-    // TODO: DeletedEphemeralKey?
+	public EphemeralKey delete()
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+        return delete((RequestOptions) null);
+	}
+
 	public EphemeralKey delete(RequestOptions options)
 			throws AuthenticationException, InvalidRequestException,
 			APIConnectionException, CardException, APIException {
@@ -69,8 +112,16 @@ public class EphemeralKey extends APIResource implements HasId {
 			return type;
 		}
 
+		public void setType(String type) {
+			this.type = type;
+		}
+
 		public String getId() {
 			return id;
+		}
+
+		public void setId(String id) {
+			this.id = id;
 		}
 	}
 }

--- a/src/main/java/com/stripe/model/EphemeralKeyAssociatedObject.java
+++ b/src/main/java/com/stripe/model/EphemeralKeyAssociatedObject.java
@@ -1,0 +1,22 @@
+package com.stripe.model;
+
+public class EphemeralKeyAssociatedObject extends StripeObject implements HasId {
+	String type;
+	String id;
+
+	public String getType() {
+		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+}

--- a/src/main/java/com/stripe/model/EphemeralKeyDeserializer.java
+++ b/src/main/java/com/stripe/model/EphemeralKeyDeserializer.java
@@ -1,0 +1,24 @@
+package com.stripe.model;
+
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+
+import java.lang.reflect.Type;
+
+public class EphemeralKeyDeserializer implements JsonDeserializer<EphemeralKey> {
+	public EphemeralKey deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+			throws JsonParseException {
+		Gson gson = new GsonBuilder()
+				.setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+				.create();
+
+        EphemeralKey result = gson.fromJson(json, EphemeralKey.class);
+        result.setRawJson(json.getAsJsonObject());
+		return result;
+	}
+}

--- a/src/main/java/com/stripe/model/EphemeralKeyDeserializer.java
+++ b/src/main/java/com/stripe/model/EphemeralKeyDeserializer.java
@@ -17,8 +17,8 @@ public class EphemeralKeyDeserializer implements JsonDeserializer<EphemeralKey> 
 				.setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
 				.create();
 
-        EphemeralKey result = gson.fromJson(json, EphemeralKey.class);
-        result.setRawJson(json.getAsJsonObject());
+		EphemeralKey result = gson.fromJson(json, EphemeralKey.class);
+		result.setRawJson(json.getAsJsonObject());
 		return result;
 	}
 }

--- a/src/main/java/com/stripe/model/EphemeralKeyDeserializer.java
+++ b/src/main/java/com/stripe/model/EphemeralKeyDeserializer.java
@@ -18,7 +18,7 @@ public class EphemeralKeyDeserializer implements JsonDeserializer<EphemeralKey> 
 				.create();
 
 		EphemeralKey result = gson.fromJson(json, EphemeralKey.class);
-		result.setRawJson(json.getAsJsonObject());
+		result.setRawJson(json.getAsJsonObject().toString());
 		return result;
 	}
 }

--- a/src/main/java/com/stripe/net/APIResource.java
+++ b/src/main/java/com/stripe/net/APIResource.java
@@ -72,7 +72,9 @@ public abstract class APIResource extends StripeObject {
 			return "apple_pay_domain";
 		} else if (className.equals("subscriptionitem")) {
 			return "subscription_item";
-		} else {
+		} else if (className.equals("ephemeralkey")) {
+            return "ephemeral_key";
+        } else {
 			return className;
 		}
 	}

--- a/src/main/java/com/stripe/net/APIResource.java
+++ b/src/main/java/com/stripe/net/APIResource.java
@@ -13,6 +13,8 @@ import com.stripe.model.ChargeRefundCollection;
 import com.stripe.model.ChargeRefundCollectionDeserializer;
 import com.stripe.model.Dispute;
 import com.stripe.model.DisputeDataDeserializer;
+import com.stripe.model.EphemeralKey;
+import com.stripe.model.EphemeralKeyDeserializer;
 import com.stripe.model.EventData;
 import com.stripe.model.EventDataDeserializer;
 import com.stripe.model.ExpandableField;
@@ -48,6 +50,7 @@ public abstract class APIResource extends StripeObject {
 			.registerTypeAdapter(Dispute.class, new DisputeDataDeserializer())
 			.registerTypeAdapter(Source.class, new SourceDeserializer())
 			.registerTypeAdapter(ExpandableField.class, new ExpandableFieldDeserializer())
+			.registerTypeAdapter(EphemeralKey.class, new EphemeralKeyDeserializer())
 			.registerTypeAdapterFactory(new ExternalAccountTypeAdapterFactory())
 			.create();
 

--- a/src/main/java/com/stripe/net/APIResource.java
+++ b/src/main/java/com/stripe/net/APIResource.java
@@ -76,8 +76,8 @@ public abstract class APIResource extends StripeObject {
 		} else if (className.equals("subscriptionitem")) {
 			return "subscription_item";
 		} else if (className.equals("ephemeralkey")) {
-            return "ephemeral_key";
-        } else {
+			return "ephemeral_key";
+		} else {
 			return className;
 		}
 	}
@@ -178,9 +178,9 @@ public abstract class APIResource extends StripeObject {
 	}
 
 	/**
-	 *  When setting a String ID for an ExpandableField, we need to be careful about keeping the String ID and the
-	 *  expanded object in sync. If they specify a new String ID that is different from the ID within the expanded object,
-	 *  we don't keep the object.
+	 * When setting a String ID for an ExpandableField, we need to be careful about keeping the String ID and the
+	 * expanded object in sync. If they specify a new String ID that is different from the ID within the expanded object,
+	 * we don't keep the object.
 	 */
 	public static <T extends HasId> ExpandableField<T> setExpandableFieldID(String newId, ExpandableField<T> currentObject) {
 		if (currentObject == null || (currentObject.isExpanded() && (currentObject.getId() != newId))) {

--- a/src/test/java/com/stripe/model/EphemeralKeyTest.java
+++ b/src/test/java/com/stripe/model/EphemeralKeyTest.java
@@ -10,6 +10,8 @@ import com.stripe.net.RequestOptions;
 import org.junit.After;
 import org.junit.Before;
 
+import java.io.IOException;
+
 import java.util.Map;
 import java.util.HashMap;
 import org.junit.Test;
@@ -79,10 +81,26 @@ public class EphemeralKeyTest extends BaseStripeTest {
 		verifyNoMoreInteractions(networkMock);
 	}
 
+    @Test
+    public void testDeserialize() throws StripeException, IOException {
+		final String json = resource("ephemeral_key.json");
+        EphemeralKey key = APIResource.GSON.fromJson(json, EphemeralKey.class);
+
+        assertEquals(key.getId(), "ephkey_123");
+        assertEquals(key.getObject(), "ephemeral_key");
+        assertEquals(key.getCreated(), Long.valueOf(100));
+        assertEquals(key.getExpires(), Long.valueOf(200));
+        assertEquals(key.getLivemode(), false);
+        assertEquals(key.getSecret(), "ek_test_hunter2");
+        assertEquals(key.getAssociatedObjects().size(), 1);
+        assertEquals(key.getAssociatedObjects().get(0).getType(), "customer");
+        assertEquals(key.getAssociatedObjects().get(0).getId(), "cus_234");
+    }
+
 	@Test
 	public void testJsonReserialization() throws StripeException {
 		final String jsonString = "{\"foo\":5,\"bar\":[\"baz\",null]}";
 		EphemeralKey key = APIResource.GSON.fromJson(jsonString, EphemeralKey.class);
-		assertEquals(key.getRawJson().toString(), jsonString);
+		assertEquals(key.getRawJson(), jsonString);
 	}
 }

--- a/src/test/java/com/stripe/model/EphemeralKeyTest.java
+++ b/src/test/java/com/stripe/model/EphemeralKeyTest.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
 public class EphemeralKeyTest extends BaseStripeTest {
-    private String oldApiVersion;
+	private String oldApiVersion;
 
 	@Before
 	public void mockStripeResponseGetter() {
@@ -33,22 +33,22 @@ public class EphemeralKeyTest extends BaseStripeTest {
 
 	@Before
 	public void saveOldStripeVersion() {
-        oldApiVersion = Stripe.apiVersion;
+		oldApiVersion = Stripe.apiVersion;
 	}
 
 	@After
 	public void restoreOldStripeVersion() {
-        Stripe.apiVersion = oldApiVersion;
+		Stripe.apiVersion = oldApiVersion;
 	}
 
 	@Test
 	public void testCreate() throws StripeException {
-        Stripe.apiVersion = "2016-06-05";
+		Stripe.apiVersion = "2016-06-05";
 
-        final Map<String, Object> params = new HashMap<String, Object>();
-        params.put("customer", "cus_123");
+		final Map<String, Object> params = new HashMap<String, Object>();
+		params.put("customer", "cus_123");
 
-        final RequestOptions options = RequestOptions.builder().setStripeVersion("2017-05-25").build();
+		final RequestOptions options = RequestOptions.builder().setStripeVersion("2017-05-25").build();
 
 		EphemeralKey.create(params, options);
 
@@ -67,10 +67,10 @@ public class EphemeralKeyTest extends BaseStripeTest {
 		verifyNoMoreInteractions(networkMock);
 	}
 
-    @Test
-    public void testJsonReserialization() throws StripeException {
-        final String jsonString = "{\"foo\":5,\"bar\":[\"baz\",null]}";
-        EphemeralKey key = APIResource.GSON.fromJson(jsonString, EphemeralKey.class);
-        assertEquals(key.getRawJson().toString(), jsonString);
-    }
+	@Test
+	public void testJsonReserialization() throws StripeException {
+		final String jsonString = "{\"foo\":5,\"bar\":[\"baz\",null]}";
+		EphemeralKey key = APIResource.GSON.fromJson(jsonString, EphemeralKey.class);
+		assertEquals(key.getRawJson().toString(), jsonString);
+	}
 }

--- a/src/test/java/com/stripe/model/EphemeralKeyTest.java
+++ b/src/test/java/com/stripe/model/EphemeralKeyTest.java
@@ -56,6 +56,18 @@ public class EphemeralKeyTest extends BaseStripeTest {
 		verifyNoMoreInteractions(networkMock);
 	}
 
+	@Test(expected=IllegalArgumentException.class)
+	public void testVersionlessCreate() throws StripeException {
+		Stripe.apiVersion = null;
+
+		final Map<String, Object> params = new HashMap<String, Object>();
+		params.put("customer", "cus_123");
+
+		final RequestOptions options = RequestOptions.getDefault();
+
+		EphemeralKey.create(params, options);
+	}
+
 	@Test
 	public void testDelete() throws StripeException {
 		EphemeralKey key = new EphemeralKey();

--- a/src/test/java/com/stripe/model/EphemeralKeyTest.java
+++ b/src/test/java/com/stripe/model/EphemeralKeyTest.java
@@ -1,0 +1,76 @@
+package com.stripe.model;
+
+import com.stripe.Stripe;
+import com.stripe.BaseStripeTest;
+import com.stripe.exception.StripeException;
+import com.stripe.model.EphemeralKey;
+import com.stripe.net.APIResource;
+import com.stripe.net.LiveStripeResponseGetter;
+import com.stripe.net.RequestOptions;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.Map;
+import java.util.HashMap;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class EphemeralKeyTest extends BaseStripeTest {
+    private String oldApiVersion;
+
+	@Before
+	public void mockStripeResponseGetter() {
+		APIResource.setStripeResponseGetter(networkMock);
+	}
+
+	@After
+	public void unmockStripeResponseGetter() {
+		/* This needs to be done because tests aren't isolated in Java */
+		APIResource.setStripeResponseGetter(new LiveStripeResponseGetter());
+	}
+
+	@Before
+	public void saveOldStripeVersion() {
+        oldApiVersion = Stripe.apiVersion;
+	}
+
+	@After
+	public void restoreOldStripeVersion() {
+        Stripe.apiVersion = oldApiVersion;
+	}
+
+	@Test
+	public void testCreate() throws StripeException {
+        Stripe.apiVersion = "2016-06-05";
+
+        final Map<String, Object> params = new HashMap<String, Object>();
+        params.put("customer", "cus_123");
+
+        final RequestOptions options = RequestOptions.builder().setStripeVersion("2017-05-25").build();
+
+		EphemeralKey.create(params, options);
+
+		verifyPost(EphemeralKey.class, "https://api.stripe.com/v1/ephemeral_keys", params, options);
+		verifyNoMoreInteractions(networkMock);
+	}
+
+	@Test
+	public void testDelete() throws StripeException {
+		EphemeralKey key = new EphemeralKey();
+		key.setId("ephkey_123");
+
+		key.delete();
+
+		verifyDelete(EphemeralKey.class, "https://api.stripe.com/v1/ephemeral_keys/ephkey_123");
+		verifyNoMoreInteractions(networkMock);
+	}
+
+    @Test
+    public void testJsonReserialization() throws StripeException {
+        final String jsonString = "{\"foo\":5,\"bar\":[\"baz\",null]}";
+        EphemeralKey key = APIResource.GSON.fromJson(jsonString, EphemeralKey.class);
+        assertEquals(key.getRawJson().toString(), jsonString);
+    }
+}

--- a/src/test/resources/com/stripe/model/ephemeral_key.json
+++ b/src/test/resources/com/stripe/model/ephemeral_key.json
@@ -1,0 +1,14 @@
+{
+  "id": "ephkey_123",
+  "object": "ephemeral_key",
+  "associated_objects": [
+    {
+      "type": "customer",
+      "id": "cus_234"
+    }
+  ],
+  "created": 100,
+  "expires": 200,
+  "livemode": false,
+  "secret": "ek_test_hunter2"
+}


### PR DESCRIPTION
This adds the `EphemeralKey` resource to the bindings.  Currently, the only supported operations are creation and deletion.

Because Java is statically typed, we define a custom JSON deserializer `EphemeralKeyDeserializer` so that we can preserve the raw JSON so it can be passed back to the frontend.  Otherwise, any unrecognized fields would be lost by deserialization/reserialization.

These bindings do not have the same behavior regarding the API version as the other bindings.  The API version is set via the `RequestOptions` object, but the object's API version is copied from the globally configured `Stripe.apiVersion`, so we can't tell if an API version was explicitly specified on the `RequestOptions`.  I doubt this is worth changing the behavior for, so I've left it as-is, but we will still throw an `IllegalArgumentException` if the resulting API version is `null`.