### PR TITLE
Fix serialization of null expandable attributes

### DIFF
--- a/src/main/java/com/stripe/model/ExpandableFieldSerializer.java
+++ b/src/main/java/com/stripe/model/ExpandableFieldSerializer.java
@@ -10,8 +10,10 @@ public class ExpandableFieldSerializer implements JsonSerializer<ExpandableField
 	public JsonElement serialize(ExpandableField src, Type typeOfSrc, JsonSerializationContext context) {
 		if (src.isExpanded()) {
 			return context.serialize(src.getExpanded());
-		} else {
+		} else if (src.getId() != null) {
 			return new JsonPrimitive(src.getId());
+		} else {
+			return null;
 		}
 	}
 }

--- a/src/test/java/com/stripe/model/ExpandableFieldSerializerTest.java
+++ b/src/test/java/com/stripe/model/ExpandableFieldSerializerTest.java
@@ -10,46 +10,46 @@ import static org.junit.Assert.assertEquals;
 
 public class ExpandableFieldSerializerTest extends BaseStripeTest {
 
-    private class TestNestedObject implements HasId {
-        String id;
-        int bar;
+	private class TestNestedObject implements HasId {
+		String id;
+		int bar;
 
-        public String getId() {
-            return id;
-        }
-    }
+		public String getId() {
+			return id;
+		}
+	}
 
-    private class TestTopLevelObject extends StripeObject {
-        ExpandableField<TestNestedObject> nested;
-    }
+	private class TestTopLevelObject extends StripeObject {
+		ExpandableField<TestNestedObject> nested;
+	}
 
-    @Test
-    public void serializeNotExpanded() throws IOException {
-        TestTopLevelObject object = new TestTopLevelObject();
-        object.nested = new ExpandableField<TestNestedObject>("id_not_expanded", null);
+	@Test
+	public void serializeNotExpanded() throws IOException {
+		TestTopLevelObject object = new TestTopLevelObject();
+		object.nested = new ExpandableField<TestNestedObject>("id_not_expanded", null);
 
-        String expected = "{\n  \"nested\": \"id_not_expanded\"\n}";
-        assertEquals(expected, object.toJson());
-    }
+		String expected = "{\n  \"nested\": \"id_not_expanded\"\n}";
+		assertEquals(expected, object.toJson());
+	}
 
-    @Test
-    public void serializeExpanded() throws IOException {
-        TestNestedObject nested = new TestNestedObject();
-        nested.id = "id_expanded";
-        nested.bar = 42;
-        TestTopLevelObject object = new TestTopLevelObject();
-        object.nested = new ExpandableField<TestNestedObject>(nested.id, nested);
+	@Test
+	public void serializeExpanded() throws IOException {
+		TestNestedObject nested = new TestNestedObject();
+		nested.id = "id_expanded";
+		nested.bar = 42;
+		TestTopLevelObject object = new TestTopLevelObject();
+		object.nested = new ExpandableField<TestNestedObject>(nested.id, nested);
 
-        String expected = "{\n  \"nested\": {\n    \"id\": \"id_expanded\",\n    \"bar\": 42\n  }\n}";
-        assertEquals(expected, object.toJson());
-    }
+		String expected = "{\n  \"nested\": {\n    \"id\": \"id_expanded\",\n    \"bar\": 42\n  }\n}";
+		assertEquals(expected, object.toJson());
+	}
 
-    @Test
-    public void serializeNull() throws IOException {
-        TestTopLevelObject object = new TestTopLevelObject();
-        object.nested = new ExpandableField<TestNestedObject>(null, null);
+	@Test
+	public void serializeNull() throws IOException {
+		TestTopLevelObject object = new TestTopLevelObject();
+		object.nested = new ExpandableField<TestNestedObject>(null, null);
 
-        String expected = "{\n  \"nested\": null\n}";
-        assertEquals(expected, object.toJson());
-    }
+		String expected = "{\n  \"nested\": null\n}";
+		assertEquals(expected, object.toJson());
+	}
 }

--- a/src/test/java/com/stripe/model/ExpandableFieldSerializerTest.java
+++ b/src/test/java/com/stripe/model/ExpandableFieldSerializerTest.java
@@ -43,4 +43,13 @@ public class ExpandableFieldSerializerTest extends BaseStripeTest {
         String expected = "{\n  \"nested\": {\n    \"id\": \"id_expanded\",\n    \"bar\": 42\n  }\n}";
         assertEquals(expected, object.toJson());
     }
+
+    @Test
+    public void serializeNull() throws IOException {
+        TestTopLevelObject object = new TestTopLevelObject();
+        object.nested = new ExpandableField<TestNestedObject>(null, null);
+
+        String expected = "{\n  \"nested\": null\n}";
+        assertEquals(expected, object.toJson());
+    }
 }


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @remi-stripe @elenacanovi

Fixes the serialization of expandable attributes when both the ID and the expanded model are `null`.

Fixes #465.
