### PR TITLE
Upgrade to Mockito 2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,8 @@ repositories {
 dependencies {
     compile group: 'com.google.code.gson', name: 'gson', version:'2.2.4'
     testCompile group: 'com.google.guava', name: 'guava', version:'18.0'
-    testCompile group: 'junit', name: 'junit', version:'4.10'
-    testCompile group: 'org.mockito', name: 'mockito-all', version:'1.10.19'
+    testCompile group: 'junit', name: 'junit', version:'4.12'
+    testCompile group: 'org.mockito', name: 'mockito-core', version:'2.12.0'
 }
 
 apply from: 'deploy.gradle'

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -113,7 +113,7 @@ public class BaseStripeTest {
 				Mockito.<Map<String, Object>>any(),
 				Mockito.<Class<T>>any(),
 				Mockito.any(APIResource.RequestType.class),
-				Mockito.any(RequestOptions.class))).thenReturn(APIResource.GSON.fromJson(response, clazz));
+				Mockito.<RequestOptions>any())).thenReturn(APIResource.GSON.fromJson(response, clazz));
 	}
 
 	public static <T> void stubOAuth(Class<T> clazz, String response) throws StripeException {
@@ -123,10 +123,10 @@ public class BaseStripeTest {
 				Mockito.<Map<String, Object>>any(),
 				Mockito.<Class<T>>any(),
 				Mockito.any(APIResource.RequestType.class),
-				Mockito.any(RequestOptions.class))).thenReturn(APIResource.GSON.fromJson(response, clazz));
+				Mockito.<RequestOptions>any())).thenReturn(APIResource.GSON.fromJson(response, clazz));
 	}
 
-	public static class ParamMapMatcher extends ArgumentMatcher<Map<String, Object>> {
+	public static class ParamMapMatcher implements ArgumentMatcher<Map<String, Object>> {
 		private Map<String, Object> other;
 
 		public ParamMapMatcher(Map<String, Object> other) {
@@ -134,23 +134,20 @@ public class BaseStripeTest {
 		}
 
 		/* Treat null references as equal to empty maps */
-		public boolean matches(Object obj) {
-			if (obj == null) {
+		public boolean matches(Map<String,Object> paramMap) {
+			if (paramMap == null) {
 				return this.other == null || this.other.isEmpty();
-			} else if (obj instanceof Map) {
-				Map<String, Object> paramMap = (Map<String, Object>) obj;
+			} else {
 				if (this.other == null) {
 					return paramMap.isEmpty();
 				} else {
 					return this.other.equals(paramMap);
 				}
-			} else {
-				return false;
 			}
 		}
 	}
 
-	public static class RequestOptionsMatcher extends ArgumentMatcher<RequestOptions> {
+	public static class RequestOptionsMatcher implements ArgumentMatcher<RequestOptions> {
 		private RequestOptions other;
 
 		public RequestOptionsMatcher(RequestOptions other) {
@@ -158,19 +155,16 @@ public class BaseStripeTest {
 		}
 
 		/* Treat null reference as RequestOptions.getDefault() */
-		public boolean matches(Object obj) {
+		public boolean matches(RequestOptions requestOptions) {
 			RequestOptions defaultOptions = RequestOptions.getDefault();
-			if (obj == null) {
+			if (requestOptions == null) {
 				return this.other == null || this.other.equals(defaultOptions);
-			} else if (obj instanceof RequestOptions) {
-				RequestOptions requestOptions = (RequestOptions) obj;
+			} else {
 				if (this.other == null) {
 					return requestOptions.equals(defaultOptions);
 				} else {
 					return this.other.equals(requestOptions);
 				}
-			} else {
-				return false;
 			}
 		}
 	}


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Bumped the test dependencies:

- JUnit to 4.12 (unfortunately, JUnit 5 requires Java 1.8+, so we'll be stuck on the 4.x branch for a while)

- Mockito to 2.12.0

The latter fixes an "illegal reflection operation" warning when running tests with Java 9.
