### PR TITLE
Force UTF-8 encoding when verifying signatures

### DIFF
--- a/src/main/java/com/stripe/net/Webhook.java
+++ b/src/main/java/com/stripe/net/Webhook.java
@@ -4,6 +4,7 @@ import com.stripe.exception.SignatureVerificationException;
 import com.stripe.model.Event;
 import com.stripe.model.StripeObject;
 
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
 import java.security.InvalidKeyException;
@@ -154,7 +155,7 @@ public final class Webhook {
 		 * @param secret  the secret used to generate the signature.
 		 * @return the signature as a string.
 		 */
-		private static String computeSignature(String payload, String secret) throws NoSuchAlgorithmException, InvalidKeyException {
+		private static String computeSignature(String payload, String secret) throws UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException {
 			return Util.computeHmacSHA256(secret, payload);
 		}
 	}
@@ -167,10 +168,10 @@ public final class Webhook {
 		 * @param message the message.
 		 * @return the code as a string.
 		 */
-		public static String computeHmacSHA256(String key, String message) throws NoSuchAlgorithmException, InvalidKeyException {
+		public static String computeHmacSHA256(String key, String message) throws UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException {
 			Mac hasher = Mac.getInstance("HmacSHA256");
-			hasher.init(new SecretKeySpec(key.getBytes(), "HmacSHA256"));
-			byte[] hash = hasher.doFinal(message.getBytes());
+			hasher.init(new SecretKeySpec(key.getBytes("UTF8"), "HmacSHA256"));
+			byte[] hash = hasher.doFinal(message.getBytes("UTF8"));
 			String result = "";
 			for (byte b : hash) {
 				result += Integer.toString((b & 0xff) + 0x100, 16).substring(1);

--- a/src/test/java/com/stripe/net/WebhookTest.java
+++ b/src/test/java/com/stripe/net/WebhookTest.java
@@ -9,6 +9,7 @@ import com.stripe.net.Webhook;
 import com.google.gson.JsonSyntaxException;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
@@ -32,12 +33,12 @@ public class WebhookTest extends BaseStripeTest {
 		payload = "{\n  \"id\": \"evt_test_webhook\",\n  \"object\": \"event\"\n}";
 	}
 
-	public String generateSigHeader() throws NoSuchAlgorithmException, InvalidKeyException {
+	public String generateSigHeader() throws UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException {
 		Map<String, Object> options = new HashMap<String, Object>();
 		return generateSigHeader(options);
 	}
 
-	public String generateSigHeader(Map<String, Object> options) throws NoSuchAlgorithmException, InvalidKeyException {
+	public String generateSigHeader(Map<String, Object> options) throws UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException {
 		long timestamp = (options.get("timestamp") != null) ? ((Long) options.get("timestamp")).longValue() : Webhook.Util.getTimeNow();
 		String payload = (options.get("payload") != null) ? (String) options.get("payload") : WebhookTest.payload;
 		String secret = (options.get("secret") != null) ? (String) options.get("secret") : WebhookTest.secret;
@@ -57,7 +58,7 @@ public class WebhookTest extends BaseStripeTest {
 	public ExpectedException thrown = ExpectedException.none();
 
 	@Test
-	public void testValidJsonAndHeader() throws SignatureVerificationException, NoSuchAlgorithmException, InvalidKeyException {
+	public void testValidJsonAndHeader() throws SignatureVerificationException, UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException {
 		String sigHeader = generateSigHeader();
 
 		Event event = Webhook.constructEvent(payload, sigHeader, secret);
@@ -66,7 +67,7 @@ public class WebhookTest extends BaseStripeTest {
 	}
 
 	@Test(expected = JsonSyntaxException.class)
-	public void testInvalidJson() throws SignatureVerificationException, NoSuchAlgorithmException, InvalidKeyException {
+	public void testInvalidJson() throws SignatureVerificationException, UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException {
 		String payload = "this is not valid JSON";
 		Map<String, Object> options = new HashMap<String, Object>();
 		options.put("payload", payload);
@@ -93,7 +94,7 @@ public class WebhookTest extends BaseStripeTest {
 	}
 
 	@Test
-	public void testNoSignaturesWithExpectedScheme() throws SignatureVerificationException, NoSuchAlgorithmException, InvalidKeyException {
+	public void testNoSignaturesWithExpectedScheme() throws SignatureVerificationException, UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException {
 		Map<String, Object> options = new HashMap<String, Object>();
 		options.put("scheme", "v0");
 		String sigHeader = generateSigHeader(options);
@@ -105,7 +106,7 @@ public class WebhookTest extends BaseStripeTest {
 	}
 
 	@Test
-	public void testNoValidSignatureForPayload() throws SignatureVerificationException, NoSuchAlgorithmException, InvalidKeyException {
+	public void testNoValidSignatureForPayload() throws SignatureVerificationException, UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException {
 		Map<String, Object> options = new HashMap<String, Object>();
 		options.put("signature", "bad_signature");
 		String sigHeader = generateSigHeader(options);
@@ -117,7 +118,7 @@ public class WebhookTest extends BaseStripeTest {
 	}
 
 	@Test
-	public void testTimestampOutsideTolerance() throws SignatureVerificationException, NoSuchAlgorithmException, InvalidKeyException {
+	public void testTimestampOutsideTolerance() throws SignatureVerificationException, UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException {
 		Map<String, Object> options = new HashMap<String, Object>();
 		options.put("timestamp", Webhook.Util.getTimeNow() - 15);
 		String sigHeader = generateSigHeader(options);
@@ -129,14 +130,14 @@ public class WebhookTest extends BaseStripeTest {
 	}
 
 	@Test
-	public void testValidHeaderAndSignature() throws SignatureVerificationException, NoSuchAlgorithmException, InvalidKeyException {
+	public void testValidHeaderAndSignature() throws SignatureVerificationException, UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException {
 		String sigHeader = generateSigHeader();
 
 		assertTrue(Webhook.Signature.verifyHeader(payload, sigHeader, secret, 10));
 	}
 
 	@Test
-	public void testHeaderContainsValidSignature() throws SignatureVerificationException, NoSuchAlgorithmException, InvalidKeyException {
+	public void testHeaderContainsValidSignature() throws SignatureVerificationException, UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException {
 		String sigHeader = generateSigHeader();
 		sigHeader += ",v1=bad_signature";
 
@@ -144,7 +145,7 @@ public class WebhookTest extends BaseStripeTest {
 	}
 
 	@Test
-	public void testTimestampOffButNoTolerance() throws SignatureVerificationException, NoSuchAlgorithmException, InvalidKeyException {
+	public void testTimestampOffButNoTolerance() throws SignatureVerificationException, UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException {
 		Map<String, Object> options = new HashMap<String, Object>();
 		options.put("timestamp", Long.valueOf(12345L));
 		String sigHeader = generateSigHeader(options);


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

This was reported by a user. [`getBytes()`](https://docs.oracle.com/javase/7/docs/api/java/lang/String.html#getBytes()) without any parameters will use the platform's default encoding. Since the header and payload sent by Stripe will always UTF-8, we should force the encoding when decoding these strings.
