### PR TITLE
[WIP] Support for deleted fields in expansions

### DIFF
--- a/src/main/java/com/stripe/model/ExpandableField.java
+++ b/src/main/java/com/stripe/model/ExpandableField.java
@@ -7,14 +7,24 @@ package com.stripe.model;
 public class ExpandableField<T extends HasId> {
 	private String id;
 	private T expandedObject;
+	Boolean deleted;
 
 	public ExpandableField(String id, T expandedObject) {
+		this(id, expandedObject, false);
+	}
+
+	public ExpandableField(String id, T expandedObject, Boolean deleted) {
 		this.id = id;
 		this.expandedObject = expandedObject;
+		this.deleted = deleted;
 	}
 
 	public boolean isExpanded() {
 		return expandedObject != null;
+	}
+
+	public boolean isDeleted() {
+		return deleted;
 	}
 
 	public String getId() {

--- a/src/main/java/com/stripe/model/ExpandableFieldDeserializer.java
+++ b/src/main/java/com/stripe/model/ExpandableFieldDeserializer.java
@@ -30,10 +30,21 @@ public class ExpandableFieldDeserializer implements JsonDeserializer<ExpandableF
 			// Get the `id` out of the response
 			JsonObject fieldAsJsonObject = json.getAsJsonObject();
 			String id = fieldAsJsonObject.getAsJsonPrimitive("id").getAsString();
+
+			// Check if the expanded object is deleted
+			JsonElement deletedElement = fieldAsJsonObject.get("deleted");
+			if (deletedElement != null) {
+				Boolean deleted = deletedElement.getAsBoolean();
+				if (deleted) {
+					expandableField = new ExpandableField(id, null, true);
+					return expandableField;
+				}
+			}
+
 			// We need to get the type inside the generic ExpandableField to make sure fromJson correctly serializes
 			// the JsonObject:
 			Type clazz = ((ParameterizedType) typeOfT).getActualTypeArguments()[0];
-			expandableField = new ExpandableField(id, (HasId) context.deserialize(json, clazz));
+			expandableField = new ExpandableField(id, (HasId) context.deserialize(json, clazz), false);
 			return expandableField;
 		}
 

--- a/src/main/java/com/stripe/model/Payout.java
+++ b/src/main/java/com/stripe/model/Payout.java
@@ -123,6 +123,13 @@ public class Payout extends APIResource implements MetadataStore<Payout>, HasId 
 		this.destination = new ExpandableField<ExternalAccount>(c.getId(), c);
 	}
 
+	public Boolean isDestinationDeleted() {
+		if (this.destination == null) {
+			return false;
+		}
+		return this.destination.isDeleted();
+	}
+
 	public String getFailureBalanceTransaction() {
 		if (this.failureBalanceTransaction == null) {
 			return null;

--- a/src/test/java/com/stripe/model/ExpandableFieldDeserializerTest.java
+++ b/src/test/java/com/stripe/model/ExpandableFieldDeserializerTest.java
@@ -14,6 +14,7 @@ import com.google.gson.reflect.TypeToken;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class ExpandableFieldDeserializerTest extends BaseStripeTest {
 
@@ -60,5 +61,19 @@ public class ExpandableFieldDeserializerTest extends BaseStripeTest {
 		assertEquals(out.getId(), "an_id_here");
 		assertEquals(out.getExpanded().id, "an_id_here");
 		assertEquals(out.getExpanded().bar, 12);
+	}
+
+	@Test
+	public void deserializeDeletedObject() throws IOException {
+		Map<String, Object> anObject = new HashMap<String, Object>();
+		anObject.put("id", "id_deleted");
+		anObject.put("deleted", true);
+		String json = gson.toJson(anObject);
+
+		//Gson also uses TypeTokens internally to get around Type Erasure for generic types, simulate that here:
+		ExpandableField<TestObject> out = gson.fromJson(json, new TypeToken<ExpandableField<TestObject>>() {
+		}.getType());
+		assertEquals(out.getId(), "id_deleted");
+		assertTrue(out.isDeleted());
 	}
 }

--- a/src/test/java/com/stripe/model/PayoutTest.java
+++ b/src/test/java/com/stripe/model/PayoutTest.java
@@ -17,6 +17,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
 public class PayoutTest extends BaseStripeTest {
@@ -46,6 +47,16 @@ public class PayoutTest extends BaseStripeTest {
 		assertEquals("card", payout.getSourceType());
 		assertEquals("paid", payout.getStatus());
 		assertEquals("bank_account", payout.getType());
+	}
+
+	@Test
+	public void testDeserializeWithExpandedDeletedBankAccount() throws StripeException, IOException {
+		String json = resource("payout_expand_deleted_bank_account.json");
+		Payout payout = APIResource.GSON.fromJson(json, Payout.class);
+
+		assertEquals("po_1BAPKEDtHb1AhhMraoSwrT29", payout.getId());
+		assertEquals("ba_18cB2uDtHb1AhhMrd08CoS4U", payout.getDestination());
+		assertTrue(payout.isDestinationDeleted());
 	}
 
 	@Test

--- a/src/test/resources/com/stripe/model/payout_expand_deleted_bank_account.json
+++ b/src/test/resources/com/stripe/model/payout_expand_deleted_bank_account.json
@@ -1,0 +1,25 @@
+{
+  "amount": 100,
+  "arrival_date": 1507507200,
+  "balance_transaction": "txn_1BAPKEDtHb1AhhMrkwNPRD47",
+  "created": 1507409710,
+  "currency": "usd",
+  "description": null,
+  "destination": {
+    "currency": "usd",
+    "deleted": true,
+    "id": "ba_18cB2uDtHb1AhhMrd08CoS4U"
+  },
+  "failure_balance_transaction": null,
+  "failure_code": null,
+  "failure_message": null,
+  "id": "po_1BAPKEDtHb1AhhMraoSwrT29",
+  "livemode": false,
+  "metadata": {},
+  "method": "standard",
+  "object": "payout",
+  "source_type": "card",
+  "statement_descriptor": null,
+  "status": "paid",
+  "type": "bank_account"
+}


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @remi-stripe 

Attempts to fix #409.

The API doesn't return an `object` attribute for deleted objects. Rather than trying to cast to the correct `DeletedClass`, I simply added a `deleted` boolean (which provides exactly the same information).

The downside is that we'd have to add an `isAttributeDeleted` accessor for every expandable attribute where the API can return a deleted resource. Users would then have to call this method before trying to access the expanded object.

Tagged as WIP because I'm not sure if this is the right approach for this issue. I've only added the accessor for payouts' [`destination`](https://stripe.com/docs/api#payout_object-destination) attribute for now.