### PR TITLE
Add parameters when calling `pay` on an invoice

### DIFF
--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -384,6 +384,12 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
 		return this.pay((RequestOptions) null);
 	}
 
+	public Invoice pay(Map<String, Object> params) throws AuthenticationException,
+			InvalidRequestException, APIConnectionException, CardException,
+			APIException {
+		return this.pay(params, (RequestOptions) null);
+	}
+
 	public Invoice update(Map<String, Object> params)
 			throws AuthenticationException, InvalidRequestException,
 			APIConnectionException, CardException, APIException {
@@ -488,7 +494,12 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
 	public Invoice pay(RequestOptions options) throws AuthenticationException,
 			InvalidRequestException, APIConnectionException, CardException,
 			APIException {
+		return pay(null, options);
+	}
+	public Invoice pay(Map<String, Object> params, RequestOptions options) throws AuthenticationException,
+			InvalidRequestException, APIConnectionException, CardException,
+			APIException {
 		return request(RequestMethod.POST, String.format("%s/pay",
-				instanceURL(Invoice.class, this.getId())), null, Invoice.class, options);
+				instanceURL(Invoice.class, this.getId())), params, Invoice.class, options);
 	}
 }

--- a/src/test/java/com/stripe/model/InvoiceTest.java
+++ b/src/test/java/com/stripe/model/InvoiceTest.java
@@ -88,4 +88,27 @@ public class InvoiceTest extends BaseStripeTest {
 		assertEquals("card_8vzsxmT0Ua0lkd", charge.getSource().getId());
 	}
 
+	@Test
+	public void testPayNoParams() throws StripeException, IOException {
+		Invoice invoice = new Invoice();
+		invoice.setId("in_test_pay");
+
+		invoice.pay();
+
+		verifyPost(Invoice.class, "https://api.stripe.com/v1/invoices/in_test_pay/pay", (Map)null);
+		verifyNoMoreInteractions(networkMock);
+	}
+
+	@Test
+	public void testPayWithParams() throws StripeException, IOException {
+		Invoice invoice = new Invoice();
+		invoice.setId("in_test_pay");
+
+		Map<String, Object> params = new HashMap<String, Object>();
+		params.put("source", "src_foo");
+		invoice.pay(params);
+
+		verifyPost(Invoice.class, "https://api.stripe.com/v1/invoices/in_test_pay/pay", params);
+		verifyNoMoreInteractions(networkMock);
+	}
 }


### PR DESCRIPTION
r? @brandur-stripe
cc @stripe/api-libraries @ark-stripe

Users can now provide a `source` parameter when paying invoices, but the `pay` method currently does not let users provide any parameters. This PR fixes that.

Not a breaking change thanks to static typing.
