### PR TITLE
Improve gradle output in Travis

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,3 +33,10 @@ dependencies {
 }
 
 apply from: 'deploy.gradle'
+
+test {
+    testLogging {
+        events "passed", "skipped", "failed"
+        exceptionFormat "full"
+    }
+}


### PR DESCRIPTION
r? @dpetrovics-stripe (dev-platform run, feel free to re-assign)
cc @stripe/api-libraries @remi-stripe 

~By default, gradle outputs the test results in an HTML report file. This is rather inconvenient since we cannot consult the contents of the file on Travis.~

~This PR uses this project: https://github.com/mendhak/Gradle-Travis-Colored-Output to enable a pretty console output that works locally and on Travis.~

~Slight FUD: the project does not have an explicit license, so not sure if we can just pull this in. I've filed an issue on the repo: https://github.com/mendhak/Gradle-Travis-Colored-Output/issues/4~
~edit: The project's author has updated the repository to release the code under the MIT license, so I think we're good!~

See comment below: https://github.com/stripe/stripe-java/pull/428#issuecomment-346647838