### PR TITLE
Add support for exchange_rates API requests

### DIFF
--- a/src/main/java/com/stripe/model/EventDataDeserializer.java
+++ b/src/main/java/com/stripe/model/EventDataDeserializer.java
@@ -36,6 +36,7 @@ public class EventDataDeserializer implements JsonDeserializer<EventData> {
 		objectMap.put("discount", Discount.class);
 		objectMap.put("dispute", Dispute.class);
 		objectMap.put("event", Event.class);
+		objectMap.put("exchange_rate", ExchangeRate.class);
 		objectMap.put("fee", Fee.class);
 		objectMap.put("fee_refund", FeeRefund.class);
 		objectMap.put("file_upload", FileUpload.class);

--- a/src/main/java/com/stripe/model/ExchangeRate.java
+++ b/src/main/java/com/stripe/model/ExchangeRate.java
@@ -1,0 +1,71 @@
+package com.stripe.model;
+
+import com.stripe.Stripe;
+import com.stripe.exception.APIConnectionException;
+import com.stripe.exception.APIException;
+import com.stripe.exception.AuthenticationException;
+import com.stripe.exception.CardException;
+import com.stripe.exception.InvalidRequestException;
+import com.stripe.net.APIResource;
+import com.stripe.net.RequestOptions;
+
+import java.util.Map;
+
+public class ExchangeRate extends APIResource implements HasId {
+	String id;
+	String object;
+	Map<String, Float> rates;
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getObject() {
+		return object;
+	}
+
+	public void setObject(String object) {
+		this.object = object;
+	}
+
+	public Map<String, Float> getRates() {
+		return rates;
+	}
+
+	public void setRates(Map<String, Float> rates) {
+		this.rates = rates;
+	}
+
+	public static ExchangeRate retrieve(String currency) throws AuthenticationException,
+			InvalidRequestException, APIConnectionException, CardException,
+			APIException {
+		return retrieve(currency, null);
+	}
+
+	public static ExchangeRate retrieve(String currency, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return request(
+				RequestMethod.GET,
+				instanceURL(ExchangeRate.class, currency),
+				null,
+				ExchangeRate.class,
+				options);
+	}
+
+	public static ExchangeRateCollection list(Map<String, Object> params)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return list(params, null);
+	}
+
+	public static ExchangeRateCollection list(Map<String, Object> params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return requestCollection(classURL(ExchangeRate.class), params, ExchangeRateCollection.class, options);
+	}
+}

--- a/src/main/java/com/stripe/model/ExchangeRateCollection.java
+++ b/src/main/java/com/stripe/model/ExchangeRateCollection.java
@@ -1,0 +1,4 @@
+package com.stripe.model;
+
+public class ExchangeRateCollection extends StripeCollection<ExchangeRate> {
+}

--- a/src/main/java/com/stripe/net/APIResource.java
+++ b/src/main/java/com/stripe/net/APIResource.java
@@ -70,26 +70,28 @@ public abstract class APIResource extends StripeObject {
 
 		// TODO: Delurk this, with invoiceitem being a valid url, we can't get too
 		// fancy yet.
-		if (className.equals("applicationfee")) {
+		if (className.equals("applepaydomain")) {
+			return "apple_pay_domain";
+		} else if (className.equals("applicationfee")) {
 			return "application_fee";
-		} else if (className.equals("fileupload")) {
-			return "file";
 		} else if (className.equals("bitcoinreceiver")) {
 			return "bitcoin_receiver";
 		} else if (className.equals("countryspec")) {
 			return "country_spec";
-		} else if (className.equals("orderreturn")) {
-			return "order_return";
-		} else if (className.equals("threedsecure")) {
-			return "three_d_secure";
-		} else if (className.equals("applepaydomain")) {
-			return "apple_pay_domain";
-		} else if (className.equals("subscriptionitem")) {
-			return "subscription_item";
 		} else if (className.equals("ephemeralkey")) {
 			return "ephemeral_key";
+		} else if (className.equals("exchangerate")) {
+			return "exchange_rate";
+		} else if (className.equals("fileupload")) {
+			return "file";
+		} else if (className.equals("orderreturn")) {
+			return "order_return";
 		} else if (className.equals("sourcetransaction")) {
 			return "source_transaction";
+		} else if (className.equals("subscriptionitem")) {
+			return "subscription_item";
+		} else if (className.equals("threedsecure")) {
+			return "three_d_secure";
 		} else {
 			return className;
 		}

--- a/src/test/java/com/stripe/model/ExchangeRateTest.java
+++ b/src/test/java/com/stripe/model/ExchangeRateTest.java
@@ -1,0 +1,53 @@
+package com.stripe.model;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+
+import com.stripe.BaseStripeTest;
+import com.stripe.exception.StripeException;
+import com.stripe.exception.InvalidRequestException;
+import com.stripe.net.APIResource;
+import com.stripe.net.LiveStripeResponseGetter;
+import com.stripe.net.RequestOptions;
+import com.stripe.net.RequestOptions.RequestOptionsBuilder;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class ExchangeRateTest extends BaseStripeTest {
+	@Before
+	public void mockStripeResponseGetter() {
+		APIResource.setStripeResponseGetter(networkMock);
+	}
+
+	@After
+	public void unmockStripeResponseGetter() {
+	/* This needs to be done because tests aren't isolated in Java */
+		APIResource.setStripeResponseGetter(new LiveStripeResponseGetter());
+	}
+
+	@Test
+	public void testRetrieve() throws StripeException {
+		ExchangeRate rates = ExchangeRate.retrieve("usd");
+
+		verifyGet(ExchangeRate.class, "https://api.stripe.com/v1/exchange_rates/usd");
+		verifyNoMoreInteractions(networkMock);
+	}
+
+	@Test
+	public void testList() throws StripeException {
+		HashMap<String, Object> params = new HashMap<String, Object>();
+		params.put("limit", 3);
+
+		ExchangeRateCollection listRates = ExchangeRate.list(params);
+
+		verifyGet(ExchangeRateCollection.class, "https://api.stripe.com/v1/exchange_rates", params);
+		verifyNoMoreInteractions(networkMock);
+	}
+}


### PR DESCRIPTION
r? @brandur-stripe
cc @stripe/api-libraries @alixander-stripe

Adds support for the new `/v1/exchange_rates` endpoints.