### PR TITLE
Provide a type-safe API method interface

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,17 @@
     </licenses>
     <dependencies>
         <dependency>
+            <groupId>com.google.auto.value</groupId>
+            <artifactId>auto-value</artifactId>
+            <version>1.2</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.2.4</version>

--- a/src/main/java/com/stripe/model/Account.java
+++ b/src/main/java/com/stripe/model/Account.java
@@ -7,6 +7,9 @@ import com.google.gson.annotations.SerializedName;
 import com.stripe.exception.*;
 import com.stripe.net.APIResource;
 import com.stripe.net.RequestOptions;
+import com.stripe.params.CreateAccount;
+import com.stripe.params.RejectAccount;
+import com.stripe.params.UpdateAccount;
 
 public class Account extends APIResource implements HasId, MetadataStore<Account> {
 	String id;
@@ -408,5 +411,41 @@ public class Account extends APIResource implements HasId, MetadataStore<Account
 		public String getSecret() {
 			return secret;
 		}
+	}
+
+	public Account reject(RejectAccount params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return reject(params, (RequestOptions) null);
+	}
+
+	public Account reject(RejectAccount params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return reject(params.toMap(), options);
+	}
+
+	public static Account create(CreateAccount params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params, (RequestOptions) null);
+	}
+
+	public static Account create(CreateAccount params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params.toMap(), options);
+	}
+
+	public Account update(UpdateAccount params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params, (RequestOptions) null);
+	}
+
+	public Account update(UpdateAccount params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params.toMap(), options);
 	}
 }

--- a/src/main/java/com/stripe/model/Account.java
+++ b/src/main/java/com/stripe/model/Account.java
@@ -328,7 +328,13 @@ public class Account extends APIResource implements HasId, MetadataStore<Account
 	public Account reject(Map<String, Object> params)
 			throws AuthenticationException, InvalidRequestException,
 			APIConnectionException, CardException, APIException {
-		return request(RequestMethod.POST, instanceURL(Account.class, this.id) + "/reject", params, Account.class, null);
+		return reject(params, (RequestOptions) null);
+	}
+
+	public Account reject(Map<String, Object> params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return request(RequestMethod.POST, instanceURL(Account.class, this.id) + "/reject", params, Account.class, options);
 	}
 
 	public Account update(Map<String, Object> params, RequestOptions options)

--- a/src/main/java/com/stripe/model/ApplePayDomain.java
+++ b/src/main/java/com/stripe/model/ApplePayDomain.java
@@ -8,6 +8,7 @@ import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
 import com.stripe.net.APIResource;
 import com.stripe.net.RequestOptions;
+import com.stripe.params.CreateApplePayDomain;
 
 import java.util.Map;
 
@@ -115,5 +116,17 @@ public class ApplePayDomain extends APIResource implements HasId {
 			return String.format("%s/%s", getClassURL(), id);
 		}
 		return null;
+	}
+
+	public static ApplePayDomain create(CreateApplePayDomain params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params, (RequestOptions) null);
+	}
+
+	public static ApplePayDomain create(CreateApplePayDomain params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params.toMap(), options);
 	}
 }

--- a/src/main/java/com/stripe/model/Card.java
+++ b/src/main/java/com/stripe/model/Card.java
@@ -6,6 +6,7 @@ import com.stripe.exception.AuthenticationException;
 import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
 import com.stripe.net.RequestOptions;
+import com.stripe.params.UpdateCard;
 
 import java.util.List;
 import java.util.Map;
@@ -331,5 +332,17 @@ public class Card extends ExternalAccount {
 		} else {
 			return null;
 		}
+	}
+
+	public Card update(UpdateCard params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params, (RequestOptions) null);
+	}
+
+	public Card update(UpdateCard params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params.toMap(), options);
 	}
 }

--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -583,7 +583,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
 	public Charge capture() throws AuthenticationException,
 			InvalidRequestException, APIConnectionException, CardException,
 			APIException {
-		return this.capture(null, (RequestOptions) null);
+		return this.capture((Map<String, Object>) null, (RequestOptions) null);
 	}
 
 	@Deprecated
@@ -727,7 +727,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
 	public Charge capture(RequestOptions options) throws AuthenticationException,
 			InvalidRequestException, APIConnectionException, CardException,
 			APIException {
-		return this.capture(null, options);
+		return this.capture((Map<String, Object>) null, options);
 	}
 
 	@Deprecated

--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -7,6 +7,9 @@ import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
 import com.stripe.net.APIResource;
 import com.stripe.net.RequestOptions;
+import com.stripe.params.CaptureCharge;
+import com.stripe.params.CreateCharge;
+import com.stripe.params.UpdateCharge;
 
 import java.util.Collections;
 import java.util.Map;
@@ -787,5 +790,41 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
 			APIConnectionException, CardException, APIException {
 		Map<String, Object> params = Collections.<String, Object>singletonMap(FRAUD_DETAILS, Collections.singletonMap(FraudDetails.USER_REPORT, "safe"));
 		return this.update(params, options);
+	}
+
+	public static Charge create(CreateCharge params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params, (RequestOptions) null);
+	}
+
+	public static Charge create(CreateCharge params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params.toMap(), options);
+	}
+
+	public Charge update(UpdateCharge params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params, (RequestOptions) null);
+	}
+
+	public Charge update(UpdateCharge params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params.toMap(), options);
+	}
+
+	public Charge capture(CaptureCharge params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return capture(params, (RequestOptions) null);
+	}
+
+	public Charge capture(CaptureCharge params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return capture(params.toMap(), options);
 	}
 }

--- a/src/main/java/com/stripe/model/Coupon.java
+++ b/src/main/java/com/stripe/model/Coupon.java
@@ -7,6 +7,8 @@ import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
 import com.stripe.net.APIResource;
 import com.stripe.net.RequestOptions;
+import com.stripe.params.CreateCoupon;
+import com.stripe.params.UpdateCoupon;
 
 import java.util.Map;
 
@@ -239,5 +241,29 @@ public class Coupon extends APIResource implements MetadataStore<Coupon>, HasId 
 			InvalidRequestException, APIConnectionException, CardException,
 			APIException {
 		return request(RequestMethod.DELETE, instanceURL(Coupon.class, this.id), null, DeletedCoupon.class, options);
+	}
+
+	public static Coupon create(CreateCoupon params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params, (RequestOptions) null);
+	}
+
+	public static Coupon create(CreateCoupon params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params.toMap(), options);
+	}
+
+	public Coupon update(UpdateCoupon params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params, (RequestOptions) null);
+	}
+
+	public Coupon update(UpdateCoupon params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params.toMap(), options);
 	}
 }

--- a/src/main/java/com/stripe/model/Customer.java
+++ b/src/main/java/com/stripe/model/Customer.java
@@ -7,6 +7,8 @@ import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
 import com.stripe.net.APIResource;
 import com.stripe.net.RequestOptions;
+import com.stripe.params.CreateCustomer;
+import com.stripe.params.UpdateCustomer;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -581,4 +583,28 @@ public class Customer extends APIResource implements MetadataStore<Customer>, Ha
 				instanceURL(Customer.class, this.id)), null, Discount.class, options);
 	}
 
+
+	public static Customer create(CreateCustomer params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params, (RequestOptions) null);
+	}
+
+	public static Customer create(CreateCustomer params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params.toMap(), options);
+	}
+
+	public Customer update(UpdateCustomer params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params, (RequestOptions) null);
+	}
+
+	public Customer update(UpdateCustomer params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params.toMap(), options);
+	}
 }

--- a/src/main/java/com/stripe/model/Dispute.java
+++ b/src/main/java/com/stripe/model/Dispute.java
@@ -7,6 +7,7 @@ import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
 import com.stripe.net.APIResource;
 import com.stripe.net.RequestOptions;
+import com.stripe.params.UpdateDispute;
 
 import java.util.List;
 import java.util.Map;
@@ -277,5 +278,17 @@ public class Dispute extends APIResource implements HasId {
 			APIConnectionException, CardException, APIException {
 		return request(RequestMethod.POST, String.format("%s/close", instanceURL(Dispute.class, this.getId())),
 				null, Dispute.class, options);
+	}
+
+	public Dispute update(UpdateDispute params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params, (RequestOptions) null);
+	}
+
+	public Dispute update(UpdateDispute params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params.toMap(), options);
 	}
 }

--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -7,6 +7,9 @@ import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
 import com.stripe.net.APIResource;
 import com.stripe.net.RequestOptions;
+import com.stripe.params.CreateInvoice;
+import com.stripe.params.PayInvoice;
+import com.stripe.params.UpdateInvoice;
 
 import java.util.Map;
 
@@ -509,5 +512,41 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
 			APIException {
 		return request(RequestMethod.POST, String.format("%s/pay",
 				instanceURL(Invoice.class, this.getId())), params, Invoice.class, options);
+	}
+
+	public Invoice pay(PayInvoice params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return pay(params, (RequestOptions) null);
+	}
+
+	public Invoice pay(PayInvoice params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return pay(params.toMap(), options);
+	}
+
+	public static Invoice create(CreateInvoice params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params, (RequestOptions) null);
+	}
+
+	public static Invoice create(CreateInvoice params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params.toMap(), options);
+	}
+
+	public Invoice update(UpdateInvoice params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params, (RequestOptions) null);
+	}
+
+	public Invoice update(UpdateInvoice params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params.toMap(), options);
 	}
 }

--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -504,7 +504,7 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
 	public Invoice pay(RequestOptions options) throws AuthenticationException,
 			InvalidRequestException, APIConnectionException, CardException,
 			APIException {
-		return pay(null, options);
+		return pay((Map<String, Object>) null, options);
 	}
 
 	public Invoice pay(Map<String, Object> params, RequestOptions options) throws AuthenticationException,

--- a/src/main/java/com/stripe/model/InvoiceItem.java
+++ b/src/main/java/com/stripe/model/InvoiceItem.java
@@ -7,6 +7,8 @@ import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
 import com.stripe.net.APIResource;
 import com.stripe.net.RequestOptions;
+import com.stripe.params.CreateInvoiceItem;
+import com.stripe.params.UpdateInvoiceItem;
 
 import java.util.Map;
 
@@ -318,4 +320,28 @@ public class InvoiceItem extends APIResource implements MetadataStore<InvoiceIte
 		return request(RequestMethod.DELETE, instanceURL(InvoiceItem.class, this.id), null, DeletedInvoiceItem.class, options);
 	}
 
+
+	public static InvoiceItem create(CreateInvoiceItem params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params, (RequestOptions) null);
+	}
+
+	public static InvoiceItem create(CreateInvoiceItem params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params.toMap(), options);
+	}
+
+	public InvoiceItem update(UpdateInvoiceItem params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params, (RequestOptions) null);
+	}
+
+	public InvoiceItem update(UpdateInvoiceItem params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params.toMap(), options);
+	}
 }

--- a/src/main/java/com/stripe/model/Order.java
+++ b/src/main/java/com/stripe/model/Order.java
@@ -10,6 +10,9 @@ import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
 import com.stripe.net.APIResource;
 import com.stripe.net.RequestOptions;
+import com.stripe.params.CreateOrder;
+import com.stripe.params.PayOrder;
+import com.stripe.params.UpdateOrder;
 
 public class Order extends APIResource implements HasId, MetadataStore<Order> {
 	String id;
@@ -344,5 +347,41 @@ public class Order extends APIResource implements HasId, MetadataStore<Order> {
 			APIException {
 		return request(RequestMethod.POST, String.format("%s/returns",
 				instanceURL(Order.class, this.getId())), params, OrderReturn.class, options);
+	}
+
+	public Order pay(PayOrder params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return pay(params, (RequestOptions) null);
+	}
+
+	public Order pay(PayOrder params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return pay(params.toMap(), options);
+	}
+
+	public static Order create(CreateOrder params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params, (RequestOptions) null);
+	}
+
+	public static Order create(CreateOrder params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params.toMap(), options);
+	}
+
+	public Order update(UpdateOrder params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params, (RequestOptions) null);
+	}
+
+	public Order update(UpdateOrder params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params.toMap(), options);
 	}
 }

--- a/src/main/java/com/stripe/model/Payout.java
+++ b/src/main/java/com/stripe/model/Payout.java
@@ -7,6 +7,8 @@ import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
 import com.stripe.net.APIResource;
 import com.stripe.net.RequestOptions;
+import com.stripe.params.CreatePayout;
+import com.stripe.params.UpdatePayout;
 
 import java.util.List;
 import java.util.Map;
@@ -281,5 +283,29 @@ public class Payout extends APIResource implements MetadataStore<Payout>, HasId 
 			throws AuthenticationException, InvalidRequestException,
 			APIConnectionException, CardException, APIException {
 		return request(RequestMethod.POST, instanceURL(Payout.class, this.id), params, Payout.class, options);
+	}
+
+	public static Payout create(CreatePayout params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params, (RequestOptions) null);
+	}
+
+	public static Payout create(CreatePayout params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params.toMap(), options);
+	}
+
+	public Payout update(UpdatePayout params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params, (RequestOptions) null);
+	}
+
+	public Payout update(UpdatePayout params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params.toMap(), options);
 	}
 }

--- a/src/main/java/com/stripe/model/Plan.java
+++ b/src/main/java/com/stripe/model/Plan.java
@@ -7,6 +7,8 @@ import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
 import com.stripe.net.APIResource;
 import com.stripe.net.RequestOptions;
+import com.stripe.params.CreatePlan;
+import com.stripe.params.UpdatePlan;
 
 import java.util.Map;
 
@@ -246,5 +248,29 @@ public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
 			InvalidRequestException, APIConnectionException, CardException,
 			APIException {
 		return request(RequestMethod.DELETE, instanceURL(Plan.class, this.id), null, DeletedPlan.class, options);
+	}
+
+	public static Plan create(CreatePlan params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params, (RequestOptions) null);
+	}
+
+	public static Plan create(CreatePlan params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params.toMap(), options);
+	}
+
+	public Plan update(UpdatePlan params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params, (RequestOptions) null);
+	}
+
+	public Plan update(UpdatePlan params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params.toMap(), options);
 	}
 }

--- a/src/main/java/com/stripe/model/Product.java
+++ b/src/main/java/com/stripe/model/Product.java
@@ -10,6 +10,8 @@ import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
 import com.stripe.net.APIResource;
 import com.stripe.net.RequestOptions;
+import com.stripe.params.CreateProduct;
+import com.stripe.params.UpdateProduct;
 
 public class Product extends APIResource implements HasId, MetadataStore<Product> {
 	String id;
@@ -240,5 +242,29 @@ public class Product extends APIResource implements HasId, MetadataStore<Product
 			throws AuthenticationException, InvalidRequestException,
 			APIConnectionException, CardException, APIException {
 		return request(RequestMethod.POST, instanceURL(Product.class, this.id), params, Product.class, options);
+	}
+
+	public static Product create(CreateProduct params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params, (RequestOptions) null);
+	}
+
+	public static Product create(CreateProduct params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params.toMap(), options);
+	}
+
+	public Product update(UpdateProduct params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params, (RequestOptions) null);
+	}
+
+	public Product update(UpdateProduct params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params.toMap(), options);
 	}
 }

--- a/src/main/java/com/stripe/model/Refund.java
+++ b/src/main/java/com/stripe/model/Refund.java
@@ -7,6 +7,7 @@ import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
 import com.stripe.net.APIResource;
 import com.stripe.net.RequestOptions;
+import com.stripe.params.UpdateRefund;
 
 import java.util.Map;
 
@@ -221,5 +222,17 @@ public class Refund extends APIResource implements MetadataStore<Charge>, HasId 
 			throws AuthenticationException, InvalidRequestException,
 			APIConnectionException, CardException, APIException {
 		return request(RequestMethod.POST, classURL(Refund.class), params, Refund.class, options);
+	}
+
+	public Refund update(UpdateRefund params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params, (RequestOptions) null);
+	}
+
+	public Refund update(UpdateRefund params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params.toMap(), options);
 	}
 }

--- a/src/main/java/com/stripe/model/SKU.java
+++ b/src/main/java/com/stripe/model/SKU.java
@@ -9,6 +9,8 @@ import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
 import com.stripe.net.APIResource;
 import com.stripe.net.RequestOptions;
+import com.stripe.params.CreateSKU;
+import com.stripe.params.UpdateSKU;
 
 
 public class SKU extends APIResource implements HasId, MetadataStore<SKU> {
@@ -234,5 +236,29 @@ public class SKU extends APIResource implements HasId, MetadataStore<SKU> {
 			throws AuthenticationException, InvalidRequestException,
 			APIConnectionException, CardException, APIException {
 		return request(RequestMethod.POST, instanceURL(SKU.class, this.id), params, SKU.class, options);
+	}
+
+	public static SKU create(CreateSKU params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params, (RequestOptions) null);
+	}
+
+	public static SKU create(CreateSKU params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params.toMap(), options);
+	}
+
+	public SKU update(UpdateSKU params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params, (RequestOptions) null);
+	}
+
+	public SKU update(UpdateSKU params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params.toMap(), options);
 	}
 }

--- a/src/main/java/com/stripe/model/Source.java
+++ b/src/main/java/com/stripe/model/Source.java
@@ -6,6 +6,9 @@ import com.stripe.exception.AuthenticationException;
 import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
 import com.stripe.net.RequestOptions;
+import com.stripe.params.CreateSource;
+import com.stripe.params.UpdateSource;
+import com.stripe.params.VerifySource;
 
 import java.io.IOException;
 import java.util.Map;
@@ -207,5 +210,41 @@ public class Source extends ExternalAccount {
 			throws AuthenticationException, InvalidRequestException,
 			APIConnectionException, CardException, APIException {
 		return request(RequestMethod.POST, this.getSourceInstanceURL(), params, Source.class, options);
+	}
+
+	public static Source create(CreateSource params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params, (RequestOptions) null);
+	}
+
+	public static Source create(CreateSource params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params.toMap(), options);
+	}
+
+	public Source verify(VerifySource params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return verify(params, (RequestOptions) null);
+	}
+
+	public Source verify(VerifySource params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return verify(params.toMap(), options);
+	}
+
+	public Source update(UpdateSource params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params, (RequestOptions) null);
+	}
+
+	public Source update(UpdateSource params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params.toMap(), options);
 	}
 }

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -7,6 +7,8 @@ import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
 import com.stripe.net.APIResource;
 import com.stripe.net.RequestOptions;
+import com.stripe.params.CreateSubscription;
+import com.stripe.params.UpdateSubscription;
 
 import java.util.Map;
 
@@ -343,5 +345,29 @@ public class Subscription extends APIResource implements MetadataStore<Subscript
 			InvalidRequestException, APIConnectionException, CardException,
 			APIException {
 		request(RequestMethod.DELETE, String.format("%s/discount", instanceURL(Subscription.class, id)), null, Discount.class, options);
+	}
+
+	public static Subscription create(CreateSubscription params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params, (RequestOptions) null);
+	}
+
+	public static Subscription create(CreateSubscription params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params.toMap(), options);
+	}
+
+	public Subscription update(UpdateSubscription params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params, (RequestOptions) null);
+	}
+
+	public Subscription update(UpdateSubscription params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params.toMap(), options);
 	}
 }

--- a/src/main/java/com/stripe/model/SubscriptionItem.java
+++ b/src/main/java/com/stripe/model/SubscriptionItem.java
@@ -7,6 +7,8 @@ import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
 import com.stripe.net.APIResource;
 import com.stripe.net.RequestOptions;
+import com.stripe.params.CreateSubscriptionItem;
+import com.stripe.params.UpdateSubscriptionItem;
 
 import java.util.Map;
 import java.util.List;
@@ -119,5 +121,29 @@ public class SubscriptionItem extends APIResource implements HasId {
 			InvalidRequestException, APIConnectionException, CardException,
 			APIException {
 		return request(RequestMethod.DELETE, instanceURL(SubscriptionItem.class, id), null, DeletedSubscriptionItem.class, options);
+	}
+
+	public static SubscriptionItem create(CreateSubscriptionItem params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params, (RequestOptions) null);
+	}
+
+	public static SubscriptionItem create(CreateSubscriptionItem params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params.toMap(), options);
+	}
+
+	public SubscriptionItem update(UpdateSubscriptionItem params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params, (RequestOptions) null);
+	}
+
+	public SubscriptionItem update(UpdateSubscriptionItem params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params.toMap(), options);
 	}
 }

--- a/src/main/java/com/stripe/model/ThreeDSecure.java
+++ b/src/main/java/com/stripe/model/ThreeDSecure.java
@@ -10,6 +10,7 @@ import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
 import com.stripe.net.APIResource;
 import com.stripe.net.RequestOptions;
+import com.stripe.params.CreateThreeDSecure;
 
 import java.util.Map;
 
@@ -139,5 +140,17 @@ public class ThreeDSecure extends APIResource implements HasId {
 			return String.format("%s/%s", getClassURL(), id);
 		}
 		return null;
+	}
+
+	public static ThreeDSecure create(CreateThreeDSecure params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params, (RequestOptions) null);
+	}
+
+	public static ThreeDSecure create(CreateThreeDSecure params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params.toMap(), options);
 	}
 }

--- a/src/main/java/com/stripe/model/Transfer.java
+++ b/src/main/java/com/stripe/model/Transfer.java
@@ -7,6 +7,8 @@ import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
 import com.stripe.net.APIResource;
 import com.stripe.net.RequestOptions;
+import com.stripe.params.CreateTransfer;
+import com.stripe.params.UpdateTransfer;
 
 import java.util.List;
 import java.util.Map;
@@ -540,5 +542,29 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
 			APIConnectionException, CardException, APIException {
 		String url = String.format("%s%s", instanceURL(Transfer.class, this.getId()), "/transactions");
 		return requestCollection(url, params, TransferTransactionCollection.class, options);
+	}
+
+	public static Transfer create(CreateTransfer params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params, (RequestOptions) null);
+	}
+
+	public static Transfer create(CreateTransfer params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return create(params.toMap(), options);
+	}
+
+	public Transfer update(UpdateTransfer params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params, (RequestOptions) null);
+	}
+
+	public Transfer update(UpdateTransfer params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return update(params.toMap(), options);
 	}
 }

--- a/src/main/java/com/stripe/params/CaptureCharge.java
+++ b/src/main/java/com/stripe/params/CaptureCharge.java
@@ -1,0 +1,52 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class CaptureCharge {
+	@Nullable abstract Integer amount();
+
+	@Nullable abstract Integer applicationFee();
+
+	@Nullable abstract String receiptEmail();
+
+	@Nullable abstract String statementDescriptor();
+
+	public static Builder builder() {
+		return new AutoValue_CaptureCharge.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (amount() != null) {
+			m.put("amount", amount());
+		}
+		if (applicationFee() != null) {
+			m.put("application_fee", applicationFee());
+		}
+		if (receiptEmail() != null) {
+			m.put("receipt_email", receiptEmail());
+		}
+		if (statementDescriptor() != null) {
+			m.put("statement_descriptor", statementDescriptor());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder amount(Integer value);
+
+		public abstract Builder applicationFee(Integer value);
+
+		public abstract Builder receiptEmail(String value);
+
+		public abstract Builder statementDescriptor(String value);
+
+		public abstract CaptureCharge build();
+	}
+}

--- a/src/main/java/com/stripe/params/CreateAccount.java
+++ b/src/main/java/com/stripe/params/CreateAccount.java
@@ -1,0 +1,143 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class CreateAccount {
+	@Nullable abstract String businessLogo();
+
+	@Nullable abstract String businessName();
+
+	@Nullable abstract String businessPrimaryColor();
+
+	@Nullable abstract String businessUrl();
+
+	@Nullable abstract String country();
+
+	@Nullable abstract Boolean debitNegativeBalances();
+
+	@Nullable abstract String defaultCurrency();
+
+	@Nullable abstract String email();
+
+	@Nullable abstract String externalAccount();
+
+	@Nullable abstract Map<String, String> metadata();
+
+	@Nullable abstract String payoutStatementDescriptor();
+
+	@Nullable abstract String productDescription();
+
+	@Nullable abstract String statementDescriptor();
+
+	@Nullable abstract String supportEmail();
+
+	@Nullable abstract String supportPhone();
+
+	@Nullable abstract String supportUrl();
+
+	@Nullable abstract String type();
+
+	public static Builder builder() {
+		return new AutoValue_CreateAccount.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (businessLogo() != null) {
+			m.put("business_logo", businessLogo());
+		}
+		if (businessName() != null) {
+			m.put("business_name", businessName());
+		}
+		if (businessPrimaryColor() != null) {
+			m.put("business_primary_color", businessPrimaryColor());
+		}
+		if (businessUrl() != null) {
+			m.put("business_url", businessUrl());
+		}
+		if (country() != null) {
+			m.put("country", country());
+		}
+		if (debitNegativeBalances() != null) {
+			m.put("debit_negative_balances", debitNegativeBalances());
+		}
+		if (defaultCurrency() != null) {
+			m.put("default_currency", defaultCurrency());
+		}
+		if (email() != null) {
+			m.put("email", email());
+		}
+		if (externalAccount() != null) {
+			m.put("external_account", externalAccount());
+		}
+		if (metadata() != null) {
+			m.put("metadata", metadata());
+		}
+		if (payoutStatementDescriptor() != null) {
+			m.put("payout_statement_descriptor", payoutStatementDescriptor());
+		}
+		if (productDescription() != null) {
+			m.put("product_description", productDescription());
+		}
+		if (statementDescriptor() != null) {
+			m.put("statement_descriptor", statementDescriptor());
+		}
+		if (supportEmail() != null) {
+			m.put("support_email", supportEmail());
+		}
+		if (supportPhone() != null) {
+			m.put("support_phone", supportPhone());
+		}
+		if (supportUrl() != null) {
+			m.put("support_url", supportUrl());
+		}
+		if (type() != null) {
+			m.put("type", type());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder businessLogo(String value);
+
+		public abstract Builder businessName(String value);
+
+		public abstract Builder businessPrimaryColor(String value);
+
+		public abstract Builder businessUrl(String value);
+
+		public abstract Builder country(String value);
+
+		public abstract Builder debitNegativeBalances(Boolean value);
+
+		public abstract Builder defaultCurrency(String value);
+
+		public abstract Builder email(String value);
+
+		public abstract Builder externalAccount(String value);
+
+		public abstract Builder metadata(Map<String, String> value);
+
+		public abstract Builder payoutStatementDescriptor(String value);
+
+		public abstract Builder productDescription(String value);
+
+		public abstract Builder statementDescriptor(String value);
+
+		public abstract Builder supportEmail(String value);
+
+		public abstract Builder supportPhone(String value);
+
+		public abstract Builder supportUrl(String value);
+
+		public abstract Builder type(String value);
+
+		public abstract CreateAccount build();
+	}
+}

--- a/src/main/java/com/stripe/params/CreateApplePayDomain.java
+++ b/src/main/java/com/stripe/params/CreateApplePayDomain.java
@@ -1,0 +1,31 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class CreateApplePayDomain {
+	@Nullable abstract String domainName();
+
+	public static Builder builder() {
+		return new AutoValue_CreateApplePayDomain.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (domainName() != null) {
+			m.put("domain_name", domainName());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder domainName(String value);
+
+		public abstract CreateApplePayDomain build();
+	}
+}

--- a/src/main/java/com/stripe/params/CreateCharge.java
+++ b/src/main/java/com/stripe/params/CreateCharge.java
@@ -1,0 +1,178 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class CreateCharge {
+	@Nullable abstract Integer amount();
+
+	@Nullable abstract String application();
+
+	@Nullable abstract Integer applicationFee();
+
+	@Nullable abstract Boolean capture();
+
+	@Nullable abstract String currency();
+
+	@Nullable abstract String customer();
+
+	@Nullable abstract String description();
+
+	@Nullable abstract String externalId();
+
+	@Nullable abstract String invoice();
+
+	@Nullable abstract String invoiceSource();
+
+	@Nullable abstract String ip();
+
+	@Nullable abstract Map<String, String> metadata();
+
+	@Nullable abstract String onBehalfOf();
+
+	@Nullable abstract String paymentUserAgent();
+
+	@Nullable abstract String receiptEmail();
+
+	@Nullable abstract Boolean recurring();
+
+	@Nullable abstract String referrer();
+
+	@Nullable abstract String source();
+
+	@Nullable abstract String statementDescriptor();
+
+	@Nullable abstract String transferGroup();
+
+	@Nullable abstract Boolean uncaptured();
+
+	@Nullable abstract String userAgent();
+
+	public static Builder builder() {
+		return new AutoValue_CreateCharge.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (amount() != null) {
+			m.put("amount", amount());
+		}
+		if (application() != null) {
+			m.put("application", application());
+		}
+		if (applicationFee() != null) {
+			m.put("application_fee", applicationFee());
+		}
+		if (capture() != null) {
+			m.put("capture", capture());
+		}
+		if (currency() != null) {
+			m.put("currency", currency());
+		}
+		if (customer() != null) {
+			m.put("customer", customer());
+		}
+		if (description() != null) {
+			m.put("description", description());
+		}
+		if (externalId() != null) {
+			m.put("external_id", externalId());
+		}
+		if (invoice() != null) {
+			m.put("invoice", invoice());
+		}
+		if (invoiceSource() != null) {
+			m.put("invoice_source", invoiceSource());
+		}
+		if (ip() != null) {
+			m.put("ip", ip());
+		}
+		if (metadata() != null) {
+			m.put("metadata", metadata());
+		}
+		if (onBehalfOf() != null) {
+			m.put("on_behalf_of", onBehalfOf());
+		}
+		if (paymentUserAgent() != null) {
+			m.put("payment_user_agent", paymentUserAgent());
+		}
+		if (receiptEmail() != null) {
+			m.put("receipt_email", receiptEmail());
+		}
+		if (recurring() != null) {
+			m.put("recurring", recurring());
+		}
+		if (referrer() != null) {
+			m.put("referrer", referrer());
+		}
+		if (source() != null) {
+			m.put("source", source());
+		}
+		if (statementDescriptor() != null) {
+			m.put("statement_descriptor", statementDescriptor());
+		}
+		if (transferGroup() != null) {
+			m.put("transfer_group", transferGroup());
+		}
+		if (uncaptured() != null) {
+			m.put("uncaptured", uncaptured());
+		}
+		if (userAgent() != null) {
+			m.put("user_agent", userAgent());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder amount(Integer value);
+
+		public abstract Builder application(String value);
+
+		public abstract Builder applicationFee(Integer value);
+
+		public abstract Builder capture(Boolean value);
+
+		public abstract Builder currency(String value);
+
+		public abstract Builder customer(String value);
+
+		public abstract Builder description(String value);
+
+		public abstract Builder externalId(String value);
+
+		public abstract Builder invoice(String value);
+
+		public abstract Builder invoiceSource(String value);
+
+		public abstract Builder ip(String value);
+
+		public abstract Builder metadata(Map<String, String> value);
+
+		public abstract Builder onBehalfOf(String value);
+
+		public abstract Builder paymentUserAgent(String value);
+
+		public abstract Builder receiptEmail(String value);
+
+		public abstract Builder recurring(Boolean value);
+
+		public abstract Builder referrer(String value);
+
+		public abstract Builder source(String value);
+
+		public abstract Builder statementDescriptor(String value);
+
+		public abstract Builder transferGroup(String value);
+
+		public abstract Builder uncaptured(Boolean value);
+
+		public abstract Builder userAgent(String value);
+
+		public abstract CreateCharge build();
+	}
+}

--- a/src/main/java/com/stripe/params/CreateCoupon.java
+++ b/src/main/java/com/stripe/params/CreateCoupon.java
@@ -1,0 +1,87 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class CreateCoupon {
+	@Nullable abstract Integer amountOff();
+
+	@Nullable abstract String currency();
+
+	@Nullable abstract String duration();
+
+	@Nullable abstract Integer durationInMonths();
+
+	@Nullable abstract String id();
+
+	@Nullable abstract Integer maxRedemptions();
+
+	@Nullable abstract Map<String, String> metadata();
+
+	@Nullable abstract Integer percentOff();
+
+	@Nullable abstract Integer redeemBy();
+
+	public static Builder builder() {
+		return new AutoValue_CreateCoupon.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (amountOff() != null) {
+			m.put("amount_off", amountOff());
+		}
+		if (currency() != null) {
+			m.put("currency", currency());
+		}
+		if (duration() != null) {
+			m.put("duration", duration());
+		}
+		if (durationInMonths() != null) {
+			m.put("duration_in_months", durationInMonths());
+		}
+		if (id() != null) {
+			m.put("id", id());
+		}
+		if (maxRedemptions() != null) {
+			m.put("max_redemptions", maxRedemptions());
+		}
+		if (metadata() != null) {
+			m.put("metadata", metadata());
+		}
+		if (percentOff() != null) {
+			m.put("percent_off", percentOff());
+		}
+		if (redeemBy() != null) {
+			m.put("redeem_by", redeemBy());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder amountOff(Integer value);
+
+		public abstract Builder currency(String value);
+
+		public abstract Builder duration(String value);
+
+		public abstract Builder durationInMonths(Integer value);
+
+		public abstract Builder id(String value);
+
+		public abstract Builder maxRedemptions(Integer value);
+
+		public abstract Builder metadata(Map<String, String> value);
+
+		public abstract Builder percentOff(Integer value);
+
+		public abstract Builder redeemBy(Integer value);
+
+		public abstract CreateCoupon build();
+	}
+}

--- a/src/main/java/com/stripe/params/CreateCustomer.java
+++ b/src/main/java/com/stripe/params/CreateCustomer.java
@@ -1,0 +1,80 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class CreateCustomer {
+	@Nullable abstract Integer accountBalance();
+
+	@Nullable abstract String businessVatId();
+
+	@Nullable abstract String coupon();
+
+	@Nullable abstract String defaultSource();
+
+	@Nullable abstract String description();
+
+	@Nullable abstract String email();
+
+	@Nullable abstract Map<String, String> metadata();
+
+	@Nullable abstract String source();
+
+	public static Builder builder() {
+		return new AutoValue_CreateCustomer.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (accountBalance() != null) {
+			m.put("account_balance", accountBalance());
+		}
+		if (businessVatId() != null) {
+			m.put("business_vat_id", businessVatId());
+		}
+		if (coupon() != null) {
+			m.put("coupon", coupon());
+		}
+		if (defaultSource() != null) {
+			m.put("default_source", defaultSource());
+		}
+		if (description() != null) {
+			m.put("description", description());
+		}
+		if (email() != null) {
+			m.put("email", email());
+		}
+		if (metadata() != null) {
+			m.put("metadata", metadata());
+		}
+		if (source() != null) {
+			m.put("source", source());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder accountBalance(Integer value);
+
+		public abstract Builder businessVatId(String value);
+
+		public abstract Builder coupon(String value);
+
+		public abstract Builder defaultSource(String value);
+
+		public abstract Builder description(String value);
+
+		public abstract Builder email(String value);
+
+		public abstract Builder metadata(Map<String, String> value);
+
+		public abstract Builder source(String value);
+
+		public abstract CreateCustomer build();
+	}
+}

--- a/src/main/java/com/stripe/params/CreateInvoice.java
+++ b/src/main/java/com/stripe/params/CreateInvoice.java
@@ -1,0 +1,73 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class CreateInvoice {
+	@Nullable abstract Integer applicationFee();
+
+	@Nullable abstract String customer();
+
+	@Nullable abstract String description();
+
+	@Nullable abstract Map<String, String> metadata();
+
+	@Nullable abstract String statementDescriptor();
+
+	@Nullable abstract String subscription();
+
+	@Nullable abstract Double taxPercent();
+
+	public static Builder builder() {
+		return new AutoValue_CreateInvoice.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (applicationFee() != null) {
+			m.put("application_fee", applicationFee());
+		}
+		if (customer() != null) {
+			m.put("customer", customer());
+		}
+		if (description() != null) {
+			m.put("description", description());
+		}
+		if (metadata() != null) {
+			m.put("metadata", metadata());
+		}
+		if (statementDescriptor() != null) {
+			m.put("statement_descriptor", statementDescriptor());
+		}
+		if (subscription() != null) {
+			m.put("subscription", subscription());
+		}
+		if (taxPercent() != null) {
+			m.put("tax_percent", taxPercent());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder applicationFee(Integer value);
+
+		public abstract Builder customer(String value);
+
+		public abstract Builder description(String value);
+
+		public abstract Builder metadata(Map<String, String> value);
+
+		public abstract Builder statementDescriptor(String value);
+
+		public abstract Builder subscription(String value);
+
+		public abstract Builder taxPercent(Double value);
+
+		public abstract CreateInvoice build();
+	}
+}

--- a/src/main/java/com/stripe/params/CreateInvoiceItem.java
+++ b/src/main/java/com/stripe/params/CreateInvoiceItem.java
@@ -1,0 +1,80 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class CreateInvoiceItem {
+	@Nullable abstract Integer amount();
+
+	@Nullable abstract String currency();
+
+	@Nullable abstract String customer();
+
+	@Nullable abstract String description();
+
+	@Nullable abstract Boolean discountable();
+
+	@Nullable abstract String invoice();
+
+	@Nullable abstract Map<String, String> metadata();
+
+	@Nullable abstract String subscription();
+
+	public static Builder builder() {
+		return new AutoValue_CreateInvoiceItem.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (amount() != null) {
+			m.put("amount", amount());
+		}
+		if (currency() != null) {
+			m.put("currency", currency());
+		}
+		if (customer() != null) {
+			m.put("customer", customer());
+		}
+		if (description() != null) {
+			m.put("description", description());
+		}
+		if (discountable() != null) {
+			m.put("discountable", discountable());
+		}
+		if (invoice() != null) {
+			m.put("invoice", invoice());
+		}
+		if (metadata() != null) {
+			m.put("metadata", metadata());
+		}
+		if (subscription() != null) {
+			m.put("subscription", subscription());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder amount(Integer value);
+
+		public abstract Builder currency(String value);
+
+		public abstract Builder customer(String value);
+
+		public abstract Builder description(String value);
+
+		public abstract Builder discountable(Boolean value);
+
+		public abstract Builder invoice(String value);
+
+		public abstract Builder metadata(Map<String, String> value);
+
+		public abstract Builder subscription(String value);
+
+		public abstract CreateInvoiceItem build();
+	}
+}

--- a/src/main/java/com/stripe/params/CreateOrder.java
+++ b/src/main/java/com/stripe/params/CreateOrder.java
@@ -1,0 +1,59 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class CreateOrder {
+	@Nullable abstract String coupon();
+
+	@Nullable abstract String currency();
+
+	@Nullable abstract String customer();
+
+	@Nullable abstract String email();
+
+	@Nullable abstract Map<String, String> metadata();
+
+	public static Builder builder() {
+		return new AutoValue_CreateOrder.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (coupon() != null) {
+			m.put("coupon", coupon());
+		}
+		if (currency() != null) {
+			m.put("currency", currency());
+		}
+		if (customer() != null) {
+			m.put("customer", customer());
+		}
+		if (email() != null) {
+			m.put("email", email());
+		}
+		if (metadata() != null) {
+			m.put("metadata", metadata());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder coupon(String value);
+
+		public abstract Builder currency(String value);
+
+		public abstract Builder customer(String value);
+
+		public abstract Builder email(String value);
+
+		public abstract Builder metadata(Map<String, String> value);
+
+		public abstract CreateOrder build();
+	}
+}

--- a/src/main/java/com/stripe/params/CreatePayout.java
+++ b/src/main/java/com/stripe/params/CreatePayout.java
@@ -1,0 +1,80 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class CreatePayout {
+	@Nullable abstract Integer amount();
+
+	@Nullable abstract String currency();
+
+	@Nullable abstract String description();
+
+	@Nullable abstract String destination();
+
+	@Nullable abstract Map<String, String> metadata();
+
+	@Nullable abstract String method();
+
+	@Nullable abstract String sourceType();
+
+	@Nullable abstract String statementDescriptor();
+
+	public static Builder builder() {
+		return new AutoValue_CreatePayout.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (amount() != null) {
+			m.put("amount", amount());
+		}
+		if (currency() != null) {
+			m.put("currency", currency());
+		}
+		if (description() != null) {
+			m.put("description", description());
+		}
+		if (destination() != null) {
+			m.put("destination", destination());
+		}
+		if (metadata() != null) {
+			m.put("metadata", metadata());
+		}
+		if (method() != null) {
+			m.put("method", method());
+		}
+		if (sourceType() != null) {
+			m.put("source_type", sourceType());
+		}
+		if (statementDescriptor() != null) {
+			m.put("statement_descriptor", statementDescriptor());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder amount(Integer value);
+
+		public abstract Builder currency(String value);
+
+		public abstract Builder description(String value);
+
+		public abstract Builder destination(String value);
+
+		public abstract Builder metadata(Map<String, String> value);
+
+		public abstract Builder method(String value);
+
+		public abstract Builder sourceType(String value);
+
+		public abstract Builder statementDescriptor(String value);
+
+		public abstract CreatePayout build();
+	}
+}

--- a/src/main/java/com/stripe/params/CreatePlan.java
+++ b/src/main/java/com/stripe/params/CreatePlan.java
@@ -1,0 +1,87 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class CreatePlan {
+	@Nullable abstract Integer amount();
+
+	@Nullable abstract String currency();
+
+	@Nullable abstract String id();
+
+	@Nullable abstract String interval();
+
+	@Nullable abstract Integer intervalCount();
+
+	@Nullable abstract Map<String, String> metadata();
+
+	@Nullable abstract String name();
+
+	@Nullable abstract String statementDescriptor();
+
+	@Nullable abstract Integer trialPeriodDays();
+
+	public static Builder builder() {
+		return new AutoValue_CreatePlan.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (amount() != null) {
+			m.put("amount", amount());
+		}
+		if (currency() != null) {
+			m.put("currency", currency());
+		}
+		if (id() != null) {
+			m.put("id", id());
+		}
+		if (interval() != null) {
+			m.put("interval", interval());
+		}
+		if (intervalCount() != null) {
+			m.put("interval_count", intervalCount());
+		}
+		if (metadata() != null) {
+			m.put("metadata", metadata());
+		}
+		if (name() != null) {
+			m.put("name", name());
+		}
+		if (statementDescriptor() != null) {
+			m.put("statement_descriptor", statementDescriptor());
+		}
+		if (trialPeriodDays() != null) {
+			m.put("trial_period_days", trialPeriodDays());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder amount(Integer value);
+
+		public abstract Builder currency(String value);
+
+		public abstract Builder id(String value);
+
+		public abstract Builder interval(String value);
+
+		public abstract Builder intervalCount(Integer value);
+
+		public abstract Builder metadata(Map<String, String> value);
+
+		public abstract Builder name(String value);
+
+		public abstract Builder statementDescriptor(String value);
+
+		public abstract Builder trialPeriodDays(Integer value);
+
+		public abstract CreatePlan build();
+	}
+}

--- a/src/main/java/com/stripe/params/CreateProduct.java
+++ b/src/main/java/com/stripe/params/CreateProduct.java
@@ -1,0 +1,80 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class CreateProduct {
+	@Nullable abstract Boolean active();
+
+	@Nullable abstract String caption();
+
+	@Nullable abstract String description();
+
+	@Nullable abstract String id();
+
+	@Nullable abstract Map<String, String> metadata();
+
+	@Nullable abstract String name();
+
+	@Nullable abstract Boolean shippable();
+
+	@Nullable abstract String url();
+
+	public static Builder builder() {
+		return new AutoValue_CreateProduct.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (active() != null) {
+			m.put("active", active());
+		}
+		if (caption() != null) {
+			m.put("caption", caption());
+		}
+		if (description() != null) {
+			m.put("description", description());
+		}
+		if (id() != null) {
+			m.put("id", id());
+		}
+		if (metadata() != null) {
+			m.put("metadata", metadata());
+		}
+		if (name() != null) {
+			m.put("name", name());
+		}
+		if (shippable() != null) {
+			m.put("shippable", shippable());
+		}
+		if (url() != null) {
+			m.put("url", url());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder active(Boolean value);
+
+		public abstract Builder caption(String value);
+
+		public abstract Builder description(String value);
+
+		public abstract Builder id(String value);
+
+		public abstract Builder metadata(Map<String, String> value);
+
+		public abstract Builder name(String value);
+
+		public abstract Builder shippable(Boolean value);
+
+		public abstract Builder url(String value);
+
+		public abstract CreateProduct build();
+	}
+}

--- a/src/main/java/com/stripe/params/CreateSKU.java
+++ b/src/main/java/com/stripe/params/CreateSKU.java
@@ -1,0 +1,73 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class CreateSKU {
+	@Nullable abstract Boolean active();
+
+	@Nullable abstract String currency();
+
+	@Nullable abstract String id();
+
+	@Nullable abstract String image();
+
+	@Nullable abstract Map<String, String> metadata();
+
+	@Nullable abstract Integer price();
+
+	@Nullable abstract String product();
+
+	public static Builder builder() {
+		return new AutoValue_CreateSKU.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (active() != null) {
+			m.put("active", active());
+		}
+		if (currency() != null) {
+			m.put("currency", currency());
+		}
+		if (id() != null) {
+			m.put("id", id());
+		}
+		if (image() != null) {
+			m.put("image", image());
+		}
+		if (metadata() != null) {
+			m.put("metadata", metadata());
+		}
+		if (price() != null) {
+			m.put("price", price());
+		}
+		if (product() != null) {
+			m.put("product", product());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder active(Boolean value);
+
+		public abstract Builder currency(String value);
+
+		public abstract Builder id(String value);
+
+		public abstract Builder image(String value);
+
+		public abstract Builder metadata(Map<String, String> value);
+
+		public abstract Builder price(Integer value);
+
+		public abstract Builder product(String value);
+
+		public abstract CreateSKU build();
+	}
+}

--- a/src/main/java/com/stripe/params/CreateSource.java
+++ b/src/main/java/com/stripe/params/CreateSource.java
@@ -1,0 +1,73 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class CreateSource {
+	@Nullable abstract Integer amount();
+
+	@Nullable abstract String currency();
+
+	@Nullable abstract String flow();
+
+	@Nullable abstract Map<String, String> metadata();
+
+	@Nullable abstract String token();
+
+	@Nullable abstract String type();
+
+	@Nullable abstract String usage();
+
+	public static Builder builder() {
+		return new AutoValue_CreateSource.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (amount() != null) {
+			m.put("amount", amount());
+		}
+		if (currency() != null) {
+			m.put("currency", currency());
+		}
+		if (flow() != null) {
+			m.put("flow", flow());
+		}
+		if (metadata() != null) {
+			m.put("metadata", metadata());
+		}
+		if (token() != null) {
+			m.put("token", token());
+		}
+		if (type() != null) {
+			m.put("type", type());
+		}
+		if (usage() != null) {
+			m.put("usage", usage());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder amount(Integer value);
+
+		public abstract Builder currency(String value);
+
+		public abstract Builder flow(String value);
+
+		public abstract Builder metadata(Map<String, String> value);
+
+		public abstract Builder token(String value);
+
+		public abstract Builder type(String value);
+
+		public abstract Builder usage(String value);
+
+		public abstract CreateSource build();
+	}
+}

--- a/src/main/java/com/stripe/params/CreateSubscription.java
+++ b/src/main/java/com/stripe/params/CreateSubscription.java
@@ -1,0 +1,94 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class CreateSubscription {
+	@Nullable abstract Double applicationFeePercent();
+
+	@Nullable abstract String coupon();
+
+	@Nullable abstract String customer();
+
+	@Nullable abstract Map<String, String> metadata();
+
+	@Nullable abstract String plan();
+
+	@Nullable abstract Integer quantity();
+
+	@Nullable abstract String source();
+
+	@Nullable abstract Double taxPercent();
+
+	@Nullable abstract String trialEnd();
+
+	@Nullable abstract Integer trialPeriodDays();
+
+	public static Builder builder() {
+		return new AutoValue_CreateSubscription.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (applicationFeePercent() != null) {
+			m.put("application_fee_percent", applicationFeePercent());
+		}
+		if (coupon() != null) {
+			m.put("coupon", coupon());
+		}
+		if (customer() != null) {
+			m.put("customer", customer());
+		}
+		if (metadata() != null) {
+			m.put("metadata", metadata());
+		}
+		if (plan() != null) {
+			m.put("plan", plan());
+		}
+		if (quantity() != null) {
+			m.put("quantity", quantity());
+		}
+		if (source() != null) {
+			m.put("source", source());
+		}
+		if (taxPercent() != null) {
+			m.put("tax_percent", taxPercent());
+		}
+		if (trialEnd() != null) {
+			m.put("trial_end", trialEnd());
+		}
+		if (trialPeriodDays() != null) {
+			m.put("trial_period_days", trialPeriodDays());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder applicationFeePercent(Double value);
+
+		public abstract Builder coupon(String value);
+
+		public abstract Builder customer(String value);
+
+		public abstract Builder metadata(Map<String, String> value);
+
+		public abstract Builder plan(String value);
+
+		public abstract Builder quantity(Integer value);
+
+		public abstract Builder source(String value);
+
+		public abstract Builder taxPercent(Double value);
+
+		public abstract Builder trialEnd(String value);
+
+		public abstract Builder trialPeriodDays(Integer value);
+
+		public abstract CreateSubscription build();
+	}
+}

--- a/src/main/java/com/stripe/params/CreateSubscriptionItem.java
+++ b/src/main/java/com/stripe/params/CreateSubscriptionItem.java
@@ -1,0 +1,59 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class CreateSubscriptionItem {
+	@Nullable abstract String plan();
+
+	@Nullable abstract Boolean prorate();
+
+	@Nullable abstract Integer prorationDate();
+
+	@Nullable abstract Integer quantity();
+
+	@Nullable abstract String subscription();
+
+	public static Builder builder() {
+		return new AutoValue_CreateSubscriptionItem.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (plan() != null) {
+			m.put("plan", plan());
+		}
+		if (prorate() != null) {
+			m.put("prorate", prorate());
+		}
+		if (prorationDate() != null) {
+			m.put("proration_date", prorationDate());
+		}
+		if (quantity() != null) {
+			m.put("quantity", quantity());
+		}
+		if (subscription() != null) {
+			m.put("subscription", subscription());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder plan(String value);
+
+		public abstract Builder prorate(Boolean value);
+
+		public abstract Builder prorationDate(Integer value);
+
+		public abstract Builder quantity(Integer value);
+
+		public abstract Builder subscription(String value);
+
+		public abstract CreateSubscriptionItem build();
+	}
+}

--- a/src/main/java/com/stripe/params/CreateThreeDSecure.java
+++ b/src/main/java/com/stripe/params/CreateThreeDSecure.java
@@ -1,0 +1,59 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class CreateThreeDSecure {
+	@Nullable abstract Integer amount();
+
+	@Nullable abstract String card();
+
+	@Nullable abstract String currency();
+
+	@Nullable abstract String customer();
+
+	@Nullable abstract String returnUrl();
+
+	public static Builder builder() {
+		return new AutoValue_CreateThreeDSecure.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (amount() != null) {
+			m.put("amount", amount());
+		}
+		if (card() != null) {
+			m.put("card", card());
+		}
+		if (currency() != null) {
+			m.put("currency", currency());
+		}
+		if (customer() != null) {
+			m.put("customer", customer());
+		}
+		if (returnUrl() != null) {
+			m.put("return_url", returnUrl());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder amount(Integer value);
+
+		public abstract Builder card(String value);
+
+		public abstract Builder currency(String value);
+
+		public abstract Builder customer(String value);
+
+		public abstract Builder returnUrl(String value);
+
+		public abstract CreateThreeDSecure build();
+	}
+}

--- a/src/main/java/com/stripe/params/CreateTransfer.java
+++ b/src/main/java/com/stripe/params/CreateTransfer.java
@@ -1,0 +1,80 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class CreateTransfer {
+	@Nullable abstract Integer amount();
+
+	@Nullable abstract String currency();
+
+	@Nullable abstract String description();
+
+	@Nullable abstract String destination();
+
+	@Nullable abstract Map<String, String> metadata();
+
+	@Nullable abstract String sourceTransaction();
+
+	@Nullable abstract String sourceType();
+
+	@Nullable abstract String transferGroup();
+
+	public static Builder builder() {
+		return new AutoValue_CreateTransfer.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (amount() != null) {
+			m.put("amount", amount());
+		}
+		if (currency() != null) {
+			m.put("currency", currency());
+		}
+		if (description() != null) {
+			m.put("description", description());
+		}
+		if (destination() != null) {
+			m.put("destination", destination());
+		}
+		if (metadata() != null) {
+			m.put("metadata", metadata());
+		}
+		if (sourceTransaction() != null) {
+			m.put("source_transaction", sourceTransaction());
+		}
+		if (sourceType() != null) {
+			m.put("source_type", sourceType());
+		}
+		if (transferGroup() != null) {
+			m.put("transfer_group", transferGroup());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder amount(Integer value);
+
+		public abstract Builder currency(String value);
+
+		public abstract Builder description(String value);
+
+		public abstract Builder destination(String value);
+
+		public abstract Builder metadata(Map<String, String> value);
+
+		public abstract Builder sourceTransaction(String value);
+
+		public abstract Builder sourceType(String value);
+
+		public abstract Builder transferGroup(String value);
+
+		public abstract CreateTransfer build();
+	}
+}

--- a/src/main/java/com/stripe/params/PayInvoice.java
+++ b/src/main/java/com/stripe/params/PayInvoice.java
@@ -1,0 +1,31 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class PayInvoice {
+	@Nullable abstract String source();
+
+	public static Builder builder() {
+		return new AutoValue_PayInvoice.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (source() != null) {
+			m.put("source", source());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder source(String value);
+
+		public abstract PayInvoice build();
+	}
+}

--- a/src/main/java/com/stripe/params/PayOrder.java
+++ b/src/main/java/com/stripe/params/PayOrder.java
@@ -1,0 +1,66 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class PayOrder {
+	@Nullable abstract Integer applicationFee();
+
+	@Nullable abstract String customer();
+
+	@Nullable abstract String email();
+
+	@Nullable abstract Map<String, String> metadata();
+
+	@Nullable abstract String shippingMethod();
+
+	@Nullable abstract String source();
+
+	public static Builder builder() {
+		return new AutoValue_PayOrder.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (applicationFee() != null) {
+			m.put("application_fee", applicationFee());
+		}
+		if (customer() != null) {
+			m.put("customer", customer());
+		}
+		if (email() != null) {
+			m.put("email", email());
+		}
+		if (metadata() != null) {
+			m.put("metadata", metadata());
+		}
+		if (shippingMethod() != null) {
+			m.put("shipping_method", shippingMethod());
+		}
+		if (source() != null) {
+			m.put("source", source());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder applicationFee(Integer value);
+
+		public abstract Builder customer(String value);
+
+		public abstract Builder email(String value);
+
+		public abstract Builder metadata(Map<String, String> value);
+
+		public abstract Builder shippingMethod(String value);
+
+		public abstract Builder source(String value);
+
+		public abstract PayOrder build();
+	}
+}

--- a/src/main/java/com/stripe/params/RejectAccount.java
+++ b/src/main/java/com/stripe/params/RejectAccount.java
@@ -1,0 +1,31 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class RejectAccount {
+	@Nullable abstract String reason();
+
+	public static Builder builder() {
+		return new AutoValue_RejectAccount.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (reason() != null) {
+			m.put("reason", reason());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder reason(String value);
+
+		public abstract RejectAccount build();
+	}
+}

--- a/src/main/java/com/stripe/params/UpdateAccount.java
+++ b/src/main/java/com/stripe/params/UpdateAccount.java
@@ -1,0 +1,129 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class UpdateAccount {
+	@Nullable abstract String businessLogo();
+
+	@Nullable abstract String businessName();
+
+	@Nullable abstract String businessPrimaryColor();
+
+	@Nullable abstract String businessUrl();
+
+	@Nullable abstract Boolean debitNegativeBalances();
+
+	@Nullable abstract String defaultCurrency();
+
+	@Nullable abstract String email();
+
+	@Nullable abstract String externalAccount();
+
+	@Nullable abstract Map<String, String> metadata();
+
+	@Nullable abstract String payoutStatementDescriptor();
+
+	@Nullable abstract String productDescription();
+
+	@Nullable abstract String statementDescriptor();
+
+	@Nullable abstract String supportEmail();
+
+	@Nullable abstract String supportPhone();
+
+	@Nullable abstract String supportUrl();
+
+	public static Builder builder() {
+		return new AutoValue_UpdateAccount.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (businessLogo() != null) {
+			m.put("business_logo", businessLogo());
+		}
+		if (businessName() != null) {
+			m.put("business_name", businessName());
+		}
+		if (businessPrimaryColor() != null) {
+			m.put("business_primary_color", businessPrimaryColor());
+		}
+		if (businessUrl() != null) {
+			m.put("business_url", businessUrl());
+		}
+		if (debitNegativeBalances() != null) {
+			m.put("debit_negative_balances", debitNegativeBalances());
+		}
+		if (defaultCurrency() != null) {
+			m.put("default_currency", defaultCurrency());
+		}
+		if (email() != null) {
+			m.put("email", email());
+		}
+		if (externalAccount() != null) {
+			m.put("external_account", externalAccount());
+		}
+		if (metadata() != null) {
+			m.put("metadata", metadata());
+		}
+		if (payoutStatementDescriptor() != null) {
+			m.put("payout_statement_descriptor", payoutStatementDescriptor());
+		}
+		if (productDescription() != null) {
+			m.put("product_description", productDescription());
+		}
+		if (statementDescriptor() != null) {
+			m.put("statement_descriptor", statementDescriptor());
+		}
+		if (supportEmail() != null) {
+			m.put("support_email", supportEmail());
+		}
+		if (supportPhone() != null) {
+			m.put("support_phone", supportPhone());
+		}
+		if (supportUrl() != null) {
+			m.put("support_url", supportUrl());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder businessLogo(String value);
+
+		public abstract Builder businessName(String value);
+
+		public abstract Builder businessPrimaryColor(String value);
+
+		public abstract Builder businessUrl(String value);
+
+		public abstract Builder debitNegativeBalances(Boolean value);
+
+		public abstract Builder defaultCurrency(String value);
+
+		public abstract Builder email(String value);
+
+		public abstract Builder externalAccount(String value);
+
+		public abstract Builder metadata(Map<String, String> value);
+
+		public abstract Builder payoutStatementDescriptor(String value);
+
+		public abstract Builder productDescription(String value);
+
+		public abstract Builder statementDescriptor(String value);
+
+		public abstract Builder supportEmail(String value);
+
+		public abstract Builder supportPhone(String value);
+
+		public abstract Builder supportUrl(String value);
+
+		public abstract UpdateAccount build();
+	}
+}

--- a/src/main/java/com/stripe/params/UpdateCard.java
+++ b/src/main/java/com/stripe/params/UpdateCard.java
@@ -1,0 +1,94 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class UpdateCard {
+	@Nullable abstract String addressCity();
+
+	@Nullable abstract String addressCountry();
+
+	@Nullable abstract String addressLine1();
+
+	@Nullable abstract String addressLine2();
+
+	@Nullable abstract String addressState();
+
+	@Nullable abstract String addressZip();
+
+	@Nullable abstract String expMonth();
+
+	@Nullable abstract String expYear();
+
+	@Nullable abstract Map<String, String> metadata();
+
+	@Nullable abstract String name();
+
+	public static Builder builder() {
+		return new AutoValue_UpdateCard.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (addressCity() != null) {
+			m.put("address_city", addressCity());
+		}
+		if (addressCountry() != null) {
+			m.put("address_country", addressCountry());
+		}
+		if (addressLine1() != null) {
+			m.put("address_line1", addressLine1());
+		}
+		if (addressLine2() != null) {
+			m.put("address_line2", addressLine2());
+		}
+		if (addressState() != null) {
+			m.put("address_state", addressState());
+		}
+		if (addressZip() != null) {
+			m.put("address_zip", addressZip());
+		}
+		if (expMonth() != null) {
+			m.put("exp_month", expMonth());
+		}
+		if (expYear() != null) {
+			m.put("exp_year", expYear());
+		}
+		if (metadata() != null) {
+			m.put("metadata", metadata());
+		}
+		if (name() != null) {
+			m.put("name", name());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder addressCity(String value);
+
+		public abstract Builder addressCountry(String value);
+
+		public abstract Builder addressLine1(String value);
+
+		public abstract Builder addressLine2(String value);
+
+		public abstract Builder addressState(String value);
+
+		public abstract Builder addressZip(String value);
+
+		public abstract Builder expMonth(String value);
+
+		public abstract Builder expYear(String value);
+
+		public abstract Builder metadata(Map<String, String> value);
+
+		public abstract Builder name(String value);
+
+		public abstract UpdateCard build();
+	}
+}

--- a/src/main/java/com/stripe/params/UpdateCharge.java
+++ b/src/main/java/com/stripe/params/UpdateCharge.java
@@ -1,0 +1,52 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class UpdateCharge {
+	@Nullable abstract String description();
+
+	@Nullable abstract Map<String, String> metadata();
+
+	@Nullable abstract String receiptEmail();
+
+	@Nullable abstract String transferGroup();
+
+	public static Builder builder() {
+		return new AutoValue_UpdateCharge.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (description() != null) {
+			m.put("description", description());
+		}
+		if (metadata() != null) {
+			m.put("metadata", metadata());
+		}
+		if (receiptEmail() != null) {
+			m.put("receipt_email", receiptEmail());
+		}
+		if (transferGroup() != null) {
+			m.put("transfer_group", transferGroup());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder description(String value);
+
+		public abstract Builder metadata(Map<String, String> value);
+
+		public abstract Builder receiptEmail(String value);
+
+		public abstract Builder transferGroup(String value);
+
+		public abstract UpdateCharge build();
+	}
+}

--- a/src/main/java/com/stripe/params/UpdateCoupon.java
+++ b/src/main/java/com/stripe/params/UpdateCoupon.java
@@ -1,0 +1,31 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class UpdateCoupon {
+	@Nullable abstract Map<String, String> metadata();
+
+	public static Builder builder() {
+		return new AutoValue_UpdateCoupon.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (metadata() != null) {
+			m.put("metadata", metadata());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder metadata(Map<String, String> value);
+
+		public abstract UpdateCoupon build();
+	}
+}

--- a/src/main/java/com/stripe/params/UpdateCustomer.java
+++ b/src/main/java/com/stripe/params/UpdateCustomer.java
@@ -1,0 +1,80 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class UpdateCustomer {
+	@Nullable abstract Integer accountBalance();
+
+	@Nullable abstract String businessVatId();
+
+	@Nullable abstract String coupon();
+
+	@Nullable abstract String defaultSource();
+
+	@Nullable abstract String description();
+
+	@Nullable abstract String email();
+
+	@Nullable abstract Map<String, String> metadata();
+
+	@Nullable abstract String source();
+
+	public static Builder builder() {
+		return new AutoValue_UpdateCustomer.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (accountBalance() != null) {
+			m.put("account_balance", accountBalance());
+		}
+		if (businessVatId() != null) {
+			m.put("business_vat_id", businessVatId());
+		}
+		if (coupon() != null) {
+			m.put("coupon", coupon());
+		}
+		if (defaultSource() != null) {
+			m.put("default_source", defaultSource());
+		}
+		if (description() != null) {
+			m.put("description", description());
+		}
+		if (email() != null) {
+			m.put("email", email());
+		}
+		if (metadata() != null) {
+			m.put("metadata", metadata());
+		}
+		if (source() != null) {
+			m.put("source", source());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder accountBalance(Integer value);
+
+		public abstract Builder businessVatId(String value);
+
+		public abstract Builder coupon(String value);
+
+		public abstract Builder defaultSource(String value);
+
+		public abstract Builder description(String value);
+
+		public abstract Builder email(String value);
+
+		public abstract Builder metadata(Map<String, String> value);
+
+		public abstract Builder source(String value);
+
+		public abstract UpdateCustomer build();
+	}
+}

--- a/src/main/java/com/stripe/params/UpdateDispute.java
+++ b/src/main/java/com/stripe/params/UpdateDispute.java
@@ -1,0 +1,38 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class UpdateDispute {
+	@Nullable abstract Map<String, String> metadata();
+
+	@Nullable abstract Boolean submit();
+
+	public static Builder builder() {
+		return new AutoValue_UpdateDispute.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (metadata() != null) {
+			m.put("metadata", metadata());
+		}
+		if (submit() != null) {
+			m.put("submit", submit());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder metadata(Map<String, String> value);
+
+		public abstract Builder submit(Boolean value);
+
+		public abstract UpdateDispute build();
+	}
+}

--- a/src/main/java/com/stripe/params/UpdateInvoice.java
+++ b/src/main/java/com/stripe/params/UpdateInvoice.java
@@ -1,0 +1,73 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class UpdateInvoice {
+	@Nullable abstract Integer applicationFee();
+
+	@Nullable abstract Boolean closed();
+
+	@Nullable abstract String description();
+
+	@Nullable abstract Boolean forgiven();
+
+	@Nullable abstract Map<String, String> metadata();
+
+	@Nullable abstract String statementDescriptor();
+
+	@Nullable abstract Double taxPercent();
+
+	public static Builder builder() {
+		return new AutoValue_UpdateInvoice.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (applicationFee() != null) {
+			m.put("application_fee", applicationFee());
+		}
+		if (closed() != null) {
+			m.put("closed", closed());
+		}
+		if (description() != null) {
+			m.put("description", description());
+		}
+		if (forgiven() != null) {
+			m.put("forgiven", forgiven());
+		}
+		if (metadata() != null) {
+			m.put("metadata", metadata());
+		}
+		if (statementDescriptor() != null) {
+			m.put("statement_descriptor", statementDescriptor());
+		}
+		if (taxPercent() != null) {
+			m.put("tax_percent", taxPercent());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder applicationFee(Integer value);
+
+		public abstract Builder closed(Boolean value);
+
+		public abstract Builder description(String value);
+
+		public abstract Builder forgiven(Boolean value);
+
+		public abstract Builder metadata(Map<String, String> value);
+
+		public abstract Builder statementDescriptor(String value);
+
+		public abstract Builder taxPercent(Double value);
+
+		public abstract UpdateInvoice build();
+	}
+}

--- a/src/main/java/com/stripe/params/UpdateInvoiceItem.java
+++ b/src/main/java/com/stripe/params/UpdateInvoiceItem.java
@@ -1,0 +1,52 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class UpdateInvoiceItem {
+	@Nullable abstract Integer amount();
+
+	@Nullable abstract String description();
+
+	@Nullable abstract Boolean discountable();
+
+	@Nullable abstract Map<String, String> metadata();
+
+	public static Builder builder() {
+		return new AutoValue_UpdateInvoiceItem.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (amount() != null) {
+			m.put("amount", amount());
+		}
+		if (description() != null) {
+			m.put("description", description());
+		}
+		if (discountable() != null) {
+			m.put("discountable", discountable());
+		}
+		if (metadata() != null) {
+			m.put("metadata", metadata());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder amount(Integer value);
+
+		public abstract Builder description(String value);
+
+		public abstract Builder discountable(Boolean value);
+
+		public abstract Builder metadata(Map<String, String> value);
+
+		public abstract UpdateInvoiceItem build();
+	}
+}

--- a/src/main/java/com/stripe/params/UpdateOrder.java
+++ b/src/main/java/com/stripe/params/UpdateOrder.java
@@ -1,0 +1,52 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class UpdateOrder {
+	@Nullable abstract String coupon();
+
+	@Nullable abstract Map<String, String> metadata();
+
+	@Nullable abstract String selectedShippingMethod();
+
+	@Nullable abstract String status();
+
+	public static Builder builder() {
+		return new AutoValue_UpdateOrder.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (coupon() != null) {
+			m.put("coupon", coupon());
+		}
+		if (metadata() != null) {
+			m.put("metadata", metadata());
+		}
+		if (selectedShippingMethod() != null) {
+			m.put("selected_shipping_method", selectedShippingMethod());
+		}
+		if (status() != null) {
+			m.put("status", status());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder coupon(String value);
+
+		public abstract Builder metadata(Map<String, String> value);
+
+		public abstract Builder selectedShippingMethod(String value);
+
+		public abstract Builder status(String value);
+
+		public abstract UpdateOrder build();
+	}
+}

--- a/src/main/java/com/stripe/params/UpdatePayout.java
+++ b/src/main/java/com/stripe/params/UpdatePayout.java
@@ -1,0 +1,31 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class UpdatePayout {
+	@Nullable abstract Map<String, String> metadata();
+
+	public static Builder builder() {
+		return new AutoValue_UpdatePayout.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (metadata() != null) {
+			m.put("metadata", metadata());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder metadata(Map<String, String> value);
+
+		public abstract UpdatePayout build();
+	}
+}

--- a/src/main/java/com/stripe/params/UpdatePlan.java
+++ b/src/main/java/com/stripe/params/UpdatePlan.java
@@ -1,0 +1,52 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class UpdatePlan {
+	@Nullable abstract Map<String, String> metadata();
+
+	@Nullable abstract String name();
+
+	@Nullable abstract String statementDescriptor();
+
+	@Nullable abstract Integer trialPeriodDays();
+
+	public static Builder builder() {
+		return new AutoValue_UpdatePlan.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (metadata() != null) {
+			m.put("metadata", metadata());
+		}
+		if (name() != null) {
+			m.put("name", name());
+		}
+		if (statementDescriptor() != null) {
+			m.put("statement_descriptor", statementDescriptor());
+		}
+		if (trialPeriodDays() != null) {
+			m.put("trial_period_days", trialPeriodDays());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder metadata(Map<String, String> value);
+
+		public abstract Builder name(String value);
+
+		public abstract Builder statementDescriptor(String value);
+
+		public abstract Builder trialPeriodDays(Integer value);
+
+		public abstract UpdatePlan build();
+	}
+}

--- a/src/main/java/com/stripe/params/UpdateProduct.java
+++ b/src/main/java/com/stripe/params/UpdateProduct.java
@@ -1,0 +1,94 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class UpdateProduct {
+	@Nullable abstract Boolean active();
+
+	@Nullable abstract String attributes();
+
+	@Nullable abstract String caption();
+
+	@Nullable abstract String deactivateOn();
+
+	@Nullable abstract String description();
+
+	@Nullable abstract String images();
+
+	@Nullable abstract Map<String, String> metadata();
+
+	@Nullable abstract String name();
+
+	@Nullable abstract Boolean shippable();
+
+	@Nullable abstract String url();
+
+	public static Builder builder() {
+		return new AutoValue_UpdateProduct.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (active() != null) {
+			m.put("active", active());
+		}
+		if (attributes() != null) {
+			m.put("attributes", attributes());
+		}
+		if (caption() != null) {
+			m.put("caption", caption());
+		}
+		if (deactivateOn() != null) {
+			m.put("deactivate_on", deactivateOn());
+		}
+		if (description() != null) {
+			m.put("description", description());
+		}
+		if (images() != null) {
+			m.put("images", images());
+		}
+		if (metadata() != null) {
+			m.put("metadata", metadata());
+		}
+		if (name() != null) {
+			m.put("name", name());
+		}
+		if (shippable() != null) {
+			m.put("shippable", shippable());
+		}
+		if (url() != null) {
+			m.put("url", url());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder active(Boolean value);
+
+		public abstract Builder attributes(String value);
+
+		public abstract Builder caption(String value);
+
+		public abstract Builder deactivateOn(String value);
+
+		public abstract Builder description(String value);
+
+		public abstract Builder images(String value);
+
+		public abstract Builder metadata(Map<String, String> value);
+
+		public abstract Builder name(String value);
+
+		public abstract Builder shippable(Boolean value);
+
+		public abstract Builder url(String value);
+
+		public abstract UpdateProduct build();
+	}
+}

--- a/src/main/java/com/stripe/params/UpdateRefund.java
+++ b/src/main/java/com/stripe/params/UpdateRefund.java
@@ -1,0 +1,31 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class UpdateRefund {
+	@Nullable abstract Map<String, String> metadata();
+
+	public static Builder builder() {
+		return new AutoValue_UpdateRefund.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (metadata() != null) {
+			m.put("metadata", metadata());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder metadata(Map<String, String> value);
+
+		public abstract UpdateRefund build();
+	}
+}

--- a/src/main/java/com/stripe/params/UpdateSKU.java
+++ b/src/main/java/com/stripe/params/UpdateSKU.java
@@ -1,0 +1,66 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class UpdateSKU {
+	@Nullable abstract Boolean active();
+
+	@Nullable abstract String currency();
+
+	@Nullable abstract String image();
+
+	@Nullable abstract Map<String, String> metadata();
+
+	@Nullable abstract Integer price();
+
+	@Nullable abstract String product();
+
+	public static Builder builder() {
+		return new AutoValue_UpdateSKU.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (active() != null) {
+			m.put("active", active());
+		}
+		if (currency() != null) {
+			m.put("currency", currency());
+		}
+		if (image() != null) {
+			m.put("image", image());
+		}
+		if (metadata() != null) {
+			m.put("metadata", metadata());
+		}
+		if (price() != null) {
+			m.put("price", price());
+		}
+		if (product() != null) {
+			m.put("product", product());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder active(Boolean value);
+
+		public abstract Builder currency(String value);
+
+		public abstract Builder image(String value);
+
+		public abstract Builder metadata(Map<String, String> value);
+
+		public abstract Builder price(Integer value);
+
+		public abstract Builder product(String value);
+
+		public abstract UpdateSKU build();
+	}
+}

--- a/src/main/java/com/stripe/params/UpdateSource.java
+++ b/src/main/java/com/stripe/params/UpdateSource.java
@@ -1,0 +1,31 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class UpdateSource {
+	@Nullable abstract Map<String, String> metadata();
+
+	public static Builder builder() {
+		return new AutoValue_UpdateSource.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (metadata() != null) {
+			m.put("metadata", metadata());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder metadata(Map<String, String> value);
+
+		public abstract UpdateSource build();
+	}
+}

--- a/src/main/java/com/stripe/params/UpdateSubscription.java
+++ b/src/main/java/com/stripe/params/UpdateSubscription.java
@@ -1,0 +1,94 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class UpdateSubscription {
+	@Nullable abstract Double applicationFeePercent();
+
+	@Nullable abstract String coupon();
+
+	@Nullable abstract Map<String, String> metadata();
+
+	@Nullable abstract String plan();
+
+	@Nullable abstract Boolean prorate();
+
+	@Nullable abstract Integer prorationDate();
+
+	@Nullable abstract Integer quantity();
+
+	@Nullable abstract String source();
+
+	@Nullable abstract Double taxPercent();
+
+	@Nullable abstract String trialEnd();
+
+	public static Builder builder() {
+		return new AutoValue_UpdateSubscription.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (applicationFeePercent() != null) {
+			m.put("application_fee_percent", applicationFeePercent());
+		}
+		if (coupon() != null) {
+			m.put("coupon", coupon());
+		}
+		if (metadata() != null) {
+			m.put("metadata", metadata());
+		}
+		if (plan() != null) {
+			m.put("plan", plan());
+		}
+		if (prorate() != null) {
+			m.put("prorate", prorate());
+		}
+		if (prorationDate() != null) {
+			m.put("proration_date", prorationDate());
+		}
+		if (quantity() != null) {
+			m.put("quantity", quantity());
+		}
+		if (source() != null) {
+			m.put("source", source());
+		}
+		if (taxPercent() != null) {
+			m.put("tax_percent", taxPercent());
+		}
+		if (trialEnd() != null) {
+			m.put("trial_end", trialEnd());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder applicationFeePercent(Double value);
+
+		public abstract Builder coupon(String value);
+
+		public abstract Builder metadata(Map<String, String> value);
+
+		public abstract Builder plan(String value);
+
+		public abstract Builder prorate(Boolean value);
+
+		public abstract Builder prorationDate(Integer value);
+
+		public abstract Builder quantity(Integer value);
+
+		public abstract Builder source(String value);
+
+		public abstract Builder taxPercent(Double value);
+
+		public abstract Builder trialEnd(String value);
+
+		public abstract UpdateSubscription build();
+	}
+}

--- a/src/main/java/com/stripe/params/UpdateSubscriptionItem.java
+++ b/src/main/java/com/stripe/params/UpdateSubscriptionItem.java
@@ -1,0 +1,52 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class UpdateSubscriptionItem {
+	@Nullable abstract String plan();
+
+	@Nullable abstract Boolean prorate();
+
+	@Nullable abstract Integer prorationDate();
+
+	@Nullable abstract Integer quantity();
+
+	public static Builder builder() {
+		return new AutoValue_UpdateSubscriptionItem.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (plan() != null) {
+			m.put("plan", plan());
+		}
+		if (prorate() != null) {
+			m.put("prorate", prorate());
+		}
+		if (prorationDate() != null) {
+			m.put("proration_date", prorationDate());
+		}
+		if (quantity() != null) {
+			m.put("quantity", quantity());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder plan(String value);
+
+		public abstract Builder prorate(Boolean value);
+
+		public abstract Builder prorationDate(Integer value);
+
+		public abstract Builder quantity(Integer value);
+
+		public abstract UpdateSubscriptionItem build();
+	}
+}

--- a/src/main/java/com/stripe/params/UpdateTransfer.java
+++ b/src/main/java/com/stripe/params/UpdateTransfer.java
@@ -1,0 +1,31 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class UpdateTransfer {
+	@Nullable abstract Map<String, String> metadata();
+
+	public static Builder builder() {
+		return new AutoValue_UpdateTransfer.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (metadata() != null) {
+			m.put("metadata", metadata());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder metadata(Map<String, String> value);
+
+		public abstract UpdateTransfer build();
+	}
+}

--- a/src/main/java/com/stripe/params/VerifySource.java
+++ b/src/main/java/com/stripe/params/VerifySource.java
@@ -1,0 +1,31 @@
+package com.stripe.params;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class VerifySource {
+	@Nullable abstract String verificationMethod();
+
+	public static Builder builder() {
+		return new AutoValue_VerifySource.Builder();
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<String, Object>();
+		if (verificationMethod() != null) {
+			m.put("verification_method", verificationMethod());
+		}
+		return m;
+	}
+
+	@AutoValue.Builder
+	public abstract static class Builder {
+		public abstract Builder verificationMethod(String value);
+
+		public abstract VerifySource build();
+	}
+}

--- a/src/test/java/com/stripe/model/ExternalAccountTest.java
+++ b/src/test/java/com/stripe/model/ExternalAccountTest.java
@@ -92,7 +92,7 @@ public class ExternalAccountTest extends BaseStripeTest {
 	public void testManagedAccountHasAvailablePayoutMethods() throws StripeException, IOException {
 		stubNetwork(Account.class, resource("managed_account.json"));
 
-		Account account = Account.create(null);
+		Account account = Account.create(new HashMap<String, Object>());
 
 		assertTrue(account.getManaged());
 

--- a/src/test/java/com/stripe/model/StandardizationTest.java
+++ b/src/test/java/com/stripe/model/StandardizationTest.java
@@ -87,24 +87,14 @@ public class StandardizationTest {
 				if (parameters.isEmpty()) {
 					continue;
 				}
-				Parameter lastParam = parameters.get(parameters.size() - 1);
-				Class<?> finalParamType = lastParam.getType().getRawType();
 
 				// Skip methods that have exactly one param which is a map.
-				if (Map.class.equals(finalParamType) && parameters.size() == 1) {
+				if (parameters.size() == 1) {
 					continue;
 				}
 
-				// Skip `public static Foo retrieve(String id) {...` helper methods
-				if (String.class.equals(finalParamType) && parameters.size() == 1 && "retrieve".equals(method.getName())) {
-					continue;
-				}
-
-				// Skip the `public static Card createCard(String id) {...` helper method on Customer.
-				if (String.class.equals(finalParamType) && parameters.size() == 1
-						&& ("createCard".equals(method.getName()) || "createBankAccount".equals(method.getName()))) {
-					continue;
-				}
+				Parameter lastParam = parameters.get(parameters.size() - 1);
+				Class<?> finalParamType = lastParam.getType().getRawType();
 
 				if (RequestOptions.class.isAssignableFrom(finalParamType)) {
 					continue;


### PR DESCRIPTION
The current interface for creating and updating records requires manual construction of HashMaps. 

```java
Map<String, Object> planParams = new HashMap<String, Object>();
planParams.put("amount", 5000);
planParams.put("interval", "month");
planParams.put("name", "Gold large");
planParams.put("currency", "usd");
planParams.put("id", "gold-large");
Plan.create(planParams);
```

This pull requests uses Google AutoValue to generate a typed interface for API requests. Creating a plan can now be down in a type-safe manner.

```java
CreatePlan params = CreatePlan.builder()
    .amount(5000)
    .interval("month")
    .name("Gold large")
    .currency("usd")
    .id("gold-large")
    .build()
Plan.create(params);
```

### Breaking changes
If you were calling a method with null before, you'll need to cast or pass an empty value object now.

```diff
-Account account = Account.create(null);
+Account account = Account.create(new HashMap<String, Object>());
```

### TODO
- [x] Support nullable arguments
- [x] Update all methods to include a signature with the correct ValueObject

### Future work
- Support nested input parameters
- Use annotations to instead of `toMap`
- Type safe interface for retrieval methods (`all`, `retrieve`, etc.)