### PR TITLE
Add support for passing parameters to autoPagingIterable()

### DIFF
--- a/src/main/java/com/stripe/model/StripeCollection.java
+++ b/src/main/java/com/stripe/model/StripeCollection.java
@@ -100,6 +100,19 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject imp
 		return new PagingIterable<T>(this);
 	}
 
+	public Iterable<T> autoPagingIterable(Map<String, Object> params) {
+		this.setRequestParams(params);
+
+		return new PagingIterable<T>(this);
+	}
+
+	public Iterable<T> autoPagingIterable(Map<String, Object> params, RequestOptions options) {
+		this.setRequestOptions(options);
+		this.setRequestParams(params);
+
+		return new PagingIterable<T>(this);
+	}
+
 	public RequestOptions getRequestOptions() {
 		return this.requestOptions;
 	}


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @remi-stripe 

Add support for passing parameters to `autoPagingIterable()`. Basically the same thing as #275.

Partial fix for #451.
