### PR TITLE
Support new Product+Plan API

### DIFF
--- a/src/main/java/com/stripe/model/Plan.java
+++ b/src/main/java/com/stripe/model/Plan.java
@@ -20,14 +20,17 @@ public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
 	Integer intervalCount;
 	Boolean livemode;
 	Map<String, String> metadata;
-	String name;
 	String nickname;
-	String statementDescriptor;
-	Integer trialPeriodDays;
 	String product;
 
 	@Deprecated
 	String statementDescription;
+	@Deprecated
+	String name;
+	@Deprecated
+	Integer trialPeriodDays;
+	@Deprecated
+	String statementDescriptor;
 
 	public String getId() {
 		return id;
@@ -101,14 +104,6 @@ public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
 		this.metadata = metadata;
 	}
 
-	public String getName() {
-		return name;
-	}
-
-	public void setName(String name) {
-		this.name = name;
-	}
-
 	public String getNickname() {
 		return nickname;
 	}
@@ -117,6 +112,28 @@ public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
 		this.nickname = nickname;
 	}
 
+	public String getProduct() {
+		return product;
+	}
+
+	public void setProduct(String product) {
+		this.product = product;
+	}
+
+	/**
+	 *  @deprecated Prefer using the product field (https://stripe.com/docs/upgrades#2018-02-05)
+	 */
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	/**
+	 *  @deprecated Prefer using the product field (https://stripe.com/docs/upgrades#2018-02-05)
+	 */
 	public String getStatementDescriptor() {
 		return statementDescriptor;
 	}
@@ -125,20 +142,15 @@ public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
 		this.statementDescriptor = statementDescriptor;
 	}
 
+	/**
+	 *  @deprecated Prefer using the product field (https://stripe.com/docs/upgrades#2018-02-05)
+	 */
 	public Integer getTrialPeriodDays() {
 		return trialPeriodDays;
 	}
 
 	public void setTrialPeriodDays(Integer trialPeriodDays) {
 		this.trialPeriodDays = trialPeriodDays;
-	}
-
-	public String getProduct() {
-		return product;
-	}
-
-	public void setProduct(String product) {
-		this.product = product;
 	}
 
 	/**

--- a/src/main/java/com/stripe/model/Plan.java
+++ b/src/main/java/com/stripe/model/Plan.java
@@ -21,8 +21,10 @@ public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
 	Boolean livemode;
 	Map<String, String> metadata;
 	String name;
+	String nickname;
 	String statementDescriptor;
 	Integer trialPeriodDays;
+	String product;
 
 	@Deprecated
 	String statementDescription;
@@ -107,6 +109,14 @@ public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
 		this.name = name;
 	}
 
+	public String getNickname() {
+		return nickname;
+	}
+
+	public void setNickname(String nickname) {
+		this.nickname = nickname;
+	}
+
 	public String getStatementDescriptor() {
 		return statementDescriptor;
 	}
@@ -121,6 +131,14 @@ public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
 
 	public void setTrialPeriodDays(Integer trialPeriodDays) {
 		this.trialPeriodDays = trialPeriodDays;
+	}
+
+	public String getProduct() {
+		return product;
+	}
+
+	public void setProduct(String product) {
+		this.product = product;
 	}
 
 	/**

--- a/src/main/java/com/stripe/model/Product.java
+++ b/src/main/java/com/stripe/model/Product.java
@@ -27,10 +27,10 @@ public class Product extends APIResource implements HasId, MetadataStore<Product
 	PackageDimensions packageDimensions;
 	Boolean shippable;
 	SKUCollection skus;
-	Long updated;
-	String url;
 	String statementDescriptor;
 	String type;
+	Long updated;
+	String url;
 
 	public String getId() {
 		return id;
@@ -160,14 +160,6 @@ public class Product extends APIResource implements HasId, MetadataStore<Product
 		this.updated = updated;
 	}
 
-	public String getURL() {
-		return url;
-	}
-
-	public void setURL(String url) {
-		this.url = url;
-	}
-
 	public String getStatementDescriptor() {
 		return statementDescriptor;
 	}
@@ -178,6 +170,18 @@ public class Product extends APIResource implements HasId, MetadataStore<Product
 
 	public String getType() {
 		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	public String getURL() {
+		return url;
+	}
+
+	public void setURL(String url) {
+		this.url = url;
 	}
 
 	public static Product create(Map<String, Object> params)

--- a/src/main/java/com/stripe/model/Product.java
+++ b/src/main/java/com/stripe/model/Product.java
@@ -29,6 +29,8 @@ public class Product extends APIResource implements HasId, MetadataStore<Product
 	SKUCollection skus;
 	Long updated;
 	String url;
+	String statementDescriptor;
+	String type;
 
 	public String getId() {
 		return id;
@@ -164,6 +166,18 @@ public class Product extends APIResource implements HasId, MetadataStore<Product
 
 	public void setURL(String url) {
 		this.url = url;
+	}
+
+	public String getStatementDescriptor() {
+		return statementDescriptor;
+	}
+
+	public void setStatementDescriptor(String statementDescriptor) {
+		this.statementDescriptor = statementDescriptor;
+	}
+
+	public String getType() {
+		return type;
 	}
 
 	public static Product create(Map<String, Object> params)

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -16,6 +16,7 @@ public class Subscription extends APIResource implements MetadataStore<Subscript
 	String object;
 	Double applicationFeePercent;
 	String billing;
+	Long billingCycleAnchor;
 	Boolean cancelAtPeriodEnd;
 	Long canceledAt;
 	Long created;
@@ -34,7 +35,6 @@ public class Subscription extends APIResource implements MetadataStore<Subscript
 	Double taxPercent;
 	Long trialEnd;
 	Long trialStart;
-	Long billingCycleAnchor;
 
 	public String getId() {
 		return id;
@@ -66,6 +66,14 @@ public class Subscription extends APIResource implements MetadataStore<Subscript
 
 	public void setBilling(String billing) {
 		this.billing = billing;
+	}
+
+	public Long getBillingCycleAnchor() {
+		return billingCycleAnchor;
+	}
+
+	public void setBillingCycleAnchor(Long billingCycleAnchor) {
+		this.billingCycleAnchor = billingCycleAnchor;
 	}
 
 	public Boolean getCancelAtPeriodEnd() {
@@ -224,14 +232,6 @@ public class Subscription extends APIResource implements MetadataStore<Subscript
 
 	public void setSubscriptionItems(SubscriptionItemCollection items) {
 		this.items = items;
-	}
-
-	public Long getBillingCycleAnchor() {
-		return billingCycleAnchor;
-	}
-
-	public void setBillingCycleAnchor(Long billingCycleAnchor) {
-		this.billingCycleAnchor = billingCycleAnchor;
 	}
 
 	@Deprecated

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -34,6 +34,7 @@ public class Subscription extends APIResource implements MetadataStore<Subscript
 	Double taxPercent;
 	Long trialEnd;
 	Long trialStart;
+	Long billingCycleAnchor;
 
 	public String getId() {
 		return id;
@@ -223,6 +224,14 @@ public class Subscription extends APIResource implements MetadataStore<Subscript
 
 	public void setSubscriptionItems(SubscriptionItemCollection items) {
 		this.items = items;
+	}
+
+	public Long getBillingCycleAnchor() {
+		return billingCycleAnchor;
+	}
+
+	public void setBillingCycleAnchor(Long billingCycleAnchor) {
+		this.billingCycleAnchor = billingCycleAnchor;
 	}
 
 	@Deprecated

--- a/src/test/java/com/stripe/BaseStripeFunctionalTest.java
+++ b/src/test/java/com/stripe/BaseStripeFunctionalTest.java
@@ -20,6 +20,8 @@ public class BaseStripeFunctionalTest {
 	public static Map<String, Object> defaultChargeParams = new HashMap<String, Object>();
 	public static Map<String, Object> defaultCustomerParams = new HashMap<String, Object>();
 	public static Map<String, Object> defaultPlanParams = new HashMap<String, Object>();
+	public static Map<String, Object> defaultPlanWithProductParams = new HashMap<String, Object>();
+	public static Map<String, Object> defaultServiceProductParams = new HashMap<String, Object>();
 	public static Map<String, Object> defaultCouponParams = new HashMap<String, Object>();
 	public static Map<String, Object> defaultTokenParams = new HashMap<String, Object>();
 	public static Map<String, Object> defaultBankAccountParams = new HashMap<String, Object>();
@@ -86,6 +88,19 @@ public class BaseStripeFunctionalTest {
 		defaultPlanParams.put("interval", "month");
 		defaultPlanParams.put("interval_count", 2);
 		defaultPlanParams.put("name", "J Bindings Plan");
+
+		Map<String, Object> productParams = new HashMap<String, Object>();
+		productParams.put("name", "Kittens on Demand");
+		defaultPlanWithProductParams.put("product", productParams);
+		defaultPlanWithProductParams.put("amount", 200);
+		defaultPlanWithProductParams.put("currency", "usd");
+		defaultPlanWithProductParams.put("interval", "month");
+		defaultPlanWithProductParams.put("interval_count", 2);
+		defaultPlanWithProductParams.put("nickname", "Two Month Kitten Plan");
+
+		defaultServiceProductParams.put("type", "service");
+		defaultServiceProductParams.put("name", "Run of the Mill Product");
+		defaultServiceProductParams.put("statement_descriptor", "Run of the Mill");
 
 		defaultCouponParams.put("duration", "once");
 		defaultCouponParams.put("percent_off", 10);

--- a/src/test/java/com/stripe/BaseStripeFunctionalTest.java
+++ b/src/test/java/com/stripe/BaseStripeFunctionalTest.java
@@ -71,7 +71,7 @@ public class BaseStripeFunctionalTest {
 
 		// Peg the API version so that it can be varied independently of the
 		// one set on the test account.
-		Stripe.apiVersion = "2017-04-06";
+		Stripe.apiVersion = "2018-02-06";
 
 		// test key
 		supportedRequestOptions = RequestOptions.builder().setStripeVersion(Stripe.apiVersion).build();

--- a/src/test/java/com/stripe/functional/PlanTest.java
+++ b/src/test/java/com/stripe/functional/PlanTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class PlanTest extends BaseStripeFunctionalTest {
@@ -21,6 +22,15 @@ public class PlanTest extends BaseStripeFunctionalTest {
 		Plan plan = Plan.create(getUniquePlanParams());
 		assertEquals(plan.getInterval(), "month");
 		assertEquals(plan.getIntervalCount(), (Integer) 2);
+	}
+
+	@Test
+	public void testPlanCreateWithProduct() throws StripeException {
+		Plan plan = Plan.create(defaultPlanWithProductParams);
+		assertEquals(plan.getInterval(), "month");
+		assertEquals(plan.getIntervalCount(), (Integer) 2);
+		assertEquals(plan.getNickname(), defaultPlanWithProductParams.get("nickname"));
+		assertNotNull(plan.getProduct());
 	}
 
 	@Test

--- a/src/test/java/com/stripe/functional/RelayTest.java
+++ b/src/test/java/com/stripe/functional/RelayTest.java
@@ -25,6 +25,7 @@ public class RelayTest extends BaseStripeFunctionalTest {
 		Map<String, Object> createParams = new HashMap<String, Object>();
 		String id = "my_first_product_" + UUID.randomUUID();
 		createParams.put("id", id);
+		createParams.put("type", "good");
 		createParams.put("name", "Watermelon");
 		Product created = Product.create(createParams, relayRequestOptions);
 		assertEquals(id, created.getId());
@@ -46,6 +47,7 @@ public class RelayTest extends BaseStripeFunctionalTest {
 		Map<String, Object> productCreateParams = new HashMap<String, Object>();
 		String productId = "my_first_product_" + UUID.randomUUID();
 		productCreateParams.put("id", productId);
+		productCreateParams.put("type", "good");
 		productCreateParams.put("name", "Watermelon");
 		productCreateParams.put("attributes[]", "size");
 		Product.create(productCreateParams, relayRequestOptions);
@@ -80,6 +82,7 @@ public class RelayTest extends BaseStripeFunctionalTest {
 		Map<String, Object> productCreateParams = new HashMap<String, Object>();
 		String productId = "my_first_product_" + UUID.randomUUID();
 		productCreateParams.put("id", productId);
+		productCreateParams.put("type", "good");
 		productCreateParams.put("name", "Watermelon");
 		productCreateParams.put("attributes[]", "size");
 		Product createdProduct = Product.create(productCreateParams, relayRequestOptions);
@@ -111,6 +114,7 @@ public class RelayTest extends BaseStripeFunctionalTest {
 		Map<String, Object> productCreateParams = new HashMap<String, Object>();
 		String productId = "my_first_product_" + UUID.randomUUID();
 		productCreateParams.put("id", productId);
+		productCreateParams.put("type", "good");
 		productCreateParams.put("name", "Watermelon");
 		productCreateParams.put("attributes[]", "size");
 		productCreateParams.put("shippable", false);

--- a/src/test/java/com/stripe/functional/ServiceProductTest.java
+++ b/src/test/java/com/stripe/functional/ServiceProductTest.java
@@ -1,0 +1,36 @@
+package com.stripe.functional;
+
+import com.stripe.BaseStripeFunctionalTest;
+import com.stripe.exception.StripeException;
+import com.stripe.model.*;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class ServiceProductTest extends BaseStripeFunctionalTest {
+    @Test
+    public void testProductCreate() throws StripeException {
+        Product product = Product.create(defaultServiceProductParams);
+
+        assertNotNull(product.getId());
+        assertEquals("service", product.getType());
+        assertEquals(defaultServiceProductParams.get("name"), product.getName());
+        assertEquals(defaultServiceProductParams.get("statement_descriptor"), product.getStatementDescriptor());
+    }
+
+    @Test
+    public void testProductUpdate() throws StripeException {
+        Product product = Product.create(defaultServiceProductParams);
+
+        HashMap<String, Object> updateParams = new HashMap<>();
+        updateParams.put("name", "New name not like the old name");
+        updateParams.put("statement_descriptor", "NEW AND IMPROVED");
+        Product updatedProduct = product.update(updateParams);
+
+        assertEquals("New name not like the old name", updatedProduct.getName());
+        assertEquals("NEW AND IMPROVED", updatedProduct.getStatementDescriptor());
+    }
+}


### PR DESCRIPTION
Add support for new Product and Plan API (`2018-02-05`)

- Added tests showing create and update of products `Product` with `type = service`
- Added tests creating a plan and product at once
- Added new fields to `Plan` and `Product`

r? @brandur-stripe @tmaxwell-stripe
cc @stripe/api-libraries