### PR TITLE
Run Oracle JDK 7 on Precise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: java
 
-jdk:
-  - openjdk7
-  - oraclejdk7
-  - oraclejdk8
+matrix:
+  include:
+    - jdk: openjdk7
+    - jdk: oraclejdk7
+      dist: precise
+    - jdk: oraclejdk8
 
 install: mvn install -Dgpg.skip=true -DskipTests
 


### PR DESCRIPTION
Travis recently migrated to Trusty containers by default, and it seems
that Oracle JDK 7 doesn't run on them very well. This moves to a build
matrix and puts the failing build back on Precise.