### PR TITLE
Fix distance linting issues

### DIFF
--- a/src/main/java/com/stripe/model/BalanceTransactionDeserializer.java
+++ b/src/main/java/com/stripe/model/BalanceTransactionDeserializer.java
@@ -33,10 +33,6 @@ public class BalanceTransactionDeserializer implements JsonDeserializer<BalanceT
   @Override
   public BalanceTransaction deserialize(JsonElement json, Type typeOfT,
       JsonDeserializationContext context) throws JsonParseException {
-    Gson gson = new GsonBuilder()
-        .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-        .create();
-
     if (json.isJsonNull()) {
       return null;
     }
@@ -51,6 +47,10 @@ public class BalanceTransactionDeserializer implements JsonDeserializer<BalanceT
     JsonElement source = btAsJsonObject.get("source");
 
     btAsJsonObject.remove("source");
+
+    Gson gson = new GsonBuilder()
+        .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+        .create();
 
     BalanceTransaction balanceTransaction = gson.fromJson(json, typeOfT);
 

--- a/src/main/java/com/stripe/model/OrderItemDeserializer.java
+++ b/src/main/java/com/stripe/model/OrderItemDeserializer.java
@@ -27,10 +27,6 @@ public class OrderItemDeserializer implements JsonDeserializer<OrderItem> {
   @Override
   public OrderItem deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
       throws JsonParseException {
-    Gson gson = new GsonBuilder()
-        .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-        .create();
-
     if (json.isJsonNull()) {
       return null;
     }
@@ -44,6 +40,10 @@ public class OrderItemDeserializer implements JsonDeserializer<OrderItem> {
     JsonElement parent = oiAsJsonObject.get("parent");
 
     oiAsJsonObject.remove("parent");
+
+    Gson gson = new GsonBuilder()
+        .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+        .create();
 
     OrderItem orderItem = gson.fromJson(json, typeOfT);
 

--- a/src/main/java/com/stripe/model/SourceTypeDataDeserializer.java
+++ b/src/main/java/com/stripe/model/SourceTypeDataDeserializer.java
@@ -35,10 +35,6 @@ public class SourceTypeDataDeserializer<T extends HasSourceTypeData>
 
   public T deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
           throws JsonParseException {
-    Gson gson = new GsonBuilder()
-            .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-            .create();
-
     if (json.isJsonNull()) {
       return null;
     }
@@ -58,7 +54,13 @@ public class SourceTypeDataDeserializer<T extends HasSourceTypeData>
 
     // Remove the `type` property.
     jsonObject.remove(type);
+
+    Gson gson = new GsonBuilder()
+            .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+            .create();
+
     T parsedData = gson.fromJson(json, typeOfT);
+
     parsedData.setTypeData(typeData);
 
     return parsedData;

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -111,7 +111,6 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
     }
     headers.put("User-Agent", userAgent);
 
-    String apiVersion = options.getStripeVersion();
     headers.put("Accept-Charset", APIResource.CHARSET);
     headers.put("Accept", "application/json");
 
@@ -132,8 +131,8 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
       propertyMap.put("application", APIResource.GSON.toJson(Stripe.getAppInfo()));
     }
     headers.put("X-Stripe-Client-User-Agent", APIResource.GSON.toJson(propertyMap));
-    if (apiVersion != null) {
-      headers.put("Stripe-Version", apiVersion);
+    if (options.getStripeVersion() != null) {
+      headers.put("Stripe-Version", options.getStripeVersion());
     }
     if (options.getIdempotencyKey() != null) {
       headers.put("Idempotency-Key", options.getIdempotencyKey());

--- a/src/main/java/com/stripe/net/OAuth.java
+++ b/src/main/java/com/stripe/net/OAuth.java
@@ -32,7 +32,7 @@ public final class OAuth {
    */
   public static String authorizeURL(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException {
-    String base = Stripe.getConnectBase();
+    final String base = Stripe.getConnectBase();
 
     params.put("client_id", getClientId(params, options));
     if (params.get("response_type") == null) {

--- a/src/main/java/com/stripe/net/StripeSSLSocketFactory.java
+++ b/src/main/java/com/stripe/net/StripeSSLSocketFactory.java
@@ -34,6 +34,7 @@ public class StripeSSLSocketFactory extends SSLSocketFactory {
     try {
       supportedProtos = SSLContext.getDefault().getSupportedSSLParameters().getProtocols();
     } catch (NoSuchAlgorithmException e) {
+      // Nothing to do.
     }
 
     for (String proto : supportedProtos) {

--- a/src/test/java/com/stripe/functional/ApplePayDomainTest.java
+++ b/src/test/java/com/stripe/functional/ApplePayDomainTest.java
@@ -41,8 +41,8 @@ public class ApplePayDomainTest extends BaseStripeFunctionalTest {
   public void testApplePayDomainList() throws StripeException {
     Map<String, Object> listParams = new HashMap<String, Object>();
     listParams.put("count", 1);
-    List<ApplePayDomain> Domains = ApplePayDomain.list(listParams).getData();
-    assertEquals(Domains.size(), 1);
+    List<ApplePayDomain> domains = ApplePayDomain.list(listParams).getData();
+    assertEquals(domains.size(), 1);
   }
 
   @Test

--- a/src/test/java/com/stripe/functional/ChargeTest.java
+++ b/src/test/java/com/stripe/functional/ChargeTest.java
@@ -291,6 +291,8 @@ public class ChargeTest extends BaseStripeFunctionalTest {
       Charge.create(defaultChargeParams, "INVALID_KEY_HERE");
       fail();
     } catch (Exception e) {
+      // An exception is expected, so do nothing.
+      // (This test is pretty bad, but it's going away Soon™.)
     }
   }
 }

--- a/src/test/java/com/stripe/functional/CouponTest.java
+++ b/src/test/java/com/stripe/functional/CouponTest.java
@@ -51,8 +51,8 @@ public class CouponTest extends BaseStripeFunctionalTest {
   public void testCouponList() throws StripeException {
     Map<String, Object> listParams = new HashMap<String, Object>();
     listParams.put("count", 1);
-    List<Coupon> Coupons = Coupon.all(listParams).getData();
-    assertEquals(Coupons.size(), 1);
+    List<Coupon> coupons = Coupon.all(listParams).getData();
+    assertEquals(coupons.size(), 1);
   }
 
   @Test
@@ -94,8 +94,8 @@ public class CouponTest extends BaseStripeFunctionalTest {
   public void testCouponListPerCallAPIKey() throws StripeException {
     Map<String, Object> listParams = new HashMap<String, Object>();
     listParams.put("count", 1);
-    List<Coupon> Coupons = Coupon.all(listParams, Stripe.apiKey).getData();
-    assertEquals(Coupons.size(), 1);
+    List<Coupon> coupons = Coupon.all(listParams, Stripe.apiKey).getData();
+    assertEquals(coupons.size(), 1);
   }
 
   @Test

--- a/src/test/java/com/stripe/functional/CustomerTest.java
+++ b/src/test/java/com/stripe/functional/CustomerTest.java
@@ -90,8 +90,8 @@ public class CustomerTest extends BaseStripeFunctionalTest {
   public void testCustomerList() throws StripeException {
     Map<String, Object> listParams = new HashMap<String, Object>();
     listParams.put("count", 1);
-    List<Customer> Customers = Customer.all(listParams).getData();
-    assertEquals(Customers.size(), 1);
+    List<Customer> customers = Customer.all(listParams).getData();
+    assertEquals(customers.size(), 1);
   }
 
   @Test
@@ -204,11 +204,11 @@ public class CustomerTest extends BaseStripeFunctionalTest {
   @Test
   public void testCustomerCardAddition() throws StripeException {
     Customer createdCustomer = Customer.create(defaultCustomerParams, supportedRequestOptions);
-    String originalDefaultSource = createdCustomer.getDefaultSource();
+    final String originalDefaultSource = createdCustomer.getDefaultSource();
 
     Map<String, Object> creationParams = new HashMap<String, Object>();
     creationParams.put("source", "tok_visa");
-    ExternalAccount addedCard = createdCustomer.getSources().create(creationParams);
+    final ExternalAccount addedCard = createdCustomer.getSources().create(creationParams);
     createdCustomer.createCard("tok_visa");
 
     Customer updatedCustomer = Customer.retrieve(createdCustomer.getId(), supportedRequestOptions);
@@ -278,11 +278,11 @@ public class CustomerTest extends BaseStripeFunctionalTest {
   @Test
   public void testCustomerBankAccountAddition() throws StripeException {
     Customer createdCustomer = Customer.create(defaultCustomerParams, supportedRequestOptions);
-    String originalDefaultCard = createdCustomer.getDefaultCard();
+    final String originalDefaultCard = createdCustomer.getDefaultCard();
 
     Map<String, Object> creationParams = new HashMap<String, Object>();
     creationParams.put("bank_account", defaultBankAccountParams);
-    BankAccount addedBankAccount = createdCustomer.createBankAccount(creationParams);
+    final BankAccount addedBankAccount = createdCustomer.createBankAccount(creationParams);
 
     createdCustomer.createCard("tok_visa");
 
@@ -362,9 +362,9 @@ public class CustomerTest extends BaseStripeFunctionalTest {
   public void testCustomerListPerCallAPIKey() throws StripeException {
     Map<String, Object> listParams = new HashMap<String, Object>();
     listParams.put("count", 1);
-    List<Customer> Customers = Customer.all(listParams, Stripe.apiKey)
+    List<Customer> customers = Customer.all(listParams, Stripe.apiKey)
         .getData();
-    assertEquals(Customers.size(), 1);
+    assertEquals(customers.size(), 1);
   }
 
   @Test

--- a/src/test/java/com/stripe/functional/DisputeTest.java
+++ b/src/test/java/com/stripe/functional/DisputeTest.java
@@ -106,17 +106,16 @@ public class DisputeTest extends BaseStripeFunctionalTest {
     assertEquals(emptyEvidence, initialDispute.getEvidenceSubObject());
     assertEquals(new HashMap<String, String>(), initialDispute.getMetadata());
 
-    Map<String, Object> params = new HashMap<String, Object>();
     Map<String, Object> evidence = new HashMap<String, Object>();
-    Map<String, String> metadata = new HashMap<String, String>();
-
     evidence.put("product_description", "my productDescription");
     evidence.put("customer_name", "my customerName");
     evidence.put("uncategorized_text", "my uncategorizedText");
 
+    Map<String, String> metadata = new HashMap<String, String>();
     metadata.put("some_info", "about the dispute");
     metadata.put("a_little_more", "12345");
 
+    Map<String, Object> params = new HashMap<String, Object>();
     params.put("evidence", evidence);
     params.put("metadata", metadata);
 

--- a/src/test/java/com/stripe/functional/InvoiceTest.java
+++ b/src/test/java/com/stripe/functional/InvoiceTest.java
@@ -64,8 +64,8 @@ public class InvoiceTest extends BaseStripeFunctionalTest {
   public void testInvoiceItemList() throws StripeException {
     Map<String, Object> listParams = new HashMap<String, Object>();
     listParams.put("count", 1);
-    List<InvoiceItem> InvoiceItems = InvoiceItem.all(listParams).getData();
-    assertEquals(InvoiceItems.size(), 1);
+    List<InvoiceItem> invoiceItems = InvoiceItem.all(listParams).getData();
+    assertEquals(invoiceItems.size(), 1);
   }
 
   @Test
@@ -149,7 +149,7 @@ public class InvoiceTest extends BaseStripeFunctionalTest {
   @Test
   public void testUpcomingInvoiceLines() throws Exception {
     Customer customer = Customer.create(defaultCustomerParams);
-    InvoiceItem item = createDefaultInvoiceItem(customer);
+    final InvoiceItem item = createDefaultInvoiceItem(customer);
     Map<String, Object> upcomingParams = new HashMap<String, Object>();
     upcomingParams.put("customer", customer.getId());
     Invoice upcomingInvoice = Invoice.upcoming(upcomingParams);
@@ -187,9 +187,9 @@ public class InvoiceTest extends BaseStripeFunctionalTest {
   public void testInvoiceItemListPerCallAPIKey() throws StripeException {
     Map<String, Object> listParams = new HashMap<String, Object>();
     listParams.put("count", 1);
-    List<InvoiceItem> InvoiceItems = InvoiceItem.all(listParams,
+    List<InvoiceItem> invoiceItems = InvoiceItem.all(listParams,
         Stripe.apiKey).getData();
-    assertEquals(InvoiceItems.size(), 1);
+    assertEquals(invoiceItems.size(), 1);
   }
 
   @Test

--- a/src/test/java/com/stripe/functional/PlanTest.java
+++ b/src/test/java/com/stripe/functional/PlanTest.java
@@ -62,8 +62,8 @@ public class PlanTest extends BaseStripeFunctionalTest {
   public void testPlanList() throws StripeException {
     Map<String, Object> listParams = new HashMap<String, Object>();
     listParams.put("count", 1);
-    List<Plan> Plans = Plan.all(listParams).getData();
-    assertEquals(Plans.size(), 1);
+    List<Plan> plans = Plan.all(listParams).getData();
+    assertEquals(plans.size(), 1);
   }
 
   @Test
@@ -107,8 +107,8 @@ public class PlanTest extends BaseStripeFunctionalTest {
   public void testPlanListPerCallAPIKey() throws StripeException {
     Map<String, Object> listParams = new HashMap<String, Object>();
     listParams.put("count", 1);
-    List<Plan> Plans = Plan.all(listParams, Stripe.apiKey).getData();
-    assertEquals(Plans.size(), 1);
+    List<Plan> plans = Plan.all(listParams, Stripe.apiKey).getData();
+    assertEquals(plans.size(), 1);
   }
 
   @Test

--- a/src/test/java/com/stripe/functional/RecipientTest.java
+++ b/src/test/java/com/stripe/functional/RecipientTest.java
@@ -56,11 +56,11 @@ public class RecipientTest extends BaseStripeFunctionalTest {
   @Test
   public void testRecipientCardAddition() throws StripeException {
     Recipient createdRecipient = Recipient.create(defaultRecipientParams);
-    String originalDefaultCard = createdRecipient.getDefaultCard();
+    final String originalDefaultCard = createdRecipient.getDefaultCard();
 
     Map<String, Object> creationParams = new HashMap<String, Object>();
     creationParams.put("card", "tok_visa_debit");
-    Card addedCard = createdRecipient.createCard(creationParams);
+    final Card addedCard = createdRecipient.createCard(creationParams);
 
     createdRecipient.createCard("tok_visa_debit");
 

--- a/src/test/java/com/stripe/functional/RelayTest.java
+++ b/src/test/java/com/stripe/functional/RelayTest.java
@@ -49,7 +49,7 @@ public class RelayTest extends BaseStripeFunctionalTest {
 
   @Test
   public void testSKUCreateReadUpdate() throws StripeException {
-    RequestOptions relayRequestOptions = RequestOptions.builder()
+    final RequestOptions relayRequestOptions = RequestOptions.builder()
         .setApiKey("sk_test_JieJALRz7rPz7boV17oMma7a")
         .build();
 
@@ -85,7 +85,7 @@ public class RelayTest extends BaseStripeFunctionalTest {
 
   @Test
   public void testSKUProductDeletion() throws StripeException {
-    RequestOptions relayRequestOptions = RequestOptions.builder()
+    final RequestOptions relayRequestOptions = RequestOptions.builder()
         .setApiKey("sk_test_JieJALRz7rPz7boV17oMma7a")
         .build();
 
@@ -95,7 +95,7 @@ public class RelayTest extends BaseStripeFunctionalTest {
     productCreateParams.put("type", "good");
     productCreateParams.put("name", "Watermelon");
     productCreateParams.put("attributes[]", "size");
-    Product createdProduct = Product.create(productCreateParams, relayRequestOptions);
+    final Product createdProduct = Product.create(productCreateParams, relayRequestOptions);
 
     Map<String, Object> skuCreateParams = new HashMap<String, Object>();
     String skuId = "my_first_sku_" + UUID.randomUUID();
@@ -117,7 +117,7 @@ public class RelayTest extends BaseStripeFunctionalTest {
 
   @Test
   public void testOrderCreateReadUpdatePayReturn() throws StripeException {
-    RequestOptions relayRequestOptions = RequestOptions.builder()
+    final RequestOptions relayRequestOptions = RequestOptions.builder()
         .setApiKey("sk_test_JieJALRz7rPz7boV17oMma7a")
         .build();
 
@@ -158,7 +158,7 @@ public class RelayTest extends BaseStripeFunctionalTest {
     assertNotNull(item);
     assertEquals("sku", item.getType());
 
-    Order retrieved = Order.retrieve(created.getId(), relayRequestOptions);
+    final Order retrieved = Order.retrieve(created.getId(), relayRequestOptions);
 
     item = null;
     for (OrderItem i : created.getItems()) {

--- a/src/test/java/com/stripe/functional/SourceTest.java
+++ b/src/test/java/com/stripe/functional/SourceTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 public class SourceTest extends BaseStripeFunctionalTest {
   @Test
   public void testSourceCreateRead() throws StripeException {
-    RequestOptions sourceRequestOptions = RequestOptions.builder()
+    final RequestOptions sourceRequestOptions = RequestOptions.builder()
         .setApiKey("sk_test_JieJALRz7rPz7boV17oMma7a")
         .build();
 

--- a/src/test/java/com/stripe/functional/SubscriptionItemTest.java
+++ b/src/test/java/com/stripe/functional/SubscriptionItemTest.java
@@ -22,16 +22,18 @@ public class SubscriptionItemTest extends BaseStripeFunctionalTest {
   static Subscription createDefaultSubscription(Customer customer)
       throws StripeException {
     Plan plan = Plan.create(getUniquePlanParams());
-    Map<String, Object> subCreateParams = new HashMap<String, Object>();
-    HashMap<String, Object> items = new HashMap<String, Object>();
-    HashMap<String, Object> item = new HashMap<String, Object>();
 
+    HashMap<String, Object> item = new HashMap<String, Object>();
     item.put("plan", plan.getId());
     item.put("quantity", 1);
+
+    HashMap<String, Object> items = new HashMap<String, Object>();
     items.put("0", item);
 
+    Map<String, Object> subCreateParams = new HashMap<String, Object>();
     subCreateParams.put("items", items);
     subCreateParams.put("customer", customer.getId());
+
     return Subscription.create(subCreateParams);
   }
 

--- a/src/test/java/com/stripe/functional/SubscriptionTest.java
+++ b/src/test/java/com/stripe/functional/SubscriptionTest.java
@@ -60,8 +60,8 @@ public class SubscriptionTest extends BaseStripeFunctionalTest {
 
   @Test
   public void testNewStyleSubscriptionAPI() throws StripeException {
-    Plan plan = Plan.create(getUniquePlanParams());
-    Plan plan2 = Plan.create(getUniquePlanParams());
+    final Plan plan = Plan.create(getUniquePlanParams());
+    final Plan plan2 = Plan.create(getUniquePlanParams());
     Customer customer = Customer.create(defaultCustomerParams);
 
     // Create
@@ -95,8 +95,8 @@ public class SubscriptionTest extends BaseStripeFunctionalTest {
 
   @Test
   public void testTopLevelSubscriptionAPI() throws StripeException {
-    Plan plan = Plan.create(getUniquePlanParams());
-    Plan plan2 = Plan.create(getUniquePlanParams());
+    final Plan plan = Plan.create(getUniquePlanParams());
+    final Plan plan2 = Plan.create(getUniquePlanParams());
     Customer customer = Customer.create(defaultCustomerParams);
 
     // Create

--- a/src/test/java/com/stripe/functional/TokenTest.java
+++ b/src/test/java/com/stripe/functional/TokenTest.java
@@ -17,12 +17,12 @@ import org.junit.Test;
 
 public class TokenTest extends BaseStripeFunctionalTest {
   private Map<String, Object> getTokenParams() {
-    Map<String, Object> tokenParams = new HashMap<String, Object>();
     Map<String, Object> cardParams = new HashMap<String, Object>();
     cardParams.put("number", "4242424242424242"); // Test token creation so needs PAN.
     cardParams.put("exp_month", 12);
     cardParams.put("exp_year", getYear());
     cardParams.put("cvc", "123");
+    Map<String, Object> tokenParams = new HashMap<String, Object>();
     tokenParams.put("card", cardParams);
 
     return tokenParams;

--- a/src/test/java/com/stripe/model/AccountTest.java
+++ b/src/test/java/com/stripe/model/AccountTest.java
@@ -34,7 +34,7 @@ public class AccountTest extends BaseStripeTest {
   @Test
   public void testDeserialize() throws StripeException, IOException {
     String json = resource("account.json");
-    Account acc = APIResource.GSON.fromJson(json, Account.class);
+    final Account acc = APIResource.GSON.fromJson(json, Account.class);
 
     assertEquals("acct_1032D82eZvKYlo2C", acc.getId());
     assertEquals(false, acc.getChargesEnabled());
@@ -134,7 +134,7 @@ public class AccountTest extends BaseStripeTest {
   public void testAccountUpdateById() throws StripeException, IOException {
     String json = resource("account.json");
     stubNetwork(Account.class, json);
-    Account acc = Account.retrieve("acct_1032D82eZvKYlo2C");
+    final Account acc = Account.retrieve("acct_1032D82eZvKYlo2C");
     verifyGet(Account.class, "https://api.stripe.com/v1/accounts/acct_1032D82eZvKYlo2C");
 
     Map<String, Object> params = new HashMap<String, Object>();
@@ -151,7 +151,7 @@ public class AccountTest extends BaseStripeTest {
   public void testAccountCreateExternalAccount() throws StripeException, IOException {
     String json = resource("account.json");
     stubNetwork(Account.class, json);
-    Account acc = Account.retrieve("acct_1032D82eZvKYlo2C");
+    final Account acc = Account.retrieve("acct_1032D82eZvKYlo2C");
     verifyGet(Account.class, "https://api.stripe.com/v1/accounts/acct_1032D82eZvKYlo2C");
 
     Map<String, Object> params = new HashMap<String, Object>();
@@ -187,8 +187,8 @@ public class AccountTest extends BaseStripeTest {
     Account acc = Account.retrieve("acct_EXPRESS");
     verifyGet(Account.class, "https://api.stripe.com/v1/accounts/acct_EXPRESS");
 
-    String json_link = resource("login_link.json");
-    stubNetwork(LoginLink.class, json_link);
+    String jsonLink = resource("login_link.json");
+    stubNetwork(LoginLink.class, jsonLink);
     acc.getLoginLinks().create();
     verifyPost(LoginLink.class, "https://api.stripe.com/v1/accounts/acct_EXPRESS/login_links", (RequestOptions) null);
   }

--- a/src/test/java/com/stripe/model/InvoiceTest.java
+++ b/src/test/java/com/stripe/model/InvoiceTest.java
@@ -45,9 +45,6 @@ public class InvoiceTest extends BaseStripeTest {
 
   @Test
   public void testUpcoming() throws StripeException {
-    Map<String, Object> params = new HashMap<String, Object>();
-    List<HashMap<String, Object>> items = new ArrayList<HashMap<String, Object>>();
-
     HashMap<String, Object> itemA = new HashMap<String, Object>();
     itemA.put("id", "si_kjnkk893jslo");
     itemA.put("quantity", 3);
@@ -60,10 +57,12 @@ public class InvoiceTest extends BaseStripeTest {
     itemC.put("plan", "silver");
     itemC.put("quantity", 1);
 
+    List<HashMap<String, Object>> items = new ArrayList<HashMap<String, Object>>();
     items.add(itemA);
     items.add(itemB);
     items.add(itemC);
 
+    Map<String, Object> params = new HashMap<String, Object>();
     params.put("subscription_items", items);
     params.put("subscription", "sub_8OgUootyH2faMz");
     params.put("customer", "cus_8OgDDsZEwoTscq");

--- a/src/test/java/com/stripe/model/SourceMandateNotificationTest.java
+++ b/src/test/java/com/stripe/model/SourceMandateNotificationTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
 
 public class SourceMandateNotificationTest extends BaseStripeTest {
   private void verifyResource(SourceMandateNotification mandateNotification) {
-    Map<String, String> typeData = mandateNotification.getTypeData();
+    final Map<String, String> typeData = mandateNotification.getTypeData();
 
     assertEquals("srcmn_1234", mandateNotification.getId());
     assertEquals("source_mandate_notification", mandateNotification.getObject());

--- a/src/test/java/com/stripe/model/SourceTransactionTest.java
+++ b/src/test/java/com/stripe/model/SourceTransactionTest.java
@@ -39,7 +39,7 @@ public class SourceTransactionTest extends BaseStripeTest {
     assertEquals(1, transactions.getData().size());
 
     SourceTransaction transaction = transactions.getData().get(0);
-    Map<String, String> typeData = transaction.getTypeData();
+    final Map<String, String> typeData = transaction.getTypeData();
 
     assertEquals("srctxn_1B4r6QKCFFPkgtRhbyo8EK7U", transaction.getId());
     assertEquals("source_transaction", transaction.getObject());

--- a/src/test/java/com/stripe/model/SubscriptionTest.java
+++ b/src/test/java/com/stripe/model/SubscriptionTest.java
@@ -71,9 +71,6 @@ public class SubscriptionTest extends BaseStripeTest {
     Subscription subscription = new Subscription();
     subscription.setId("test_sub");
 
-    HashMap<String, Object> params = new HashMap<String, Object>();
-    List<HashMap<String, Object>> items = new ArrayList<HashMap<String, Object>>();
-
     HashMap<String, Object> itemA = new HashMap<String, Object>();
     itemA.put("plan", "gold");
     itemA.put("quantity", 1);
@@ -82,9 +79,11 @@ public class SubscriptionTest extends BaseStripeTest {
     itemB.put("plan", "silver");
     itemB.put("quantity", 2);
 
+    List<HashMap<String, Object>> items = new ArrayList<HashMap<String, Object>>();
     items.add(itemA);
     items.add(itemB);
 
+    HashMap<String, Object> params = new HashMap<String, Object>();
     params.put("items", items);
 
     subscription.update(params);
@@ -107,9 +106,6 @@ public class SubscriptionTest extends BaseStripeTest {
 
   @Test
   public void testCreateWithItems() throws StripeException {
-    Map<String, Object> params = new HashMap<String, Object>();
-    List<HashMap<String, Object>> items = new ArrayList<HashMap<String, Object>>();
-
     HashMap<String, Object> itemA = new HashMap<String, Object>();
     itemA.put("plan", "gold");
     itemA.put("quantity", 1);
@@ -118,9 +114,11 @@ public class SubscriptionTest extends BaseStripeTest {
     itemB.put("plan", "silver");
     itemB.put("quantity", 2);
 
+    List<HashMap<String, Object>> items = new ArrayList<HashMap<String, Object>>();
     items.add(itemA);
     items.add(itemB);
 
+    Map<String, Object> params = new HashMap<String, Object>();
     params.put("customer", "test_cus");
     params.put("items", items);
 

--- a/src/test/java/com/stripe/net/OAuthTest.java
+++ b/src/test/java/com/stripe/net/OAuthTest.java
@@ -62,7 +62,7 @@ public class OAuthTest extends BaseStripeTest {
     String urlStr = OAuth.authorizeURL(urlParams, null);
 
     URL url = new URL(urlStr);
-    Map<String, String> queryPairs = splitQuery(url.getQuery());
+    final Map<String, String> queryPairs = splitQuery(url.getQuery());
 
     assertEquals("https", url.getProtocol());
     assertEquals("connect.stripe.com", url.getHost());

--- a/src/test/java/com/stripe/net/StripeHeadersTest.java
+++ b/src/test/java/com/stripe/net/StripeHeadersTest.java
@@ -15,15 +15,18 @@ import org.junit.Test;
 public class StripeHeadersTest extends BaseStripeTest {
 
   private Map<String, List<String>> generateHeaderMap() {
-    Map<String, List<String>> headerMap = new HashMap<String, List<String>>();
     List<String> multiValueHeader = new ArrayList<String>();
     multiValueHeader.add("FirstValue");
     multiValueHeader.add("SecondValue");
+ 
     List<String> requestIdHeader = new ArrayList<String>();
     requestIdHeader.add("req_12345");
+ 
+    Map<String, List<String>> headerMap = new HashMap<String, List<String>>();
     headerMap.put("Request-Id", requestIdHeader);
     headerMap.put("Multi-Val", multiValueHeader);
     headerMap.put("Empty-Header", new ArrayList<String>());
+ 
     return headerMap;
   }
 

--- a/src/test/java/com/stripe/net/StripeResponseTest.java
+++ b/src/test/java/com/stripe/net/StripeResponseTest.java
@@ -27,13 +27,16 @@ public class StripeResponseTest extends BaseStripeTest {
   }
 
   private Map<String, List<String>> generateHeaderMap() {
-    Map<String, List<String>> headerMap = new HashMap<String, List<String>>();
     List<String> idempotencyHeader = new ArrayList<String>();
     idempotencyHeader.add("12345");
+
     List<String> requestIdHeader = new ArrayList<String>();
     requestIdHeader.add("req_12345");
+
+    Map<String, List<String>> headerMap = new HashMap<String, List<String>>();
     headerMap.put("Idempotency-Key", idempotencyHeader);
     headerMap.put("Request-Id", requestIdHeader);
+
     return headerMap;
   }
 


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Fixes distance linting issues. The linter doesn't like it when a variable is declared too far away from its first usage. This can be fixed in one of two ways:
- move the declaration closer to the first usage
- make the variable `final`

I also fixed a few other unrelated linting issues (mostly some variables in tests starting with a capital letter).
