### PR TITLE
Make charge field on Dispute objects expandable

### DIFF
--- a/src/main/java/com/stripe/model/Dispute.java
+++ b/src/main/java/com/stripe/model/Dispute.java
@@ -16,7 +16,7 @@ public class Dispute extends APIResource implements HasId {
 	String object;
 	Long amount;
 	List<BalanceTransaction> balanceTransactions;
-	String charge;
+	ExpandableField<Charge> charge;
 	Long created;
 	String currency;
 	EvidenceSubObject evidenceSubObject; // `evidence`
@@ -77,11 +77,25 @@ public class Dispute extends APIResource implements HasId {
 	}
 
 	public String getCharge() {
-		return charge;
+		if (charge == null) {
+			return null;
+		}
+		return charge.getId();
 	}
 
-	public void setCharge(String charge) {
-		this.charge = charge;
+	public void setCharge(String chargeID) {
+		this.charge = setExpandableFieldID(chargeID, this.charge);
+	}
+
+	public Charge getChargeObject() {
+		if (this.charge == null) {
+			return null;
+		}
+		return this.charge.getExpanded();
+	}
+
+	public void setChargeObject(Charge charge) {
+		this.charge = new ExpandableField<Charge>(charge.getId(), charge);
 	}
 
 	public Long getCreated() {
@@ -218,13 +232,19 @@ public class Dispute extends APIResource implements HasId {
 	public static Dispute retrieve(String id) throws AuthenticationException,
 			InvalidRequestException, APIConnectionException, CardException,
 			APIException {
-		return retrieve(id, null);
+		return retrieve(id, null, null);
 	}
 
 	public static Dispute retrieve(String id, RequestOptions options) throws AuthenticationException,
 			InvalidRequestException, APIConnectionException, CardException,
 			APIException {
-		return request(RequestMethod.GET, instanceURL(Dispute.class, id), null, Dispute.class, options);
+		return retrieve(id, null, options);
+	}
+
+	public static Dispute retrieve(String id, Map<String, Object> params, RequestOptions options) throws AuthenticationException,
+			InvalidRequestException, APIConnectionException, CardException,
+			APIException {
+		return request(RequestMethod.GET, instanceURL(Dispute.class, id), params, Dispute.class, options);
 	}
 
 	public static DisputeCollection list(Map<String, Object> params) throws AuthenticationException,

--- a/src/main/java/com/stripe/model/DisputeDataDeserializer.java
+++ b/src/main/java/com/stripe/model/DisputeDataDeserializer.java
@@ -17,6 +17,8 @@ public class DisputeDataDeserializer implements JsonDeserializer<Dispute> {
 		Gson gson = new GsonBuilder()
 				.setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
 				.registerTypeAdapter(ExpandableField.class, new ExpandableFieldDeserializer())
+				.registerTypeAdapter(Source.class, new SourceTypeDataDeserializer<Source>())
+				.registerTypeAdapterFactory(new ExternalAccountTypeAdapterFactory())
 				.create();
 		if (json.isJsonNull()) {
 			return null;

--- a/src/test/java/com/stripe/functional/DisputeTest.java
+++ b/src/test/java/com/stripe/functional/DisputeTest.java
@@ -12,6 +12,7 @@ import java.io.File;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -55,6 +56,29 @@ public class DisputeTest extends BaseStripeFunctionalTest {
 		Dispute dispute = disputedCharge.getDisputeObject();
 		Dispute retrievedDispute = Dispute.retrieve(dispute.getId());
 		assertEquals(dispute.getId(), retrievedDispute.getId());
+	}
+
+	@Test
+	public void testRetrieveDisputeWithExpand() throws StripeException, InterruptedException {
+		int chargeValueCents = 100;
+		Charge disputedCharge = createDisputedCharge(chargeValueCents, null);
+		Dispute dispute = disputedCharge.getDisputeObject();
+
+		List<String> expandList = new LinkedList<String>();
+		expandList.add("charge");
+
+		Map<String, Object> retrieveParams = new HashMap<String, Object>();
+		retrieveParams.put("expand", expandList);
+
+		Dispute retrievedDispute = Dispute.retrieve(dispute.getId(), retrieveParams, null);
+		assertEquals(dispute.getId(), retrievedDispute.getId());
+
+		Charge expandedCharge = retrievedDispute.getChargeObject();
+		assertNotNull(expandedCharge);
+		assertEquals(disputedCharge.getId(), expandedCharge.getId());
+
+		Card card = (Card) expandedCharge.getSource();
+		assertEquals("0259", card.getLast4());
 	}
 
 	@Test


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Fixes #431.

~No tests because expansion itself is already tested and I've verified in the OpenAPI spec that the `charge` attribute is expandable in dispute objects.~