### PR TITLE
Fix import order and * imports

### DIFF
--- a/src/main/java/com/stripe/model/Account.java
+++ b/src/main/java/com/stripe/model/Account.java
@@ -1,12 +1,17 @@
 package com.stripe.model;
 
-import java.util.List;
-import java.util.Map;
-
 import com.google.gson.annotations.SerializedName;
-import com.stripe.exception.*;
+
+import com.stripe.exception.APIConnectionException;
+import com.stripe.exception.APIException;
+import com.stripe.exception.AuthenticationException;
+import com.stripe.exception.CardException;
+import com.stripe.exception.InvalidRequestException;
 import com.stripe.net.APIResource;
 import com.stripe.net.RequestOptions;
+
+import java.util.List;
+import java.util.Map;
 
 public class Account extends APIResource implements HasId, MetadataStore<Account> {
   String id;

--- a/src/main/java/com/stripe/model/BalanceTransaction.java
+++ b/src/main/java/com/stripe/model/BalanceTransaction.java
@@ -1,8 +1,5 @@
 package com.stripe.model;
 
-import java.util.List;
-import java.util.Map;
-
 import com.stripe.Stripe;
 import com.stripe.exception.APIConnectionException;
 import com.stripe.exception.APIException;
@@ -11,6 +8,9 @@ import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
 import com.stripe.net.APIResource;
 import com.stripe.net.RequestOptions;
+
+import java.util.List;
+import java.util.Map;
 
 public class BalanceTransaction extends APIResource implements HasId {
   String id;

--- a/src/main/java/com/stripe/model/DisputeDataDeserializer.java
+++ b/src/main/java/com/stripe/model/DisputeDataDeserializer.java
@@ -1,7 +1,5 @@
 package com.stripe.model;
 
-import java.lang.reflect.Type;
-
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -11,6 +9,8 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonPrimitive;
+
+import java.lang.reflect.Type;
 
 public class DisputeDataDeserializer implements JsonDeserializer<Dispute> {
   public Dispute deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {

--- a/src/main/java/com/stripe/model/ExpandableFieldDeserializer.java
+++ b/src/main/java/com/stripe/model/ExpandableFieldDeserializer.java
@@ -1,6 +1,11 @@
 package com.stripe.model;
 
-import com.google.gson.*;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;

--- a/src/main/java/com/stripe/model/ExpandableFieldSerializer.java
+++ b/src/main/java/com/stripe/model/ExpandableFieldSerializer.java
@@ -1,6 +1,9 @@
 package com.stripe.model;
 
-import com.google.gson.*;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
 
 import java.lang.reflect.Type;
 

--- a/src/main/java/com/stripe/model/ExternalAccountTypeAdapterFactory.java
+++ b/src/main/java/com/stripe/model/ExternalAccountTypeAdapterFactory.java
@@ -1,13 +1,11 @@
 package com.stripe.model;
 
 import com.google.gson.Gson;
-import com.google.gson.JsonObject;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
-
 import com.google.gson.reflect.TypeToken;
-
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 

--- a/src/main/java/com/stripe/model/LegalEntity.java
+++ b/src/main/java/com/stripe/model/LegalEntity.java
@@ -1,8 +1,8 @@
 package com.stripe.model;
 
-import java.util.List;
-
 import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
 
 public class LegalEntity extends StripeObject {
   List<Owner> additionalOwners;

--- a/src/main/java/com/stripe/model/Order.java
+++ b/src/main/java/com/stripe/model/Order.java
@@ -1,8 +1,5 @@
 package com.stripe.model;
 
-import java.util.List;
-import java.util.Map;
-
 import com.stripe.exception.APIConnectionException;
 import com.stripe.exception.APIException;
 import com.stripe.exception.AuthenticationException;
@@ -10,6 +7,9 @@ import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
 import com.stripe.net.APIResource;
 import com.stripe.net.RequestOptions;
+
+import java.util.List;
+import java.util.Map;
 
 public class Order extends APIResource implements HasId, MetadataStore<Order> {
   String id;

--- a/src/main/java/com/stripe/model/OrderReturn.java
+++ b/src/main/java/com/stripe/model/OrderReturn.java
@@ -1,8 +1,5 @@
 package com.stripe.model;
 
-import java.util.List;
-import java.util.Map;
-
 import com.stripe.exception.APIConnectionException;
 import com.stripe.exception.APIException;
 import com.stripe.exception.AuthenticationException;
@@ -10,6 +7,9 @@ import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
 import com.stripe.net.APIResource;
 import com.stripe.net.RequestOptions;
+
+import java.util.List;
+import java.util.Map;
 
 public class OrderReturn extends APIResource implements HasId {
   String id;

--- a/src/main/java/com/stripe/model/PagingIterator.java
+++ b/src/main/java/com/stripe/model/PagingIterator.java
@@ -1,13 +1,13 @@
 package com.stripe.model;
 
+import com.stripe.Stripe;
+import com.stripe.net.APIResource;
+import com.stripe.net.RequestOptions;
+
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
-
-import com.stripe.Stripe;
-import com.stripe.net.APIResource;
-import com.stripe.net.RequestOptions;
 
 public class PagingIterator<T extends HasId> extends APIResource implements Iterator<T> {
   private final String url;

--- a/src/main/java/com/stripe/model/Product.java
+++ b/src/main/java/com/stripe/model/Product.java
@@ -1,8 +1,5 @@
 package com.stripe.model;
 
-import java.util.List;
-import java.util.Map;
-
 import com.stripe.exception.APIConnectionException;
 import com.stripe.exception.APIException;
 import com.stripe.exception.AuthenticationException;
@@ -10,6 +7,9 @@ import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
 import com.stripe.net.APIResource;
 import com.stripe.net.RequestOptions;
+
+import java.util.List;
+import java.util.Map;
 
 public class Product extends APIResource implements HasId, MetadataStore<Product> {
   String id;

--- a/src/main/java/com/stripe/model/SKU.java
+++ b/src/main/java/com/stripe/model/SKU.java
@@ -1,7 +1,5 @@
 package com.stripe.model;
 
-import java.util.Map;
-
 import com.stripe.exception.APIConnectionException;
 import com.stripe.exception.APIException;
 import com.stripe.exception.AuthenticationException;
@@ -10,6 +8,7 @@ import com.stripe.exception.InvalidRequestException;
 import com.stripe.net.APIResource;
 import com.stripe.net.RequestOptions;
 
+import java.util.Map;
 
 public class SKU extends APIResource implements HasId, MetadataStore<SKU> {
   String id;

--- a/src/main/java/com/stripe/model/SourceMandateNotification.java
+++ b/src/main/java/com/stripe/model/SourceMandateNotification.java
@@ -1,9 +1,8 @@
 package com.stripe.model;
 
-import java.util.Map;
-
 import com.stripe.net.APIResource;
 
+import java.util.Map;
 
 public class SourceMandateNotification extends APIResource implements HasId, HasSourceTypeData {
   String id;

--- a/src/main/java/com/stripe/model/SourceTransaction.java
+++ b/src/main/java/com/stripe/model/SourceTransaction.java
@@ -1,9 +1,8 @@
 package com.stripe.model;
 
-import java.util.Map;
-
 import com.stripe.net.APIResource;
 
+import java.util.Map;
 
 public class SourceTransaction extends APIResource implements HasId, HasSourceTypeData {
   String id;

--- a/src/main/java/com/stripe/model/SourceTypeDataDeserializer.java
+++ b/src/main/java/com/stripe/model/SourceTypeDataDeserializer.java
@@ -1,10 +1,17 @@
 package com.stripe.model;
 
-import com.google.gson.*;
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
 
 import java.lang.reflect.Type;
-import java.util.Map;
 import java.util.HashMap;
+import java.util.Map;
 
 /* source and source_transaction objects have a `type` attribute with a string
  * value, and another attribute whose name is the value of `type` and whose value

--- a/src/main/java/com/stripe/model/StripeObject.java
+++ b/src/main/java/com/stripe/model/StripeObject.java
@@ -1,10 +1,10 @@
 package com.stripe.model;
 
-import com.stripe.net.StripeResponse;
-
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+
+import com.stripe.net.StripeResponse;
 
 import java.lang.reflect.Field;
 

--- a/src/main/java/com/stripe/model/Topup.java
+++ b/src/main/java/com/stripe/model/Topup.java
@@ -1,6 +1,10 @@
 package com.stripe.model;
 
-import com.stripe.exception.*;
+import com.stripe.exception.APIConnectionException;
+import com.stripe.exception.APIException;
+import com.stripe.exception.AuthenticationException;
+import com.stripe.exception.CardException;
+import com.stripe.exception.InvalidRequestException;
 import com.stripe.net.APIResource;
 import com.stripe.net.RequestOptions;
 

--- a/src/main/java/com/stripe/net/APIResource.java
+++ b/src/main/java/com/stripe/net/APIResource.java
@@ -1,9 +1,5 @@
 package com.stripe.net;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.util.Map;
-
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -42,6 +38,10 @@ import com.stripe.model.StripeCollectionInterface;
 import com.stripe.model.StripeObject;
 import com.stripe.model.StripeRawJsonObject;
 import com.stripe.model.StripeRawJsonObjectDeserializer;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.Map;
 
 public abstract class APIResource extends StripeObject {
   private static StripeResponseGetter stripeResponseGetter = new LiveStripeResponseGetter();

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -1,24 +1,21 @@
 package com.stripe.net;
 
 import com.stripe.Stripe;
-import com.stripe.model.StripeObject;
 import com.stripe.exception.APIConnectionException;
 import com.stripe.exception.APIException;
 import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.PermissionException;
-import com.stripe.exception.RateLimitException;
 import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.PermissionException;
+import com.stripe.exception.RateLimitException;
 import com.stripe.exception.oauth.InvalidClientException;
 import com.stripe.exception.oauth.InvalidGrantException;
-//import com.stripe.exception.oauth.InvalidRequestException;
 import com.stripe.exception.oauth.InvalidScopeException;
 import com.stripe.exception.oauth.OAuthException;
 import com.stripe.exception.oauth.UnsupportedGrantTypeException;
 import com.stripe.exception.oauth.UnsupportedResponseTypeException;
+import com.stripe.model.StripeObject;
 
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLSocketFactory;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -39,6 +36,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Scanner;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSocketFactory;
 
 public class LiveStripeResponseGetter implements StripeResponseGetter {
   private static final String DNS_CACHE_TTL_PROPERTY_NAME = "networkaddress.cache.ttl";

--- a/src/main/java/com/stripe/net/MultipartProcessor.java
+++ b/src/main/java/com/stripe/net/MultipartProcessor.java
@@ -2,11 +2,11 @@ package com.stripe.net;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.net.URLConnection;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.net.URLConnection;
 import java.util.Random;
 
 public class MultipartProcessor {

--- a/src/main/java/com/stripe/net/OAuth.java
+++ b/src/main/java/com/stripe/net/OAuth.java
@@ -1,8 +1,5 @@
 package com.stripe.net;
 
-import java.io.UnsupportedEncodingException;
-import java.util.Map;
-
 import com.stripe.Stripe;
 import com.stripe.exception.APIConnectionException;
 import com.stripe.exception.APIException;
@@ -15,6 +12,9 @@ import com.stripe.net.APIResource;
 import com.stripe.net.LiveStripeResponseGetter;
 import com.stripe.net.RequestOptions;
 import com.stripe.net.StripeResponseGetter;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Map;
 
 public final class OAuth {
   private static StripeResponseGetter stripeResponseGetter = new LiveStripeResponseGetter();

--- a/src/main/java/com/stripe/net/StripeSSLSocketFactory.java
+++ b/src/main/java/com/stripe/net/StripeSSLSocketFactory.java
@@ -1,9 +1,5 @@
 package com.stripe.net;
 
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSocket;
-import javax.net.ssl.SSLSocketFactory;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Socket;
@@ -11,6 +7,10 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
 
 /**
  * Wraps a SSLSocketFactory and enables more TLS versions

--- a/src/main/java/com/stripe/net/Webhook.java
+++ b/src/main/java/com/stripe/net/Webhook.java
@@ -4,12 +4,11 @@ import com.stripe.exception.SignatureVerificationException;
 import com.stripe.model.Event;
 
 import java.io.UnsupportedEncodingException;
-import java.util.ArrayList;
-import java.util.List;
 import java.security.InvalidKeyException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-
+import java.util.ArrayList;
+import java.util.List;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 

--- a/src/test/java/com/stripe/BaseStripeFunctionalTest.java
+++ b/src/test/java/com/stripe/BaseStripeFunctionalTest.java
@@ -1,20 +1,26 @@
 package com.stripe;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import com.stripe.exception.StripeException;
 import com.stripe.model.Customer;
 import com.stripe.model.MetadataStore;
 import com.stripe.model.Plan;
 import com.stripe.net.RequestOptions;
 import com.stripe.net.StripeResponseGetter;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import java.util.*;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 public class BaseStripeFunctionalTest {
   public static Map<String, Object> defaultChargeParams = new HashMap<String, Object>();

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -1,20 +1,27 @@
 package com.stripe;
 
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.stripe.exception.StripeException;
 import com.stripe.net.APIResource;
 import com.stripe.net.RequestOptions;
 import com.stripe.net.StripeResponseGetter;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.mockito.ArgumentMatcher;
-import org.mockito.Mockito;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
 
-import static org.mockito.Mockito.*;
+import org.junit.Before;
+import org.junit.BeforeClass;
+
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mockito;
 
 public class BaseStripeTest {
   public static StripeResponseGetter networkMock;

--- a/src/test/java/com/stripe/DocumentationTest.java
+++ b/src/test/java/com/stripe/DocumentationTest.java
@@ -1,8 +1,6 @@
 package com.stripe;
 
 import com.google.common.base.Joiner;
-import org.junit.Assert;
-import org.junit.Test;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -13,6 +11,9 @@ import java.util.Calendar;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Pattern;
+
+import org.junit.Assert;
+import org.junit.Test;
 
 public class DocumentationTest {
 

--- a/src/test/java/com/stripe/functional/AccountTest.java
+++ b/src/test/java/com/stripe/functional/AccountTest.java
@@ -1,16 +1,19 @@
 package com.stripe.functional;
 
+import static org.junit.Assert.assertTrue;
+
 import com.stripe.BaseStripeFunctionalTest;
 import com.stripe.exception.StripeException;
-import com.stripe.model.*;
-import junit.framework.Assert;
-import org.junit.Test;
+import com.stripe.model.Account;
+import com.stripe.model.AccountCollection;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import static org.junit.Assert.assertTrue;
+import junit.framework.Assert;
+
+import org.junit.Test;
 
 public class AccountTest extends BaseStripeFunctionalTest {
   @Test

--- a/src/test/java/com/stripe/functional/ApplePayDomainTest.java
+++ b/src/test/java/com/stripe/functional/ApplePayDomainTest.java
@@ -1,18 +1,19 @@
 package com.stripe.functional;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import com.stripe.BaseStripeFunctionalTest;
 import com.stripe.exception.StripeException;
 import com.stripe.model.ApplePayDomain;
 import com.stripe.model.DeletedApplePayDomain;
-import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
 
 public class ApplePayDomainTest extends BaseStripeFunctionalTest {
   static Map<String, Object> getApplePayDomainParams() throws StripeException {

--- a/src/test/java/com/stripe/functional/ApplicationFeeTest.java
+++ b/src/test/java/com/stripe/functional/ApplicationFeeTest.java
@@ -1,15 +1,16 @@
 package com.stripe.functional;
 
+import static org.junit.Assert.assertEquals;
+
 import com.stripe.BaseStripeFunctionalTest;
 import com.stripe.exception.StripeException;
 import com.stripe.model.ApplicationFee;
 import com.stripe.model.ApplicationFeeCollection;
-import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 public class ApplicationFeeTest extends BaseStripeFunctionalTest {
   @Test

--- a/src/test/java/com/stripe/functional/BalanceTest.java
+++ b/src/test/java/com/stripe/functional/BalanceTest.java
@@ -1,11 +1,12 @@
 package com.stripe.functional;
 
+import static org.junit.Assert.assertEquals;
+
 import com.stripe.BaseStripeFunctionalTest;
 import com.stripe.exception.StripeException;
 import com.stripe.model.Balance;
-import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 public class BalanceTest extends BaseStripeFunctionalTest {
   @Test

--- a/src/test/java/com/stripe/functional/BalanceTransactionTest.java
+++ b/src/test/java/com/stripe/functional/BalanceTransactionTest.java
@@ -1,17 +1,18 @@
 package com.stripe.functional;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
 import com.stripe.BaseStripeFunctionalTest;
 import com.stripe.exception.StripeException;
 import com.stripe.model.BalanceTransaction;
 import com.stripe.model.BalanceTransactionCollection;
 import com.stripe.model.Charge;
-import org.junit.Test;
 
 import java.util.HashMap;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+import org.junit.Test;
 
 public class BalanceTransactionTest extends BaseStripeFunctionalTest {
   @Test

--- a/src/test/java/com/stripe/functional/CardTest.java
+++ b/src/test/java/com/stripe/functional/CardTest.java
@@ -3,10 +3,11 @@ package com.stripe.functional;
 import com.stripe.BaseStripeFunctionalTest;
 import com.stripe.exception.StripeException;
 import com.stripe.model.Customer;
-import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import org.junit.Test;
 
 public class CardTest extends BaseStripeFunctionalTest {
   @Test

--- a/src/test/java/com/stripe/functional/ChargeTest.java
+++ b/src/test/java/com/stripe/functional/ChargeTest.java
@@ -1,9 +1,18 @@
 package com.stripe.functional;
 
-import com.google.common.collect.ImmutableMap;
-
 import static org.hamcrest.CoreMatchers.instanceOf;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.google.common.collect.ImmutableMap;
+
+import com.stripe.BaseStripeFunctionalTest;
 import com.stripe.Stripe;
 import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
@@ -12,14 +21,12 @@ import com.stripe.model.Address;
 import com.stripe.model.Card;
 import com.stripe.model.Charge;
 import com.stripe.model.ShippingDetails;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.junit.Test;
-
-import java.util.*;
-
-import com.stripe.BaseStripeFunctionalTest;
-
-import static org.junit.Assert.*;
-import static org.junit.Assert.assertTrue;
 
 public class ChargeTest extends BaseStripeFunctionalTest {
 

--- a/src/test/java/com/stripe/functional/CountrySpecTest.java
+++ b/src/test/java/com/stripe/functional/CountrySpecTest.java
@@ -1,17 +1,23 @@
 package com.stripe.functional;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+
 import com.stripe.BaseStripeFunctionalTest;
 import com.stripe.exception.StripeException;
-import com.stripe.model.*;
-import org.junit.Test;
+import com.stripe.model.Card;
+import com.stripe.model.Charge;
+import com.stripe.model.CountrySpec;
+import com.stripe.model.CountrySpecCollection;
+import com.stripe.model.VerificationFields;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
+import org.junit.Test;
 
 public class CountrySpecTest extends BaseStripeFunctionalTest {
   @Test

--- a/src/test/java/com/stripe/functional/CouponTest.java
+++ b/src/test/java/com/stripe/functional/CouponTest.java
@@ -1,20 +1,21 @@
 package com.stripe.functional;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import com.stripe.BaseStripeFunctionalTest;
 import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
 import com.stripe.model.Coupon;
 import com.stripe.model.Customer;
 import com.stripe.model.DeletedCoupon;
-import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
 
 public class CouponTest extends BaseStripeFunctionalTest {
   static Map<String, Object> getUniqueCouponParams() {

--- a/src/test/java/com/stripe/functional/CustomerTest.java
+++ b/src/test/java/com/stripe/functional/CustomerTest.java
@@ -1,21 +1,37 @@
 package com.stripe.functional;
 
-import com.google.common.collect.ImmutableMap;
-
 import static org.hamcrest.CoreMatchers.instanceOf;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableMap;
 
 import com.stripe.BaseStripeFunctionalTest;
 import com.stripe.Stripe;
 import com.stripe.exception.InvalidRequestException;
 import com.stripe.exception.StripeException;
-import com.stripe.model.*;
+import com.stripe.model.Address;
+import com.stripe.model.BankAccount;
+import com.stripe.model.Card;
+import com.stripe.model.Customer;
+import com.stripe.model.DeletedBankAccount;
+import com.stripe.model.DeletedCustomer;
+import com.stripe.model.DeletedExternalAccount;
+import com.stripe.model.ExternalAccount;
+import com.stripe.model.ExternalAccountCollection;
+import com.stripe.model.Plan;
+import com.stripe.model.ShippingDetails;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
 import org.junit.Test;
-
-import java.util.*;
-
-import static org.junit.Assert.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class CustomerTest extends BaseStripeFunctionalTest {
 

--- a/src/test/java/com/stripe/functional/DisputeTest.java
+++ b/src/test/java/com/stripe/functional/DisputeTest.java
@@ -1,11 +1,27 @@
 package com.stripe.functional;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+
 import com.google.common.collect.ImmutableMap;
 import com.stripe.BaseStripeFunctionalTest;
-import com.stripe.exception.*;
-import com.stripe.model.*;
+import com.stripe.exception.APIConnectionException;
+import com.stripe.exception.APIException;
+import com.stripe.exception.AuthenticationException;
+import com.stripe.exception.CardException;
+import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
+import com.stripe.model.Card;
+import com.stripe.model.Charge;
+import com.stripe.model.Dispute;
+import com.stripe.model.EvidenceDetails;
+import com.stripe.model.EvidenceSubObject;
+import com.stripe.model.FileUpload;
+import com.stripe.model.FraudDetails;
 import com.stripe.net.RequestOptions;
-import org.junit.Test;
 
 import java.io.File;
 import java.net.URISyntaxException;
@@ -15,9 +31,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.junit.Test;
 
 public class DisputeTest extends BaseStripeFunctionalTest {
 

--- a/src/test/java/com/stripe/functional/EventTest.java
+++ b/src/test/java/com/stripe/functional/EventTest.java
@@ -1,16 +1,17 @@
 package com.stripe.functional;
 
+import static org.junit.Assert.assertEquals;
+
 import com.stripe.BaseStripeFunctionalTest;
 import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
 import com.stripe.model.Event;
-import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 public class EventTest extends BaseStripeFunctionalTest {
   @Test

--- a/src/test/java/com/stripe/functional/IdempotentTest.java
+++ b/src/test/java/com/stripe/functional/IdempotentTest.java
@@ -1,15 +1,20 @@
 package com.stripe.functional;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+
 import com.stripe.BaseStripeFunctionalTest;
-import com.stripe.exception.*;
+import com.stripe.exception.APIConnectionException;
+import com.stripe.exception.APIException;
+import com.stripe.exception.AuthenticationException;
+import com.stripe.exception.CardException;
+import com.stripe.exception.InvalidRequestException;
 import com.stripe.model.Charge;
 import com.stripe.net.RequestOptions;
-import org.junit.Test;
 
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
+import org.junit.Test;
 
 public class IdempotentTest extends BaseStripeFunctionalTest {
   @Test

--- a/src/test/java/com/stripe/functional/InvoiceTest.java
+++ b/src/test/java/com/stripe/functional/InvoiceTest.java
@@ -1,17 +1,27 @@
 package com.stripe.functional;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import com.google.common.collect.ImmutableMap;
 import com.stripe.BaseStripeFunctionalTest;
 import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
-import com.stripe.model.*;
-import org.junit.Test;
+import com.stripe.model.Customer;
+import com.stripe.model.DeletedInvoiceItem;
+import com.stripe.model.Invoice;
+
+import com.stripe.model.InvoiceItem;
+import com.stripe.model.InvoiceLineItemCollection;
+import com.stripe.model.Plan;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import org.junit.Test;
 
 public class InvoiceTest extends BaseStripeFunctionalTest {
   static InvoiceItem createDefaultInvoiceItem(Customer customer)

--- a/src/test/java/com/stripe/functional/PlanTest.java
+++ b/src/test/java/com/stripe/functional/PlanTest.java
@@ -1,20 +1,21 @@
 package com.stripe.functional;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import com.stripe.BaseStripeFunctionalTest;
 import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
 import com.stripe.model.Customer;
 import com.stripe.model.DeletedPlan;
 import com.stripe.model.Plan;
-import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
 
 public class PlanTest extends BaseStripeFunctionalTest {
   @Test

--- a/src/test/java/com/stripe/functional/RecipientTest.java
+++ b/src/test/java/com/stripe/functional/RecipientTest.java
@@ -1,17 +1,21 @@
 package com.stripe.functional;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import com.stripe.BaseStripeFunctionalTest;
 import com.stripe.exception.StripeException;
-import com.stripe.model.*;
-import org.junit.Test;
+import com.stripe.model.Card;
+import com.stripe.model.DeletedCard;
+import com.stripe.model.DeletedRecipient;
+import com.stripe.model.Recipient;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
 
 public class RecipientTest extends BaseStripeFunctionalTest {
   // Recipient Tests:

--- a/src/test/java/com/stripe/functional/RefundTest.java
+++ b/src/test/java/com/stripe/functional/RefundTest.java
@@ -1,5 +1,10 @@
 package com.stripe.functional;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import com.stripe.BaseStripeFunctionalTest;
 import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
@@ -7,17 +12,13 @@ import com.stripe.model.BalanceTransaction;
 import com.stripe.model.Charge;
 import com.stripe.model.ChargeRefundCollection;
 import com.stripe.model.Refund;
-import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
 
 public class RefundTest extends BaseStripeFunctionalTest {
   @Test

--- a/src/test/java/com/stripe/functional/RelayTest.java
+++ b/src/test/java/com/stripe/functional/RelayTest.java
@@ -1,19 +1,27 @@
 package com.stripe.functional;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import com.google.common.collect.ImmutableMap;
+
 import com.stripe.BaseStripeFunctionalTest;
 import com.stripe.exception.StripeException;
-import com.stripe.model.*;
+import com.stripe.model.DeletedProduct;
+import com.stripe.model.DeletedSKU;
+import com.stripe.model.Order;
+import com.stripe.model.OrderItem;
+import com.stripe.model.OrderReturn;
+import com.stripe.model.Product;
+import com.stripe.model.SKU;
 import com.stripe.net.RequestOptions;
-import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
 
 public class RelayTest extends BaseStripeFunctionalTest {
   @Test

--- a/src/test/java/com/stripe/functional/ServiceProductTest.java
+++ b/src/test/java/com/stripe/functional/ServiceProductTest.java
@@ -1,14 +1,15 @@
 package com.stripe.functional;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import com.stripe.BaseStripeFunctionalTest;
 import com.stripe.exception.StripeException;
-import com.stripe.model.*;
-import org.junit.Test;
+import com.stripe.model.Product;
 
 import java.util.HashMap;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.junit.Test;
 
 public class ServiceProductTest extends BaseStripeFunctionalTest {
   @Test

--- a/src/test/java/com/stripe/functional/SourceTest.java
+++ b/src/test/java/com/stripe/functional/SourceTest.java
@@ -1,15 +1,16 @@
 package com.stripe.functional;
 
+import static org.junit.Assert.assertEquals;
+
 import com.stripe.BaseStripeFunctionalTest;
 import com.stripe.exception.StripeException;
 import com.stripe.model.Source;
 import com.stripe.net.RequestOptions;
-import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 public class SourceTest extends BaseStripeFunctionalTest {
   @Test

--- a/src/test/java/com/stripe/functional/StripeResponseTest.java
+++ b/src/test/java/com/stripe/functional/StripeResponseTest.java
@@ -2,26 +2,25 @@ package com.stripe.functional;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 
-import com.stripe.Stripe;
-import com.stripe.model.Customer;
-import com.stripe.model.CustomerCollection;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import com.stripe.BaseStripeFunctionalTest;
+import com.stripe.Stripe;
 import com.stripe.exception.APIConnectionException;
 import com.stripe.exception.APIException;
 import com.stripe.exception.AuthenticationException;
 import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
-import com.stripe.net.StripeResponse;
+import com.stripe.model.Customer;
+import com.stripe.model.CustomerCollection;
 import com.stripe.net.RequestOptions;
-
-import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertThat;
+import com.stripe.net.StripeResponse;
 
 import java.util.HashMap;
+
+import org.junit.Test;
 
 public class StripeResponseTest extends BaseStripeFunctionalTest {
   @Test

--- a/src/test/java/com/stripe/functional/SubscriptionItemTest.java
+++ b/src/test/java/com/stripe/functional/SubscriptionItemTest.java
@@ -1,16 +1,22 @@
 package com.stripe.functional;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import com.stripe.BaseStripeFunctionalTest;
 import com.stripe.exception.StripeException;
-import com.stripe.model.*;
-import org.junit.Test;
+import com.stripe.model.Customer;
+import com.stripe.model.DeletedSubscriptionItem;
+import com.stripe.model.Plan;
+import com.stripe.model.Subscription;
+import com.stripe.model.SubscriptionItem;
+import com.stripe.model.SubscriptionItemCollection;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
 
 public class SubscriptionItemTest extends BaseStripeFunctionalTest {
   static Subscription createDefaultSubscription(Customer customer)

--- a/src/test/java/com/stripe/functional/SubscriptionTest.java
+++ b/src/test/java/com/stripe/functional/SubscriptionTest.java
@@ -1,16 +1,21 @@
 package com.stripe.functional;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import com.stripe.BaseStripeFunctionalTest;
 import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
-import com.stripe.model.*;
-import org.junit.Test;
+import com.stripe.model.Customer;
+import com.stripe.model.CustomerSubscriptionCollection;
+import com.stripe.model.Plan;
+import com.stripe.model.Subscription;
+import com.stripe.model.SubscriptionCollection;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.junit.Test;
 
 public class SubscriptionTest extends BaseStripeFunctionalTest {
   static Map<String, Object> getSubscriptionParams() throws StripeException {

--- a/src/test/java/com/stripe/functional/TimeoutTest.java
+++ b/src/test/java/com/stripe/functional/TimeoutTest.java
@@ -1,12 +1,12 @@
 package com.stripe.functional;
 
-import org.junit.Test;
-
 import com.stripe.BaseStripeFunctionalTest;
 import com.stripe.exception.APIConnectionException;
 import com.stripe.exception.StripeException;
 import com.stripe.model.Token;
 import com.stripe.net.RequestOptions;
+
+import org.junit.Test;
 
 public class TimeoutTest extends BaseStripeFunctionalTest {
 

--- a/src/test/java/com/stripe/functional/TokenTest.java
+++ b/src/test/java/com/stripe/functional/TokenTest.java
@@ -1,18 +1,19 @@
 package com.stripe.functional;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import com.stripe.BaseStripeFunctionalTest;
 import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
 import com.stripe.model.Charge;
 import com.stripe.model.Token;
-import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
 
 public class TokenTest extends BaseStripeFunctionalTest {
   private Map<String, Object> getTokenParams() {

--- a/src/test/java/com/stripe/functional/TransferTest.java
+++ b/src/test/java/com/stripe/functional/TransferTest.java
@@ -1,5 +1,7 @@
 package com.stripe.functional;
 
+import static org.junit.Assert.assertEquals;
+
 import com.stripe.BaseStripeFunctionalTest;
 import com.stripe.exception.InvalidRequestException;
 import com.stripe.exception.StripeException;
@@ -7,14 +9,14 @@ import com.stripe.model.Account;
 import com.stripe.model.Transfer;
 import com.stripe.model.TransferTransactionCollection;
 import com.stripe.net.RequestOptions;
-import junit.framework.Assert;
-import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import junit.framework.Assert;
+
+import org.junit.Test;
 
 public class TransferTest extends BaseStripeFunctionalTest {
   static Map<String, Object> getDefaultAccountParams() {

--- a/src/test/java/com/stripe/model/AccountTest.java
+++ b/src/test/java/com/stripe/model/AccountTest.java
@@ -1,9 +1,7 @@
 package com.stripe.model;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.Map;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -11,12 +9,15 @@ import com.stripe.net.APIResource;
 import com.stripe.net.LiveStripeResponseGetter;
 import com.stripe.net.RequestOptions;
 import com.stripe.net.RequestOptions.RequestOptionsBuilder;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
 
 public class AccountTest extends BaseStripeTest {
   @Before

--- a/src/test/java/com/stripe/model/BalanceTest.java
+++ b/src/test/java/com/stripe/model/BalanceTest.java
@@ -1,19 +1,20 @@
 package com.stripe.model;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
 import com.stripe.model.Balance;
 import com.stripe.model.Money;
 import com.stripe.net.APIResource;
 import com.stripe.net.LiveStripeResponseGetter;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 public class BalanceTest extends BaseStripeTest {
   @Before

--- a/src/test/java/com/stripe/model/BalanceTransactionTest.java
+++ b/src/test/java/com/stripe/model/BalanceTransactionTest.java
@@ -1,5 +1,8 @@
 package com.stripe.model;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
 import com.stripe.net.APIResource;
@@ -7,9 +10,6 @@ import com.stripe.net.APIResource;
 import java.io.IOException;
 
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 public class BalanceTransactionTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/CardTest.java
+++ b/src/test/java/com/stripe/model/CardTest.java
@@ -1,13 +1,14 @@
 package com.stripe.model;
 
+import static org.junit.Assert.assertEquals;
+
 import com.stripe.BaseStripeTest;
 import com.stripe.net.APIResource;
-import org.junit.Before;
-import org.junit.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
 
 public class CardTest extends BaseStripeTest {
   Card card;

--- a/src/test/java/com/stripe/model/ChargeOutcomeTest.java
+++ b/src/test/java/com/stripe/model/ChargeOutcomeTest.java
@@ -1,5 +1,7 @@
 package com.stripe.model;
 
+import static org.junit.Assert.assertEquals;
+
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
 import com.stripe.net.APIResource;
@@ -7,8 +9,6 @@ import com.stripe.net.APIResource;
 import java.io.IOException;
 
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
 
 public class ChargeOutcomeTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/ChargeTest.java
+++ b/src/test/java/com/stripe/model/ChargeTest.java
@@ -1,14 +1,15 @@
 package com.stripe.model;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import com.stripe.BaseStripeTest;
 import com.stripe.net.APIResource;
-import org.junit.Before;
-import org.junit.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.Before;
+import org.junit.Test;
 
 public class ChargeTest extends BaseStripeTest {
   Charge basicCharge;

--- a/src/test/java/com/stripe/model/DeserializerTest.java
+++ b/src/test/java/com/stripe/model/DeserializerTest.java
@@ -1,17 +1,20 @@
 package com.stripe.model;
 
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.core.IsNull.nullValue;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
 import com.google.gson.Gson;
+
 import com.stripe.BaseStripeTest;
 import com.stripe.net.APIResource;
-import org.junit.Test;
 
 import java.io.IOException;
 import java.util.List;
 
-import static org.hamcrest.core.IsNull.notNullValue;
-import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import org.junit.Test;
 
 public class DeserializerTest extends BaseStripeTest {
 

--- a/src/test/java/com/stripe/model/EphemeralKeyTest.java
+++ b/src/test/java/com/stripe/model/EphemeralKeyTest.java
@@ -1,24 +1,23 @@
 package com.stripe.model;
 
-import com.stripe.Stripe;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
 import com.stripe.BaseStripeTest;
+import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
 import com.stripe.model.EphemeralKey;
 import com.stripe.net.APIResource;
 import com.stripe.net.LiveStripeResponseGetter;
 import com.stripe.net.RequestOptions;
-import org.junit.After;
-import org.junit.Before;
 
 import java.io.IOException;
-
-import java.util.Map;
 import java.util.HashMap;
+import java.util.Map;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
 
 public class EphemeralKeyTest extends BaseStripeTest {
   private String oldApiVersion;

--- a/src/test/java/com/stripe/model/EventTest.java
+++ b/src/test/java/com/stripe/model/EventTest.java
@@ -1,16 +1,16 @@
 package com.stripe.model;
 
+import static org.junit.Assert.assertEquals;
+
+import com.google.gson.Gson;
+
 import com.stripe.BaseStripeTest;
 import com.stripe.model.Event;
 import com.stripe.net.APIResource;
 
-import com.google.gson.Gson;
-
 import java.io.IOException;
 
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
 
 public class EventTest extends BaseStripeTest {
   private static Gson gson = APIResource.GSON;

--- a/src/test/java/com/stripe/model/ExchangeRateTest.java
+++ b/src/test/java/com/stripe/model/ExchangeRateTest.java
@@ -1,17 +1,17 @@
 package com.stripe.model;
 
-import java.util.HashMap;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
 import com.stripe.net.APIResource;
 import com.stripe.net.LiveStripeResponseGetter;
 
+import java.util.HashMap;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.mockito.Mockito.*;
 
 public class ExchangeRateTest extends BaseStripeTest {
   @Before

--- a/src/test/java/com/stripe/model/ExpandableFieldDeserializerTest.java
+++ b/src/test/java/com/stripe/model/ExpandableFieldDeserializerTest.java
@@ -1,19 +1,20 @@
 package com.stripe.model;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+
 import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
 import com.stripe.BaseStripeTest;
 import com.stripe.net.APIResource;
-import org.junit.Test;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.google.gson.reflect.TypeToken;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import org.junit.Test;
 
 public class ExpandableFieldDeserializerTest extends BaseStripeTest {
 

--- a/src/test/java/com/stripe/model/ExpandableFieldSerializerTest.java
+++ b/src/test/java/com/stripe/model/ExpandableFieldSerializerTest.java
@@ -1,12 +1,13 @@
 package com.stripe.model;
 
+import static org.junit.Assert.assertEquals;
+
 import com.stripe.BaseStripeTest;
 import com.stripe.model.StripeObject;
 
 import java.io.IOException;
 
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
 
 public class ExpandableFieldSerializerTest extends BaseStripeTest {
 

--- a/src/test/java/com/stripe/model/ExternalAccountTest.java
+++ b/src/test/java/com/stripe/model/ExternalAccountTest.java
@@ -1,5 +1,9 @@
 package com.stripe.model;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import com.google.common.collect.ImmutableList;
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -8,18 +12,14 @@ import com.stripe.model.ExternalAccount;
 import com.stripe.net.APIResource;
 import com.stripe.net.LiveStripeResponseGetter;
 import com.stripe.net.RequestOptions;
-import org.junit.After;
-import org.junit.Before;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 public class ExternalAccountTest extends BaseStripeTest {
   @Before

--- a/src/test/java/com/stripe/model/InvoiceTest.java
+++ b/src/test/java/com/stripe/model/InvoiceTest.java
@@ -5,6 +5,11 @@ import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNull;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+import com.stripe.BaseStripeTest;
+import com.stripe.exception.StripeException;
+import com.stripe.net.APIResource;
+import com.stripe.net.LiveStripeResponseGetter;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -14,11 +19,6 @@ import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.stripe.BaseStripeTest;
-import com.stripe.exception.StripeException;
-import com.stripe.net.APIResource;
-import com.stripe.net.LiveStripeResponseGetter;
 
 public class InvoiceTest extends BaseStripeTest {
   Invoice basicInvoice;

--- a/src/test/java/com/stripe/model/LegalEntityTest.java
+++ b/src/test/java/com/stripe/model/LegalEntityTest.java
@@ -1,5 +1,7 @@
 package com.stripe.model;
 
+import static org.junit.Assert.assertEquals;
+
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
 import com.stripe.model.LegalEntity;
@@ -9,8 +11,6 @@ import java.io.IOException;
 import java.util.LinkedList;
 
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
 
 public class LegalEntityTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/OrderTest.java
+++ b/src/test/java/com/stripe/model/OrderTest.java
@@ -1,22 +1,23 @@
 package com.stripe.model;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.stripe.BaseStripeTest;
+import com.stripe.exception.StripeException;
+import com.stripe.net.APIResource;
+import com.stripe.net.LiveStripeResponseGetter;
+
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import com.stripe.BaseStripeTest;
-import com.stripe.exception.StripeException;
-import com.stripe.net.APIResource;
-import com.stripe.net.LiveStripeResponseGetter;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.*;
 
 public class OrderTest extends BaseStripeTest {
   @Before

--- a/src/test/java/com/stripe/model/PagingIteratorTest.java
+++ b/src/test/java/com/stripe/model/PagingIteratorTest.java
@@ -1,5 +1,9 @@
 package com.stripe.model;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.APIConnectionException;
 import com.stripe.exception.APIException;
@@ -13,20 +17,18 @@ import com.stripe.net.RequestOptions;
 import com.stripe.net.RequestOptions.RequestOptionsBuilder;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
 
 public class PagingIteratorTest extends BaseStripeTest {
   @Before

--- a/src/test/java/com/stripe/model/PayoutTest.java
+++ b/src/test/java/com/stripe/model/PayoutTest.java
@@ -1,19 +1,20 @@
 package com.stripe.model;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
 import com.stripe.net.APIResource;
 import com.stripe.net.LiveStripeResponseGetter;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
 
 public class PayoutTest extends BaseStripeTest {
   @Before

--- a/src/test/java/com/stripe/model/RefundTest.java
+++ b/src/test/java/com/stripe/model/RefundTest.java
@@ -1,18 +1,18 @@
 package com.stripe.model;
 
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
 import com.stripe.model.Refund;
 import com.stripe.net.APIResource;
 import com.stripe.net.LiveStripeResponseGetter;
-import org.junit.After;
-import org.junit.Before;
 
 import java.util.HashMap;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
-
-import static org.mockito.Mockito.*;
 
 public class RefundTest extends BaseStripeTest {
 

--- a/src/test/java/com/stripe/model/ReviewTest.java
+++ b/src/test/java/com/stripe/model/ReviewTest.java
@@ -1,5 +1,7 @@
 package com.stripe.model;
 
+import static org.junit.Assert.assertEquals;
+
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
 import com.stripe.net.APIResource;
@@ -7,8 +9,6 @@ import com.stripe.net.APIResource;
 import java.io.IOException;
 
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
 
 public class ReviewTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/SourceMandateNotificationTest.java
+++ b/src/test/java/com/stripe/model/SourceMandateNotificationTest.java
@@ -1,15 +1,15 @@
 package com.stripe.model;
 
-import java.io.IOException;
-import java.util.Map;
+import static org.junit.Assert.assertEquals;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
 import com.stripe.net.APIResource;
 
-import org.junit.Test;
+import java.io.IOException;
+import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 public class SourceMandateNotificationTest extends BaseStripeTest {
   private void verifyResource(SourceMandateNotification mandateNotification) {

--- a/src/test/java/com/stripe/model/SourceTest.java
+++ b/src/test/java/com/stripe/model/SourceTest.java
@@ -1,20 +1,20 @@
 package com.stripe.model;
 
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.stripe.BaseStripeTest;
+import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
+import com.stripe.net.APIResource;
+import com.stripe.net.LiveStripeResponseGetter;
+
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.stripe.BaseStripeTest;
-import com.stripe.exception.StripeException;
-import com.stripe.exception.InvalidRequestException;
-import com.stripe.net.APIResource;
-import com.stripe.net.LiveStripeResponseGetter;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.mockito.Mockito.*;
 
 public class SourceTest extends BaseStripeTest {
   @Before

--- a/src/test/java/com/stripe/model/SourceTransactionTest.java
+++ b/src/test/java/com/stripe/model/SourceTransactionTest.java
@@ -1,19 +1,20 @@
 package com.stripe.model;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
 import com.stripe.net.APIResource;
 import com.stripe.net.LiveStripeResponseGetter;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
 
 public class SourceTransactionTest extends BaseStripeTest {
   @Before

--- a/src/test/java/com/stripe/model/StandardizationTest.java
+++ b/src/test/java/com/stripe/model/StandardizationTest.java
@@ -6,18 +6,19 @@ import com.google.common.collect.Lists;
 import com.google.common.reflect.ClassPath;
 import com.google.common.reflect.Invokable;
 import com.google.common.reflect.Parameter;
+
 import com.stripe.net.APIResource;
 import com.stripe.net.RequestOptions;
-import junit.framework.Assert;
-import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
 
 /**
  * Simple test to make sure stripe-java provides consistent bindings.

--- a/src/test/java/com/stripe/model/SubscriptionItemTest.java
+++ b/src/test/java/com/stripe/model/SubscriptionItemTest.java
@@ -1,18 +1,18 @@
 package com.stripe.model;
 
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
 import com.stripe.model.SubscriptionItem;
 import com.stripe.net.APIResource;
 import com.stripe.net.LiveStripeResponseGetter;
-import org.junit.After;
-import org.junit.Before;
 
 import java.util.HashMap;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
-
-import static org.mockito.Mockito.*;
 
 public class SubscriptionItemTest extends BaseStripeTest {
 

--- a/src/test/java/com/stripe/model/SubscriptionTest.java
+++ b/src/test/java/com/stripe/model/SubscriptionTest.java
@@ -1,21 +1,22 @@
 package com.stripe.model;
 
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
 import com.stripe.net.APIResource;
 import com.stripe.net.LiveStripeResponseGetter;
-import org.junit.After;
-import org.junit.Before;
-import junit.framework.Assert;
 
-import java.util.Map;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.ArrayList;
+import java.util.Map;
 
+import junit.framework.Assert;
+
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
-
-import static org.mockito.Mockito.*;
 
 public class SubscriptionTest extends BaseStripeTest {
 

--- a/src/test/java/com/stripe/model/ThreeDSecureTest.java
+++ b/src/test/java/com/stripe/model/ThreeDSecureTest.java
@@ -1,16 +1,17 @@
 package com.stripe.model;
 
-import java.util.HashMap;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
 import com.stripe.net.APIResource;
 import com.stripe.net.LiveStripeResponseGetter;
+
+import java.util.HashMap;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.mockito.Mockito.*;
 
 public class ThreeDSecureTest extends BaseStripeTest {
   @Before

--- a/src/test/java/com/stripe/model/TopupTest.java
+++ b/src/test/java/com/stripe/model/TopupTest.java
@@ -1,22 +1,23 @@
 package com.stripe.model;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
 import com.stripe.net.APIResource;
 import com.stripe.net.LiveStripeResponseGetter;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 public class TopupTest extends BaseStripeTest {
   @Before

--- a/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
+++ b/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
@@ -6,6 +6,12 @@ import static org.junit.Assert.assertNotNull;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 
+import com.stripe.Stripe;
+import com.stripe.exception.StripeException;
+import com.stripe.net.LiveStripeResponseGetter;
+import com.stripe.net.RequestOptions;
+import com.stripe.net.RequestOptions.RequestOptionsBuilder;
+
 import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -15,12 +21,6 @@ import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
-
-import com.stripe.Stripe;
-import com.stripe.exception.StripeException;
-import com.stripe.net.LiveStripeResponseGetter;
-import com.stripe.net.RequestOptions;
-import com.stripe.net.RequestOptions.RequestOptionsBuilder;
 
 public class LiveStripeResponseGetterTest {
   LiveStripeResponseGetter srg;

--- a/src/test/java/com/stripe/net/OAuthTest.java
+++ b/src/test/java/com/stripe/net/OAuthTest.java
@@ -1,5 +1,7 @@
 package com.stripe.net;
 
+import static org.junit.Assert.assertEquals;
+
 import com.stripe.BaseStripeTest;
 import com.stripe.Stripe;
 import com.stripe.exception.AuthenticationException;
@@ -11,17 +13,15 @@ import com.stripe.net.OAuth;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.util.HashMap;
-import java.util.Map;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLDecoder;
-import java.net.MalformedURLException;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
 
 public class OAuthTest extends BaseStripeTest {
   @Before

--- a/src/test/java/com/stripe/net/StripeHeadersTest.java
+++ b/src/test/java/com/stripe/net/StripeHeadersTest.java
@@ -1,16 +1,16 @@
 package com.stripe.net;
 
+import static org.junit.Assert.assertEquals;
+
 import com.stripe.BaseStripeTest;
 import com.stripe.net.StripeHeaders;
 
-import java.util.List;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
 
 public class StripeHeadersTest extends BaseStripeTest {
 

--- a/src/test/java/com/stripe/net/StripeResponseTest.java
+++ b/src/test/java/com/stripe/net/StripeResponseTest.java
@@ -2,21 +2,21 @@ package com.stripe.net;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 
-import com.stripe.BaseStripeTest;
-import com.stripe.net.StripeResponse;
-import com.stripe.net.StripeHeaders;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
-import java.util.List;
-import java.util.ArrayList;
+import com.stripe.BaseStripeTest;
+import com.stripe.net.StripeHeaders;
+import com.stripe.net.StripeResponse;
+
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 public class StripeResponseTest extends BaseStripeTest {
   String chargeBody;

--- a/src/test/java/com/stripe/net/WebhookTest.java
+++ b/src/test/java/com/stripe/net/WebhookTest.java
@@ -1,12 +1,14 @@
 package com.stripe.net;
 
-import com.stripe.exception.SignatureVerificationException;
-
-import com.stripe.BaseStripeTest;
-import com.stripe.model.Event;
-import com.stripe.net.Webhook;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.google.gson.JsonSyntaxException;
+
+import com.stripe.BaseStripeTest;
+import com.stripe.exception.SignatureVerificationException;
+import com.stripe.model.Event;
+import com.stripe.net.Webhook;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -19,9 +21,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class WebhookTest extends BaseStripeTest {
   public static String secret = null;


### PR DESCRIPTION
cc @stripe/api-libraries 

- Fix all imports to respect lexicographical order
- Replace `.*` imports with explicit imports
