### PR TITLE
Add support for code attribute on all Stripe exceptions

### DIFF
--- a/src/main/java/com/stripe/exception/APIConnectionException.java
+++ b/src/main/java/com/stripe/exception/APIConnectionException.java
@@ -1,15 +1,13 @@
 package com.stripe.exception;
 
 public class APIConnectionException extends StripeException {
-
-	private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 2L;
 
 	public APIConnectionException(String message) {
-		super(message, null, 0);
+		this(message, null);
 	}
 
 	public APIConnectionException(String message, Throwable e) {
-		super(message, null, 0, e);
+		super(message, null, null, 0, e);
 	}
-
 }

--- a/src/main/java/com/stripe/exception/APIException.java
+++ b/src/main/java/com/stripe/exception/APIException.java
@@ -1,11 +1,18 @@
 package com.stripe.exception;
 
 public class APIException extends StripeException {
+	private static final long serialVersionUID = 2L;
 
-	private static final long serialVersionUID = 1L;
-
+	/**
+	 * @deprecated Use new constructor with `code` argument instead.
+	 */
+	@Deprecated
+	// TODO: remove this constructor in next major version bump
 	public APIException(String message, String requestId, Integer statusCode, Throwable e) {
-		super(message, requestId, statusCode, e);
+		this(message, requestId, null, statusCode, e);
 	}
 
+	public APIException(String message, String requestId, String code, Integer statusCode, Throwable e) {
+		super(message, requestId, code, statusCode, e);
+	}
 }

--- a/src/main/java/com/stripe/exception/AuthenticationException.java
+++ b/src/main/java/com/stripe/exception/AuthenticationException.java
@@ -1,12 +1,18 @@
 package com.stripe.exception;
 
 public class AuthenticationException extends StripeException {
+	private static final long serialVersionUID = 2L;
 
-
+	/**
+	 * @deprecated Use new constructor with `code` argument instead.
+	 */
+	@Deprecated
+	// TODO: remove this constructor in next major version bump
 	public AuthenticationException(String message, String requestId, Integer statusCode) {
-		super(message, requestId, statusCode);
+		this(message, requestId, null, statusCode);
 	}
 
-	private static final long serialVersionUID = 1L;
-
+	public AuthenticationException(String message, String requestId, String code, Integer statusCode) {
+		super(message, requestId, code, statusCode);
+	}
 }

--- a/src/main/java/com/stripe/exception/CardException.java
+++ b/src/main/java/com/stripe/exception/CardException.java
@@ -1,23 +1,17 @@
 package com.stripe.exception;
 
 public class CardException extends StripeException {
-	private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 2L;
 
-	private String code;
 	private String param;
 	private String declineCode;
 	private String charge;
 
 	public CardException(String message, String requestId, String code, String param, String declineCode, String charge, Integer statusCode, Throwable e) {
-		super(message, requestId, statusCode, e);
-		this.code = code;
+		super(message, requestId, code, statusCode, e);
 		this.param = param;
 		this.declineCode = declineCode;
 		this.charge = charge;
-	}
-
-	public String getCode() {
-		return code;
 	}
 
 	public String getParam() {

--- a/src/main/java/com/stripe/exception/InvalidRequestException.java
+++ b/src/main/java/com/stripe/exception/InvalidRequestException.java
@@ -1,18 +1,25 @@
 package com.stripe.exception;
 
 public class InvalidRequestException extends StripeException {
-
-	private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 2L;
 
 	private final String param;
 
+	/**
+	 * @deprecated Use new constructor with `code` argument instead.
+	 */
+	@Deprecated
+	// TODO: remove this constructor in next major version bump
 	public InvalidRequestException(String message, String param, String requestId, Integer statusCode, Throwable e) {
-		super(message, requestId, statusCode, e);
+		this(message, param, requestId, null, statusCode, e);
+	}
+
+	public InvalidRequestException(String message, String param, String requestId, String code, Integer statusCode, Throwable e) {
+		super(message, requestId, code, statusCode, e);
 		this.param = param;
 	}
 
 	public String getParam() {
 		return param;
 	}
-
 }

--- a/src/main/java/com/stripe/exception/PermissionException.java
+++ b/src/main/java/com/stripe/exception/PermissionException.java
@@ -1,9 +1,18 @@
 package com.stripe.exception;
 
 public class PermissionException extends AuthenticationException {
-	private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 2L;
 
+	/**
+	 * @deprecated Use new constructor with `code` argument instead.
+	 */
+	@Deprecated
+	// TODO: remove this constructor in next major version bump
 	public PermissionException(String message, String requestId, Integer statusCode) {
-		super(message, requestId, statusCode);
+		this(message, requestId, null, statusCode);
+	}
+
+	public PermissionException(String message, String requestId, String code, Integer statusCode) {
+		super(message, requestId, code, statusCode);
 	}
 }

--- a/src/main/java/com/stripe/exception/RateLimitException.java
+++ b/src/main/java/com/stripe/exception/RateLimitException.java
@@ -1,9 +1,18 @@
 package com.stripe.exception;
 
 public class RateLimitException extends InvalidRequestException {
+	private static final long serialVersionUID = 2L;
 
+	/**
+	 * @deprecated Use new constructor with `code` argument instead.
+	 */
+	@Deprecated
+	// TODO: remove this constructor in next major version bump
 	public RateLimitException(String message, String param, String requestId, Integer statusCode, Throwable e) {
-		super(message, param, requestId, statusCode, e);
+		this(message, param, null, requestId, statusCode, e);
 	}
 
+	public RateLimitException(String message, String param, String requestId, String code, Integer statusCode, Throwable e) {
+		super(message, param, code, requestId, statusCode, e);
+	}
 }

--- a/src/main/java/com/stripe/exception/SignatureVerificationException.java
+++ b/src/main/java/com/stripe/exception/SignatureVerificationException.java
@@ -1,18 +1,16 @@
 package com.stripe.exception;
 
 public class SignatureVerificationException extends StripeException {
-
-	private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 2L;
 
 	private final String sigHeader;
 
 	public SignatureVerificationException(String message, String sigHeader) {
-		super(message, null, 0);
+		super(message, null, null, 0);
 		this.sigHeader = sigHeader;
 	}
 
 	public String getSigHeader() {
 		return sigHeader;
 	}
-
 }

--- a/src/main/java/com/stripe/exception/StripeException.java
+++ b/src/main/java/com/stripe/exception/StripeException.java
@@ -1,23 +1,44 @@
 package com.stripe.exception;
 
 public abstract class StripeException extends Exception {
+	private static final long serialVersionUID = 2L;
 
+	private String code;
 	private String requestId;
 	private Integer statusCode;
 
+	/**
+	 * @deprecated Use new constructor with `code` argument instead.
+	 */
+	@Deprecated
+	// TODO: remove this constructor in next major version bump
 	public StripeException(String message, String requestId, Integer statusCode) {
-		super(message, null);
-		this.requestId = requestId;
-		this.statusCode = statusCode;
+		this(message, requestId, null, statusCode, null);
 	}
 
+	/**
+	 * @deprecated Use new constructor with `code` argument instead.
+	 */
+	@Deprecated
+	// TODO: remove this constructor in next major version bump
 	public StripeException(String message, String requestId, Integer statusCode, Throwable e) {
-		super(message, e);
-		this.statusCode = statusCode;
-		this.requestId = requestId;
+		this(message, requestId, null, statusCode, e);
 	}
 
-	private static final long serialVersionUID = 1L;
+	public StripeException(String message, String requestId, String code, Integer statusCode) {
+		this(message, requestId, code, statusCode, null);
+	}
+
+	public StripeException(String message, String requestId, String code, Integer statusCode, Throwable e) {
+		super(message, e);
+		this.code = code;
+		this.requestId = requestId;
+		this.statusCode = statusCode;
+	}
+
+	public String getCode() {
+		return code;
+	}
 
 	public String getRequestId() {
 		return requestId;
@@ -28,11 +49,13 @@ public abstract class StripeException extends Exception {
 	}
 
 	public String toString() {
-		String reqIdStr = "";
-		if (requestId != null) {
-			reqIdStr = "; request-id: " + requestId;
+		String additionalInfo = "";
+		if (code != null) {
+			additionalInfo += "; code: " + code;
 		}
-		return super.toString() + reqIdStr;
+		if (requestId != null) {
+			additionalInfo += "; request-id: " + requestId;
+		}
+		return super.toString() + additionalInfo;
 	}
 }
-

--- a/src/main/java/com/stripe/exception/oauth/InvalidClientException.java
+++ b/src/main/java/com/stripe/exception/oauth/InvalidClientException.java
@@ -4,8 +4,7 @@ package com.stripe.exception.oauth;
  * InvalidClientException is raised when authentication fails.
  */
 public class InvalidClientException extends OAuthException {
-
-	private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 2L;
 
 	public InvalidClientException(String code, String description, String requestId, Integer statusCode, Throwable e) {
 		super(code, description, requestId, statusCode, e);

--- a/src/main/java/com/stripe/exception/oauth/InvalidGrantException.java
+++ b/src/main/java/com/stripe/exception/oauth/InvalidGrantException.java
@@ -7,11 +7,9 @@ package com.stripe.exception.oauth;
  * doesn't match the mode of a code or refresh token.
  */
 public class InvalidGrantException extends OAuthException {
-
-	private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 2L;
 
 	public InvalidGrantException(String code, String description, String requestId, Integer statusCode, Throwable e) {
 		super(code, description, requestId, statusCode, e);
 	}
-
 }

--- a/src/main/java/com/stripe/exception/oauth/InvalidRequestException.java
+++ b/src/main/java/com/stripe/exception/oauth/InvalidRequestException.java
@@ -5,11 +5,9 @@ package com.stripe.exception.oauth;
  * parameter is not provided, but was required.
  */
 public class InvalidRequestException extends OAuthException {
-
-	private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 2L;
 
 	public InvalidRequestException(String code, String description, String requestId, Integer statusCode, Throwable e) {
 		super(code, description, requestId, statusCode, e);
 	}
-
 }

--- a/src/main/java/com/stripe/exception/oauth/InvalidScopeException.java
+++ b/src/main/java/com/stripe/exception/oauth/InvalidScopeException.java
@@ -4,11 +4,9 @@ package com.stripe.exception.oauth;
  * InvalidScopeException is raised when an invalid scope parameter is provided.
  */
 public class InvalidScopeException extends OAuthException {
-
-	private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 2L;
 
 	public InvalidScopeException(String code, String description, String requestId, Integer statusCode, Throwable e) {
 		super(code, description, requestId, statusCode, e);
 	}
-
 }

--- a/src/main/java/com/stripe/exception/oauth/OAuthException.java
+++ b/src/main/java/com/stripe/exception/oauth/OAuthException.java
@@ -6,17 +6,9 @@ import com.stripe.exception.StripeException;
  * Base parent class for all OAuth exceptions.
  */
 public class OAuthException extends StripeException {
-
-	private static final long serialVersionUID = 1L;
-
-	private final String code;
+	private static final long serialVersionUID = 2L;
 
 	public OAuthException(String code, String description, String requestId, Integer statusCode, Throwable e) {
-		super(description, requestId, statusCode, e);
-		this.code = code;
-	}
-
-	public String getCode() {
-		return code;
+		super(description, requestId, code, statusCode, e);
 	}
 }

--- a/src/main/java/com/stripe/exception/oauth/UnsupportedGrantTypeException.java
+++ b/src/main/java/com/stripe/exception/oauth/UnsupportedGrantTypeException.java
@@ -5,11 +5,9 @@ package com.stripe.exception.oauth;
  * parameter is specified.
  */
 public class UnsupportedGrantTypeException extends OAuthException {
-
-	private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 2L;
 
 	public UnsupportedGrantTypeException(String code, String description, String requestId, Integer statusCode, Throwable e) {
 		super(code, description, requestId, statusCode, e);
 	}
-
 }

--- a/src/main/java/com/stripe/exception/oauth/UnsupportedResponseTypeException.java
+++ b/src/main/java/com/stripe/exception/oauth/UnsupportedResponseTypeException.java
@@ -5,11 +5,9 @@ package com.stripe.exception.oauth;
  * parameter is specified.
  */
 public class UnsupportedResponseTypeException extends OAuthException {
-
-	private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 2L;
 
 	public UnsupportedResponseTypeException(String code, String description, String requestId, Integer statusCode, Throwable e) {
 		super(code, description, requestId, statusCode, e);
 	}
-
 }

--- a/src/main/java/com/stripe/model/ExternalAccount.java
+++ b/src/main/java/com/stripe/model/ExternalAccount.java
@@ -83,7 +83,8 @@ public class ExternalAccount extends APIResource implements HasId, MetadataStore
 		if (this.getCustomer() != null) {
 			return request(RequestMethod.POST, String.format("%s/verify", this.getInstanceURL()), params, ExternalAccount.class, options);
 		} else {
-			throw new InvalidRequestException("Only customer bank accounts can be verified in this manner.", null, null, null, null);
+			throw new InvalidRequestException("Only customer bank accounts can be verified in this manner.",
+				null, null, null, 0, null);
 		}
 	}
 

--- a/src/main/java/com/stripe/model/Source.java
+++ b/src/main/java/com/stripe/model/Source.java
@@ -213,7 +213,8 @@ public class Source extends ExternalAccount implements HasSourceTypeData {
 	public DeletedExternalAccount delete(RequestOptions options) throws
 			AuthenticationException, InvalidRequestException,
 			APIConnectionException, CardException, APIException {
-			throw new InvalidRequestException("Source objects cannot be deleted. If you want to detach the source from a customer object, use detach().", null, null, null, null);
+			throw new InvalidRequestException("Source objects cannot be deleted. If you want to detach the source from a customer object, use detach().",
+				null, null, null, 0, null);
 	}
 
 	public Source detach()
@@ -235,7 +236,8 @@ public class Source extends ExternalAccount implements HasSourceTypeData {
 			String url = String.format("%s/%s/sources/%s", classURL(Customer.class), this.getCustomer(), this.getId());
 			return request(RequestMethod.DELETE, url, params, Source.class, options);
 		} else {
-			throw new InvalidRequestException("This source object does not appear to be currently attached to a customer object.", null, null, null, null);
+			throw new InvalidRequestException("This source object does not appear to be currently attached to a customer object.",
+				null, null, null, 0, null);
 		}
 	}
 

--- a/src/main/java/com/stripe/net/APIResource.java
+++ b/src/main/java/com/stripe/net/APIResource.java
@@ -128,7 +128,7 @@ public abstract class APIResource extends StripeObject {
 			throw new InvalidRequestException("Unable to encode parameters to "
 					+ CHARSET
 					+ ". Please contact support@stripe.com for assistance.",
-					null, null, 0, e);
+					null, null, null, 0, e);
 		}
 	}
 

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -326,7 +326,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 			throw new InvalidRequestException("You cannot set '" + keyPrefix + "' to an empty string. " +
 					"We interpret empty strings as null in requests. " +
 					"You may set '" + keyPrefix + "' to null to delete the property.",
-					keyPrefix, null, 0, null);
+					keyPrefix, null, null, 0, null);
 		} else if (value == null) {
 			flatParams = new LinkedList<Parameter>();
 			flatParams.add(new Parameter(keyPrefix, ""));
@@ -465,7 +465,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 					"No API key provided. (HINT: set your API key using 'Stripe.apiKey = <API-KEY>'. "
 							+ "You can generate API keys from the Stripe web interface. "
 							+ "See https://stripe.com/api for details or email support@stripe.com if you have questions.",
-					null, 0);
+					null, null, 0);
 		}
 
 		try {
@@ -549,7 +549,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 			throw new InvalidRequestException("Unable to encode parameters to "
 					+ APIResource.CHARSET
 					+ ". Please contact support@stripe.com for assistance.",
-					null, null, 0, e);
+					null, null, null, 0, e);
 		}
 
 		try {
@@ -577,7 +577,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 		if (method != APIResource.RequestMethod.POST) {
 			throw new InvalidRequestException(
 					"Multipart requests for HTTP methods other than POST "
-							+ "are currently not supported.", null, null, 0, null);
+							+ "are currently not supported.", null, null, null, 0, null);
 		}
 
 		java.net.HttpURLConnection conn = null;
@@ -603,16 +603,16 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 						File currentFile = (File) value;
 						if (!currentFile.exists()) {
 							throw new InvalidRequestException("File for key "
-									+ key + " must exist.", null, null, 0, null);
+									+ key + " must exist.", null, null, null, 0, null);
 						} else if (!currentFile.isFile()) {
 							throw new InvalidRequestException("File for key "
 									+ key
 									+ " must be a file and not a directory.",
-									null, null, 0, null);
+									null, null, null, 0, null);
 						} else if (!currentFile.canRead()) {
 							throw new InvalidRequestException(
 									"Must have read permissions on file for key "
-											+ key + ".", null, null, 0, null);
+											+ key + ".", null, null, null, 0, null);
 						}
 						multipartProcessor.addFileField(key, currentFile);
 					} else {
@@ -664,19 +664,19 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 				LiveStripeResponseGetter.ErrorContainer.class).error;
 		switch (rCode) {
 			case 400:
-				throw new InvalidRequestException(error.message, error.param, requestId, rCode, null);
+				throw new InvalidRequestException(error.message, error.param, requestId, error.code, rCode, null);
 			case 404:
-				throw new InvalidRequestException(error.message, error.param, requestId, rCode, null);
+				throw new InvalidRequestException(error.message, error.param, requestId, error.code, rCode, null);
 			case 401:
-				throw new AuthenticationException(error.message, requestId, rCode);
+				throw new AuthenticationException(error.message, requestId, error.code, rCode);
 			case 402:
 				throw new CardException(error.message, requestId, error.code, error.param, error.decline_code, error.charge, rCode, null);
 			case 403:
-				throw new PermissionException(error.message, requestId, rCode);
+				throw new PermissionException(error.message, requestId, error.code, rCode);
 			case 429:
-				throw new RateLimitException(error.message, error.param, requestId, rCode, null);
+				throw new RateLimitException(error.message, error.param, requestId, error.code, rCode, null);
 			default:
-				throw new APIException(error.message, requestId, rCode, null);
+				throw new APIException(error.message, requestId, error.code, rCode, null);
 		}
 	}
 
@@ -789,25 +789,25 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 					.getDeclaredMethod("getContent").invoke(response), APIResource.CHARSET);
 			return new StripeResponse(responseCode, body);
 		} catch (InvocationTargetException e) {
-			throw new APIException(unknownErrorMessage, null, 0, e);
+			throw new APIException(unknownErrorMessage, null, null, 0, e);
 		} catch (MalformedURLException e) {
-			throw new APIException(unknownErrorMessage, null, 0, e);
+			throw new APIException(unknownErrorMessage, null, null, 0, e);
 		} catch (NoSuchFieldException e) {
-			throw new APIException(unknownErrorMessage, null, 0, e);
+			throw new APIException(unknownErrorMessage, null, null, 0, e);
 		} catch (SecurityException e) {
-			throw new APIException(unknownErrorMessage, null, 0, e);
+			throw new APIException(unknownErrorMessage, null, null, 0, e);
 		} catch (NoSuchMethodException e) {
-			throw new APIException(unknownErrorMessage, null, 0, e);
+			throw new APIException(unknownErrorMessage, null, null, 0, e);
 		} catch (ClassNotFoundException e) {
-			throw new APIException(unknownErrorMessage, null, 0, e);
+			throw new APIException(unknownErrorMessage, null, null, 0, e);
 		} catch (IllegalArgumentException e) {
-			throw new APIException(unknownErrorMessage, null, 0, e);
+			throw new APIException(unknownErrorMessage, null, null, 0, e);
 		} catch (IllegalAccessException e) {
-			throw new APIException(unknownErrorMessage, null, 0, e);
+			throw new APIException(unknownErrorMessage, null, null, 0, e);
 		} catch (InstantiationException e) {
-			throw new APIException(unknownErrorMessage, null, 0, e);
+			throw new APIException(unknownErrorMessage, null, null, 0, e);
 		} catch (UnsupportedEncodingException e) {
-			throw new APIException(unknownErrorMessage, null, 0, e);
+			throw new APIException(unknownErrorMessage, null, null, 0, e);
 		}
 	}
 }

--- a/src/main/java/com/stripe/net/OAuth.java
+++ b/src/main/java/com/stripe/net/OAuth.java
@@ -44,7 +44,7 @@ public final class OAuth {
 			throw new InvalidRequestException("Unable to encode parameters to "
 					+ APIResource.CHARSET
 					+ ". Please contact support@stripe.com for assistance.",
-					null, null, 0, e);
+					null, null, null, 0, e);
 		}
 
 		String url = base + "/oauth/authorize?" + query;
@@ -107,7 +107,7 @@ public final class OAuth {
 							+ "after registering your account as a platform. See "
 							+ "https://stripe.com/docs/connect/standard-accounts for details, "
 							+ "or email support@stripe.com if you have any questions.",
-					null, 0);
+					null, null, 0);
 		}
 
 		return clientId;


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

- Move the `code` attribute directly in `StripeException` class so that it is available on all Stripe exceptions
- Bump the `serialVersionUID` value from 1 to 2 on all exception classes
- Clean up / Normalize whitespace
- Mark existing constructors as deprecated with a reminder to remove them in the next major version bump (so we can avoid a breaking change for this, in case users are instantiating Stripe exceptions themselves for some reason)
- Update all existing Stripe exception raises to use the new constructor, with the code returned by the API or `null` for client-side errors

I didn't add any new tests as stripe-java's existing testing infrastructure does not provide an easy way of testing errors, but I can look into adding that if you think it'd be useful.
