### PR TITLE
Add setAppInfo() for passing custom application information in headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,16 @@ Please take care to set conservative read timeouts. Some API requests can take
 some time, and a short timeout increases the likelihood of a problem within our
 servers.
 
+### Writing a plugin
+
+If you're writing a plugin that uses the library, we'd appreciate it if you
+identified using `Stripe.setAppInfo()`:
+
+    Stripe.setAppInfo("MyAwesomePlugin", "1.2.34", "https://myawesomeplugin.info");
+
+This information is passed along when the library makes calls to the Stripe
+API.
+
 ## Testing
 
 You must have Gradle installed. To run the tests:

--- a/src/main/java/com/stripe/Stripe.java
+++ b/src/main/java/com/stripe/Stripe.java
@@ -3,6 +3,9 @@ package com.stripe;
 import java.net.PasswordAuthentication;
 import java.net.Proxy;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public abstract class Stripe {
 	private final static int DEFAULT_CONNECT_TIMEOUT = 30 * 1000;
 	private final static int DEFAULT_READ_TIMEOUT = 80 * 1000;
@@ -26,6 +29,8 @@ public abstract class Stripe {
 	private static volatile String connectBase = CONNECT_API_BASE;
 	private static volatile Proxy connectionProxy = null;
 	private static volatile PasswordAuthentication proxyCredential = null;
+
+	private static volatile Map<String, String> appInfo = null;
 
 
 	/**
@@ -115,5 +120,27 @@ public abstract class Stripe {
 
 	public static PasswordAuthentication getProxyCredential() {
 		return proxyCredential;
+	}
+
+	public static void setAppInfo(String name) {
+		setAppInfo(name, null, null);
+	}
+
+	public static void setAppInfo(String name, String version) {
+		setAppInfo(name, version, null);
+	}
+
+	public static void setAppInfo(String name, String version, String url) {
+		if (appInfo == null) {
+			appInfo = new HashMap<String, String>();
+		}
+
+		appInfo.put("name", name);
+		appInfo.put("version", version);
+		appInfo.put("url", url);
+	}
+
+	public static Map<String, String> getAppInfo() {
+		return appInfo;
 	}
 }

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -89,13 +89,29 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 		return String.format("%s=%s", APIResource.urlEncode(k), APIResource.urlEncode(v));
 	}
 
+	static String formatAppInfo(Map<String, String> info) {
+		String str = info.get("name");
+		if (info.get("version") != null) {
+			str += String.format("/%s", info.get("version"));
+		}
+		if (info.get("url") != null) {
+			str += String.format(" (%s)", info.get("url"));
+		}
+		return str;
+	}
+
 	static Map<String, String> getHeaders(RequestOptions options) {
 		Map<String, String> headers = new HashMap<String, String>();
+
+		String userAgent = String.format("Stripe/v1 JavaBindings/%s", Stripe.VERSION);
+		if (Stripe.getAppInfo() != null) {
+			userAgent += " " + formatAppInfo(Stripe.getAppInfo());
+		}
+		headers.put("User-Agent", userAgent);
+
 		String apiVersion = options.getStripeVersion();
 		headers.put("Accept-Charset", APIResource.CHARSET);
 		headers.put("Accept", "application/json");
-		headers.put("User-Agent",
-				String.format("Stripe/v1 JavaBindings/%s", Stripe.VERSION));
 
 		headers.put("Authorization", String.format("Bearer %s", options.getApiKey()));
 
@@ -110,6 +126,9 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 		propertyMap.put("bindings.version", Stripe.VERSION);
 		propertyMap.put("lang", "Java");
 		propertyMap.put("publisher", "Stripe");
+		if (Stripe.getAppInfo() != null) {
+			propertyMap.put("application", APIResource.GSON.toJson(Stripe.getAppInfo()));
+		}
 		headers.put("X-Stripe-Client-User-Agent", APIResource.GSON.toJson(propertyMap));
 		if (apiVersion != null) {
 			headers.put("Stripe-Version", apiVersion);


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

A port of the feature that already exists in the Ruby, Python and PHP libraries for providing custom application information in the `User-Agent` and `X-Stripe-Client-User-Agent` headers.
