### PR TITLE
Drop support for Java < 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 
 jdk:
-  - openjdk6
   - openjdk7
   - oraclejdk7
   - oraclejdk8

--- a/pom.xml
+++ b/pom.xml
@@ -82,8 +82,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

A few updates since we officially no longer support Java 6.

We also probably can get rid of some code in `StripeSSLSocketFactory` as Java 7 should always support TLS 1.2 (though it still needs to be explicitly enabled as it isn't used by default), but any such changes should be handled in a separate PR and tested thoroughly.
