### PR TITLE
Stripe's API requires TLS 1.2 for all requests which requires Java 1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ You can sign up for a Stripe account at https://stripe.com.
 
 ## Requirements
 
-Java 1.6 or later.
+Java 1.7 or later.
 
 ## Installation
 


### PR DESCRIPTION
More details in https://support.stripe.com/questions/how-do-i-upgrade-my-stripe-integration-from-tls-1-0-to-tls-1-2#java

r? @brandur-stripe 