### PR TITLE
OAuth support

### DIFF
--- a/src/main/java/com/stripe/Stripe.java
+++ b/src/main/java/com/stripe/Stripe.java
@@ -9,10 +9,12 @@ public abstract class Stripe {
 
 	public static final String UPLOAD_API_BASE = "https://uploads.stripe.com";
 	public static final String LIVE_API_BASE = "https://api.stripe.com";
+	public static final String CONNECT_API_BASE = "https://connect.stripe.com";
 	public static final String VERSION = "5.7.1";
 
 	public static volatile String apiKey;
 	public static volatile String apiVersion;
+	public static volatile String clientId;
 
 	// Note that URLConnection reserves the value of 0 to mean "infinite
 	// timeout", so we use -1 here to represent an unset value which should
@@ -21,6 +23,7 @@ public abstract class Stripe {
 	private static volatile int readTimeout = -1;
 
 	private static volatile String apiBase = LIVE_API_BASE;
+	private static volatile String connectBase = CONNECT_API_BASE;
 	private static volatile Proxy connectionProxy = null;
 	private static volatile PasswordAuthentication proxyCredential = null;
 
@@ -35,6 +38,19 @@ public abstract class Stripe {
 
 	public static String getApiBase() {
 		return apiBase;
+	}
+
+	/**
+	 * (FOR TESTING ONLY) If you'd like your OAuth requests to hit your own
+	 * (mocked) server, you can set this up here by overriding the base Connect
+	 * URL.
+	 */
+	public static void overrideConnectBase(final String overriddenConnectBase) {
+		connectBase = overriddenConnectBase;
+	}
+
+	public static String getConnectBase() {
+		return connectBase;
 	}
 
 	/**

--- a/src/main/java/com/stripe/exception/oauth/InvalidClientException.java
+++ b/src/main/java/com/stripe/exception/oauth/InvalidClientException.java
@@ -1,0 +1,14 @@
+package com.stripe.exception.oauth;
+
+/**
+ * InvalidClientException is raised when authentication fails.
+ */
+public class InvalidClientException extends OAuthException {
+
+	private static final long serialVersionUID = 1L;
+
+	public InvalidClientException(String code, String description, String requestId, Integer statusCode, Throwable e) {
+		super(code, description, requestId, statusCode, e);
+	}
+
+}

--- a/src/main/java/com/stripe/exception/oauth/InvalidGrantException.java
+++ b/src/main/java/com/stripe/exception/oauth/InvalidGrantException.java
@@ -1,0 +1,17 @@
+package com.stripe.exception.oauth;
+
+/**
+ * InvalidGrantException is raised when a specified code doesn't exist, is
+ * expired, has been used, or doesn't belong to you; a refresh token doesn't
+ * exist, or doesn't belong to you; or if an API key's mode (live or test)
+ * doesn't match the mode of a code or refresh token.
+ */
+public class InvalidGrantException extends OAuthException {
+
+	private static final long serialVersionUID = 1L;
+
+	public InvalidGrantException(String code, String description, String requestId, Integer statusCode, Throwable e) {
+		super(code, description, requestId, statusCode, e);
+	}
+
+}

--- a/src/main/java/com/stripe/exception/oauth/InvalidRequestException.java
+++ b/src/main/java/com/stripe/exception/oauth/InvalidRequestException.java
@@ -1,0 +1,15 @@
+package com.stripe.exception.oauth;
+
+/**
+ * InvalidRequestException is raised when a code, refresh token, or grant type
+ * parameter is not provided, but was required.
+ */
+public class InvalidRequestException extends OAuthException {
+
+	private static final long serialVersionUID = 1L;
+
+	public InvalidRequestException(String code, String description, String requestId, Integer statusCode, Throwable e) {
+		super(code, description, requestId, statusCode, e);
+	}
+
+}

--- a/src/main/java/com/stripe/exception/oauth/InvalidScopeException.java
+++ b/src/main/java/com/stripe/exception/oauth/InvalidScopeException.java
@@ -1,0 +1,14 @@
+package com.stripe.exception.oauth;
+
+/**
+ * InvalidScopeException is raised when an invalid scope parameter is provided.
+ */
+public class InvalidScopeException extends OAuthException {
+
+	private static final long serialVersionUID = 1L;
+
+	public InvalidScopeException(String code, String description, String requestId, Integer statusCode, Throwable e) {
+		super(code, description, requestId, statusCode, e);
+	}
+
+}

--- a/src/main/java/com/stripe/exception/oauth/OAuthException.java
+++ b/src/main/java/com/stripe/exception/oauth/OAuthException.java
@@ -1,0 +1,22 @@
+package com.stripe.exception.oauth;
+
+import com.stripe.exception.StripeException;
+
+/**
+ * Base parent class for all OAuth exceptions.
+ */
+public class OAuthException extends StripeException {
+
+	private static final long serialVersionUID = 1L;
+
+	private final String code;
+
+	public OAuthException(String code, String description, String requestId, Integer statusCode, Throwable e) {
+		super(description, requestId, statusCode, e);
+		this.code = code;
+	}
+
+	public String getCode() {
+		return code;
+	}
+}

--- a/src/main/java/com/stripe/exception/oauth/UnsupportedGrantTypeException.java
+++ b/src/main/java/com/stripe/exception/oauth/UnsupportedGrantTypeException.java
@@ -1,0 +1,15 @@
+package com.stripe.exception.oauth;
+
+/**
+ * UnsupportedGrantTypeException is raised when an unuspported grant type
+ * parameter is specified.
+ */
+public class UnsupportedGrantTypeException extends OAuthException {
+
+	private static final long serialVersionUID = 1L;
+
+	public UnsupportedGrantTypeException(String code, String description, String requestId, Integer statusCode, Throwable e) {
+		super(code, description, requestId, statusCode, e);
+	}
+
+}

--- a/src/main/java/com/stripe/exception/oauth/UnsupportedResponseTypeException.java
+++ b/src/main/java/com/stripe/exception/oauth/UnsupportedResponseTypeException.java
@@ -1,0 +1,15 @@
+package com.stripe.exception.oauth;
+
+/**
+ * UnsupportedResponseTypeException is raised when an unsupported response type
+ * parameter is specified.
+ */
+public class UnsupportedResponseTypeException extends OAuthException {
+
+	private static final long serialVersionUID = 1L;
+
+	public UnsupportedResponseTypeException(String code, String description, String requestId, Integer statusCode, Throwable e) {
+		super(code, description, requestId, statusCode, e);
+	}
+
+}

--- a/src/main/java/com/stripe/model/oauth/DeauthorizedAccount.java
+++ b/src/main/java/com/stripe/model/oauth/DeauthorizedAccount.java
@@ -1,0 +1,15 @@
+package com.stripe.model.oauth;
+
+import com.stripe.model.StripeObject;
+
+public class DeauthorizedAccount extends StripeObject {
+	String stripeUserId;
+
+	public String getStripeUserId() {
+		return stripeUserId;
+	}
+
+	public void setStripeUserId(String stripeUserId) {
+		this.stripeUserId = stripeUserId;
+	}
+}

--- a/src/main/java/com/stripe/model/oauth/TokenResponse.java
+++ b/src/main/java/com/stripe/model/oauth/TokenResponse.java
@@ -1,0 +1,33 @@
+package com.stripe.model.oauth;
+
+import com.stripe.model.StripeObject;
+
+public class TokenResponse extends StripeObject {
+	Boolean livemode;
+	String scope;
+	String stripeUserId;
+
+	public Boolean getLivemode() {
+		return livemode;
+	}
+
+	public void setLivemode(Boolean livemode) {
+		this.livemode = livemode;
+	}
+
+	public String getScope() {
+		return scope;
+	}
+
+	public void setScope(String scope) {
+		this.scope = scope;
+	}
+
+	public String getStripeUserId() {
+		return stripeUserId;
+	}
+
+	public void setStripeUserId(String stripeUserId) {
+		this.stripeUserId = stripeUserId;
+	}
+}

--- a/src/main/java/com/stripe/net/OAuth.java
+++ b/src/main/java/com/stripe/net/OAuth.java
@@ -1,0 +1,115 @@
+package com.stripe.net;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Map;
+
+import com.stripe.Stripe;
+import com.stripe.exception.APIConnectionException;
+import com.stripe.exception.APIException;
+import com.stripe.exception.AuthenticationException;
+import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.oauth.OAuthException;
+import com.stripe.model.oauth.DeauthorizedAccount;
+import com.stripe.model.oauth.TokenResponse;
+import com.stripe.net.APIResource;
+import com.stripe.net.LiveStripeResponseGetter;
+import com.stripe.net.RequestOptions;
+import com.stripe.net.StripeResponseGetter;
+
+public final class OAuth {
+	private static StripeResponseGetter stripeResponseGetter = new LiveStripeResponseGetter();
+
+	public static void setStripeResponseGetter(StripeResponseGetter srg) {
+		OAuth.stripeResponseGetter = srg;
+	}
+
+	/**
+	 * Generates a URL to Stripe's OAuth form.
+	 *
+	 * @param params  the parameters to include in the URL.
+	 * @param options the request options.
+	 * @return the URL to Stripe's OAuth form.
+	 */
+	public static String authorizeURL(Map<String, Object> params, RequestOptions options) throws AuthenticationException, InvalidRequestException {
+		String base = Stripe.getConnectBase();
+
+		params.put("client_id", getClientId(params, options));
+		if (params.get("response_type") == null) {
+			params.put("response_type", "code");
+		}
+		String query;
+		try {
+			query = LiveStripeResponseGetter.createQuery(params);
+		} catch (UnsupportedEncodingException e) {
+			throw new InvalidRequestException("Unable to encode parameters to "
+					+ APIResource.CHARSET
+					+ ". Please contact support@stripe.com for assistance.",
+					null, null, 0, e);
+		}
+
+		String url = base + "/oauth/authorize?" + query;
+		return url;
+	}
+
+
+	/**
+	 * Uses an authorization code to connect an account to your platform and
+	 * fetch the user's credentials.
+	 *
+	 * @param params  the request parameters.
+	 * @param options the request options.
+	 * @return the TokenResponse instance containing the response from the OAuth
+	 *         API.
+	 */
+	public static TokenResponse token(Map<String, Object> params, RequestOptions options) throws AuthenticationException, InvalidRequestException, APIConnectionException, APIException, OAuthException {
+		String url = Stripe.getConnectBase() + "/oauth/token";
+		return OAuth.stripeResponseGetter.oAuthRequest(APIResource.RequestMethod.POST, url, params, TokenResponse.class,
+				APIResource.RequestType.NORMAL, options);
+	}
+
+
+	/**
+	 * Disconnects an account from your platform.
+	 *
+	 * @param params  the request parameters.
+	 * @param options the request options.
+	 * @return the DeauthorizedAccount instance containing the response from the
+	 *         OAuth API.
+	 */
+	public static DeauthorizedAccount deauthorize(Map<String, Object> params, RequestOptions options) throws AuthenticationException, InvalidRequestException, APIConnectionException, APIException, OAuthException {
+		String url = Stripe.getConnectBase() + "/oauth/deauthorize";
+		params.put("client_id", getClientId(params, options));
+		return OAuth.stripeResponseGetter.oAuthRequest(APIResource.RequestMethod.POST, url, params, DeauthorizedAccount.class,
+				APIResource.RequestType.NORMAL, options);
+	}
+
+	/**
+	 * Returns the client_id to use in OAuth requests.
+	 *
+	 * @param params  the request parameters.
+	 * @param options the request options.
+	 * @return the client_id.
+	 */
+	private static String getClientId(Map<String, Object> params, RequestOptions options) throws AuthenticationException {
+		String clientId = Stripe.clientId;
+		if ((options != null) && (options.getClientId() != null)) {
+			clientId = options.getClientId();
+		}
+		if ((params != null) && (params.get("client_id") != null)) {
+			clientId = (String) params.get("client_id");
+		}
+
+		if (clientId == null) {
+			throw new AuthenticationException(
+					"No client_id provided. (HINT: set client_id key using 'Stripe.clientId = <CLIENT-ID>'. "
+							+ "You can find your client_ids in your Stripe dashboard at "
+							+ "https://dashboard.stripe.com/account/applications/settings, "
+							+ "after registering your account as a platform. See "
+							+ "https://stripe.com/docs/connect/standard-accounts for details, "
+							+ "or email support@stripe.com if you have any questions.",
+					null, 0);
+		}
+
+		return clientId;
+	}
+}

--- a/src/main/java/com/stripe/net/RequestOptions.java
+++ b/src/main/java/com/stripe/net/RequestOptions.java
@@ -4,18 +4,20 @@ import com.stripe.Stripe;
 
 public class RequestOptions {
 	public static RequestOptions getDefault() {
-		return new RequestOptions(Stripe.apiKey, Stripe.apiVersion, null, null, Stripe.getConnectTimeout(), Stripe.getReadTimeout());
+		return new RequestOptions(Stripe.apiKey, Stripe.clientId, Stripe.apiVersion, null, null, Stripe.getConnectTimeout(), Stripe.getReadTimeout());
 	}
 
 	private final String apiKey;
+	private final String clientId;
 	private final String stripeVersion;
 	private final String idempotencyKey;
 	private final String stripeAccount;
 	private final int connectTimeout;
 	private final int readTimeout;
 
-	private RequestOptions(String apiKey, String stripeVersion, String idempotencyKey, String stripeAccount, int connectTimeout, int readTimeout) {
+	private RequestOptions(String apiKey, String clientId, String stripeVersion, String idempotencyKey, String stripeAccount, int connectTimeout, int readTimeout) {
 		this.apiKey = apiKey;
+		this.clientId = clientId;
 		this.stripeVersion = stripeVersion;
 		this.idempotencyKey = idempotencyKey;
 		this.stripeAccount = stripeAccount;
@@ -25,6 +27,10 @@ public class RequestOptions {
 
 	public String getApiKey() {
 		return apiKey;
+	}
+
+	public String getClientId() {
+		return clientId;
 	}
 
 	public String getStripeVersion() {
@@ -57,6 +63,9 @@ public class RequestOptions {
 		if (apiKey != null ? !apiKey.equals(that.apiKey) : that.apiKey != null) {
 			return false;
 		}
+		if (clientId != null ? !clientId.equals(that.clientId) : that.clientId != null) {
+			return false;
+		}
 		if (idempotencyKey != null ? !idempotencyKey.equals(that.idempotencyKey) : that.idempotencyKey != null) {
 			return false;
 		}
@@ -74,6 +83,7 @@ public class RequestOptions {
 	@Override
 	public int hashCode() {
 		int result = apiKey != null ? apiKey.hashCode() : 0;
+		result = 31 * result + (clientId != null ? clientId.hashCode() : 0);
 		result = 31 * result + (stripeVersion != null ? stripeVersion.hashCode() : 0);
 		result = 31 * result + (idempotencyKey != null ? idempotencyKey.hashCode() : 0);
 		result = 31 * result + readTimeout;
@@ -91,6 +101,7 @@ public class RequestOptions {
 
 	public static final class RequestOptionsBuilder {
 		private String apiKey;
+		private String clientId;
 		private String stripeVersion;
 		private String idempotencyKey;
 		private String stripeAccount;
@@ -99,11 +110,16 @@ public class RequestOptions {
 
 		public RequestOptionsBuilder() {
 			this.apiKey = Stripe.apiKey;
+			this.clientId = Stripe.clientId;
 			this.stripeVersion = Stripe.apiVersion;
 		}
 
 		public String getApiKey() {
 			return apiKey;
+		}
+
+		public String getClientId() {
+			return clientId;
 		}
 
 		public RequestOptionsBuilder setApiKey(String apiKey) {
@@ -190,6 +206,7 @@ public class RequestOptions {
 		public RequestOptions build() {
 			return new RequestOptions(
 					normalizeApiKey(this.apiKey),
+					normalizeClientId(this.clientId),
 					normalizeStripeVersion(this.stripeVersion),
 					normalizeIdempotencyKey(this.idempotencyKey),
 					normalizeStripeAccount(this.stripeAccount),
@@ -206,6 +223,18 @@ public class RequestOptions {
 		String normalized = apiKey.trim();
 		if (normalized.isEmpty()) {
 			throw new InvalidRequestOptionsException("Empty API key specified!");
+		}
+		return normalized;
+	}
+
+	private static String normalizeClientId(String clientId) {
+		// null client_ids are considered "valid"
+		if (clientId == null) {
+			return null;
+		}
+		String normalized = clientId.trim();
+		if (normalized.isEmpty()) {
+			throw new InvalidRequestOptionsException("Empty client_id specified!");
 		}
 		return normalized;
 	}

--- a/src/main/java/com/stripe/net/StripeResponse.java
+++ b/src/main/java/com/stripe/net/StripeResponse.java
@@ -40,4 +40,14 @@ public class StripeResponse {
 	public Map<String, List<String>> getResponseHeaders() {
 		return responseHeaders;
 	}
+
+	public String getRequestId() {
+		String requestId = null;
+		Map<String, List<String>> headers = getResponseHeaders();
+		List<String> requestIdList = headers == null ? null : headers.get("Request-Id");
+		if (requestIdList != null && requestIdList.size() > 0) {
+			requestId = requestIdList.get(0);
+		}
+		return requestId;
+	}
 }

--- a/src/main/java/com/stripe/net/StripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/StripeResponseGetter.java
@@ -5,6 +5,7 @@ import com.stripe.exception.APIException;
 import com.stripe.exception.AuthenticationException;
 import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.oauth.OAuthException;
 
 import java.util.Map;
 
@@ -16,5 +17,15 @@ public interface StripeResponseGetter {
 			Class<T> clazz,
 			APIResource.RequestType type,
 			RequestOptions options) throws AuthenticationException, InvalidRequestException, APIConnectionException, CardException, APIException;
+
+	<T> T oAuthRequest(
+			APIResource.RequestMethod method,
+			String url,
+			Map<String, Object> params,
+			Class<T> clazz,
+			APIResource.RequestType type,
+			RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, APIException, OAuthException;
 }
 

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -116,6 +116,16 @@ public class BaseStripeTest {
 				Mockito.any(RequestOptions.class))).thenReturn(APIResource.GSON.fromJson(response, clazz));
 	}
 
+	public static <T> void stubOAuth(Class<T> clazz, String response) throws StripeException {
+		when(networkMock.oAuthRequest(
+				Mockito.any(APIResource.RequestMethod.class),
+				Mockito.anyString(),
+				Mockito.<Map<String, Object>>any(),
+				Mockito.<Class<T>>any(),
+				Mockito.any(APIResource.RequestType.class),
+				Mockito.any(RequestOptions.class))).thenReturn(APIResource.GSON.fromJson(response, clazz));
+	}
+
 	public static class ParamMapMatcher extends ArgumentMatcher<Map<String, Object>> {
 		private Map<String, Object> other;
 

--- a/src/test/java/com/stripe/net/OAuthTest.java
+++ b/src/test/java/com/stripe/net/OAuthTest.java
@@ -1,0 +1,104 @@
+package com.stripe.net;
+
+import com.stripe.BaseStripeTest;
+import com.stripe.Stripe;
+import com.stripe.exception.AuthenticationException;
+import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
+import com.stripe.model.oauth.DeauthorizedAccount;
+import com.stripe.model.oauth.TokenResponse;
+import com.stripe.net.OAuth;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.util.HashMap;
+import java.util.Map;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.net.MalformedURLException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class OAuthTest extends BaseStripeTest {
+	@Before
+	public void setUpMockAndClientId() {
+		OAuth.setStripeResponseGetter(networkMock);
+		Stripe.clientId = "ca_test";
+	}
+
+	@After
+	public void tearDownMockAndClientId() {
+		Stripe.clientId = null;
+		OAuth.setStripeResponseGetter(new LiveStripeResponseGetter());
+	}
+
+	private static Map<String, String> splitQuery(String query) throws UnsupportedEncodingException {
+		Map<String, String> queryPairs = new HashMap<String, String>();
+		String[] pairs = query.split("&");
+		for (String pair : pairs) {
+			int idx = pair.indexOf("=");
+			queryPairs.put(URLDecoder.decode(pair.substring(0, idx), "UTF8"), URLDecoder.decode(pair.substring(idx + 1), "UTF8"));
+		}
+		return queryPairs;
+	}
+
+	@Test
+	public void testAuthorizeURL() throws AuthenticationException, InvalidRequestException, MalformedURLException, UnsupportedEncodingException {
+		Map<String, Object> urlParams = new HashMap<String, Object>();
+		urlParams.put("scope", "read_write");
+		urlParams.put("state", "csrf_token");
+		Map<String, Object> stripeUserParams = new HashMap<String, Object>();
+		stripeUserParams.put("email", "test@example.com");
+		stripeUserParams.put("url", "https://example.com/profile/test");
+		stripeUserParams.put("country", "US");
+		urlParams.put("stripe_user", stripeUserParams);
+
+		String urlStr = OAuth.authorizeURL(urlParams, null);
+
+		URL url = new URL(urlStr);
+		Map<String, String> queryPairs = splitQuery(url.getQuery());
+
+		assertEquals("https", url.getProtocol());
+		assertEquals("connect.stripe.com", url.getHost());
+		assertEquals("/oauth/authorize", url.getPath());
+
+		assertEquals("ca_test", queryPairs.get("client_id"));
+		assertEquals("read_write", queryPairs.get("scope"));
+		assertEquals("test@example.com", queryPairs.get("stripe_user[email]"));
+		assertEquals("https://example.com/profile/test", queryPairs.get("stripe_user[url]"));
+		assertEquals("US", queryPairs.get("stripe_user[country]"));
+	}
+
+	@Test
+	public void testToken() throws StripeException, IOException {
+		String json = resource("../model/oauth_token_response.json");
+		stubOAuth(TokenResponse.class, json);
+
+		Map<String, Object> tokenParams = new HashMap<String, Object>();
+		tokenParams.put("grant_type", "authorization_code");
+		tokenParams.put("code", "this_is_an_authorization_code");
+
+		TokenResponse resp = OAuth.token(tokenParams, null);
+
+		assertEquals(false, resp.getLivemode());
+		assertEquals("acct_test_token", resp.getStripeUserId());
+		assertEquals("read_only", resp.getScope());
+	}
+
+	@Test
+	public void testDeauthorize() throws StripeException {
+		String json = "{stripe_user_id: \"acct_test_deauth\"}";
+		stubOAuth(DeauthorizedAccount.class, json);
+
+		Map<String, Object> deauthParams = new HashMap<String, Object>();
+		deauthParams.put("stripe_user_id", "acct_test_deauth");
+
+		DeauthorizedAccount account = OAuth.deauthorize(deauthParams, null);
+
+		assertEquals("acct_test_deauth", account.getStripeUserId());
+	}
+}

--- a/src/test/resources/com/stripe/model/oauth_token_response.json
+++ b/src/test/resources/com/stripe/model/oauth_token_response.json
@@ -1,0 +1,9 @@
+{
+  "access_token": "sk_test_access_token",
+  "livemode": false,
+  "refresh_token": "rt_refresh_token",
+  "token_type": "bearer",
+  "stripe_publishable_key": "pk_test_stripe_publishable_key",
+  "stripe_user_id": "acct_test_token",
+  "scope": "read_only"
+}


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Adds native support for OAuth in the Java library.

The implementation is mostly based on the existing ones (cf. https://github.com/stripe/stripe-ruby/pull/523). One notable difference is that I split the existing `_request` method in `LiveStripeResponseGetter` into two different `_request` (for normal API requests) and `_oauthRequest` (for OAuth requests) methods, with the common code factorized into a new `_rawRequest` method.

I did this because if I had simply updated the `_request` method to handle OAuth errors (like I did in the other languages implementations), then I'd have to update every request method in every model to account for the new possible OAuth exceptions (even though in practice, OAuth exceptions will never occur in normal API requests, but the compiler has no way of knowing this).

There might be a smarter / more elegant way of handling this. Open to all suggestions here!
