### PR TITLE
Add title and version in JAR manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,14 @@ dependencies {
     testRuntime group: 'org.slf4j', name: 'slf4j-api', version: '1.7.10'
 }
 
+jar {
+    manifest {
+        attributes("Implementation-Title": POM_NAME,
+                   "Implementation-Version": VERSION_NAME,
+                   "Implementation-Vendor": VENDOR_NAME)
+    }
+}
+
 apply from: 'deploy.gradle'
 
 test {

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,5 @@ POM_NAME=stripe-java
 POM_ARTIFACT_ID=stripe-java
 POM_PACKAGING=jar
 POM_ORGANIZATION_URL=https://stripe.com
+
+VENDOR_NAME=Stripe, Inc. (https://stripe.com)


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Adds the `Implementation-Title`, `Implementation-Version` and `Implementation-Vendor` attributes to the JAR manifest file. This is good practice for distributed JARs and allows for programmatically checking the version.
