### PR TITLE
Results Dashboard for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ jdk:
   - oraclejdk9
 
 before_install:
+  - mkdir -p $HOME/bin
+  - curl -fsSL https://testspace-client.s3.amazonaws.com/testspace-linux.tgz | tar -zxvf- -C $HOME/bin
+  - testspace config url $TS_ORG.testspace.com
   # Work around missing crypto in openjdk7
   - |
     if [ "$TRAVIS_JDK_VERSION" == "openjdk7" ]; then
@@ -30,6 +33,13 @@ sudo: false
 script:
   - ./gradlew clean test
 
+after_script:
+  - testspace [${TRAVIS_JDK_VERSION}]./build/test-results/test/TEST-*.xml{src/test/java/com/stripe}
+  - if [[ ${TRAVIS_JDK_VERSION} = "oraclejdk8" ]]; then
+      ./gradlew jacocoTestReport;
+      testspace **/test/jacocoTestReport.xml;
+    fi
+ 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
 plugins {
     id 'java'
     id 'maven'
+    id 'jacoco'
 }
 
 sourceCompatibility = 1.7
@@ -41,5 +42,11 @@ test {
     testLogging {
         events "passed", "skipped", "failed"
         exceptionFormat "full"
+    }
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
     }
 }


### PR DESCRIPTION
Hi, `stripe-java` team. We’ve made a few minor changes to demonstrate how you can add a Results Dashboard for Travis CI using [Testspace.com](https://www.testspace.com/).
 
Check out YOUR RESULTS at https://open.testspace.com/projects/TryTestspace:stripe-java from our fork.

A few of the **benefits** for your Contributors:
 * Move beyond the flat, endless console output. Results in Testspace mirror your matrix jobs, test folders, suites, and cases hierarchy.
 * Triage failures faster with single-click filtering and complete failure context; call stack, timing info, and more.

And for Owners:
 * Monitor the status of all your repositories, their local branches, and pull requests from a single dashboard.
 * View historical tracking of all your important metrics; test case and coverage growth, static analysis issues, custom metrics, etc.

Note: We also generated a Pull Request for the [stripe-ruby](https://github.com/stripe/stripe-ruby/pulls) Repo. You could have a dashboard for all your APIs (python, etc.).

[Read more...](https://blog.testspace.com/testspace-and-open-source/)

----

**Want to Give Testspace a try?**

1. Create **Open** (free) account: https://testspace.com/pricing. 
2. Add a **New Project** from the list of Github repo's
3. Add a Travis **Environment Variable**: Name: `TS_ORG`  Value: `organization name` - based on name selected in step 1
4. Invite others: https://help.testspace.com/how-to:invite-other-users
