### PR TITLE
Support for detaching sources

### DIFF
--- a/src/main/java/com/stripe/model/ExternalAccount.java
+++ b/src/main/java/com/stripe/model/ExternalAccount.java
@@ -23,8 +23,16 @@ public class ExternalAccount extends APIResource implements HasId, MetadataStore
 		return id;
 	}
 
+	public void setId(String id) {
+		this.id = id;
+	}
+
 	public String getObject() {
 		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
 	}
 
 	public String getAccount() {

--- a/src/main/java/com/stripe/model/Source.java
+++ b/src/main/java/com/stripe/model/Source.java
@@ -150,11 +150,7 @@ public class Source extends ExternalAccount {
 
 	public String getSourceInstanceURL()
 			throws InvalidRequestException {
-		if (this.getCustomer() != null) {
-			return String.format("%s/%s/sources/%s", classURL(Customer.class), this.getCustomer(), this.getId());
-		} else {
-			return instanceURL(Source.class, this.getId());
-		}
+		return instanceURL(Source.class, this.getId());
 	}
 
 	public static Source create(Map<String, Object> params)
@@ -207,5 +203,34 @@ public class Source extends ExternalAccount {
 			throws AuthenticationException, InvalidRequestException,
 			APIConnectionException, CardException, APIException {
 		return request(RequestMethod.POST, this.getSourceInstanceURL(), params, Source.class, options);
+	}
+
+	public DeletedExternalAccount delete(RequestOptions options) throws
+			AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+			throw new InvalidRequestException("Source objects cannot be deleted. If you want to detach the source from a customer object, use detach().", null, null, null, null);
+	}
+
+	public Source detach()
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return detach(null, null);
+	}
+
+	public Source detach(Map<String, Object> params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return detach(params, null);
+	}
+
+	public Source detach(Map<String, Object> params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		if (this.getCustomer() != null) {
+			String url = String.format("%s/%s/sources/%s", classURL(Customer.class), this.getCustomer(), this.getId());
+			return request(RequestMethod.DELETE, url, params, Source.class, options);
+		} else {
+			throw new InvalidRequestException("This source object does not appear to be currently attached to a customer object.", null, null, null, null);
+		}
 	}
 }


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @stan-stripe 

- Adds support for detaching sources. We can't override `delete()` because the method would need to return a `DeletedExternalAccount` instance, but in the case of sources the API will simply return the detached source object. I added a `detach()` method instead (which is more descriptive of what the method does anyway) and overrode `delete()` to raise an exception with an explicit message.

- Ensures that all requests on existing sources (save for detaching sources) use the `/v1/sources/src_...` endpoint even if the source is attached to a customer (rather than using `/v1/customers/cus_.../sources/src_...` in the latter case). While both URLs would work for update requests, using the customer URL wouldn't work for verify requests.