### PR TITLE
Add support for passing parameters in SubscriptionItem.delete()

### DIFF
--- a/src/main/java/com/stripe/model/SubscriptionItem.java
+++ b/src/main/java/com/stripe/model/SubscriptionItem.java
@@ -112,12 +112,24 @@ public class SubscriptionItem extends APIResource implements HasId {
 	public DeletedSubscriptionItem delete() throws AuthenticationException,
 			InvalidRequestException, APIConnectionException, CardException,
 			APIException {
-		return delete(null);
+		return delete(null, null);
+	}
+
+	public DeletedSubscriptionItem delete(Map<String, Object> params) throws AuthenticationException,
+			InvalidRequestException, APIConnectionException, CardException,
+			APIException {
+		return delete(params, null);
 	}
 
 	public DeletedSubscriptionItem delete(RequestOptions options) throws AuthenticationException,
 			InvalidRequestException, APIConnectionException, CardException,
 			APIException {
-		return request(RequestMethod.DELETE, instanceURL(SubscriptionItem.class, id), null, DeletedSubscriptionItem.class, options);
+		return delete(null, options);
+	}
+
+	public DeletedSubscriptionItem delete(Map<String, Object> params, RequestOptions options) throws AuthenticationException,
+			InvalidRequestException, APIConnectionException, CardException,
+			APIException {
+		return request(RequestMethod.DELETE, instanceURL(SubscriptionItem.class, id), params, DeletedSubscriptionItem.class, options);
 	}
 }

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -85,6 +85,31 @@ public class BaseStripeTest {
 
 	public static <T> void verifyDelete(
 			Class<T> clazz,
+			String url,
+			Map<String, Object> params) throws StripeException {
+		verifyRequest(APIResource.RequestMethod.DELETE, clazz, url, params,
+				APIResource.RequestType.NORMAL, RequestOptions.getDefault());
+	}
+
+	public static <T> void verifyDelete(
+			Class<T> clazz,
+			String url,
+			RequestOptions requestOptions) throws StripeException {
+		verifyRequest(APIResource.RequestMethod.DELETE, clazz, url, null,
+				APIResource.RequestType.NORMAL, requestOptions);
+	}
+
+	public static <T> void verifyDelete(
+			Class<T> clazz,
+			String url,
+			Map<String, Object> params,
+			RequestOptions requestOptions) throws StripeException {
+		verifyRequest(APIResource.RequestMethod.DELETE, clazz, url, params,
+				APIResource.RequestType.NORMAL, requestOptions);
+	}
+
+	public static <T> void verifyDelete(
+			Class<T> clazz,
 			String url) throws StripeException {
 		verifyRequest(APIResource.RequestMethod.DELETE, clazz, url, null,
 				APIResource.RequestType.NORMAL, RequestOptions.getDefault());

--- a/src/test/java/com/stripe/model/SubscriptionItemTest.java
+++ b/src/test/java/com/stripe/model/SubscriptionItemTest.java
@@ -84,9 +84,12 @@ public class SubscriptionItemTest extends BaseStripeTest {
 		SubscriptionItem item = new SubscriptionItem();
 		item.setId("test_item");
 
-		item.delete();
+		HashMap<String, Object> params = new HashMap<String, Object>();
+		params.put("prorate", false);
 
-		verifyDelete(DeletedSubscriptionItem.class, "https://api.stripe.com/v1/subscription_items/test_item");
+		item.delete(params);
+
+		verifyDelete(DeletedSubscriptionItem.class, "https://api.stripe.com/v1/subscription_items/test_item", params);
 		verifyNoMoreInteractions(networkMock);
 	}
 }


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Add support for passing parameters in `SubscriptionItem.delete()`.

Fixes #437.