### PR TITLE
Support for new failure_reason attribute

### DIFF
--- a/src/main/java/com/stripe/model/SourceRedirectFlow.java
+++ b/src/main/java/com/stripe/model/SourceRedirectFlow.java
@@ -1,16 +1,17 @@
 package com.stripe.model;
 
 public final class SourceRedirectFlow extends StripeObject {
-	String url;
+	String failureReason;
 	String returnUrl;
 	String status;
+	String url;
 
-	public String getURL() {
-		return url;
+	public String getFailureReason() {
+		return failureReason;
 	}
 
-	public void setURL(String url) {
-		this.url = url;
+	public void setFailureReason(String failureReason) {
+		this.failureReason = failureReason;
 	}
 
 	public String getReturnURL() {
@@ -27,5 +28,13 @@ public final class SourceRedirectFlow extends StripeObject {
 
 	public void setStatus(String status) {
 		this.status = status;
+	}
+
+	public String getURL() {
+		return url;
+	}
+
+	public void setURL(String url) {
+		this.url = url;
 	}
 }


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @stan-stripe 

Adds support for the new [`redirect.failure_reason`](https://stripe.com/docs/api#source_object-redirect-failure_reason) attribute.

(Also moved `url` to maintain alphabetical order.)
