### PR TITLE
Set indentation settings in VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,17 @@
+{
+  "editor.renderWhitespace": "all",
+  "[java]": {
+    "editor.detectIndentation": false,
+    "editor.insertSpaces": false,
+    "editor.rulers": [
+      100
+    ],
+    "editor.tabSize": 2,
+  },
+  "[json]": {
+    "editor.detectIndentation": false,
+    "editor.insertSpaces": true,
+    "editor.tabSize": 2,
+  },
+  "java.configuration.updateBuildConfiguration": "automatic"
+}


### PR DESCRIPTION
cc @stripe/api-libraries 

Set indentation settings in VSCode:
- always render whitespace
- use tabs in `.java` files and spaces in `.json` files
- display a ruler at 100 characters

(At some point in the future, I'd like us to start using Google's Java style guide, which uses 2 spaces for indents and 100 characters per line.)
