### PR TITLE
Remove Alipay account functional tests

### DIFF
--- a/src/test/java/com/stripe/BaseStripeFunctionalTest.java
+++ b/src/test/java/com/stripe/BaseStripeFunctionalTest.java
@@ -25,7 +25,6 @@ public class BaseStripeFunctionalTest {
 	public static Map<String, Object> defaultBankAccountParams = new HashMap<String, Object>();
 	public static Map<String, Object> defaultRecipientParams = new HashMap<String, Object>();
 	public static Map<String, Object> defaultBitcoinReceiverParams = new HashMap<String, Object>();
-	public static Map<String, Object> defaultAlipayTokenParams = new HashMap<String, Object>();
 	public static Map<String, Object> defaultManagedAccountParams = new HashMap<String, Object>();
 	public static RequestOptions supportedRequestOptions;
 	public static StripeResponseGetter networkMock;
@@ -108,12 +107,6 @@ public class BaseStripeFunctionalTest {
 		defaultBitcoinReceiverParams.put("currency", "usd");
 		defaultBitcoinReceiverParams.put("description", "some details");
 		defaultBitcoinReceiverParams.put("email", "do+fill_now@stripe.com");
-
-		Map<String, Object> alipayParams = new HashMap<String, Object>();
-		alipayParams.put("reusable", true);
-		alipayParams.put("alipay_username", "stripe+alipay");
-		defaultAlipayTokenParams.put("alipay_account", alipayParams);
-		defaultAlipayTokenParams.put("email", "alipay+account@stripe.com");
 
 		defaultManagedAccountParams.put("managed", true);
 		defaultManagedAccountParams.put("country", "US");

--- a/src/test/java/com/stripe/functional/AccountTest.java
+++ b/src/test/java/com/stripe/functional/AccountTest.java
@@ -21,51 +21,6 @@ public class AccountTest extends BaseStripeFunctionalTest {
 	}
 
 	@Test
-	public void testAlipayAccountCreation() throws StripeException {
-		Token alipayToken = Token.create(defaultAlipayTokenParams);
-		Map<String, Object> customerParams = new HashMap<String, Object>();
-		customerParams.put("source", alipayToken.getId());
-		Customer cus = Customer.create(customerParams);
-
-		ExternalAccount alipayAccount = cus.getSources().getData().get(0);
-		assertEquals("alipay_account", alipayAccount.getObject());
-		assertEquals(cus.getId(), alipayAccount.getCustomer());
-		assertTrue(AlipayAccount.class.isInstance(alipayAccount));
-	}
-
-	@Test
-	public void testAlipayAccountUpdating() throws StripeException {
-		Token alipayToken = Token.create(defaultAlipayTokenParams);
-		Map<String, Object> customerParams = new HashMap<String, Object>();
-		customerParams.put("source", alipayToken.getId());
-		Customer cus = Customer.create(customerParams);
-
-		Map<String, Object> updateParams = new HashMap<String, Object>();
-		Map<String, Object> metadata = new HashMap<String, Object>();
-		metadata.put("foo", "bar");
-		updateParams.put("metadata", metadata);
-
-		ExternalAccount alipayAccount = cus.getSources().getData().get(0);
-		ExternalAccount updatedAccount = alipayAccount.update(updateParams);
-
-		assertEquals("bar", updatedAccount.getMetadata().get("foo"));
-	}
-
-	@Test
-	public void testAlipayAccountDeleting() throws StripeException {
-		Token alipayToken = Token.create(defaultAlipayTokenParams);
-		Map<String, Object> customerParams = new HashMap<String, Object>();
-		customerParams.put("source", alipayToken.getId());
-		Customer cus = Customer.create(customerParams);
-
-		AlipayAccount alipayAccount = (AlipayAccount) cus.getSources().getData().get(0);
-		alipayAccount.delete();
-
-		ExternalAccountCollection sources = cus.getSources().all(new HashMap<String, Object>());
-		assertEquals(0, sources.getData().size());
-	}
-
-	@Test
 	public void testGetAllExternalAccounts() throws StripeException {
 		Account account = Account.create(defaultManagedAccountParams);
 		Assert.assertNotNull(account);


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Those tests used to create Alipay tokens, which was never officially documented and is no longer possible (Alipay payments must now use the sources API and go through a redirect flow), so I removed the failing tests.
