### PR TITLE
Flexible billing primitives

### DIFF
--- a/src/main/java/com/stripe/model/ApplicationFee.java
+++ b/src/main/java/com/stripe/model/ApplicationFee.java
@@ -183,6 +183,7 @@ public class ApplicationFee extends APIResource implements HasId {
     // API versions 2014-07-26 and earlier render charge refunds as an array
     // instead of an object, meaning there is no sublist URL.
     if (refunds.getURL() == null) {
+      // TODO replace with subresourceURL
       refunds.setURL(String.format("/v1/application_fees/%s/refunds", getId()));
     }
 

--- a/src/main/java/com/stripe/model/ExternalAccount.java
+++ b/src/main/java/com/stripe/model/ExternalAccount.java
@@ -112,6 +112,7 @@ public class ExternalAccount extends APIResource implements HasId, MetadataStore
   }
 
   protected String getInstanceURL() {
+    // TODO: Replace with subresourceURL
     if (this.getCustomer() != null) {
       return String.format("%s/%s/sources/%s", classURL(Customer.class), this.getCustomer(),
           this.getId());

--- a/src/main/java/com/stripe/model/Plan.java
+++ b/src/main/java/com/stripe/model/Plan.java
@@ -8,12 +8,14 @@ import com.stripe.exception.InvalidRequestException;
 import com.stripe.net.APIResource;
 import com.stripe.net.RequestOptions;
 
+import java.util.List;
 import java.util.Map;
 
 public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
   String id;
   String object;
   Long amount;
+  String billingScheme;
   Long created;
   String currency;
   String interval;
@@ -22,6 +24,10 @@ public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
   Map<String, String> metadata;
   String nickname;
   ExpandableField<Product> product;
+  List<PlanTier> tiers;
+  String tiersMode;
+  PlanTransformUsage transformUsage;
+  String usageType;
 
   @Deprecated
   String statementDescription;
@@ -54,6 +60,14 @@ public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
 
   public void setAmount(Long amount) {
     this.amount = amount;
+  }
+
+  public String getBillingScheme() {
+    return billingScheme;
+  }
+
+  public void setBillingScheme(String billingScheme) {
+    this.billingScheme = billingScheme;
   }
 
   public Long getCreated() {
@@ -190,6 +204,38 @@ public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
   @Deprecated
   public void setStatementDescription(String statementDescription) {
     this.statementDescription = statementDescription;
+  }
+
+  public List<PlanTier> getTiers() {
+    return tiers;
+  }
+
+  public void setTiers(List<PlanTier> tiers) {
+    this.tiers = tiers;
+  }
+
+  public String getTiersMode() {
+    return tiersMode;
+  }
+
+  public void setTiersMode(String tiersMode) {
+    this.tiersMode = tiersMode;
+  }
+
+  public PlanTransformUsage getTransformUsage() {
+    return transformUsage;
+  }
+
+  public void setTransformUsage(PlanTransformUsage transformUsage) {
+    this.transformUsage = transformUsage;
+  }
+
+  public String getUsageType() {
+    return usageType;
+  }
+
+  public void setUsageType(String usageType) {
+    this.usageType = usageType;
   }
 
   public static Plan create(Map<String, Object> params)

--- a/src/main/java/com/stripe/model/PlanTier.java
+++ b/src/main/java/com/stripe/model/PlanTier.java
@@ -1,0 +1,24 @@
+package com.stripe.model;
+
+import com.stripe.net.APIResource;
+
+public class PlanTier extends APIResource {
+  Long amount;
+  Long upTo;
+
+  public Long getAmount() {
+    return amount;
+  }
+
+  public void setAmount(Long amount) {
+    this.amount = amount;
+  }
+
+  public Long getUpTo() {
+    return upTo;
+  }
+
+  public void setUpTo(Long upTo) {
+    this.upTo = upTo;
+  }
+}

--- a/src/main/java/com/stripe/model/PlanTransformUsage.java
+++ b/src/main/java/com/stripe/model/PlanTransformUsage.java
@@ -1,0 +1,22 @@
+package com.stripe.model;
+
+public class PlanTransformUsage {
+  Long divideBy;
+  String round;
+
+  public Long getDivideBy() {
+    return divideBy;
+  }
+
+  public void setDivideBy(Long divideBy) {
+    this.divideBy = divideBy;
+  }
+
+  public String getRound() {
+    return round;
+  }
+
+  public void setRound(String round) {
+    this.round = round;
+  }
+}

--- a/src/main/java/com/stripe/model/TransferReversalCollection.java
+++ b/src/main/java/com/stripe/model/TransferReversalCollection.java
@@ -54,9 +54,16 @@ public class TransferReversalCollection extends StripeCollection<Reversal> {
     return retrieve(id, RequestOptions.builder().setApiKey(apiKey).build());
   }
 
+  /**
+   * Load a transfer reversal.
+   * @param id Id of the reversal
+   * @param options Further request options
+   * @return The transfer reversal
+   */
   public Reversal retrieve(String id, RequestOptions options) throws AuthenticationException,
       InvalidRequestException, APIConnectionException, CardException,
       APIException {
+    // TODO replace with subresourceURL
     String url = String.format("%s%s/%s", Stripe.getApiBase(), this.getURL(), id);
     return APIResource.request(APIResource.RequestMethod.GET, url, null, Reversal.class, options);
   }

--- a/src/main/java/com/stripe/model/UsageRecord.java
+++ b/src/main/java/com/stripe/model/UsageRecord.java
@@ -1,0 +1,98 @@
+package com.stripe.model;
+
+import com.stripe.exception.APIConnectionException;
+import com.stripe.exception.APIException;
+import com.stripe.exception.AuthenticationException;
+import com.stripe.exception.CardException;
+import com.stripe.exception.InvalidRequestException;
+import com.stripe.net.APIResource;
+import com.stripe.net.RequestOptions;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class UsageRecord extends APIResource implements HasId {
+  String id;
+  String object;
+  Boolean livemode;
+  Long quantity;
+  String subscriptionItem;
+  Long timestamp;
+
+  @Override
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getObject() {
+    return object;
+  }
+
+  public void setObject(String object) {
+    this.object = object;
+  }
+
+  public Boolean getLivemode() {
+    return livemode;
+  }
+
+  public void setLivemode(Boolean livemode) {
+    this.livemode = livemode;
+  }
+
+  public Long getQuantity() {
+    return quantity;
+  }
+
+  public void setQuantity(Long quantity) {
+    this.quantity = quantity;
+  }
+
+  public String getSubscriptionItem() {
+    return subscriptionItem;
+  }
+
+  public void setSubscriptionItem(String subscriptionItem) {
+    this.subscriptionItem = subscriptionItem;
+  }
+
+  public Long getTimestamp() {
+    return timestamp;
+  }
+
+  public void setTimestamp(Long timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  /**
+   * Create a new usage record associated with a subscription item.
+   * @param params The quantity, the timestamp and the conflict behaviour (action)
+   * @param options Request options
+   * @return The created usage record
+   */
+  public static UsageRecord create(Map<String, Object> params, RequestOptions options)
+          throws AuthenticationException, InvalidRequestException,
+          APIConnectionException, CardException, APIException {
+    String subscriptionItem = (String)params.get("subscription_item");
+    if (subscriptionItem == null) {
+      throw new InvalidRequestException(
+              "The params object must contain a subscription_item element",
+              "subscription_item",
+              null,
+              null,
+              null,
+              null
+      );
+    }
+    Map<String, Object> requestParams = new HashMap<String, Object>(params);
+    requestParams.remove("subscription_item");
+    return request(
+            RequestMethod.POST,
+            subresourceURL(SubscriptionItem.class, subscriptionItem, UsageRecord.class),
+            requestParams, UsageRecord.class, options);
+  }
+}

--- a/src/main/java/com/stripe/net/APIResource.java
+++ b/src/main/java/com/stripe/net/APIResource.java
@@ -97,6 +97,8 @@ public abstract class APIResource extends StripeObject {
       return "subscription_item";
     } else if (className.equals("threedsecure")) {
       return "three_d_secure";
+    } else if (className.equals("usagerecord")) {
+      return "usage_record";
     } else {
       return className;
     }
@@ -132,6 +134,25 @@ public abstract class APIResource extends StripeObject {
           + CHARSET
           + ". Please contact support@stripe.com for assistance.",
           null, null, null, 0, e);
+    }
+  }
+
+  protected static String subresourceURL(Class<?> clazz, String id, Class<?> subClazz)
+      throws InvalidRequestException {
+    return subresourceURL(clazz, id, subClazz, Stripe.getApiBase());
+  }
+
+
+  private static String subresourceURL(Class<?> clazz, String id, Class<?> subClazz, String apiBase)
+      throws InvalidRequestException {
+    try {
+      return String.format("%s/%s/%ss", classURL(clazz, apiBase),
+              urlEncode(id), className(subClazz));
+    } catch (UnsupportedEncodingException e) {
+      throw new InvalidRequestException("Unable to encode parameters to "
+              + CHARSET
+              + ". Please contact support@stripe.com for assistance.",
+              null, null, null, 0, e);
     }
   }
 

--- a/src/test/java/com/stripe/functional/UsageRecordTest.java
+++ b/src/test/java/com/stripe/functional/UsageRecordTest.java
@@ -1,0 +1,65 @@
+package com.stripe.functional;
+
+import static org.junit.Assert.assertEquals;
+
+import com.stripe.BaseStripeFunctionalTest;
+import com.stripe.exception.StripeException;
+import com.stripe.model.Customer;
+import com.stripe.model.Plan;
+import com.stripe.model.Subscription;
+import com.stripe.model.SubscriptionItem;
+import com.stripe.model.UsageRecord;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+public class UsageRecordTest extends BaseStripeFunctionalTest {
+  @Test
+  public void testUsageRecordCreate() throws StripeException {
+    Plan plan = createMeteredPlan();
+    Subscription sub = createSubscription(plan);
+    SubscriptionItem subItem = sub.getSubscriptionItems().getData().get(0);
+
+    Map<String, Object> params = new HashMap<>();
+    params.put("quantity", 1000);
+    long unixTime = System.currentTimeMillis() / 1000L;
+    params.put("timestamp", unixTime);
+    params.put("subscription_item", subItem.getId());
+
+    UsageRecord ur = UsageRecord.create(params, null);
+
+    assertEquals(new Long(1000), ur.getQuantity());
+    assertEquals(new Long(unixTime), ur.getTimestamp());
+  }
+
+  private Plan createMeteredPlan() throws StripeException {
+    Map<String, Object> productParams = new HashMap<String, Object>();
+    productParams.put("name", "Bar");
+
+    Map<String, Object> params = getUniquePlanParams();
+    params.remove("name");
+    params.put("nickname", "Foo");
+    params.put("product", productParams);
+
+    params.put("usage_type", "metered");
+
+    return Plan.create(params);
+  }
+
+  private Subscription createSubscription(Plan plan) throws StripeException {
+    final Customer customer = Customer.create(defaultCustomerParams);
+    Map<String, Object> subscriptionParams = new HashMap<String, Object>();
+
+    Map<String, Object> planEntry = new HashMap<>();
+    planEntry.put("plan", plan.getId());
+
+    List<Map<String, Object>> subItems = new ArrayList<>();
+    subItems.add(planEntry);
+
+    subscriptionParams.put("items", subItems);
+    subscriptionParams.put("customer", customer.getId());
+    return Subscription.create(subscriptionParams);
+  }
+}

--- a/src/test/java/com/stripe/model/StandardizationTest.java
+++ b/src/test/java/com/stripe/model/StandardizationTest.java
@@ -99,9 +99,10 @@ public class StandardizationTest {
         }
         Assert.assertTrue(
             String.format(
-                "Methods on %ss like %s.%s should take a final parameter as a %s parameter.%n",
+                "Methods on %ss like %s.%s should take a final "
+                  + "parameter as a %s parameter, but got %s.%n",
                 APIResource.class.getSimpleName(), model.getSimpleName(), method.getName(),
-                RequestOptions.class.getSimpleName()),
+                RequestOptions.class.getSimpleName(), finalParamType.getCanonicalName()),
             RequestOptions.class.isAssignableFrom(finalParamType));
       }
     }

--- a/src/test/java/com/stripe/model/UsageRecordTest.java
+++ b/src/test/java/com/stripe/model/UsageRecordTest.java
@@ -1,0 +1,61 @@
+package com.stripe.model;
+
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.stripe.BaseStripeTest;
+import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
+import com.stripe.net.APIResource;
+import com.stripe.net.LiveStripeResponseGetter;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class UsageRecordTest extends BaseStripeTest {
+
+  @Before
+  public void mockStripeResponseGetter() {
+    APIResource.setStripeResponseGetter(networkMock);
+  }
+
+  @After
+  public void unmockStripeResponseGetter() {
+    /* This needs to be done because tests aren't isolated in Java */
+    APIResource.setStripeResponseGetter(new LiveStripeResponseGetter());
+  }
+
+  @Test
+  public void testCreate() throws StripeException {
+    Map<String, Object> params = new HashMap<>();
+    params.put("quantity", 1000);
+    long unixTime = System.currentTimeMillis() / 1000L;
+    params.put("timestamp", unixTime);
+    params.put("livemode", true);
+    params.put("subscription_item", "si_abc");
+
+    UsageRecord ur = UsageRecord.create(params, null);
+
+    Map<String, Object> apiParams = new HashMap<>();
+    apiParams.put("quantity", 1000);
+    apiParams.put("timestamp", unixTime);
+    apiParams.put("livemode", true);
+
+    verifyPost(UsageRecord.class,
+            "https://api.stripe.com/v1/subscription_items/si_abc/usage_records",
+            apiParams);
+    verifyNoMoreInteractions(networkMock);
+  }
+
+  @Test(expected = InvalidRequestException.class)
+  public void testInvalidCreate() throws StripeException {
+    Map<String, Object> params = new HashMap<>();
+    params.put("quantity", 1000);
+    long unixTime = System.currentTimeMillis() / 1000L;
+    params.put("timestamp", unixTime);
+    params.put("livemode", true);
+
+    UsageRecord.create(params, null);
+  }
+}


### PR DESCRIPTION
Adds flexible billing primitives to the SDK for beta functionality. Tests require an API key that has the functionality enabled.