### PR TITLE
Use Gradle caching on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,12 @@ sudo: false
 
 script:
   - ./gradlew clean test
+
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

This is straight from [Travis' own documentation](https://docs.travis-ci.com/user/languages/java/#Caching). Should help shorten Travis build times.