### PR TITLE
Upgrade Gradle, and use new plugin DSL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,3 @@
-apply plugin: 'java'
-apply plugin: 'maven'
-
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
-tasks.withType(JavaCompile) {
-	options.encoding = 'UTF-8'
-}
-
-configurations.all {
-}
-
 buildscript {
     repositories {
         jcenter()
@@ -19,6 +7,21 @@ buildscript {
     dependencies {
         classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.11.0"
     }
+}
+
+plugins {
+    id 'java'
+    id 'maven'
+}
+
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
+
+tasks.withType(JavaCompile) {
+	options.encoding = 'UTF-8'
+}
+
+configurations.all {
 }
 
 repositories {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-bin.zip


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Upgrade Gradle to latest version (4.4), and use [new plugin DSL](https://docs.gradle.org/current/userguide/plugins.html#sec:plugins_block) in `build.gradle`.
