### PR TITLE
Fix a failing test case in stripe-java's build

### DIFF
--- a/src/test/java/com/stripe/functional/ApplicationFeeTest.java
+++ b/src/test/java/com/stripe/functional/ApplicationFeeTest.java
@@ -3,6 +3,7 @@ package com.stripe.functional;
 import com.stripe.BaseStripeFunctionalTest;
 import com.stripe.exception.StripeException;
 import com.stripe.model.ApplicationFee;
+import com.stripe.model.ApplicationFeeCollection;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -15,8 +16,7 @@ public class ApplicationFeeTest extends BaseStripeFunctionalTest {
 	@Test
 	public void testApplicationFeeList() throws StripeException {
 		Map<String, Object> listParams = new HashMap<String, Object>();
-		listParams.put("count", 0);
-		List<ApplicationFee> fees = ApplicationFee.all(listParams).getData();
-		assertEquals(fees.size(), 0);
+		ApplicationFeeCollection fees = ApplicationFee.list(listParams);
+		assertEquals("/v1/application_fees", fees.getURL());
 	}
 }


### PR DESCRIPTION
This test case seems to have been trying to fetch zero items of a
collection and then comparing against the returned `data`'s count.
Unfortunately for our build's reliability, for one the parameter is
actually called `limit`, and two it only supports numbers of one or
more [1].

I believe that the only thing keeping this build running until now is
that the collection of application fees for the account could be
reliably assumed to be zero.

This patch changes what we assert on for the return list -- we move over
to a stable value; in this case the collection's URL.

[1] https://stripe.com/docs/api/curl#list_application_fees-limit

cc @mrmcduff-stripe