### PR TITLE
update to a current version of gson

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ repositories {
 }
 
 dependencies {
-    compile group: 'com.google.code.gson', name: 'gson', version:'2.2.4'
+    compile group: 'com.google.code.gson', name: 'gson', version:'2.8.2'
     testCompile group: 'com.google.guava', name: 'guava', version:'18.0'
     testCompile group: 'junit', name: 'junit', version:'4.12'
     testCompile group: 'org.mockito', name: 'mockito-core', version:'2.12.0'


### PR DESCRIPTION
The current version of gson used `2.2.4` is quite old (2013-05-13) and is starting to cause conflicts with tools like selenium.

Version `2.8.2` is still compatible with Java 6 and should not have any breaking changes. Just a lot of bug fixes and new features. Some that may be helpful with #433