### PR TITLE
Power test suite with external API stub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ sudo: false
 env:
   global:
     - STRIPE_STUB_PORT=6065
-    - STRIPE_STUB_VERSION=0.1.1
+    - STRIPE_STUB_VERSION=0.1.4
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,31 @@ jdk:
   - oraclejdk7
   - oraclejdk8
 
-install: mvn install -Dgpg.skip=true -DskipTests
-
 notifications:
   email:
     on_success: never
 
 sudo: false
+
+env:
+  global:
+    - STRIPE_STUB_PORT=6065
+    - STRIPE_STUB_VERSION=0.1.1
+
+cache:
+  directories:
+    - stripestubs
+
+before_install:
+  # Unpack and start the Stripe API stub so that the test suite can talk to it
+  - |
+    if [ ! -d "stripestubs/stripestub_${STRIPE_STUB_VERSION}" ]; then
+      mkdir -p stripestubs/stripestub_${STRIPE_STUB_VERSION}/
+      curl -L "https://github.com/brandur/stripestub/releases/download/v${STRIPE_STUB_VERSION}/stripestub_${STRIPE_STUB_VERSION}_linux_amd64.tar.gz" -o "stripestubs/stripestub_${STRIPE_STUB_VERSION}_linux_amd64.tar.gz"
+      tar -zxf "stripestubs/stripestub_${STRIPE_STUB_VERSION}_linux_amd64.tar.gz" -C "stripestubs/stripestub_${STRIPE_STUB_VERSION}/"
+    fi
+  - |
+    stripestubs/stripestub_${STRIPE_STUB_VERSION}/stripestub -port ${STRIPE_STUB_PORT} &
+    STRIPE_STUB_PID=$!
+
+install: mvn install -Dgpg.skip=true -DskipTests

--- a/README.md
+++ b/README.md
@@ -103,16 +103,24 @@ servers.
 
 ## Testing
 
+You'll need to install [stripestub] before being able to run the entire test
+suite. From another terminal run:
+
+    go get -u github.com/brandur/stripestub
+    stripestub -port 6065
+
 You must have Maven installed. To run the tests:
 
-    mvn test
+    STRIPE_STUB_PORT=6065 mvn test
 
 You can run particular tests by passing `-D test=Class#method`. Make sure you use the fully qualified class name to differentiate between
 unit and functional tests. For example:
 
-    mvn test -D test=com.stripe.model.AccountTest
-    mvn test -D test=com.stripe.functional.ChargeTest
-    mvn test -D test=com.stripe.functional.ChargeTest#testChargeCreate
+    STRIPE_STUB_PORT=6065 mvn test -D test=com.stripe.model.AccountTest
+    STRIPE_STUB_PORT=6065 mvn test -D test=com.stripe.functional.ChargeTest
+    STRIPE_STUB_PORT=6065 mvn test -D test=com.stripe.functional.ChargeTest#testChargeCreate
+
+[stripestub]: https://github.com/brandur/stripestub
 
 <!--
 # vim: set tw=79:

--- a/src/main/java/com/stripe/model/ExpandableFieldDeserializer.java
+++ b/src/main/java/com/stripe/model/ExpandableFieldDeserializer.java
@@ -30,7 +30,13 @@ public class ExpandableFieldDeserializer implements JsonDeserializer<ExpandableF
 		else if (json.isJsonObject()) {
 			// Get the `id` out of the response
 			JsonObject fieldAsJsonObject = json.getAsJsonObject();
-			String id = fieldAsJsonObject.getAsJsonPrimitive("id").getAsString();
+			JsonPrimitive jsonPrimitive = fieldAsJsonObject.getAsJsonPrimitive("id");
+			String id = null;
+			// Protects against the case where an expanded object didn't
+			// include an ID, which is hopefully vanishingly rare.
+			if (jsonPrimitive != null) {
+				id = jsonPrimitive.getAsString();
+			}
 			// We need to get the type inside the generic ExpandableField to make sure fromJson correctly serializes
 			// the JsonObject:
 			Type clazz = ((ParameterizedType) typeOfT).getActualTypeArguments()[0];

--- a/src/test/java/com/stripe/BaseStripeStubTest.java
+++ b/src/test/java/com/stripe/BaseStripeStubTest.java
@@ -1,0 +1,108 @@
+package com.stripe;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.reflect.Type;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.ProtocolException;
+import java.net.URL;
+import java.util.*;
+
+public class BaseStripeStubTest {
+	private String oldApiBase;
+	private static String stubPort;
+
+	@BeforeClass
+	public static void checkStripeStubPort() throws Exception {
+		stubPort = System.getenv().get("STRIPE_STUB_PORT");
+		if (stubPort == null) {
+			throw new RuntimeException(
+				"Please specify STRIPE_STUB_PORT. See README for setup instructions."
+			);
+		}
+
+		try {
+			String _data = getFixture("/v1/charges/ch_123");
+		} catch (IOException _e) {
+			throw new RuntimeException(
+				"Couldn't reach Stripe stub server at `localhost:" + stubPort + "`. Is it running? Please see README for setup instructions."
+			);
+		}
+	}
+
+	@Before
+	public void setUpStripeStub() {
+		Stripe.apiKey = "sk_test_myValidKey";
+		this.oldApiBase = Stripe.getApiBase();
+		Stripe.overrideApiBase("http://localhost:"+stubPort);
+	}
+
+	@After
+	public void tearDownStripeStub() {
+		Stripe.overrideApiBase(this.oldApiBase);
+	}
+
+	protected static String getDataAt(String data, String field) {
+		Gson gson = new Gson();
+		Type type = new TypeToken<Map<String, Object>>(){}.getType();
+		Map<String, Object> map = gson.fromJson(data, type);
+		Object value = map.get(field);
+		return gson.toJson(value);
+	}
+
+	protected static String getFixture(String path) throws Exception, IOException, MalformedURLException, ProtocolException {
+		return getFixture(path, null);
+	}
+
+	protected static String getFixture(String path, String[] expansions) throws Exception, IOException, MalformedURLException, ProtocolException {
+		StringBuffer urlStringBuffer = new StringBuffer();
+		urlStringBuffer.append("http://localhost:"+stubPort+path);
+
+		if (expansions != null) {
+			urlStringBuffer.append("?");
+			for (String expansion : expansions) {
+				urlStringBuffer.append("expand[]=");
+				urlStringBuffer.append(expansion);
+				urlStringBuffer.append("&");
+			}
+		}
+		URL url = new URL(urlStringBuffer.toString());
+
+		HttpURLConnection conn = (HttpURLConnection)url.openConnection();
+		conn.setRequestMethod("GET");
+
+		// This is the line that actually triggers the request.
+		int status = conn.getResponseCode();
+
+		if (status != 200) {
+			throw new Exception("Couldn't reach stub.");
+		}
+
+		return readUntilEnd(conn.getInputStream());
+	}
+
+	private static String readUntilEnd(InputStream inputStream) throws IOException {
+		BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+		try {
+			StringBuffer buffer = new StringBuffer();
+			String line;
+			while ((line = reader.readLine()) != null) {
+			  buffer.append(line);
+			  buffer.append('\r');
+			}
+			return buffer.toString();
+		} finally {
+			reader.close();
+		}
+	}
+}

--- a/src/test/java/com/stripe/BaseStripeStubTest.java
+++ b/src/test/java/com/stripe/BaseStripeStubTest.java
@@ -22,6 +22,11 @@ public class BaseStripeStubTest {
 	private String oldApiBase;
 	private static String stubPort;
 
+	/**
+	 * Checks that STRIPE_STUB_PORT is specified in the environment and that
+	 * the stub is online by making a sample request. If either isn't true, an
+	 * exception is thrown and the test suite stops.
+	 */
 	@BeforeClass
 	public static void checkStripeStubPort() throws Exception {
 		stubPort = System.getenv().get("STRIPE_STUB_PORT");
@@ -40,6 +45,10 @@ public class BaseStripeStubTest {
 		}
 	}
 
+	/**
+	 * Activates stripestub by overriding the API host and putting a test key
+	 * into the environment.
+	 */
 	@Before
 	public void setUpStripeStub() {
 		Stripe.apiKey = "sk_test_myValidKey";
@@ -47,11 +56,27 @@ public class BaseStripeStubTest {
 		Stripe.overrideApiBase("http://localhost:"+stubPort);
 	}
 
+	/**
+	 * Deactivates stripestub by returning the API host to whatever it was
+	 * before stripestub was activated.
+	 */
 	@After
 	public void tearDownStripeStub() {
 		Stripe.overrideApiBase(this.oldApiBase);
 	}
 
+	/**
+	 * Convenience method that extracts a subset of JSON data and returns it.
+	 *
+	 * <p>For example, if I know that my charge object has a customer under it,
+	 * I can pass my charge JSON data and specify {@code field} as {@code
+	 * customer}. This returns everything that had been under the {@code
+	 * customer} key (encoded as JSON).
+	 *
+	 * @param data JSON encoded data.
+	 * @param field Field under data which to extract.
+	 * @return Extracted JSON encoded data.
+	 */
 	protected static String getDataAt(String data, String field) {
 		Gson gson = new Gson();
 		Type type = new TypeToken<Map<String, Object>>(){}.getType();
@@ -60,10 +85,34 @@ public class BaseStripeStubTest {
 		return gson.toJson(value);
 	}
 
+	/**
+	 * Gets fixture data from stripestub for a resource expected to be at the
+	 * given API path. stripestub ignores whether IDs are actually valid, so
+	 * it's only important to make sure that the route exists, rather than the
+	 * actual resource. It's common to use a symbolic ID stand-in like {@code
+	 * ch_123}.
+	 *
+	 * <pre>
+	 * getFixture("/v1/charges/ch_123")
+	 * </pre>
+	 *
+	 * @param path API path to use to get a fixture for stripestub.
+	 * @return Fixture data encoded as JSON.
+	 */
 	protected static String getFixture(String path) throws Exception, IOException, MalformedURLException, ProtocolException {
 		return getFixture(path, null);
 	}
 
+	/**
+	 * Gets fixture data with expansions specified. Expansions are specified
+	 * the same way as they are in the normal API like {@code customer} or
+	 * {@code data.customer}. Use the special {@code *} character to specify
+	 * that all fields should be expanded.
+	 *
+	 * @param path API path to use to get a fixture for stripestub.
+	 * @param expansions Set of expansions that should be applied.
+	 * @return Fixture data encoded as JSON.
+	 */
 	protected static String getFixture(String path, String[] expansions) throws Exception, IOException, MalformedURLException, ProtocolException {
 		StringBuffer urlStringBuffer = new StringBuffer();
 		urlStringBuffer.append("http://localhost:"+stubPort+path);

--- a/src/test/java/com/stripe/functional/PlanTest.java
+++ b/src/test/java/com/stripe/functional/PlanTest.java
@@ -1,11 +1,14 @@
 package com.stripe.functional;
 
-import com.stripe.BaseStripeFunctionalTest;
+import com.stripe.BaseStripeStubTest;
 import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
 import com.stripe.model.Customer;
 import com.stripe.model.DeletedPlan;
 import com.stripe.model.Plan;
+import com.stripe.model.PlanCollection;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -15,101 +18,36 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class PlanTest extends BaseStripeFunctionalTest {
-    @Test
-    public void testPlanCreate() throws StripeException {
-        Plan plan = Plan.create(getUniquePlanParams());
-        assertEquals(plan.getInterval(), "month");
-        assertEquals(plan.getIntervalCount(), (Integer) 2);
-    }
+public class PlanTest extends BaseStripeStubTest {
+	@Test
+	public void testPlanCreate() throws StripeException {
+		Map<String, Object> params = new HashMap<String, Object>();
+		params.put("id", "gold");
+		Plan _plan = Plan.create(params);
+	}
 
-    @Test
-    public void testPlanCreateWithStatementDescriptor() throws StripeException {
-        Map<String, Object> planParamsWithStatementDescriptor = getUniquePlanParams();
-        planParamsWithStatementDescriptor.put("statement_descriptor", "Stripe");
-        Plan plan = Plan.create(planParamsWithStatementDescriptor);
-        assertEquals(plan.getStatementDescriptor(), "Stripe");
-    }
+	@Test
+	public void testPlanRetrieve() throws StripeException {
+		Plan _plan = Plan.retrieve("gold");
+	}
 
-    @Test
-    public void testPlanUpdate() throws StripeException {
-        Plan createdPlan = Plan.create(getUniquePlanParams());
-        Map<String, Object> updateParams = new HashMap<String, Object>();
-        updateParams.put("name", "Updated Plan Name");
-        Plan updatedplan = createdPlan.update(updateParams);
-        assertEquals(updatedplan.getName(), "Updated Plan Name");
-    }
+	@Test
+	public void testPlanUpdate() throws StripeException {
+		Plan plan = Plan.retrieve("gold");
+		Map<String, Object> params = new HashMap<String, Object>();
+		params.put("name", "silver");
+		Plan _plan = plan.update(params);
+	}
 
-    @Test
-    public void testPlanRetrieve() throws StripeException {
-        Plan createdPlan = Plan.create(getUniquePlanParams());
-        Plan retrievedPlan = Plan.retrieve(createdPlan.getId());
-        assertEquals(createdPlan.getId(), retrievedPlan.getId());
-    }
+	@Test
+	public void testPlanDelete() throws StripeException {
+		Plan plan = Plan.retrieve("gold");
+		DeletedPlan _deletedPlan = plan.delete();
+	}
 
-    @Test
-    public void testPlanList() throws StripeException {
-        Map<String, Object> listParams = new HashMap<String, Object>();
-        listParams.put("count", 1);
-        List<Plan> Plans = Plan.all(listParams).getData();
-        assertEquals(Plans.size(), 1);
-    }
-
-    @Test
-    public void testPlanDelete() throws StripeException {
-        Plan createdPlan = Plan.create(getUniquePlanParams());
-        DeletedPlan deletedPlan = createdPlan.delete();
-        assertTrue(deletedPlan.getDeleted());
-        assertEquals(deletedPlan.getId(), createdPlan.getId());
-    }
-
-    @Test
-    public void testCustomerCreateWithPlan() throws StripeException {
-        Plan plan = Plan.create(getUniquePlanParams());
-        Customer customer = createDefaultCustomerWithPlan(plan);
-        assertEquals(customer.getSubscriptions().getData().get(0).getPlan().getId(), plan.getId());
-    }
-
-    @Test
-    public void testPlanCreatePerCallAPIKey() throws StripeException {
-        Plan plan = Plan.create(getUniquePlanParams(), Stripe.apiKey);
-        assertEquals(plan.getInterval(), "month");
-    }
-
-    @Test
-    public void testPlanUpdatePerCallAPIKey() throws StripeException {
-        Plan createdPlan = Plan.create(getUniquePlanParams(), Stripe.apiKey);
-        Map<String, Object> updateParams = new HashMap<String, Object>();
-        updateParams.put("name", "Updated Plan Name");
-        Plan updatedplan = createdPlan.update(updateParams, Stripe.apiKey);
-        assertEquals(updatedplan.getName(), "Updated Plan Name");
-    }
-
-    @Test
-    public void testPlanRetrievePerCallAPIKey() throws StripeException {
-        Plan createdPlan = Plan.create(getUniquePlanParams(), Stripe.apiKey);
-        Plan retrievedPlan = Plan.retrieve(createdPlan.getId(), Stripe.apiKey);
-        assertEquals(createdPlan.getId(), retrievedPlan.getId());
-    }
-
-    @Test
-    public void testPlanListPerCallAPIKey() throws StripeException {
-        Map<String, Object> listParams = new HashMap<String, Object>();
-        listParams.put("count", 1);
-        List<Plan> Plans = Plan.all(listParams, Stripe.apiKey).getData();
-        assertEquals(Plans.size(), 1);
-    }
-
-    @Test
-    public void testPlanDeletePerCallAPIKey() throws StripeException {
-        Plan createdPlan = Plan.create(getUniquePlanParams(), Stripe.apiKey);
-        DeletedPlan deletedPlan = createdPlan.delete(Stripe.apiKey);
-        assertTrue(deletedPlan.getDeleted());
-        assertEquals(deletedPlan.getId(), createdPlan.getId());
-    }
-
-    @Test
-    public void testPlanMetadata() throws StripeException {
-        testMetadata(Plan.create(getUniquePlanParams()));
-    }
+	@Test
+	public void testPlanList() throws StripeException {
+		PlanCollection plans = Plan.all(null);
+		assertEquals(1, plans.getData().size());
+	}
 }

--- a/src/test/java/com/stripe/model/ChargeOutcomeTest.java
+++ b/src/test/java/com/stripe/model/ChargeOutcomeTest.java
@@ -1,49 +1,28 @@
 package com.stripe.model;
 
-import com.stripe.BaseStripeTest;
-import com.stripe.exception.StripeException;
+import com.stripe.BaseStripeStubTest;
 import com.stripe.net.APIResource;
-
-import java.io.IOException;
-
 import org.junit.Test;
+import static org.junit.Assert.assertNotNull;
 
-import static org.junit.Assert.assertEquals;
-
-public class ChargeOutcomeTest extends BaseStripeTest {
+public class ChargeOutcomeTest extends BaseStripeStubTest {
 	@Test
-	public void testDeserialize() throws StripeException, IOException {
-		String json = resource("charge_outcome.json");
-		ChargeOutcome outcome = APIResource.GSON.fromJson(json, ChargeOutcome.class);
-
-		assertEquals("approved_by_network", outcome.getNetworkStatus());
-		assertEquals("normal", outcome.getRiskLevel());
-		assertEquals(null, outcome.getReason());
-		assertEquals(null, outcome.getRule());
-		assertEquals("ssr_199IRC2eZvKYlo2CPfFd4CB6", outcome.getRuleId());
-		assertEquals("Payment complete.", outcome.getSellerMessage());
-		assertEquals("authorized", outcome.getType());
+	public void testDeserialize() throws Exception {
+		String chargeData = getFixture("/v1/charges/ch_123");
+		String data = getDataAt(chargeData, "outcome");
+		ChargeOutcome object = APIResource.GSON.fromJson(data, ChargeOutcome.class);
+		assertNotNull(object);
+		assertNotNull(object.getNetworkStatus());
 	}
 
-	public void testDeserializeWithRule() throws StripeException, IOException {
-		String json = resource("charge_outcome_expansions.json");
-		ChargeOutcome outcome = APIResource.GSON.fromJson(json, ChargeOutcome.class);
-
-		assertEquals("approved_by_network", outcome.getNetworkStatus());
-		assertEquals("elevated", outcome.getRiskLevel());
-		assertEquals("elevated_risk_level", outcome.getReason());
-		assertEquals("ssr_199IRC2eZvKYlo2CPfFd4CB6", outcome.getRuleId());
-		assertEquals("Stripe evaluated this charge as having elevated risk, and placed it in your manual review queue.", outcome.getSellerMessage());
-		assertEquals("manual_review", outcome.getType());
-
-		ChargeOutcomeRule rule = outcome.getRuleObject();
-		assertEquals("manual_review", rule.getAction());
-		assertEquals("ssr_199IRC2eZvKYlo2CPfFd4CB6", rule.getId());
-		assertEquals(":risk_level: = 'elevated'", rule.getPredicate());
-
-		// Deprecated usage, but should still work.
-		rule = outcome.getRule();
-		assertEquals("manual_review", rule.getAction());
-		assertEquals(":risk_level: = 'elevated'", rule.getPredicate());
+	@Test
+	public void testDeserializeWithExpansions() throws Exception {
+		// Specify expansions manually because it's a nested resource
+		String[] expansions = { "outcome.rule" };
+		String chargeData = getFixture("/v1/charges/ch_123", expansions);
+		String data = getDataAt(chargeData, "outcome");
+		ChargeOutcome object = APIResource.GSON.fromJson(data, ChargeOutcome.class);
+		assertNotNull(object);
+		assertNotNull(object.getRule());
 	}
 }

--- a/src/test/java/com/stripe/model/PlanTest.java
+++ b/src/test/java/com/stripe/model/PlanTest.java
@@ -1,0 +1,16 @@
+package com.stripe.model;
+
+import com.stripe.BaseStripeStubTest;
+import com.stripe.net.APIResource;
+import org.junit.Test;
+import static org.junit.Assert.assertNotNull;
+
+public class PlanTest extends BaseStripeStubTest {
+	@Test
+	public void testDeserialize() throws Exception {
+		String data = getFixture("/v1/plans/gold");
+		Plan object = APIResource.GSON.fromJson(data, Plan.class);
+		assertNotNull(object);
+		assertNotNull(object.getId());
+	}
+}

--- a/src/test/java/com/stripe/model/SubscriptionTest.java
+++ b/src/test/java/com/stripe/model/SubscriptionTest.java
@@ -1,157 +1,25 @@
 package com.stripe.model;
 
-import com.stripe.BaseStripeTest;
-import com.stripe.exception.StripeException;
+import com.stripe.BaseStripeStubTest;
 import com.stripe.net.APIResource;
-import com.stripe.net.LiveStripeResponseGetter;
-import org.junit.After;
-import org.junit.Before;
-import junit.framework.Assert;
-
-import java.util.Map;
-import java.util.HashMap;
-import java.util.List;
-import java.util.ArrayList;
 import org.junit.Test;
+import static org.junit.Assert.assertNotNull;
 
-import static org.mockito.Mockito.*;
-
-public class SubscriptionTest extends BaseStripeTest {
-
-	@Before
-	public void mockStripeResponseGetter() {
-		APIResource.setStripeResponseGetter(networkMock);
-	}
-
-	@After
-	public void unmockStripeResponseGetter() {
-		/* This needs to be done because tests aren't isolated in Java */
-		APIResource.setStripeResponseGetter(new LiveStripeResponseGetter());
+public class SubscriptionTest extends BaseStripeStubTest {
+	@Test
+	public void testDeserialize() throws Exception {
+		String data = getFixture("/v1/subscriptions/sub_123");
+		Subscription object = APIResource.GSON.fromJson(data, Subscription.class);
+		assertNotNull(object);
+		assertNotNull(object.getId());
 	}
 
 	@Test
-	public void testRetrieve() throws StripeException {
-		Subscription.retrieve("test_sub");
-
-		verifyGet(Subscription.class, "https://api.stripe.com/v1/subscriptions/test_sub");
-		verifyNoMoreInteractions(networkMock);
-	}
-
-	@Test
-	public void testAll() throws StripeException {
-		HashMap<String, Object> params = new HashMap<String, Object>();
-		params.put("limit", 3);
-		params.put("customer", "test_cus");
-		params.put("plan", "gold");
-
-		Subscription.all(params);
-
-		verifyGet(SubscriptionCollection.class, "https://api.stripe.com/v1/subscriptions", params);
-		verifyNoMoreInteractions(networkMock);
-	}
-
-	@Test
-	public void testUpdate() throws StripeException {
-		Subscription subscription = new Subscription();
-		subscription.setId("test_sub");
-
-		HashMap<String, Object> params = new HashMap<String, Object>();
-		params.put("plan", "gold");
-
-		subscription.update(params);
-
-		verifyPost(Subscription.class, "https://api.stripe.com/v1/subscriptions/test_sub", params);
-		verifyNoMoreInteractions(networkMock);
-	}
-
-	@Test
-	public void testUpdateWithItems() throws StripeException {
-		Subscription subscription = new Subscription();
-		subscription.setId("test_sub");
-
-		HashMap<String, Object> params = new HashMap<String, Object>();
-		List<HashMap<String, Object>> items = new ArrayList<HashMap<String, Object>>();
-
-		HashMap<String, Object> itemA = new HashMap<String, Object>();
-		itemA.put("plan", "gold");
-		itemA.put("quantity", 1);
-
-		HashMap<String, Object> itemB = new HashMap<String, Object>();
-		itemB.put("plan", "silver");
-		itemB.put("quantity", 2);
-
-		items.add(itemA);
-		items.add(itemB);
-
-		params.put("items", items);
-
-		subscription.update(params);
-
-		verifyPost(Subscription.class, "https://api.stripe.com/v1/subscriptions/test_sub", params);
-		verifyNoMoreInteractions(networkMock);
-	}
-
-	@Test
-	public void testCreate() throws StripeException {
-		HashMap<String, Object> params = new HashMap<String, Object>();
-		params.put("customer", "test_cus");
-		params.put("plan", "gold");
-
-		Subscription subscription = Subscription.create(params);
-
-		verifyPost(Subscription.class, "https://api.stripe.com/v1/subscriptions", params);
-		verifyNoMoreInteractions(networkMock);
-	}
-
-	@Test
-	public void testCreateWithItems() throws StripeException {
-		Map<String, Object> params = new HashMap<String, Object>();
-		List<HashMap<String, Object>> items = new ArrayList<HashMap<String, Object>>();
-
-		HashMap<String, Object> itemA = new HashMap<String, Object>();
-		itemA.put("plan", "gold");
-		itemA.put("quantity", 1);
-
-		HashMap<String, Object> itemB = new HashMap<String, Object>();
-		itemB.put("plan", "silver");
-		itemB.put("quantity", 2);
-
-		items.add(itemA);
-		items.add(itemB);
-
-		params.put("customer", "test_cus");
-		params.put("items", items);
-
-		Subscription subscription = Subscription.create(params);
-
-		verifyPost(Subscription.class, "https://api.stripe.com/v1/subscriptions", params);
-		verifyNoMoreInteractions(networkMock);
-	}
-
-	@Test
-	public void testCancel() throws StripeException {
-		Subscription subscription = new Subscription();
-		subscription.setId("test_sub");
-
-		subscription.cancel(null);
-
-		verifyDelete(Subscription.class, "https://api.stripe.com/v1/subscriptions/test_sub");
-		verifyNoMoreInteractions(networkMock);
-	}
-
-	@Test
-	public void testSetDeleteDiscount() throws StripeException {
-		Subscription subscription = new Subscription();
-		subscription.setId("test_sub");
-
-		Discount discount = new Discount();
-		discount.setId("test_dis");
-		subscription.setDiscount(discount);
-		Assert.assertEquals("test_dis", subscription.getDiscount().id);
-
-		subscription.deleteDiscount();
-
-		verifyDelete(Discount.class, "https://api.stripe.com/v1/subscriptions/test_sub/discount");
-		verifyNoMoreInteractions(networkMock);
+	public void testDeserializeWithExpansions() throws Exception {
+		String[] expansions = { "*" };
+		String data = getFixture("/v1/subscriptions/sub_123", expansions);
+		Subscription object = APIResource.GSON.fromJson(data, Subscription.class);
+		assertNotNull(object);
+		assertNotNull(object.getCustomer());
 	}
 }


### PR DESCRIPTION
Move to using an external API stub in the test suite instead of issuing live API calls so that we can have tests that run more quickly and more reliably.

For the time being, I've just converted the plan test suite over to use the new scheme.

This is an experimental prototype for demonstrative purposes and should not be merged.

See also:

* https://github.com/stripe/stripe-go/issues/424
* https://github.com/stripe/stripe-php/pull/357
* https://github.com/stripe/stripe-ruby/pull/553