### PR TITLE
Add support for /v1/topups/ endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ target
 # Gradle files
 .gradle/*
 build/*
+out/*
 
 # compiler output
 bin/

--- a/src/main/java/com/stripe/model/Topup.java
+++ b/src/main/java/com/stripe/model/Topup.java
@@ -1,0 +1,213 @@
+package com.stripe.model;
+
+import com.stripe.exception.*;
+import com.stripe.net.APIResource;
+import com.stripe.net.RequestOptions;
+
+import java.util.Map;
+
+public class Topup extends APIResource implements MetadataStore<Topup>, HasId {
+    String id;
+    String object;
+    Integer amount;
+    ExpandableField<BalanceTransaction> balanceTransaction;
+    Long created;
+    String currency;
+    String description;
+    Long expectedAvailabilityDate;
+    String failureCode;
+    String failureMessage;
+    Boolean livemode;
+    Map<String, String> metadata;
+    Source source;
+    String statementDescriptor;
+    String status;
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getObject() {
+        return object;
+    }
+
+    public void setObject(String object) {
+        this.object = object;
+    }
+
+    public Integer getAmount() {
+        return amount;
+    }
+
+    public void setAmount(Integer amount) {
+        this.amount = amount;
+    }
+
+    public String getBalanceTransaction() {
+        if (this.balanceTransaction == null) {
+            return null;
+        }
+        return this.balanceTransaction.getId();
+    }
+
+    public void setBalanceTransaction(String balanceTransactionID) {
+        this.balanceTransaction = setExpandableFieldID(balanceTransactionID, this.balanceTransaction);
+    }
+
+    public BalanceTransaction getBalanceTransactionObject() {
+        if (this.balanceTransaction == null) {
+            return null;
+        }
+        return this.balanceTransaction.getExpanded();
+    }
+
+    public void setBalanceTransactionObject(BalanceTransaction c) {
+        this.balanceTransaction = new ExpandableField<BalanceTransaction>(c.getId(), c);
+    }
+
+    public Long getCreated() {
+        return created;
+    }
+
+    public void setCreated(Long created) {
+        this.created = created;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Long getExpectedAvailabilityDate() {
+        return expectedAvailabilityDate;
+    }
+
+    public void setExpectedAvailabilityDate(Long expectedAvailabilityDate) {
+        this.expectedAvailabilityDate = expectedAvailabilityDate;
+    }
+
+    public String getFailureCode() {
+        return failureCode;
+    }
+
+    public void setFailureCode(String failureCode) {
+        this.failureCode = failureCode;
+    }
+
+    public String getFailureMessage() {
+        return failureMessage;
+    }
+
+    public void setFailureMessage(String failureMessage) {
+        this.failureMessage = failureMessage;
+    }
+
+    public Boolean getLivemode() {
+        return livemode;
+    }
+
+    public void setLivemode(Boolean livemode) {
+        this.livemode = livemode;
+    }
+
+    @Override
+    public Map<String, String> getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(Map<String, String> metadata) {
+        this.metadata = metadata;
+    }
+
+    public Source getSource() {
+        return source;
+    }
+
+    public void setSource(Source source) {
+        this.source = source;
+    }
+
+    public String getStatementDescriptor() {
+        return statementDescriptor;
+    }
+
+    public void setStatementDescriptor(String statementDescriptor) {
+        this.statementDescriptor = statementDescriptor;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public static Topup create(Map<String, Object> params)
+            throws AuthenticationException, InvalidRequestException,
+            APIConnectionException, CardException, APIException {
+        return create(params, null);
+    }
+
+    public static Topup create(Map<String, Object> params, RequestOptions options)
+            throws AuthenticationException, InvalidRequestException,
+            APIConnectionException, CardException, APIException {
+        return request(RequestMethod.POST, classURL(Topup.class), params, Topup.class, options);
+    }
+
+    public static Topup retrieve(String id) throws AuthenticationException,
+            InvalidRequestException, APIConnectionException, CardException,
+            APIException {
+        return retrieve(id, null);
+    }
+
+    public static Topup retrieve(String id, RequestOptions options)
+            throws AuthenticationException, InvalidRequestException,
+            APIConnectionException, CardException, APIException {
+        return retrieve(id, null, options);
+    }
+
+    public static Topup retrieve(String id, Map<String, Object> params, RequestOptions options)
+            throws AuthenticationException, InvalidRequestException,
+            APIConnectionException, CardException, APIException {
+        return request(RequestMethod.GET, instanceURL(Topup.class, id), params, Topup.class, options);
+    }
+
+    public static TopupCollection list(Map<String, Object> params)
+            throws AuthenticationException, InvalidRequestException,
+            APIConnectionException, CardException, APIException {
+        return list(params, null);
+    }
+
+    public static TopupCollection list(Map<String, Object> params, RequestOptions options)
+            throws AuthenticationException, InvalidRequestException,
+            APIConnectionException, CardException, APIException {
+        return requestCollection(classURL(Topup.class), params, TopupCollection.class, options);
+    }
+
+    @Override
+    public Topup update(Map<String, Object> params) throws AuthenticationException, InvalidRequestException, APIConnectionException, CardException, APIException {
+        return update(params, null);
+    }
+
+    @Override
+    public Topup update(Map<String, Object> params, RequestOptions options) throws AuthenticationException, InvalidRequestException, APIConnectionException, CardException, APIException {
+        return request(RequestMethod.POST, instanceURL(Topup.class, id), params, Topup.class, options);
+    }
+}

--- a/src/main/java/com/stripe/model/TopupCollection.java
+++ b/src/main/java/com/stripe/model/TopupCollection.java
@@ -1,0 +1,4 @@
+package com.stripe.model;
+
+public class TopupCollection extends StripeCollection<Topup> {
+}

--- a/src/test/java/com/stripe/model/TopupTest.java
+++ b/src/test/java/com/stripe/model/TopupTest.java
@@ -1,0 +1,121 @@
+package com.stripe.model;
+
+import com.stripe.BaseStripeTest;
+import com.stripe.exception.StripeException;
+import com.stripe.net.APIResource;
+import com.stripe.net.LiveStripeResponseGetter;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+
+public class TopupTest extends BaseStripeTest {
+    @Before
+    public void mockStripeResponseGetter() {
+        APIResource.setStripeResponseGetter(networkMock);
+    }
+
+    @After
+    public void unmockStripeResponseGetter() {
+        /* This needs to be done because tests aren't isolated in Java */
+        APIResource.setStripeResponseGetter(new LiveStripeResponseGetter());
+    }
+
+    @Test
+    public void testDeserialize() throws IOException {
+        String json = resource("topup.json");
+        Topup topup = APIResource.GSON.fromJson(json, Topup.class);
+        assertEquals("tu_123", topup.getId());
+        assertEquals("topup", topup.getObject());
+        assertEquals(1000, topup.getAmount().intValue());
+        assertEquals("usd", topup.getCurrency());
+        assertEquals("Testing", topup.getDescription());
+        assertEquals(1518134400, topup.getExpectedAvailabilityDate().longValue());
+        assertEquals(1517619386, topup.getCreated().longValue());
+        assertEquals("pending", topup.getStatus());
+        assertEquals("statement_descriptor", topup.getStatementDescriptor());
+        assertEquals("txn_123", topup.getBalanceTransaction());
+        assertFalse(topup.getLivemode());
+        assertFalse(topup.getMetadata().isEmpty());
+        assertTrue(topup.getMetadata().containsKey("email"));
+        assertEquals("test@test.com", topup.getMetadata().get("email"));
+        Source source = topup.getSource();
+        assertEquals("src_123", source.getId());
+        assertEquals("ach_debit", source.getType());
+    }
+
+    @Test
+    public void testDeserializeExpandBalanceTransaction() throws IOException {
+        String expandedJson = resource("topup_expansions.json");
+        Topup expandedTopup = APIResource.GSON.fromJson(expandedJson, Topup.class);
+
+        BalanceTransaction balanceTransaction = expandedTopup.getBalanceTransactionObject();
+        assertEquals("txn_18tjj22eZvKYlo2CeFxM3FxI", expandedTopup.getBalanceTransaction());
+        assertEquals("txn_18tjj22eZvKYlo2CeFxM3FxI", balanceTransaction.getId());
+        assertEquals(316, balanceTransaction.getAmount().longValue());
+
+        expandedTopup.setBalanceTransaction("txn_456");
+        assertEquals("txn_456", expandedTopup.getBalanceTransaction());
+        BalanceTransaction newBalanceTranscation = new BalanceTransaction();
+        expandedTopup.setBalanceTransactionObject(newBalanceTranscation);
+        assertEquals(newBalanceTranscation, expandedTopup.getBalanceTransactionObject());
+    }
+
+    @Test
+    public void testCreate() throws StripeException {
+        Map<String, Object> params = new HashMap<>();
+        params.put("id", "tu_123");
+        params.put("amount", 1000);
+        params.put("currency", "usd");
+        params.put("description", "top-up description");
+        params.put("source", "src_foo");
+        params.put("statement_descriptor", "Stripe");
+
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("extra-data", "More data");
+        params.put("metadata", metadata);
+
+        Topup.create(params);
+        verifyPost(Topup.class, "https://api.stripe.com/v1/topups", params);
+        verifyNoMoreInteractions(networkMock);
+    }
+
+    @Test
+    public void testRetrieve() throws StripeException {
+        Topup.retrieve("tu_123");
+        verifyGet(Topup.class, "https://api.stripe.com/v1/topups/tu_123");
+        verifyNoMoreInteractions(networkMock);
+    }
+
+    @Test
+    public void testUpdate() throws StripeException {
+        Topup topup = new Topup();
+        topup.setId("tu_123");
+
+        Map<String, String> metadata = new HashMap<String, String>();
+        metadata.put("email", "test@test.com");
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("metadata", metadata);
+        topup.update(params);
+
+        verifyPost(Topup.class, "https://api.stripe.com/v1/topups/tu_123", params);
+        verifyNoMoreInteractions(networkMock);
+    }
+
+    @Test
+    public void testList() throws StripeException {
+        Topup.list(Collections.<String, Object>emptyMap());
+
+        verifyGet(TopupCollection.class, "https://api.stripe.com/v1/topups");
+        verifyNoMoreInteractions(networkMock);
+    }
+}

--- a/src/test/resources/com/stripe/model/topup.json
+++ b/src/test/resources/com/stripe/model/topup.json
@@ -1,0 +1,61 @@
+{
+  "id": "tu_123",
+  "object": "topup",
+  "amount": 1000,
+  "balance_transaction": "txn_123",
+  "created": 1517619386,
+  "currency": "usd",
+  "description": "Testing",
+  "expected_availability_date": 1518134400,
+  "failure_code": null,
+  "failure_message": null,
+  "livemode": false,
+  "metadata": {
+    "email": "test@test.com"
+  },
+  "source": {
+    "id": "src_123",
+    "object": "source",
+    "amount": null,
+    "client_secret": "src_client_secret_123",
+    "code_verification": {
+      "attempts_remaining": 10,
+      "status": "pending"
+    },
+    "created": 1517423043,
+    "currency": "usd",
+    "flow": "code_verification",
+    "livemode": true,
+    "metadata": {},
+    "owner": {
+      "address": {
+        "city": null,
+        "country": "US",
+        "line1": null,
+        "line2": null,
+        "postal_code": null,
+        "state": null
+      },
+      "email": null,
+      "name": null,
+      "phone": null,
+      "verified_address": null,
+      "verified_email": null,
+      "verified_name": null,
+      "verified_phone": null
+    },
+    "statement_descriptor": null,
+    "status": "chargeable",
+    "type": "ach_debit",
+    "usage": "reusable",
+    "ach_debit": {
+      "country": "US",
+      "type": "individual",
+      "routing_number": "011111110",
+      "fingerprint": "test_fingerprint",
+      "last4": "1111"
+    }
+  },
+  "statement_descriptor": "statement_descriptor",
+  "status": "pending"
+}

--- a/src/test/resources/com/stripe/model/topup_expansions.json
+++ b/src/test/resources/com/stripe/model/topup_expansions.json
@@ -1,0 +1,91 @@
+{
+  "id": "tu_123",
+  "object": "topup",
+  "amount": 1000,
+  "balance_transaction": {
+    "id": "txn_18tjj22eZvKYlo2CeFxM3FxI",
+    "object": "balance_transaction",
+    "amount": 316,
+    "available_on": 1474416000,
+    "created": 1473883880,
+    "currency": "usd",
+    "description": "User: 832. Events: 1283. Total Tickets: 1",
+    "fee": 39,
+    "fee_details": [
+      {
+        "amount": 39,
+        "application": null,
+        "currency": "usd",
+        "description": "Stripe processing fees",
+        "type": "stripe_fee"
+      }
+    ],
+    "net": 277,
+    "source": "ch_18tjj22eZvKYlo2CBMsf6JfQ",
+    "sourced_transfers": {
+      "object": "list",
+      "data": [
+      ],
+      "has_more": false,
+      "total_count": 0,
+      "url": "/v1/transfers?source_transaction=ch_18tjj22eZvKYlo2CBMsf6JfQ"
+    },
+    "status": "pending",
+    "type": "charge"
+  },
+  "created": 1517619386,
+  "currency": "usd",
+  "description": "Testing",
+  "expected_availability_date": 1518134400,
+  "failure_code": null,
+  "failure_message": null,
+  "livemode": false,
+  "metadata": {
+    "email": "test@test.com"
+  },
+  "source": {
+    "id": "src_123",
+    "object": "source",
+    "amount": null,
+    "client_secret": "src_client_secret_123",
+    "code_verification": {
+      "attempts_remaining": 10,
+      "status": "pending"
+    },
+    "created": 1517423043,
+    "currency": "usd",
+    "flow": "code_verification",
+    "livemode": true,
+    "metadata": {},
+    "owner": {
+      "address": {
+        "city": null,
+        "country": "US",
+        "line1": null,
+        "line2": null,
+        "postal_code": null,
+        "state": null
+      },
+      "email": null,
+      "name": null,
+      "phone": null,
+      "verified_address": null,
+      "verified_email": null,
+      "verified_name": null,
+      "verified_phone": null
+    },
+    "statement_descriptor": null,
+    "status": "chargeable",
+    "type": "ach_debit",
+    "usage": "reusable",
+    "ach_debit": {
+      "country": "US",
+      "type": "individual",
+      "routing_number": "011111110",
+      "fingerprint": "test_fingerprint",
+      "last4": "1111"
+    }
+  },
+  "statement_descriptor": "statement_descriptor",
+  "status": "pending"
+}


### PR DESCRIPTION
This change adds support for /v1/topups endpoint.

r? @jkakar-stripe @ccontinanza-stripe @chellman-stripe @kenneth-stripe @miguel-stripe
r? @stripe/api-libraries

I dropped `com.stripe.functional.Topup` because `stripe-java` doesn't use `stripe-mock` for functional testing and relies on publicly exposed endpoints, but at the moment `/v1/topups` is gated. 