### PR TITLE
Add UsageRecord creation ability

### DIFF
--- a/src/main/java/com/stripe/model/UsageRecord.java
+++ b/src/main/java/com/stripe/model/UsageRecord.java
@@ -1,0 +1,71 @@
+package com.stripe.model;
+
+import com.stripe.exception.*;
+import com.stripe.net.APIResource;
+import com.stripe.net.RequestOptions;
+
+import java.util.Map;
+
+
+public class UsageRecord extends APIResource implements HasId {
+
+    String id;
+    String object;
+    Long timestamp;
+    String subscriptionItem;
+    Integer quantity;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getObject() {
+        return object;
+    }
+
+    public void setObject(String object) {
+        this.object = object;
+    }
+
+    public Long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getSubscriptionItem() {
+        return subscriptionItem;
+    }
+
+    public void setSubscriptionItem(String subscriptionItem) {
+        this.subscriptionItem = subscriptionItem;
+    }
+
+    public Integer getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(Integer quantity) {
+        this.quantity = quantity;
+    }
+
+    public static UsageRecord create(String subscriptionItem, Map<String, Object> params)
+            throws AuthenticationException, InvalidRequestException,
+            APIConnectionException, CardException, APIException {
+        return create(subscriptionItem, params, null);
+    }
+
+    public static UsageRecord create(String subscriptionItem, Map<String, Object> params, RequestOptions options)
+            throws AuthenticationException, InvalidRequestException,
+            APIConnectionException, CardException, APIException {
+        return request(RequestMethod.POST, subclassInstanceURL(SubscriptionItem.class, subscriptionItem, UsageRecord.class), params, UsageRecord.class, options);
+    }
+
+
+}

--- a/src/main/java/com/stripe/net/APIResource.java
+++ b/src/main/java/com/stripe/net/APIResource.java
@@ -94,6 +94,8 @@ public abstract class APIResource extends StripeObject {
 			return "subscription_item";
 		} else if (className.equals("threedsecure")) {
 			return "three_d_secure";
+		} else if (className.equals("usagerecord")) {
+			return "usage_record";
 		} else {
 			return className;
 		}
@@ -105,6 +107,10 @@ public abstract class APIResource extends StripeObject {
 
 	protected static String singleClassURL(Class<?> clazz, String apiBase) {
 		return String.format("%s/v1/%s", apiBase, className(clazz));
+	}
+
+	protected static String subclassInstanceURL(Class<?> parentClass, String parentId, Class<?> subclass) throws InvalidRequestException {
+		return String.format("%s/%ss", instanceURL(parentClass, parentId), className(subclass));
 	}
 
 	protected static String classURL(Class<?> clazz) {


### PR DESCRIPTION
While working on a project utilizing the new metered/usage based billing, I noticed the library didn't support UsageRecords yet, despite the docs having Java examples (probably due to auto-generated docs based on the template):

https://stripe.com/docs/api/java#usage_record_create

This is not really what I would consider a 'final' or mergeable copy of work, but I wanted to throw it out there for anyone utilizing the new feature.

I had to add `subscriptionItem` ID as a parameter passed to `create` because Stripe API will throw a 400 if you are using a sub-object endpoint such as `subscription_items/<subscription_item_id>/usage_records` and you pass the subscription item ID in both the URL and the body params. I think this problem needs to be solved in a more generic way, but for the intent of moving forward in my current project I am leaving as is and am open for suggestions :)
