### PR TITLE
Add support for deserializing source_mandate_notification objects

### DIFF
--- a/src/main/java/com/stripe/model/EventDataDeserializer.java
+++ b/src/main/java/com/stripe/model/EventDataDeserializer.java
@@ -54,6 +54,7 @@ public class EventDataDeserializer implements JsonDeserializer<EventData> {
 		objectMap.put("review", Review.class);
 		objectMap.put("sku", SKU.class);
 		objectMap.put("source", Source.class);
+		objectMap.put("source_mandate_notification", SourceMandateNotification.class);
 		objectMap.put("source_transaction", SourceTransaction.class);
 		objectMap.put("subscription", Subscription.class);
 		objectMap.put("subscription_item", SubscriptionItem.class);

--- a/src/main/java/com/stripe/model/SourceMandateNotification.java
+++ b/src/main/java/com/stripe/model/SourceMandateNotification.java
@@ -1,0 +1,109 @@
+package com.stripe.model;
+
+import java.util.Map;
+
+import com.stripe.exception.APIConnectionException;
+import com.stripe.exception.APIException;
+import com.stripe.exception.AuthenticationException;
+import com.stripe.exception.CardException;
+import com.stripe.exception.InvalidRequestException;
+import com.stripe.net.APIResource;
+import com.stripe.net.RequestOptions;
+
+
+public class SourceMandateNotification extends APIResource implements HasId, HasSourceTypeData {
+  String id;
+  String object;
+  Long amount;
+  Long created;
+  Boolean livemode;
+  String reason;
+  Source source;
+  String status;
+  String type;
+
+  // Type-specific properties
+  Map<String, String> typeData;
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getObject() {
+    return object;
+  }
+
+  public void setObject(String object) {
+    this.object = object;
+  }
+
+  public Long getAmount() {
+    return amount;
+  }
+
+  public void setAmount(Long amount) {
+    this.amount = amount;
+  }
+
+  public Long getCreated() {
+    return created;
+  }
+
+  public void setCreated(Long created) {
+    this.created = created;
+  }
+
+  public Boolean getLivemode() {
+    return livemode;
+  }
+
+  public void setLivemode(Boolean livemode) {
+    this.livemode = livemode;
+  }
+
+  public String getReason() {
+    return reason;
+  }
+
+  public void setReason(String reason) {
+    this.reason = reason;
+  }
+
+  public Source getSource() {
+    return source;
+  }
+
+  public void setSource(Source source) {
+    this.source = source;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public void setStatus(String status) {
+    this.status = status;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  // Type-specific getters/setters
+
+  public Map<String, String> getTypeData() {
+    return typeData;
+  }
+
+  public void setTypeData(Map<String, String> typeData) {
+    this.typeData = typeData;
+  }
+}

--- a/src/main/java/com/stripe/model/SourceMandateNotification.java
+++ b/src/main/java/com/stripe/model/SourceMandateNotification.java
@@ -12,98 +12,98 @@ import com.stripe.net.RequestOptions;
 
 
 public class SourceMandateNotification extends APIResource implements HasId, HasSourceTypeData {
-  String id;
-  String object;
-  Long amount;
-  Long created;
-  Boolean livemode;
-  String reason;
-  Source source;
-  String status;
-  String type;
+	String id;
+	String object;
+	Long amount;
+	Long created;
+	Boolean livemode;
+	String reason;
+	Source source;
+	String status;
+	String type;
 
-  // Type-specific properties
-  Map<String, String> typeData;
+	// Type-specific properties
+	Map<String, String> typeData;
 
-  public String getId() {
-    return id;
-  }
+	public String getId() {
+		return id;
+	}
 
-  public void setId(String id) {
-    this.id = id;
-  }
+	public void setId(String id) {
+		this.id = id;
+	}
 
-  public String getObject() {
-    return object;
-  }
+	public String getObject() {
+		return object;
+	}
 
-  public void setObject(String object) {
-    this.object = object;
-  }
+	public void setObject(String object) {
+		this.object = object;
+	}
 
-  public Long getAmount() {
-    return amount;
-  }
+	public Long getAmount() {
+		return amount;
+	}
 
-  public void setAmount(Long amount) {
-    this.amount = amount;
-  }
+	public void setAmount(Long amount) {
+		this.amount = amount;
+	}
 
-  public Long getCreated() {
-    return created;
-  }
+	public Long getCreated() {
+		return created;
+	}
 
-  public void setCreated(Long created) {
-    this.created = created;
-  }
+	public void setCreated(Long created) {
+		this.created = created;
+	}
 
-  public Boolean getLivemode() {
-    return livemode;
-  }
+	public Boolean getLivemode() {
+		return livemode;
+	}
 
-  public void setLivemode(Boolean livemode) {
-    this.livemode = livemode;
-  }
+	public void setLivemode(Boolean livemode) {
+		this.livemode = livemode;
+	}
 
-  public String getReason() {
-    return reason;
-  }
+	public String getReason() {
+		return reason;
+	}
 
-  public void setReason(String reason) {
-    this.reason = reason;
-  }
+	public void setReason(String reason) {
+		this.reason = reason;
+	}
 
-  public Source getSource() {
-    return source;
-  }
+	public Source getSource() {
+		return source;
+	}
 
-  public void setSource(Source source) {
-    this.source = source;
-  }
+	public void setSource(Source source) {
+		this.source = source;
+	}
 
-  public String getStatus() {
-    return status;
-  }
+	public String getStatus() {
+		return status;
+	}
 
-  public void setStatus(String status) {
-    this.status = status;
-  }
+	public void setStatus(String status) {
+		this.status = status;
+	}
 
-  public String getType() {
-    return type;
-  }
+	public String getType() {
+		return type;
+	}
 
-  public void setType(String type) {
-    this.type = type;
-  }
+	public void setType(String type) {
+		this.type = type;
+	}
 
-  // Type-specific getters/setters
+	// Type-specific getters/setters
 
-  public Map<String, String> getTypeData() {
-    return typeData;
-  }
+	public Map<String, String> getTypeData() {
+		return typeData;
+	}
 
-  public void setTypeData(Map<String, String> typeData) {
-    this.typeData = typeData;
-  }
+	public void setTypeData(Map<String, String> typeData) {
+		this.typeData = typeData;
+	}
 }

--- a/src/main/java/com/stripe/net/APIResource.java
+++ b/src/main/java/com/stripe/net/APIResource.java
@@ -34,6 +34,7 @@ import com.stripe.model.HasId;
 import com.stripe.model.OrderItem;
 import com.stripe.model.OrderItemDeserializer;
 import com.stripe.model.Source;
+import com.stripe.model.SourceMandateNotification;
 import com.stripe.model.SourceTransaction;
 import com.stripe.model.SourceTypeDataDeserializer;
 import com.stripe.model.StripeCollectionInterface;
@@ -61,6 +62,7 @@ public abstract class APIResource extends StripeObject {
 			.registerTypeAdapter(OrderItem.class, new OrderItemDeserializer())
 			.registerTypeAdapter(Source.class, new SourceTypeDataDeserializer<Source>())
 			.registerTypeAdapter(SourceTransaction.class, new SourceTypeDataDeserializer<SourceTransaction>())
+			.registerTypeAdapter(SourceMandateNotification.class, new SourceTypeDataDeserializer<SourceTransaction>())
 			.registerTypeAdapter(StripeRawJsonObject.class, new StripeRawJsonObjectDeserializer())
 			.registerTypeAdapterFactory(new ExternalAccountTypeAdapterFactory())
 			.create();

--- a/src/main/java/com/stripe/net/APIResource.java
+++ b/src/main/java/com/stripe/net/APIResource.java
@@ -61,8 +61,8 @@ public abstract class APIResource extends StripeObject {
 			.registerTypeAdapter(FeeRefundCollection.class, new FeeRefundCollectionDeserializer())
 			.registerTypeAdapter(OrderItem.class, new OrderItemDeserializer())
 			.registerTypeAdapter(Source.class, new SourceTypeDataDeserializer<Source>())
+			.registerTypeAdapter(SourceMandateNotification.class, new SourceTypeDataDeserializer<SourceMandateNotification>())
 			.registerTypeAdapter(SourceTransaction.class, new SourceTypeDataDeserializer<SourceTransaction>())
-			.registerTypeAdapter(SourceMandateNotification.class, new SourceTypeDataDeserializer<SourceTransaction>())
 			.registerTypeAdapter(StripeRawJsonObject.class, new StripeRawJsonObjectDeserializer())
 			.registerTypeAdapterFactory(new ExternalAccountTypeAdapterFactory())
 			.create();

--- a/src/test/java/com/stripe/model/SourceMandateNotificationTest.java
+++ b/src/test/java/com/stripe/model/SourceMandateNotificationTest.java
@@ -19,10 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
 public class SourceMandateNotificationTest extends BaseStripeTest {
-	@Test
-	public void testDeserialize() throws StripeException, IOException {
-		String json = resource("source_mandate_notification.json");
-		SourceMandateNotification mandateNotification = APIResource.GSON.fromJson(json, SourceMandateNotification.class);
+	private void verifyResource(SourceMandateNotification mandateNotification) {
 		Map<String, String> typeData = mandateNotification.getTypeData();
 
 		assertEquals("srcmn_1234", mandateNotification.getId());
@@ -39,5 +36,23 @@ public class SourceMandateNotificationTest extends BaseStripeTest {
 		assertEquals("TEST111111111111111", typeData.get("creditor_identifier"));
 		assertEquals("OAAAAAAAAAAAAAAO", typeData.get("mandate_reference"));
 		assertEquals("3000", typeData.get("last4"));
+	}
+
+	@Test
+	public void testDeserializeResource() throws StripeException, IOException {
+		String json = resource("source_mandate_notification.json");
+		SourceMandateNotification mandateNotification = APIResource.GSON.fromJson(json, SourceMandateNotification.class);
+
+		verifyResource(mandateNotification);
+	}
+
+	@Test
+	public void testDeserializeEvent() throws StripeException, IOException {
+		String json = resource("source_mandate_notification_event.json");
+		Event event = APIResource.GSON.fromJson(json, Event.class);
+
+		SourceMandateNotification mandateNotification = (com.stripe.model.SourceMandateNotification) event.getData().getObject();
+
+		verifyResource(mandateNotification);
 	}
 }

--- a/src/test/java/com/stripe/model/SourceMandateNotificationTest.java
+++ b/src/test/java/com/stripe/model/SourceMandateNotificationTest.java
@@ -1,0 +1,54 @@
+package com.stripe.model;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+
+import com.stripe.BaseStripeTest;
+import com.stripe.exception.StripeException;
+import com.stripe.net.APIResource;
+import com.stripe.net.LiveStripeResponseGetter;
+import com.stripe.net.RequestOptions;
+import com.stripe.net.RequestOptions.RequestOptionsBuilder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class SourceMandateNotificationTest extends BaseStripeTest {
+  @Before
+  public void mockStripeResponseGetter() {
+    APIResource.setStripeResponseGetter(networkMock);
+  }
+
+  @After
+  public void unmockStripeResponseGetter() {
+  /* This needs to be done because tests aren't isolated in Java */
+    APIResource.setStripeResponseGetter(new LiveStripeResponseGetter());
+  }
+
+  @Test
+  public void testDeserialize() throws StripeException, IOException {
+    String json = resource("source_mandate_notification.json");
+    SourceMandateNotification mandateNotification = APIResource.GSON.fromJson(json, SourceMandateNotification.class);
+    Map<String, String> typeData = mandateNotification.getTypeData();
+
+    assertEquals("srcmn_1234", mandateNotification.getId());
+    assertEquals("source_mandate_notification", mandateNotification.getObject());
+    assertEquals(1000L, (long) mandateNotification.getAmount());
+    assertEquals(1516981090, (long) mandateNotification.getCreated());
+    assertEquals(false, mandateNotification.getLivemode());
+    assertEquals("debit_initiated", mandateNotification.getReason());
+    assertEquals("pending", mandateNotification.getStatus());
+    assertEquals("sepa_debit", mandateNotification.getType());
+    assertEquals("src_123", mandateNotification.getSource().getId());
+    assertEquals("sepa_debit", mandateNotification.getSource().getType());
+
+    assertEquals("TEST111111111111111", typeData.get("creditor_identifier"));
+    assertEquals("OAAAAAAAAAAAAAAO", typeData.get("mandate_reference"));
+    assertEquals("3000", typeData.get("last4"));
+  }
+}

--- a/src/test/java/com/stripe/model/SourceMandateNotificationTest.java
+++ b/src/test/java/com/stripe/model/SourceMandateNotificationTest.java
@@ -19,36 +19,25 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
 public class SourceMandateNotificationTest extends BaseStripeTest {
-  @Before
-  public void mockStripeResponseGetter() {
-    APIResource.setStripeResponseGetter(networkMock);
-  }
+	@Test
+	public void testDeserialize() throws StripeException, IOException {
+		String json = resource("source_mandate_notification.json");
+		SourceMandateNotification mandateNotification = APIResource.GSON.fromJson(json, SourceMandateNotification.class);
+		Map<String, String> typeData = mandateNotification.getTypeData();
 
-  @After
-  public void unmockStripeResponseGetter() {
-  /* This needs to be done because tests aren't isolated in Java */
-    APIResource.setStripeResponseGetter(new LiveStripeResponseGetter());
-  }
+		assertEquals("srcmn_1234", mandateNotification.getId());
+		assertEquals("source_mandate_notification", mandateNotification.getObject());
+		assertEquals(1000L, (long) mandateNotification.getAmount());
+		assertEquals(1516981090, (long) mandateNotification.getCreated());
+		assertEquals(false, mandateNotification.getLivemode());
+		assertEquals("debit_initiated", mandateNotification.getReason());
+		assertEquals("pending", mandateNotification.getStatus());
+		assertEquals("sepa_debit", mandateNotification.getType());
+		assertEquals("src_123", mandateNotification.getSource().getId());
+		assertEquals("sepa_debit", mandateNotification.getSource().getType());
 
-  @Test
-  public void testDeserialize() throws StripeException, IOException {
-    String json = resource("source_mandate_notification.json");
-    SourceMandateNotification mandateNotification = APIResource.GSON.fromJson(json, SourceMandateNotification.class);
-    Map<String, String> typeData = mandateNotification.getTypeData();
-
-    assertEquals("srcmn_1234", mandateNotification.getId());
-    assertEquals("source_mandate_notification", mandateNotification.getObject());
-    assertEquals(1000L, (long) mandateNotification.getAmount());
-    assertEquals(1516981090, (long) mandateNotification.getCreated());
-    assertEquals(false, mandateNotification.getLivemode());
-    assertEquals("debit_initiated", mandateNotification.getReason());
-    assertEquals("pending", mandateNotification.getStatus());
-    assertEquals("sepa_debit", mandateNotification.getType());
-    assertEquals("src_123", mandateNotification.getSource().getId());
-    assertEquals("sepa_debit", mandateNotification.getSource().getType());
-
-    assertEquals("TEST111111111111111", typeData.get("creditor_identifier"));
-    assertEquals("OAAAAAAAAAAAAAAO", typeData.get("mandate_reference"));
-    assertEquals("3000", typeData.get("last4"));
-  }
+		assertEquals("TEST111111111111111", typeData.get("creditor_identifier"));
+		assertEquals("OAAAAAAAAAAAAAAO", typeData.get("mandate_reference"));
+		assertEquals("3000", typeData.get("last4"));
+	}
 }

--- a/src/test/resources/com/stripe/model/source_mandate_notification.json
+++ b/src/test/resources/com/stripe/model/source_mandate_notification.json
@@ -1,0 +1,69 @@
+{
+  "id": "srcmn_1234",
+  "object": "source_mandate_notification",
+  "amount": 1000,
+  "created": 1516981090,
+  "livemode": false,
+  "reason": "debit_initiated",
+  "source": {
+    "id": "src_123",
+    "object": "source",
+    "amount": null,
+    "client_secret": "src_client_secret_123",
+    "created": 1516981089,
+    "currency": "eur",
+    "customer": "cus_123",
+    "flow": "none",
+    "livemode": false,
+    "mandate": {
+      "acceptance": {
+        "date": null,
+        "ip": null,
+        "status": "pending",
+        "user_agent": null
+      },
+      "notification_method": "manual",
+      "reference": "OAAAAAAAAAAAAAAO",
+      "url": "https://hooks.stripe.com/adapter/sepa_debit/file/src_123/src_client_secret_123"
+    },
+    "metadata": {
+    },
+    "owner": {
+      "address": {
+        "city": "City",
+        "country": "DE",
+        "line1": "line1",
+        "line2": null,
+        "postal_code": "11111",
+        "state": null
+      },
+      "email": null,
+      "name": "Jenny Rosen",
+      "phone": null,
+      "verified_address": null,
+      "verified_email": null,
+      "verified_name": null,
+      "verified_phone": null
+    },
+    "statement_descriptor": null,
+    "status": "chargeable",
+    "type": "sepa_debit",
+    "usage": "reusable",
+    "sepa_debit": {
+      "bank_code": "11111111",
+      "country": "DE",
+      "fingerprint": "123",
+      "last4": "3000",
+      "mandate_reference": "OAAAAAAAAAAAAAAO",
+      "mandate_url": "https://hooks.stripe.com/adapter/sepa_debit/file/src_123/src_client_secret_123",
+      "branch_code": null
+    }
+  },
+  "status": "pending",
+  "type": "sepa_debit",
+  "sepa_debit": {
+    "creditor_identifier": "TEST111111111111111",
+    "last4": "3000",
+    "mandate_reference": "OAAAAAAAAAAAAAAO"
+  }
+}

--- a/src/test/resources/com/stripe/model/source_mandate_notification_event.json
+++ b/src/test/resources/com/stripe/model/source_mandate_notification_event.json
@@ -1,0 +1,83 @@
+{
+  "created":1326853478,
+  "livemode":false,
+  "id":"evt_00000000000000",
+  "type":"source.mandate_notification",
+  "object":"event",
+  "data":{
+    "object":{
+      "id": "srcmn_1234",
+      "object": "source_mandate_notification",
+      "amount": 1000,
+      "created": 1516981090,
+      "livemode": false,
+      "reason": "debit_initiated",
+      "source": {
+        "id": "src_123",
+        "object": "source",
+        "amount": null,
+        "client_secret": "src_client_secret_123",
+        "created": 1516981089,
+        "currency": "eur",
+        "customer": "cus_123",
+        "flow": "none",
+        "livemode": false,
+        "mandate": {
+          "acceptance": {
+            "date": null,
+            "ip": null,
+            "status": "pending",
+            "user_agent": null
+          },
+          "notification_method": "manual",
+          "reference": "OAAAAAAAAAAAAAAO",
+          "url": "https://hooks.stripe.com/adapter/sepa_debit/file/src_123/src_client_secret_123"
+        },
+        "metadata": {
+        },
+        "owner": {
+          "address": {
+            "city": "City",
+            "country": "DE",
+            "line1": "line1",
+            "line2": null,
+            "postal_code": "11111",
+            "state": null
+          },
+          "email": null,
+          "name": "Jenny Rosen",
+          "phone": null,
+          "verified_address": null,
+          "verified_email": null,
+          "verified_name": null,
+          "verified_phone": null
+        },
+        "statement_descriptor": null,
+        "status": "chargeable",
+        "type": "sepa_debit",
+        "usage": "reusable",
+        "sepa_debit": {
+          "bank_code": "11111111",
+          "country": "DE",
+          "fingerprint": "123",
+          "last4": "3000",
+          "mandate_reference": "OAAAAAAAAAAAAAAO",
+          "mandate_url": "https://hooks.stripe.com/adapter/sepa_debit/file/src_123/src_client_secret_123",
+          "branch_code": null
+        }
+      },
+      "status": "pending",
+      "type": "sepa_debit",
+      "sepa_debit": {
+        "creditor_identifier": "TEST111111111111111",
+        "last4": "3000",
+        "mandate_reference": "OAAAAAAAAAAAAAAO"
+      }
+    },
+    "previous_attributes": null
+  },
+  "request":{
+    "id":"req_1234",
+    "idempotency_key":"1234"
+  }
+}


### PR DESCRIPTION
This fixes https://github.com/stripe/stripe-java/issues/445

r? @stan-stripe @ob-stripe 
cc @stripe/api-libraries 