### PR TITLE
Fix more linting errors

### DIFF
--- a/src/main/java/com/stripe/Stripe.java
+++ b/src/main/java/com/stripe/Stripe.java
@@ -7,8 +7,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 public abstract class Stripe {
-  private final static int DEFAULT_CONNECT_TIMEOUT = 30 * 1000;
-  private final static int DEFAULT_READ_TIMEOUT = 80 * 1000;
+  private static final int DEFAULT_CONNECT_TIMEOUT = 30 * 1000;
+  private static final int DEFAULT_READ_TIMEOUT = 80 * 1000;
 
   public static final String UPLOAD_API_BASE = "https://uploads.stripe.com";
   public static final String LIVE_API_BASE = "https://api.stripe.com";

--- a/src/main/java/com/stripe/model/Account.java
+++ b/src/main/java/com/stripe/model/Account.java
@@ -405,10 +405,10 @@ public class Account extends APIResource implements HasId, MetadataStore<Account
       }
 
       Verification ve = (Verification) o;
-      return equals(contacted, ve.contacted) &&
-          equals(disabledReason, ve.disabledReason) &&
-          equals(dueBy, ve.dueBy) &&
-          equals(fieldsNeeded, ve.fieldsNeeded);
+      return equals(contacted, ve.contacted)
+          && equals(disabledReason, ve.disabledReason)
+          && equals(dueBy, ve.dueBy)
+          && equals(fieldsNeeded, ve.fieldsNeeded);
     }
   }
 

--- a/src/main/java/com/stripe/model/AccountPayoutSchedule.java
+++ b/src/main/java/com/stripe/model/AccountPayoutSchedule.java
@@ -48,9 +48,9 @@ public class AccountPayoutSchedule extends StripeObject {
     }
 
     AccountPayoutSchedule schedule = (AccountPayoutSchedule) o;
-    return equals(delayDays, schedule.delayDays) &&
-        equals(interval, schedule.interval) &&
-        equals(monthlyAnchor, schedule.monthlyAnchor) &&
-        equals(weeklyAnchor, schedule.weeklyAnchor);
+    return equals(delayDays, schedule.delayDays)
+        && equals(interval, schedule.interval)
+        && equals(monthlyAnchor, schedule.monthlyAnchor)
+        && equals(weeklyAnchor, schedule.weeklyAnchor);
   }
 }

--- a/src/main/java/com/stripe/model/EventDataDeserializer.java
+++ b/src/main/java/com/stripe/model/EventDataDeserializer.java
@@ -98,9 +98,9 @@ public class EventDataDeserializer implements JsonDeserializer<EventData> {
     } else if (element.isJsonArray()) {
       return deserializeJsonArray(element.getAsJsonArray());
     } else {
-      System.err.println("Unknown JSON element type for element " + element + ". " +
-          "If you're seeing this messaage, it's probably a bug in the Stripe Java " +
-          "library. Please contact us by email at support@stripe.com.");
+      System.err.println("Unknown JSON element type for element " + element + ". "
+          + "If you're seeing this messaage, it's probably a bug in the Stripe Java "
+          + "library. Please contact us by email at support@stripe.com.");
       return null;
     }
   }

--- a/src/main/java/com/stripe/model/EvidenceSubObject.java
+++ b/src/main/java/com/stripe/model/EvidenceSubObject.java
@@ -682,7 +682,7 @@ public final class EvidenceSubObject extends StripeObject {
         : that.shippingDate != null) {
       return false;
     }
-    if (shippingDocumentation != null ?!shippingDocumentation.equals(that.shippingDocumentation)
+    if (shippingDocumentation != null ? !shippingDocumentation.equals(that.shippingDocumentation)
         : that.shippingDocumentation != null) {
       return false;
     }

--- a/src/main/java/com/stripe/model/ExpandableFieldDeserializer.java
+++ b/src/main/java/com/stripe/model/ExpandableFieldDeserializer.java
@@ -29,11 +29,10 @@ public class ExpandableFieldDeserializer implements JsonDeserializer<ExpandableF
       } else {
         throw new JsonParseException("ExpandableField is a non-string primitive type.");
       }
-    }
     // Check if json is an expanded Object. If so, the field has been expanded, so we need to
     // serialize it into the proper typeOfT, and create an ExpandableField with both the String id
     // and this serialized object.
-    else if (json.isJsonObject()) {
+    } else if (json.isJsonObject()) {
       // Get the `id` out of the response
       JsonObject fieldAsJsonObject = json.getAsJsonObject();
       String id = fieldAsJsonObject.getAsJsonPrimitive("id").getAsString();

--- a/src/main/java/com/stripe/model/LegalEntity.java
+++ b/src/main/java/com/stripe/model/LegalEntity.java
@@ -89,17 +89,17 @@ public class LegalEntity extends StripeObject {
     }
 
     LegalEntity le = (LegalEntity) o;
-    return equals(additionalOwners, le.additionalOwners) &&
-        equals(address, le.address) &&
-        equals(businessName, le.businessName) &&
-        equals(dob, le.dob) &&
-        equals(firstName, le.firstName) &&
-        equals(lastName, le.lastName) &&
-        equals(personalAddress, le.personalAddress) &&
-        equals(personalIdNumberProvided, le.personalIdNumberProvided) &&
-        equals(ssnLast4Provided, le.ssnLast4Provided) &&
-        equals(type, le.type) &&
-        equals(verification, le.verification);
+    return equals(additionalOwners, le.additionalOwners)
+        && equals(address, le.address)
+        && equals(businessName, le.businessName)
+        && equals(dob, le.dob)
+        && equals(firstName, le.firstName)
+        && equals(lastName, le.lastName)
+        && equals(personalAddress, le.personalAddress)
+        && equals(personalIdNumberProvided, le.personalIdNumberProvided)
+        && equals(ssnLast4Provided, le.ssnLast4Provided)
+        && equals(type, le.type)
+        && equals(verification, le.verification);
   }
 
   public static class DateOfBirth extends StripeObject {
@@ -129,9 +129,9 @@ public class LegalEntity extends StripeObject {
       }
 
       DateOfBirth dob = (DateOfBirth) o;
-      return equals(day, dob.day) &&
-          equals(month, dob.month) &&
-          equals(year, dob.year);
+      return equals(day, dob.day)
+          && equals(month, dob.month)
+          && equals(year, dob.year);
     }
   }
 
@@ -167,10 +167,10 @@ public class LegalEntity extends StripeObject {
       }
 
       Verification verification = (Verification) o;
-      return equals(details, verification.details) &&
-          equals(detailsCode, verification.detailsCode) &&
-          equals(document, verification.document) &&
-          equals(status, verification.status);
+      return equals(details, verification.details)
+          && equals(detailsCode, verification.detailsCode)
+          && equals(document, verification.document)
+          && equals(status, verification.status);
     }
   }
 
@@ -211,11 +211,11 @@ public class LegalEntity extends StripeObject {
       }
 
       Owner owner = (Owner) o;
-      return equals(address, owner.address) &&
-          equals(dob, owner.dob) &&
-          equals(firstName, owner.firstName) &&
-          equals(lastName, owner.lastName) &&
-          equals(verification, owner.verification);
+      return equals(address, owner.address)
+          && equals(dob, owner.dob)
+          && equals(firstName, owner.firstName)
+          && equals(lastName, owner.lastName)
+          && equals(verification, owner.verification);
     }
   }
 }

--- a/src/main/java/com/stripe/model/Money.java
+++ b/src/main/java/com/stripe/model/Money.java
@@ -77,10 +77,10 @@ public class Money extends StripeObject {
       }
 
       SourceTypes st = (SourceTypes) o;
-      return equals(alipayAccount, st.alipayAccount) &&
-          equals(bankAccount, st.bankAccount) &&
-          equals(bitcoinReceiver, st.bitcoinReceiver) &&
-          equals(card, st.card);
+      return equals(alipayAccount, st.alipayAccount)
+          && equals(bankAccount, st.bankAccount)
+          && equals(bitcoinReceiver, st.bitcoinReceiver)
+          && equals(card, st.card);
     }
   }
 }

--- a/src/main/java/com/stripe/model/PagingIterator.java
+++ b/src/main/java/com/stripe/model/PagingIterator.java
@@ -31,8 +31,7 @@ public class PagingIterator<T extends HasId> extends APIResource implements Iter
 
   @Override
   public boolean hasNext() {
-    return currentDataIterator.hasNext() ||
-        currentCollection.getHasMore();
+    return currentDataIterator.hasNext() || currentCollection.getHasMore();
   }
 
   @Override

--- a/src/main/java/com/stripe/model/StripeObject.java
+++ b/src/main/java/com/stripe/model/StripeObject.java
@@ -10,15 +10,15 @@ import java.lang.reflect.Field;
 
 public abstract class StripeObject {
 
-  public static final Gson PRETTY_PRINT_GSON = new GsonBuilder().
-      setPrettyPrinting().
-      serializeNulls().
-      setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).
-      registerTypeAdapter(ExpandableField.class, new ExpandableFieldSerializer()).
+  public static final Gson PRETTY_PRINT_GSON = new GsonBuilder()
+      .setPrettyPrinting()
+      .serializeNulls()
+      .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+      .registerTypeAdapter(ExpandableField.class, new ExpandableFieldSerializer())
       // TODO: remove the deserializers in the next major release
-      registerTypeAdapter(EventData.class, new EventDataDeserializer()).
-      registerTypeAdapter(EventRequest.class, new EventRequestDeserializer()).
-      create();
+      .registerTypeAdapter(EventData.class, new EventDataDeserializer())
+      .registerTypeAdapter(EventRequest.class, new EventRequestDeserializer())
+      .create();
 
   @Override
   public String toString() {
@@ -33,6 +33,7 @@ public abstract class StripeObject {
   public StripeResponse getLastResponse() {
     return lastResponse;
   }
+
   public void setLastResponse(StripeResponse response) {
     this.lastResponse = response; 
   }

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -42,7 +42,7 @@ import javax.net.ssl.SSLSocketFactory;
 public class LiveStripeResponseGetter implements StripeResponseGetter {
   private static final String DNS_CACHE_TTL_PROPERTY_NAME = "networkaddress.cache.ttl";
 
-  private final static class Parameter {
+  private static final class Parameter {
     public final String key;
     public final String value;
 
@@ -347,9 +347,9 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
     } else if (value instanceof Object[]) {
       flatParams = flattenParamsArray((Object[]) value, keyPrefix);
     } else if ("".equals(value)) {
-      throw new InvalidRequestException("You cannot set '" + keyPrefix + "' to an empty string. " +
-          "We interpret empty strings as null in requests. " +
-          "You may set '" + keyPrefix + "' to null to delete the property.",
+      throw new InvalidRequestException("You cannot set '" + keyPrefix + "' to an empty string. "
+          + "We interpret empty strings as null in requests. "
+          + "You may set '" + keyPrefix + "' to null to delete the property.",
           keyPrefix, null, null, 0, null);
     } else if (value == null) {
       flatParams = new LinkedList<Parameter>();

--- a/src/main/java/com/stripe/net/RequestOptions.java
+++ b/src/main/java/com/stripe/net/RequestOptions.java
@@ -57,8 +57,12 @@ public class RequestOptions {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
 
     RequestOptions that = (RequestOptions) o;
 

--- a/src/main/java/com/stripe/net/StripeSSLSocketFactory.java
+++ b/src/main/java/com/stripe/net/StripeSSLSocketFactory.java
@@ -17,15 +17,18 @@ import javax.net.ssl.SSLSocketFactory;
  */
 public class StripeSSLSocketFactory extends SSLSocketFactory {
   private final SSLSocketFactory under;
-  private final boolean tlsv11Supported, tlsv12Supported;
+  private final boolean tlsv11Supported;
+  private final boolean tlsv12Supported;
 
-  private static final String TLSv11Proto = "TLSv1.1", TLSv12Proto = "TLSv1.2";
+  private static final String TLSv11Proto = "TLSv1.1";
+  private static final String TLSv12Proto = "TLSv1.2";
 
   public StripeSSLSocketFactory() {
     this.under = HttpsURLConnection.getDefaultSSLSocketFactory();
 
     // For sufficiently old Java, TLSv1.1 and TLSv1.2 might not be supported, so do some detection
-    boolean tlsv11Supported = false, tlsv12Supported = false;
+    boolean tlsv11Supported = false;
+    boolean tlsv12Supported = false;
 
     String[] supportedProtos = new String[0];
     try {

--- a/src/test/java/com/stripe/functional/StripeResponseTest.java
+++ b/src/test/java/com/stripe/functional/StripeResponseTest.java
@@ -44,6 +44,7 @@ public class StripeResponseTest extends BaseStripeFunctionalTest {
     assertTrue(resp.requestId().startsWith("req_"));
     assertTrue(resp.body().length() > 0);
   }
+
   @Test
   public void testResponseIncludedList() throws
       AuthenticationException,

--- a/src/test/java/com/stripe/net/StripeHeadersTest.java
+++ b/src/test/java/com/stripe/net/StripeHeadersTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 
 public class StripeHeadersTest extends BaseStripeTest {
 
-  private Map<String, List<String>> generateHeaderMap () {
+  private Map<String, List<String>> generateHeaderMap() {
     Map<String, List<String>> headerMap = new HashMap<String, List<String>>();
     List<String> multiValueHeader = new ArrayList<String>();
     multiValueHeader.add("FirstValue");

--- a/src/test/java/com/stripe/net/StripeResponseTest.java
+++ b/src/test/java/com/stripe/net/StripeResponseTest.java
@@ -26,7 +26,7 @@ public class StripeResponseTest extends BaseStripeTest {
     chargeBody = resource("charge.json");
   }
 
-  private Map<String, List<String>> generateHeaderMap () {
+  private Map<String, List<String>> generateHeaderMap() {
     Map<String, List<String>> headerMap = new HashMap<String, List<String>>();
     List<String> idempotencyHeader = new ArrayList<String>();
     idempotencyHeader.add("12345");


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Fix more linting errors:
- break lines before symbols (e.g.
```
foo
&& bar
```
not
```
foo &&
bar
```
- `static` immediately after visibility modifier
- declare each variable separately

Asking for a r? as there's always a minor chance I broke something with these changes.
