### PR TITLE
Drop oraclejdk7 and start testing openjdk7 on Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: required
+
 language: java
 
 addons:
@@ -5,14 +7,19 @@ addons:
     - short-hostname
   hostname: short-hostname
 
-matrix:
-  include:
-    - jdk: openjdk7
-      dist: precise
-    - jdk: oraclejdk7
-      dist: precise
-    - jdk: oraclejdk8
-    - jdk: oraclejdk9
+jdk:
+  - openjdk7
+  - oraclejdk8
+  - oraclejdk9
+
+before_install:
+  # Work around missing crypto in openjdk7
+  - |
+    if [ "$TRAVIS_JDK_VERSION" == "openjdk7" ]; then
+      sudo wget "https://bouncycastle.org/download/bcprov-ext-jdk15on-158.jar" -O "${JAVA_HOME}/jre/lib/ext/bcprov-ext-jdk15on-158.jar"
+      sudo perl -pi.bak -e 's/^(security\.provider\.)([0-9]+)/$1.($2+1)/ge' /etc/java-7-openjdk/security/java.security
+      echo "security.provider.1=org.bouncycastle.jce.provider.BouncyCastleProvider" | sudo tee -a /etc/java-7-openjdk/security/java.security
+    fi
 
 notifications:
   email:


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Travis is going to drop support for Precise soon [1], so we need to update the CI in order to use Trusty.

oraclejdk7 is not available at all on Trusty [2] so I've removed it entirely.

openjdk7 is available, but there's an issue with Gradle (that I briefly mentioned in the original Gradle PR [3]). Using Precise was the simplest workaround, but now that that's no longer an option, I added a `before_install` script to use the BouncyCastle JCE [4]. This is the solution that's mentioned on the GitHub issue on Gradle's repo [5].



[1] https://blog.travis-ci.com/2017-08-31-trusty-as-default-status
[2] https://docs.travis-ci.com/user/reference/trusty/#JVM-(Clojure%2C-Groovy%2C-Java%2C-Scala)-images
[3] https://github.com/stripe/stripe-java/pull/385#issuecomment-335113696
[4] https://bouncycastle.org
[5] https://github.com/gradle/gradle/issues/2421#issuecomment-327349246