### PR TITLE
Rule for consecutive capital letters

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -174,7 +174,7 @@
         </module>
         <module name="AbbreviationAsWordInName">
             <property name="ignoreFinal" value="false"/>
-            <property name="allowedAbbreviationLength" value="1"/>
+            <property name="allowedAbbreviationLength" value="4"/>
         </module>
         <module name="OverloadMethodsDeclarationOrder"/>
         <module name="VariableDeclarationUsageDistance"/>

--- a/src/main/java/com/stripe/model/ExternalAccountTypeAdapterFactory.java
+++ b/src/main/java/com/stripe/model/ExternalAccountTypeAdapterFactory.java
@@ -17,7 +17,7 @@ public class ExternalAccountTypeAdapterFactory implements TypeAdapterFactory {
       return null; // this class only serializes 'ExternalAccount' and its subtypes
     }
 
-    final String SOURCE_OBJECT_PROP = "object";
+    final String sourceObjectProp = "object";
 
     final TypeAdapter<JsonElement> elementAdapter = gson.getAdapter(JsonElement.class);
     final TypeAdapter<ExternalAccount> externalAccountAdapter
@@ -41,7 +41,7 @@ public class ExternalAccountTypeAdapterFactory implements TypeAdapterFactory {
 
       public ExternalAccount read(JsonReader in) throws IOException {
         JsonObject object = elementAdapter.read(in).getAsJsonObject();
-        String sourceObject = object.getAsJsonPrimitive(SOURCE_OBJECT_PROP).getAsString();
+        String sourceObject = object.getAsJsonPrimitive(sourceObjectProp).getAsString();
 
         if (sourceObject.equals("alipay_account")) {
           return alipayAccountAdapter.fromJsonTree(object);

--- a/src/test/java/com/stripe/functional/ChargeTest.java
+++ b/src/test/java/com/stripe/functional/ChargeTest.java
@@ -249,12 +249,12 @@ public class ChargeTest extends BaseStripeFunctionalTest {
   public void testChargePartialRefundPerCallAPIKey() throws StripeException {
     Charge createdCharge = Charge.create(defaultChargeParams);
     Map<String, Object> refundParams = new HashMap<String, Object>();
-    final Long REFUND_AMOUNT = 50l;
-    refundParams.put("amount", REFUND_AMOUNT);
+    final Long refundAmount = 50L;
+    refundParams.put("amount", refundAmount);
     Charge refundedCharge = createdCharge.refund(refundParams,
         Stripe.apiKey);
     assertFalse(refundedCharge.getRefunded());
-    assertEquals(refundedCharge.getAmountRefunded(), REFUND_AMOUNT);
+    assertEquals(refundedCharge.getAmountRefunded(), refundAmount);
   }
 
   @Test

--- a/src/test/java/com/stripe/functional/RefundTest.java
+++ b/src/test/java/com/stripe/functional/RefundTest.java
@@ -73,11 +73,11 @@ public class RefundTest extends BaseStripeFunctionalTest {
   public void testChargePartialRefund() throws StripeException {
     Charge createdCharge = Charge.create(defaultChargeParams);
     Map<String, Object> refundParams = new HashMap<String, Object>();
-    final Long REFUND_AMOUNT = 50l;
-    refundParams.put("amount", REFUND_AMOUNT);
+    final Long refundAmount = 50L;
+    refundParams.put("amount", refundAmount);
     Charge refundedCharge = createdCharge.refund(refundParams);
     assertFalse(refundedCharge.getRefunded());
-    assertEquals(refundedCharge.getAmountRefunded(), REFUND_AMOUNT);
+    assertEquals(refundedCharge.getAmountRefunded(), refundAmount);
   }
 
   @Test


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Google's style rules state names should not have more than 2 consecutive capital letters / acronyms should be camel-case like regular words: https://google.github.io/styleguide/javaguide.html#s5.3-camel-case.

In the library, we keep acronyms in all caps. As much as I'd like to stick to the standard, I don't think we should introduce a breaking change just for the sake of style.

This PR changes the rule to allow for up to 5 consecutive capital letters (to allow the worst case of `populateMapFromJSONObject`), and fixes a couple instances of final variables that were styled as constants.