### PR TITLE
Fix encoding of arrays

### DIFF
--- a/src/main/java/com/stripe/net/APIResource.java
+++ b/src/main/java/com/stripe/net/APIResource.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+
 import com.stripe.Stripe;
 import com.stripe.exception.APIConnectionException;
 import com.stripe.exception.APIException;
@@ -148,7 +149,12 @@ public abstract class APIResource extends StripeObject {
 		if (str == null) {
 			return null;
 		} else {
-			return URLEncoder.encode(str, CHARSET);
+			// Don't use strict form encoding by changing the square bracket control
+			// characters back to their literals. This is fine by the server, and
+			// makes these parameter strings easier to read.
+			return URLEncoder.encode(str, CHARSET)
+				.replaceAll("%5B", "[")
+				.replaceAll("%5D", "]");
 		}
 	}
 


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

While working on #452, I noticed that the library can encode `List`s, but not native arrays.

- fix encoding of arrays
- no longer URL-encode `[` and `]`. This is consistent with stripe-ruby (https://github.com/stripe/stripe-ruby/blob/529b9ec4176c1c3c1b0d65587c88cc008f8652c5/lib/stripe/util.rb#L198-L202) and makes the encoded query strings easier to read
