### PR TITLE
Group overload methods

### DIFF
--- a/src/main/java/com/stripe/model/BitcoinReceiver.java
+++ b/src/main/java/com/stripe/model/BitcoinReceiver.java
@@ -198,12 +198,6 @@ public class BitcoinReceiver extends ExternalAccount {
     return create(params, null);
   }
 
-  public static BitcoinReceiver retrieve(String id) throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    return retrieve(id, null);
-  }
-
   public static BitcoinReceiver create(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
@@ -211,6 +205,13 @@ public class BitcoinReceiver extends ExternalAccount {
         "v1/bitcoin/receivers"), params, BitcoinReceiver.class, options);
   }
 
+  public static BitcoinReceiver retrieve(String id) throws AuthenticationException,
+      InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    return retrieve(id, null);
+  }
+
+  
   public static BitcoinReceiver retrieve(String id, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -560,56 +560,6 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
     return create(params, (RequestOptions) null);
   }
 
-  public static Charge retrieve(String id) throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    return retrieve(id, (RequestOptions) null);
-  }
-
-  public Charge update(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return update(params, (RequestOptions) null);
-  }
-
-  public Charge refund() throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    return this.refund(null, (RequestOptions) null);
-  }
-
-  public Charge capture() throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    return this.capture(null, (RequestOptions) null);
-  }
-
-  @Deprecated
-  public Dispute updateDispute(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return this.updateDispute(params, (RequestOptions) null);
-  }
-
-  @Deprecated
-  public Dispute closeDispute() throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    return this.closeDispute((RequestOptions) null);
-  }
-
-  public Charge refund(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return this.refund(params, (RequestOptions) null);
-  }
-
-  public Charge capture(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return this.capture(params, (RequestOptions) null);
-  }
-
   @Deprecated
   public static Charge create(Map<String, Object> params, String apiKey)
       throws AuthenticationException, InvalidRequestException,
@@ -621,6 +571,12 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
     return request(RequestMethod.POST, classURL(Charge.class), params, Charge.class, options);
+  }
+
+  public static Charge retrieve(String id) throws AuthenticationException,
+      InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    return retrieve(id, (RequestOptions) null);
   }
 
   @Deprecated
@@ -642,6 +598,12 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
     return request(RequestMethod.GET, instanceURL(Charge.class, id), params, Charge.class, options);
   }
 
+  public Charge update(Map<String, Object> params)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return update(params, (RequestOptions) null);
+  }
+
   @Deprecated
   public Charge update(Map<String, Object> params, String apiKey)
       throws AuthenticationException, InvalidRequestException,
@@ -654,6 +616,130 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
       APIConnectionException, CardException, APIException {
     return request(RequestMethod.POST, instanceURL(Charge.class, id), params, Charge.class,
         options);
+  }
+
+  public Charge refund() throws AuthenticationException,
+      InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    return this.refund(null, (RequestOptions) null);
+  }
+
+  public Charge refund(Map<String, Object> params)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return this.refund(params, (RequestOptions) null);
+  }
+
+  @Deprecated
+  public Charge refund(String apiKey) throws AuthenticationException,
+      InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    return this.refund(RequestOptions.builder().setApiKey(apiKey).build()); // full refund
+  }
+
+  public Charge refund(RequestOptions options) throws AuthenticationException,
+      InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    return this.refund(null, options); // full refund
+  }
+
+  @Deprecated
+  public Charge refund(Map<String, Object> params, String apiKey)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return refund(params, RequestOptions.builder().setApiKey(apiKey).build());
+  }
+
+  public Charge refund(Map<String, Object> params, RequestOptions options)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return request(RequestMethod.POST, String.format("%s/refund",
+        instanceURL(Charge.class, this.getId())), params, Charge.class, options);
+  }
+
+  public Charge capture() throws AuthenticationException,
+      InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    return this.capture(null, (RequestOptions) null);
+  }
+
+  public Charge capture(Map<String, Object> params)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return this.capture(params, (RequestOptions) null);
+  }
+
+  @Deprecated
+  public Charge capture(String apiKey) throws AuthenticationException,
+      InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    return capture(RequestOptions.builder().setApiKey(apiKey).build());
+  }
+
+  public Charge capture(RequestOptions options) throws AuthenticationException,
+      InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    return this.capture(null, options);
+  }
+
+  @Deprecated
+  public Charge capture(Map<String, Object> params, String apiKey)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return capture(params, RequestOptions.builder().setApiKey(apiKey).build());
+  }
+
+  public Charge capture(Map<String, Object> params, RequestOptions options)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return request(RequestMethod.POST, String.format("%s/capture",
+        instanceURL(Charge.class, this.getId())), params, Charge.class, options);
+  }
+
+  @Deprecated
+  public Dispute updateDispute(Map<String, Object> params)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return this.updateDispute(params, (RequestOptions) null);
+  }
+
+  @Deprecated
+  public Dispute updateDispute(Map<String, Object> params, String apiKey)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return updateDispute(params, RequestOptions.builder().setApiKey(apiKey).build());
+  }
+
+  @Deprecated
+  public Dispute updateDispute(Map<String, Object> params, RequestOptions options)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return request(RequestMethod.POST,
+        String.format("%s/dispute", instanceURL(Charge.class, this.id)), params, Dispute.class,
+        options);
+  }
+
+  @Deprecated
+  public Dispute closeDispute() throws AuthenticationException,
+      InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    return this.closeDispute((RequestOptions) null);
+  }
+
+  @Deprecated
+  public Dispute closeDispute(String apiKey)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return closeDispute(RequestOptions.builder().setApiKey(apiKey).build());
+  }
+
+  @Deprecated
+  public Dispute closeDispute(RequestOptions options)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return request(RequestMethod.POST,
+        String.format("%s/dispute/close", instanceURL(Charge.class, this.getId())), null,
+        Dispute.class, options);
   }
 
   public static ChargeCollection list(Map<String, Object> params)
@@ -687,92 +773,6 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
     return list(params, options);
-  }
-
-  @Deprecated
-  public Charge refund(String apiKey) throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    return this.refund(RequestOptions.builder().setApiKey(apiKey).build()); // full refund
-  }
-
-  public Charge refund(RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    return this.refund(null, options); // full refund
-  }
-
-  @Deprecated
-  public Charge refund(Map<String, Object> params, String apiKey)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return refund(params, RequestOptions.builder().setApiKey(apiKey).build());
-  }
-
-  public Charge refund(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return request(RequestMethod.POST, String.format("%s/refund",
-        instanceURL(Charge.class, this.getId())), params, Charge.class, options);
-  }
-
-  @Deprecated
-  public Charge capture(String apiKey) throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    return capture(RequestOptions.builder().setApiKey(apiKey).build());
-  }
-
-  public Charge capture(RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    return this.capture(null, options);
-  }
-
-  @Deprecated
-  public Charge capture(Map<String, Object> params, String apiKey)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return capture(params, RequestOptions.builder().setApiKey(apiKey).build());
-  }
-
-  public Charge capture(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return request(RequestMethod.POST, String.format("%s/capture",
-        instanceURL(Charge.class, this.getId())), params, Charge.class, options);
-  }
-
-  @Deprecated
-  public Dispute updateDispute(Map<String, Object> params, String apiKey)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return updateDispute(params, RequestOptions.builder().setApiKey(apiKey).build());
-  }
-
-  @Deprecated
-  public Dispute updateDispute(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return request(RequestMethod.POST,
-        String.format("%s/dispute", instanceURL(Charge.class, this.id)), params, Dispute.class,
-        options);
-  }
-
-  @Deprecated
-  public Dispute closeDispute(String apiKey)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return closeDispute(RequestOptions.builder().setApiKey(apiKey).build());
-  }
-
-  @Deprecated
-  public Dispute closeDispute(RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return request(RequestMethod.POST,
-        String.format("%s/dispute/close", instanceURL(Charge.class, this.getId())), null,
-        Dispute.class, options);
   }
 
   /**

--- a/src/main/java/com/stripe/model/Coupon.java
+++ b/src/main/java/com/stripe/model/Coupon.java
@@ -144,10 +144,36 @@ public class Coupon extends APIResource implements MetadataStore<Coupon>, HasId 
     return create(params, (RequestOptions) null);
   }
 
+  @Deprecated
+  public static Coupon create(Map<String, Object> params, String apiKey)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return create(params, RequestOptions.builder().setApiKey(apiKey).build());
+  }
+
+  public static Coupon create(Map<String, Object> params, RequestOptions options)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return request(RequestMethod.POST, classURL(Coupon.class), params, Coupon.class, options);
+  }
+
   public static Coupon retrieve(String id) throws AuthenticationException,
       InvalidRequestException, APIConnectionException, CardException,
       APIException {
     return retrieve(id, (RequestOptions) null);
+  }
+
+  @Deprecated
+  public static Coupon retrieve(String id, String apiKey)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return retrieve(id, RequestOptions.builder().setApiKey(apiKey).build());
+  }
+
+  public static Coupon retrieve(String id, RequestOptions options)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return request(RequestMethod.GET, instanceURL(Coupon.class, id), null, Coupon.class, options);
   }
 
   public Coupon update(Map<String, Object> params)
@@ -168,32 +194,6 @@ public class Coupon extends APIResource implements MetadataStore<Coupon>, HasId 
       CardException, APIException {
     return request(RequestMethod.POST, instanceURL(Coupon.class, this.id), params, Coupon.class,
         options);
-  }
-
-  @Deprecated
-  public static Coupon create(Map<String, Object> params, String apiKey)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return create(params, RequestOptions.builder().setApiKey(apiKey).build());
-  }
-
-  public static Coupon create(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return request(RequestMethod.POST, classURL(Coupon.class), params, Coupon.class, options);
-  }
-
-  @Deprecated
-  public static Coupon retrieve(String id, String apiKey)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return retrieve(id, RequestOptions.builder().setApiKey(apiKey).build());
-  }
-
-  public static Coupon retrieve(String id, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return request(RequestMethod.GET, instanceURL(Coupon.class, id), null, Coupon.class, options);
   }
 
   public static CouponCollection list(Map<String, Object> params)

--- a/src/main/java/com/stripe/model/Customer.java
+++ b/src/main/java/com/stripe/model/Customer.java
@@ -265,10 +265,44 @@ public class Customer extends APIResource implements MetadataStore<Customer>, Ha
     return create(params, (RequestOptions) null);
   }
 
+  @Deprecated
+  public static Customer create(Map<String, Object> params, String apiKey)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return create(params, RequestOptions.builder().setApiKey(apiKey).build());
+  }
+
+  public static Customer create(Map<String, Object> params, RequestOptions options)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return request(RequestMethod.POST, classURL(Customer.class), params, Customer.class, options);
+  }
+
   public static Customer retrieve(String id) throws AuthenticationException,
       InvalidRequestException, APIConnectionException, CardException,
       APIException {
     return retrieve(id, (RequestOptions) null);
+  }
+
+  @Deprecated
+  public static Customer retrieve(String id, String apiKey)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return retrieve(id, RequestOptions.builder().setApiKey(apiKey).build());
+  }
+
+  public static Customer retrieve(String id, RequestOptions options)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return request(RequestMethod.GET, instanceURL(Customer.class, id), null, Customer.class,
+        options);
+  }
+
+  public static Customer retrieve(String id, Map<String, Object> params, RequestOptions options)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return request(RequestMethod.GET, instanceURL(Customer.class, id), params, Customer.class,
+        options);
   }
 
   public Customer update(Map<String, Object> params)
@@ -277,10 +311,46 @@ public class Customer extends APIResource implements MetadataStore<Customer>, Ha
     return update(params, (RequestOptions) null);
   }
 
+  @Deprecated
+  public Customer update(Map<String, Object> params, String apiKey)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return update(params, RequestOptions.builder().setApiKey(apiKey).build());
+  }
+
+  public Customer update(Map<String, Object> params, RequestOptions options)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return request(RequestMethod.POST, instanceURL(Customer.class, this.id), params,
+        Customer.class, options);
+  }
+
   public DeletedCustomer delete() throws AuthenticationException,
       InvalidRequestException, APIConnectionException, CardException,
       APIException {
     return delete((RequestOptions) null);
+  }
+
+  @Deprecated
+  public DeletedCustomer delete(String apiKey)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return delete(RequestOptions.builder().setApiKey(apiKey).build());
+  }
+
+  public DeletedCustomer delete(RequestOptions options)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return request(RequestMethod.DELETE, instanceURL(Customer.class, this.id), null,
+        DeletedCustomer.class, options);
+  }
+
+  // Use `(Card)customer.getSources().create(params)` instead.
+  @Deprecated
+  public Card createCard(String token, String apiKey) throws AuthenticationException,
+      InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    return createCard(token, RequestOptions.builder().setApiKey(apiKey).build());
   }
 
   public Card createCard(String token) throws AuthenticationException,
@@ -293,6 +363,31 @@ public class Customer extends APIResource implements MetadataStore<Customer>, Ha
       InvalidRequestException, APIConnectionException, CardException,
       APIException {
     return createCard(params, (RequestOptions) null);
+  }
+
+  @Deprecated
+  public Card createCard(String token, RequestOptions options) throws AuthenticationException,
+      InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    Map<String, Object> postParams = new HashMap<String, Object>();
+    postParams.put("card", token);
+
+    return createCard(postParams, options);
+  }
+
+  @Deprecated
+  public Card createCard(Map<String, Object> params, String apiKey) throws AuthenticationException,
+      InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    return createCard(params, RequestOptions.builder().setApiKey(apiKey).build());
+  }
+
+  @Deprecated
+  public Card createCard(Map<String, Object> params, RequestOptions options)
+      throws AuthenticationException,InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    return request(RequestMethod.POST, String.format("%s/cards",
+        instanceURL(Customer.class, this.id)), params, Card.class, options);
   }
 
   // Use `(BankAccount)customer.getSources().create(params)` instead.
@@ -334,6 +429,20 @@ public class Customer extends APIResource implements MetadataStore<Customer>, Ha
     return createSubscription(params, (RequestOptions) null);
   }
 
+  @Deprecated
+  public Subscription createSubscription(Map<String, Object> params, String apiKey)
+      throws AuthenticationException,InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    return createSubscription(params, RequestOptions.builder().setApiKey(apiKey).build());
+  }
+
+  public Subscription createSubscription(Map<String, Object> params, RequestOptions options)
+      throws AuthenticationException,InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    return request(RequestMethod.POST, String.format("%s/subscriptions",
+        instanceURL(Customer.class, this.id)), params, Subscription.class, options);
+  }
+
   /**
    * 1/2014: Legacy (from before multiple subscriptions per customer)
    */
@@ -341,6 +450,28 @@ public class Customer extends APIResource implements MetadataStore<Customer>, Ha
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
     return updateSubscription(params, (RequestOptions) null);
+  }
+
+  /**
+   * 1/2014: Legacy (from before multiple subscriptions per customer)
+   */
+  @Deprecated
+  public Subscription updateSubscription(Map<String, Object> params,
+                       String apiKey) throws AuthenticationException,
+      InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    return updateSubscription(params, RequestOptions.builder().setApiKey(apiKey).build());
+  }
+
+  /**
+   * 1/2014: Legacy (from before multiple subscriptions per customer)
+   */
+  public Subscription updateSubscription(Map<String, Object> params,
+                       RequestOptions options) throws AuthenticationException,
+      InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    return request(RequestMethod.POST, String.format("%s/subscription",
+        instanceURL(Customer.class, this.id)), params, Subscription.class, options);
   }
 
   /**
@@ -361,6 +492,41 @@ public class Customer extends APIResource implements MetadataStore<Customer>, Ha
     return cancelSubscription(params, (RequestOptions) null);
   }
 
+  /**
+   * 1/2014: Legacy (from before multiple subscriptions per customer)
+   */
+  @Deprecated
+  public Subscription cancelSubscription(String apiKey)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return cancelSubscription(RequestOptions.builder().setApiKey(apiKey).build());
+  }
+
+  public Subscription cancelSubscription(RequestOptions options)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return cancelSubscription(null, options);
+  }
+
+  /**
+   * 1/2014: Legacy (from before multiple subscriptions per customer)
+   */
+  @Deprecated
+  public Subscription cancelSubscription(Map<String, Object> params,
+                       String apiKey) throws AuthenticationException,
+      InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    return cancelSubscription(params, RequestOptions.builder().setApiKey(apiKey).build());
+  }
+
+  public Subscription cancelSubscription(Map<String, Object> params,
+                       RequestOptions options) throws AuthenticationException,
+      InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    return request(RequestMethod.DELETE, String.format("%s/subscription",
+        instanceURL(Customer.class, this.id)), params, Subscription.class, options);
+  }
+
   public void deleteDiscount() throws AuthenticationException,
       InvalidRequestException, APIConnectionException, CardException,
       APIException {
@@ -368,37 +534,17 @@ public class Customer extends APIResource implements MetadataStore<Customer>, Ha
   }
 
   @Deprecated
-  public static Customer create(Map<String, Object> params, String apiKey)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return create(params, RequestOptions.builder().setApiKey(apiKey).build());
+  public void deleteDiscount(String apiKey) throws AuthenticationException,
+      InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    deleteDiscount(RequestOptions.builder().setApiKey(apiKey).build());
   }
 
-  public static Customer create(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return request(RequestMethod.POST, classURL(Customer.class), params, Customer.class, options);
-  }
-
-  @Deprecated
-  public static Customer retrieve(String id, String apiKey)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return retrieve(id, RequestOptions.builder().setApiKey(apiKey).build());
-  }
-
-  public static Customer retrieve(String id, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return request(RequestMethod.GET, instanceURL(Customer.class, id), null, Customer.class,
-        options);
-  }
-
-  public static Customer retrieve(String id, Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return request(RequestMethod.GET, instanceURL(Customer.class, id), params, Customer.class,
-        options);
+  public void deleteDiscount(RequestOptions options) throws AuthenticationException,
+      InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    request(RequestMethod.DELETE, String.format("%s/discount",
+        instanceURL(Customer.class, this.id)), null, Discount.class, options);
   }
 
   public static CustomerCollection list(Map<String, Object> params)
@@ -437,151 +583,4 @@ public class Customer extends APIResource implements MetadataStore<Customer>, Ha
       APIException {
     return list(params, options);
   }
-
-  @Deprecated
-  public Customer update(Map<String, Object> params, String apiKey)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return update(params, RequestOptions.builder().setApiKey(apiKey).build());
-  }
-
-  public Customer update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return request(RequestMethod.POST, instanceURL(Customer.class, this.id), params,
-        Customer.class, options);
-  }
-
-  @Deprecated
-  public DeletedCustomer delete(String apiKey)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return delete(RequestOptions.builder().setApiKey(apiKey).build());
-  }
-
-  public DeletedCustomer delete(RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return request(RequestMethod.DELETE, instanceURL(Customer.class, this.id), null,
-        DeletedCustomer.class, options);
-  }
-
-  // Use `(Card)customer.getSources().create(params)` instead.
-  @Deprecated
-  public Card createCard(String token, String apiKey) throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    return createCard(token, RequestOptions.builder().setApiKey(apiKey).build());
-  }
-
-  @Deprecated
-  public Card createCard(String token, RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    Map<String, Object> postParams = new HashMap<String, Object>();
-    postParams.put("card", token);
-
-    return createCard(postParams, options);
-  }
-
-  @Deprecated
-  public Card createCard(Map<String, Object> params, String apiKey) throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    return createCard(params, RequestOptions.builder().setApiKey(apiKey).build());
-  }
-
-  @Deprecated
-  public Card createCard(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException,InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    return request(RequestMethod.POST, String.format("%s/cards",
-        instanceURL(Customer.class, this.id)), params, Card.class, options);
-  }
-
-  @Deprecated
-  public Subscription createSubscription(Map<String, Object> params, String apiKey)
-      throws AuthenticationException,InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    return createSubscription(params, RequestOptions.builder().setApiKey(apiKey).build());
-  }
-
-  public Subscription createSubscription(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException,InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    return request(RequestMethod.POST, String.format("%s/subscriptions",
-        instanceURL(Customer.class, this.id)), params, Subscription.class, options);
-  }
-
-  /**
-   * 1/2014: Legacy (from before multiple subscriptions per customer)
-   */
-  @Deprecated
-  public Subscription updateSubscription(Map<String, Object> params,
-                       String apiKey) throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    return updateSubscription(params, RequestOptions.builder().setApiKey(apiKey).build());
-  }
-
-  /**
-   * 1/2014: Legacy (from before multiple subscriptions per customer)
-   */
-  public Subscription updateSubscription(Map<String, Object> params,
-                       RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    return request(RequestMethod.POST, String.format("%s/subscription",
-        instanceURL(Customer.class, this.id)), params, Subscription.class, options);
-  }
-
-  /**
-   * 1/2014: Legacy (from before multiple subscriptions per customer)
-   */
-  @Deprecated
-  public Subscription cancelSubscription(String apiKey)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return cancelSubscription(RequestOptions.builder().setApiKey(apiKey).build());
-  }
-
-  public Subscription cancelSubscription(RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return cancelSubscription(null, options);
-  }
-
-  /**
-   * 1/2014: Legacy (from before multiple subscriptions per customer)
-   */
-  @Deprecated
-  public Subscription cancelSubscription(Map<String, Object> params,
-                       String apiKey) throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    return cancelSubscription(params, RequestOptions.builder().setApiKey(apiKey).build());
-  }
-
-  public Subscription cancelSubscription(Map<String, Object> params,
-                       RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    return request(RequestMethod.DELETE, String.format("%s/subscription",
-        instanceURL(Customer.class, this.id)), params, Subscription.class, options);
-  }
-
-  @Deprecated
-  public void deleteDiscount(String apiKey) throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    deleteDiscount(RequestOptions.builder().setApiKey(apiKey).build());
-  }
-
-  public void deleteDiscount(RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    request(RequestMethod.DELETE, String.format("%s/discount",
-        instanceURL(Customer.class, this.id)), null, Discount.class, options);
-  }
-
 }

--- a/src/main/java/com/stripe/model/FileUpload.java
+++ b/src/main/java/com/stripe/model/FileUpload.java
@@ -82,12 +82,6 @@ public class FileUpload extends APIResource implements HasId {
     return create(params, (RequestOptions) null);
   }
 
-  public static FileUpload retrieve(String id)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return retrieve(id, (RequestOptions) null);
-  }
-
   @Deprecated
   public static FileUpload create(Map<String, Object> params, String apiKey)
       throws AuthenticationException, InvalidRequestException,
@@ -102,6 +96,12 @@ public class FileUpload extends APIResource implements HasId {
       APIException {
     return multipartRequest(RequestMethod.POST, classURL(FileUpload.class, Stripe.UPLOAD_API_BASE),
         params, FileUpload.class, options);
+  }
+
+  public static FileUpload retrieve(String id)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return retrieve(id, (RequestOptions) null);
   }
 
   @Deprecated

--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -366,36 +366,6 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
     return retrieve(id, (RequestOptions) null);
   }
 
-  public static Invoice create(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return create(params, (RequestOptions) null);
-  }
-
-  public static Invoice upcoming(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return upcoming(params, (RequestOptions) null);
-  }
-
-  public Invoice pay() throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    return this.pay((RequestOptions) null);
-  }
-
-  public Invoice pay(Map<String, Object> params) throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    return this.pay(params, null);
-  }
-
-  public Invoice update(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return update(params, (RequestOptions) null);
-  }
-
   @Deprecated
   public static Invoice retrieve(String id, String apiKey)
       throws AuthenticationException, InvalidRequestException,
@@ -416,6 +386,12 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
         options);
   }
 
+  public static Invoice create(Map<String, Object> params)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return create(params, (RequestOptions) null);
+  }
+
   @Deprecated
   public static Invoice create(Map<String, Object> params, String apiKey)
       throws AuthenticationException, InvalidRequestException,
@@ -427,6 +403,12 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
     return request(RequestMethod.POST, classURL(Invoice.class), params, Invoice.class, options);
+  }
+
+  public static Invoice upcoming(Map<String, Object> params)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return upcoming(params, (RequestOptions) null);
   }
 
   @Deprecated
@@ -441,6 +423,59 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
       APIConnectionException, CardException, APIException {
     return request(RequestMethod.GET, String.format("%s/upcoming", classURL(Invoice.class)), params,
         Invoice.class, options);
+  }
+
+  public Invoice pay() throws AuthenticationException,
+      InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    return this.pay((RequestOptions) null);
+  }
+
+  public Invoice pay(Map<String, Object> params) throws AuthenticationException,
+      InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    return this.pay(params, null);
+  }
+
+  @Deprecated
+  public Invoice pay(String apiKey) throws AuthenticationException,
+      InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    return pay(RequestOptions.builder().setApiKey(apiKey).build());
+  }
+
+  @Deprecated
+  public Invoice pay(RequestOptions options) throws AuthenticationException,
+      InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    return pay(null, options);
+  }
+
+  public Invoice pay(Map<String, Object> params, RequestOptions options)
+      throws AuthenticationException, InvalidRequestException, APIConnectionException,
+      CardException, APIException {
+    return request(RequestMethod.POST, String.format("%s/pay",
+        instanceURL(Invoice.class, this.getId())), params, Invoice.class, options);
+  }
+
+  public Invoice update(Map<String, Object> params)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return update(params, (RequestOptions) null);
+  }
+
+  @Deprecated
+  public Invoice update(Map<String, Object> params, String apiKey)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return update(params, RequestOptions.builder().setApiKey(apiKey).build());
+  }
+
+  public Invoice update(Map<String, Object> params, RequestOptions options)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return request(RequestMethod.POST, instanceURL(Invoice.class, this.id), params, Invoice.class,
+        options);
   }
 
   public static InvoiceCollection list(Map<String, Object> params)
@@ -477,40 +512,5 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
       InvalidRequestException, APIConnectionException, CardException,
       APIException {
     return list(params, options);
-  }
-
-  @Deprecated
-  public Invoice update(Map<String, Object> params, String apiKey)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return update(params, RequestOptions.builder().setApiKey(apiKey).build());
-  }
-
-  public Invoice update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return request(RequestMethod.POST, instanceURL(Invoice.class, this.id), params, Invoice.class,
-        options);
-  }
-
-  @Deprecated
-  public Invoice pay(String apiKey) throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    return pay(RequestOptions.builder().setApiKey(apiKey).build());
-  }
-
-  @Deprecated
-  public Invoice pay(RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    return pay(null, options);
-  }
-
-  public Invoice pay(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException, APIConnectionException,
-      CardException, APIException {
-    return request(RequestMethod.POST, String.format("%s/pay",
-        instanceURL(Invoice.class, this.getId())), params, Invoice.class, options);
   }
 }

--- a/src/main/java/com/stripe/model/InvoiceItem.java
+++ b/src/main/java/com/stripe/model/InvoiceItem.java
@@ -206,24 +206,6 @@ public class InvoiceItem extends APIResource implements MetadataStore<InvoiceIte
     return create(params, (RequestOptions) null);
   }
 
-  public static InvoiceItem retrieve(String id)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return retrieve(id, (RequestOptions) null);
-  }
-
-  public InvoiceItem update(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return update(params, (RequestOptions) null);
-  }
-
-  public DeletedInvoiceItem delete() throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    return delete((RequestOptions) null);
-  }
-
   @Deprecated
   public static InvoiceItem create(Map<String, Object> params, String apiKey)
       throws AuthenticationException, InvalidRequestException,
@@ -236,6 +218,12 @@ public class InvoiceItem extends APIResource implements MetadataStore<InvoiceIte
       APIConnectionException, CardException, APIException {
     return request(RequestMethod.POST, classURL(InvoiceItem.class), params, InvoiceItem.class,
         options);
+  }
+
+  public static InvoiceItem retrieve(String id)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return retrieve(id, (RequestOptions) null);
   }
 
   @Deprecated
@@ -257,6 +245,46 @@ public class InvoiceItem extends APIResource implements MetadataStore<InvoiceIte
       APIConnectionException, CardException, APIException {
     return request(RequestMethod.GET, instanceURL(InvoiceItem.class, id), params, InvoiceItem.class,
         options);
+  }
+
+  public InvoiceItem update(Map<String, Object> params)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return update(params, (RequestOptions) null);
+  }
+
+  @Deprecated
+  public InvoiceItem update(Map<String, Object> params, String apiKey)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return update(params, RequestOptions.builder().setApiKey(apiKey).build());
+  }
+
+  public InvoiceItem update(Map<String, Object> params, RequestOptions options)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return request(RequestMethod.POST, instanceURL(InvoiceItem.class, this.id), params, 
+        InvoiceItem.class, options);
+  }
+
+  public DeletedInvoiceItem delete() throws AuthenticationException,
+      InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    return delete((RequestOptions) null);
+  }
+
+  @Deprecated
+  public DeletedInvoiceItem delete(String apiKey)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return delete(RequestOptions.builder().setApiKey(apiKey).build());
+  }
+
+  public DeletedInvoiceItem delete(RequestOptions options)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return request(RequestMethod.DELETE, instanceURL(InvoiceItem.class, this.id), null,
+        DeletedInvoiceItem.class, options);
   }
 
   public static InvoiceItemCollection list(Map<String, Object> params)
@@ -295,33 +323,4 @@ public class InvoiceItem extends APIResource implements MetadataStore<InvoiceIte
       APIException {
     return list(params, options);
   }
-
-  @Deprecated
-  public InvoiceItem update(Map<String, Object> params, String apiKey)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return update(params, RequestOptions.builder().setApiKey(apiKey).build());
-  }
-
-  public InvoiceItem update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return request(RequestMethod.POST, instanceURL(InvoiceItem.class, this.id), params, 
-        InvoiceItem.class, options);
-  }
-
-  @Deprecated
-  public DeletedInvoiceItem delete(String apiKey)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return delete(RequestOptions.builder().setApiKey(apiKey).build());
-  }
-
-  public DeletedInvoiceItem delete(RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return request(RequestMethod.DELETE, instanceURL(InvoiceItem.class, this.id), null,
-        DeletedInvoiceItem.class, options);
-  }
-
 }

--- a/src/main/java/com/stripe/model/Order.java
+++ b/src/main/java/com/stripe/model/Order.java
@@ -255,22 +255,16 @@ public class Order extends APIResource implements HasId, MetadataStore<Order> {
     return create(params, null);
   }
 
-  public static Order retrieve(String id)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return retrieve(id, null);
-  }
-
-  public Order update(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return update(params, null);
-  }
-
   public static Order create(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
     return request(RequestMethod.POST, classURL(Order.class), params, Order.class, options);
+  }
+
+  public static Order retrieve(String id)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return retrieve(id, null);
   }
 
   public static Order retrieve(String id, RequestOptions options)
@@ -283,6 +277,20 @@ public class Order extends APIResource implements HasId, MetadataStore<Order> {
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
     return request(RequestMethod.GET, instanceURL(Order.class, id), params, Order.class, options);
+  }
+
+  public Order update(Map<String, Object> params)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return update(params, null);
+  }
+
+  @Deprecated
+  public Order update(Map<String, Object> params, RequestOptions options)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return request(RequestMethod.POST, instanceURL(Order.class, this.id), params, Order.class,
+        options);
   }
 
   public static OrderCollection list(Map<String, Object> params)
@@ -311,14 +319,6 @@ public class Order extends APIResource implements HasId, MetadataStore<Order> {
       InvalidRequestException, APIConnectionException, CardException,
       APIException {
     return list(params, options);
-  }
-
-  @Deprecated
-  public Order update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return request(RequestMethod.POST, instanceURL(Order.class, this.id), params, Order.class,
-        options);
   }
 
   public Order pay(Map<String, Object> params) throws AuthenticationException,

--- a/src/main/java/com/stripe/model/Plan.java
+++ b/src/main/java/com/stripe/model/Plan.java
@@ -189,24 +189,6 @@ public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
     return create(params, (RequestOptions) null);
   }
 
-  public static Plan retrieve(String id) throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    return retrieve(id, (RequestOptions) null);
-  }
-
-  public Plan update(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return update(params, (RequestOptions) null);
-  }
-
-  public DeletedPlan delete() throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    return delete((RequestOptions) null);
-  }
-
   @Deprecated
   public static Plan create(Map<String, Object> params, String apiKey)
       throws AuthenticationException, InvalidRequestException,
@@ -218,6 +200,12 @@ public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
     return request(RequestMethod.POST, classURL(Plan.class), params, Plan.class, options);
+  }
+
+  public static Plan retrieve(String id) throws AuthenticationException,
+      InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    return retrieve(id, (RequestOptions) null);
   }
 
   @Deprecated
@@ -233,6 +221,12 @@ public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
     return request(RequestMethod.GET, instanceURL(Plan.class, id), null, Plan.class, options);
   }
 
+  public Plan update(Map<String, Object> params)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return update(params, (RequestOptions) null);
+  }
+
   @Deprecated
   public Plan update(Map<String, Object> params, String apiKey)
       throws AuthenticationException, InvalidRequestException,
@@ -244,6 +238,26 @@ public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
     return request(RequestMethod.POST, instanceURL(Plan.class, this.id), params, Plan.class,
+        options);
+  }
+
+  public DeletedPlan delete() throws AuthenticationException,
+      InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    return delete((RequestOptions) null);
+  }
+
+  @Deprecated
+  public DeletedPlan delete(String apiKey) throws AuthenticationException,
+      InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    return delete(RequestOptions.builder().setApiKey(apiKey).build());
+  }
+
+  public DeletedPlan delete(RequestOptions options) throws AuthenticationException,
+      InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    return request(RequestMethod.DELETE, instanceURL(Plan.class, this.id), null, DeletedPlan.class,
         options);
   }
 
@@ -278,19 +292,5 @@ public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
     return list(params, options);
-  }
-
-  @Deprecated
-  public DeletedPlan delete(String apiKey) throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    return delete(RequestOptions.builder().setApiKey(apiKey).build());
-  }
-
-  public DeletedPlan delete(RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    return request(RequestMethod.DELETE, instanceURL(Plan.class, this.id), null, DeletedPlan.class,
-        options);
   }
 }

--- a/src/main/java/com/stripe/model/Product.java
+++ b/src/main/java/com/stripe/model/Product.java
@@ -190,10 +190,22 @@ public class Product extends APIResource implements HasId, MetadataStore<Product
     return create(params, null);
   }
 
+  public static Product create(Map<String, Object> params, RequestOptions options)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return request(RequestMethod.POST, classURL(Product.class), params, Product.class, options);
+  }
+
   public static Product retrieve(String id)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
     return retrieve(id, null);
+  }
+
+  public static Product retrieve(String id, RequestOptions options)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return request(RequestMethod.GET, instanceURL(Product.class, id), null, Product.class, options);
   }
 
   public Product update(Map<String, Object> params)
@@ -202,16 +214,11 @@ public class Product extends APIResource implements HasId, MetadataStore<Product
     return update(params, null);
   }
 
-  public static Product create(Map<String, Object> params, RequestOptions options)
+  public Product update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
-    return request(RequestMethod.POST, classURL(Product.class), params, Product.class, options);
-  }
-
-  public static Product retrieve(String id, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return request(RequestMethod.GET, instanceURL(Product.class, id), null, Product.class, options);
+    return request(RequestMethod.POST, instanceURL(Product.class, this.id), params,
+        Product.class, options);
   }
 
   public DeletedProduct delete()
@@ -253,12 +260,5 @@ public class Product extends APIResource implements HasId, MetadataStore<Product
       InvalidRequestException, APIConnectionException, CardException,
       APIException {
     return list(params, options);
-  }
-
-  public Product update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return request(RequestMethod.POST, instanceURL(Product.class, this.id), params,
-        Product.class, options);
   }
 }

--- a/src/main/java/com/stripe/model/Recipient.java
+++ b/src/main/java/com/stripe/model/Recipient.java
@@ -174,10 +174,44 @@ public class Recipient extends APIResource implements MetadataStore<Recipient>, 
     return create(params, (RequestOptions) null);
   }
 
+  @Deprecated
+  public static Recipient create(Map<String, Object> params, String apiKey)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return create(params, RequestOptions.builder().setApiKey(apiKey).build());
+  }
+
+  public static Recipient create(Map<String, Object> params, RequestOptions options)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return request(RequestMethod.POST, classURL(Recipient.class), params, Recipient.class, options);
+  }
+
   public static Recipient retrieve(String id) throws AuthenticationException,
       InvalidRequestException, APIConnectionException, CardException,
       APIException {
     return retrieve(id, (RequestOptions) null);
+  }
+
+  @Deprecated
+  public static Recipient retrieve(String id, String apiKey)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return retrieve(id, RequestOptions.builder().setApiKey(apiKey).build());
+  }
+
+  public static Recipient retrieve(String id, RequestOptions options)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return request(RequestMethod.GET, instanceURL(Recipient.class, id), null, Recipient.class,
+        options);
+  }
+
+  public static Recipient retrieve(String id, Map<String, Object> params, RequestOptions options)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return request(RequestMethod.GET, instanceURL(Recipient.class, id), params, Recipient.class,
+        options);
   }
 
   public Recipient update(Map<String, Object> params)
@@ -186,10 +220,38 @@ public class Recipient extends APIResource implements MetadataStore<Recipient>, 
     return update(params, (RequestOptions) null);
   }
 
+  @Deprecated
+  public Recipient update(Map<String, Object> params, String apiKey)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return update(params, RequestOptions.builder().setApiKey(apiKey).build());
+  }
+
+  public Recipient update(Map<String, Object> params, RequestOptions options)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return request(RequestMethod.POST, instanceURL(Recipient.class, this.id), params,
+        Recipient.class, options);
+  }
+
   public DeletedRecipient delete() throws AuthenticationException,
       InvalidRequestException, APIConnectionException, CardException,
       APIException {
     return delete((RequestOptions) null);
+  }
+
+  @Deprecated
+  public DeletedRecipient delete(String apiKey)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return delete(RequestOptions.builder().setApiKey(apiKey).build());
+  }
+
+  public DeletedRecipient delete(RequestOptions options)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return request(RequestMethod.DELETE, instanceURL(Recipient.class, this.id), null,
+        DeletedRecipient.class, options);
   }
 
   public Card createCard(String token) throws AuthenticationException,
@@ -234,40 +296,6 @@ public class Recipient extends APIResource implements MetadataStore<Recipient>, 
         instanceURL(Recipient.class, this.id)), params, Card.class, options);
   }
 
-  @Deprecated
-  public static Recipient create(Map<String, Object> params, String apiKey)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return create(params, RequestOptions.builder().setApiKey(apiKey).build());
-  }
-
-  public static Recipient create(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return request(RequestMethod.POST, classURL(Recipient.class), params, Recipient.class, options);
-  }
-
-  @Deprecated
-  public static Recipient retrieve(String id, String apiKey)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return retrieve(id, RequestOptions.builder().setApiKey(apiKey).build());
-  }
-
-  public static Recipient retrieve(String id, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return request(RequestMethod.GET, instanceURL(Recipient.class, id), null, Recipient.class,
-        options);
-  }
-
-  public static Recipient retrieve(String id, Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return request(RequestMethod.GET, instanceURL(Recipient.class, id), params, Recipient.class,
-        options);
-  }
-
   public static RecipientCollection list(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
@@ -302,33 +330,5 @@ public class Recipient extends APIResource implements MetadataStore<Recipient>, 
       InvalidRequestException, APIConnectionException, CardException,
       APIException {
     return list(params, options);
-  }
-
-  @Deprecated
-  public Recipient update(Map<String, Object> params, String apiKey)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return update(params, RequestOptions.builder().setApiKey(apiKey).build());
-  }
-
-  public Recipient update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return request(RequestMethod.POST, instanceURL(Recipient.class, this.id), params,
-        Recipient.class, options);
-  }
-
-  @Deprecated
-  public DeletedRecipient delete(String apiKey)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return delete(RequestOptions.builder().setApiKey(apiKey).build());
-  }
-
-  public DeletedRecipient delete(RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return request(RequestMethod.DELETE, instanceURL(Recipient.class, this.id), null,
-        DeletedRecipient.class, options);
   }
 }

--- a/src/main/java/com/stripe/model/Refund.java
+++ b/src/main/java/com/stripe/model/Refund.java
@@ -154,18 +154,6 @@ public class Refund extends APIResource implements MetadataStore<Charge>, HasId 
     return update(params, (RequestOptions) null);
   }
 
-  public static Refund retrieve(String id)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return retrieve(id, null);
-  }
-
-  public static Refund create(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return create(params, null);
-  }
-
   @Deprecated
   public Refund update(Map<String, Object> params, String apiKey)
       throws AuthenticationException, InvalidRequestException,
@@ -180,6 +168,12 @@ public class Refund extends APIResource implements MetadataStore<Charge>, HasId 
         options);
   }
 
+  public static Refund retrieve(String id)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return retrieve(id, null);
+  }
+
   public static Refund retrieve(String id, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
@@ -190,6 +184,18 @@ public class Refund extends APIResource implements MetadataStore<Charge>, HasId 
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
     return request(RequestMethod.GET, instanceURL(Refund.class, id), params, Refund.class, options);
+  }
+
+  public static Refund create(Map<String, Object> params)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return create(params, null);
+  }
+
+  public static Refund create(Map<String, Object> params, RequestOptions options)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return request(RequestMethod.POST, classURL(Refund.class), params, Refund.class, options);
   }
 
   public static RefundCollection list(Map<String, Object> params)
@@ -216,11 +222,5 @@ public class Refund extends APIResource implements MetadataStore<Charge>, HasId 
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
     return list(params, options);
-  }
-
-  public static Refund create(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return request(RequestMethod.POST, classURL(Refund.class), params, Refund.class, options);
   }
 }

--- a/src/main/java/com/stripe/model/SKU.java
+++ b/src/main/java/com/stripe/model/SKU.java
@@ -159,22 +159,16 @@ public class SKU extends APIResource implements HasId, MetadataStore<SKU> {
     return create(params, null);
   }
 
-  public static SKU retrieve(String id)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return retrieve(id, null);
-  }
-
-  public SKU update(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return update(params, null);
-  }
-
   public static SKU create(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
     return request(RequestMethod.POST, classURL(SKU.class), params, SKU.class, options);
+  }
+
+  public static SKU retrieve(String id)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return retrieve(id, null);
   }
 
   public static SKU retrieve(String id, RequestOptions options)
@@ -187,6 +181,18 @@ public class SKU extends APIResource implements HasId, MetadataStore<SKU> {
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
     return request(RequestMethod.GET, instanceURL(SKU.class, id), params, SKU.class, options);
+  }
+
+  public SKU update(Map<String, Object> params)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return update(params, null);
+  }
+
+  public SKU update(Map<String, Object> params, RequestOptions options)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return request(RequestMethod.POST, instanceURL(SKU.class, this.id), params, SKU.class, options);
   }
 
   public DeletedSKU delete()
@@ -228,11 +234,5 @@ public class SKU extends APIResource implements HasId, MetadataStore<SKU> {
       InvalidRequestException, APIConnectionException, CardException,
       APIException {
     return list(params, options);
-  }
-
-  public SKU update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return request(RequestMethod.POST, instanceURL(SKU.class, this.id), params, SKU.class, options);
   }
 }

--- a/src/main/java/com/stripe/model/Token.java
+++ b/src/main/java/com/stripe/model/Token.java
@@ -126,12 +126,6 @@ public class Token extends APIResource implements HasId {
     return create(params, (RequestOptions) null);
   }
 
-  public static Token retrieve(String id) throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    return retrieve(id, (RequestOptions) null);
-  }
-
   @Deprecated
   public static Token create(Map<String, Object> params, String apiKey)
       throws AuthenticationException, InvalidRequestException,
@@ -143,6 +137,12 @@ public class Token extends APIResource implements HasId {
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
     return request(RequestMethod.POST, classURL(Token.class), params, Token.class, options);
+  }
+
+  public static Token retrieve(String id) throws AuthenticationException,
+      InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    return retrieve(id, (RequestOptions) null);
   }
 
   @Deprecated

--- a/src/main/java/com/stripe/model/Transfer.java
+++ b/src/main/java/com/stripe/model/Transfer.java
@@ -402,34 +402,6 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
     return create(params, (RequestOptions) null);
   }
 
-  public static Transfer retrieve(String id) throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
-    return retrieve(id, (RequestOptions) null);
-  }
-
-  /**
-   * @deprecated Use Transfer.getReversals().create() instead of Transfer.cancel().
-   */
-  @Deprecated
-  public Transfer cancel()
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return cancel((RequestOptions) null);
-  }
-
-  public Transfer update(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return update(params, (RequestOptions) null);
-  }
-
-  public TransferTransactionCollection transactions(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return transactions(params, (RequestOptions) null);
-  }
-
   @Deprecated
   public static Transfer create(Map<String, Object> params, String apiKey)
       throws AuthenticationException, InvalidRequestException,
@@ -443,32 +415,10 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
     return request(RequestMethod.POST, classURL(Transfer.class), params, Transfer.class, options);
   }
 
-  @Deprecated
-  public Transfer update(Map<String, Object> params, String apiKey)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return update(params, RequestOptions.builder().setApiKey(apiKey).build());
-  }
-
-  public Transfer update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return request(RequestMethod.POST, instanceURL(Transfer.class, this.id), params,
-        Transfer.class, options);
-  }
-
-  @Deprecated
-  public Transfer cancel(String apiKey)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return cancel(RequestOptions.builder().setApiKey(apiKey).build());
-  }
-
-  public Transfer cancel(RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return request(RequestMethod.POST, instanceURL(Transfer.class, this.id) + "/cancel", null,
-        Transfer.class, options);
+  public static Transfer retrieve(String id) throws AuthenticationException,
+      InvalidRequestException, APIConnectionException, CardException,
+      APIException {
+    return retrieve(id, (RequestOptions) null);
   }
 
   @Deprecated
@@ -490,6 +440,72 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
       APIConnectionException, CardException, APIException {
     return request(RequestMethod.GET, instanceURL(Transfer.class, id), params, Transfer.class,
         options);
+  }
+
+  /**
+   * @deprecated Use Transfer.getReversals().create() instead of Transfer.cancel().
+   */
+  @Deprecated
+  public Transfer cancel()
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return cancel((RequestOptions) null);
+  }
+
+  @Deprecated
+  public Transfer cancel(String apiKey)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return cancel(RequestOptions.builder().setApiKey(apiKey).build());
+  }
+
+  public Transfer cancel(RequestOptions options)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return request(RequestMethod.POST, instanceURL(Transfer.class, this.id) + "/cancel", null,
+        Transfer.class, options);
+  }
+
+  public Transfer update(Map<String, Object> params)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return update(params, (RequestOptions) null);
+  }
+
+  @Deprecated
+  public Transfer update(Map<String, Object> params, String apiKey)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return update(params, RequestOptions.builder().setApiKey(apiKey).build());
+  }
+
+  public Transfer update(Map<String, Object> params, RequestOptions options)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return request(RequestMethod.POST, instanceURL(Transfer.class, this.id), params,
+        Transfer.class, options);
+  }
+
+  public TransferTransactionCollection transactions(Map<String, Object> params)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return transactions(params, (RequestOptions) null);
+  }
+
+  @Deprecated
+  public TransferTransactionCollection transactions(
+      Map<String, Object> params, String apiKey)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    return transactions(params, RequestOptions.builder().setApiKey(apiKey).build());
+  }
+
+  public TransferTransactionCollection transactions(
+      Map<String, Object> params, RequestOptions options)
+      throws AuthenticationException, InvalidRequestException,
+      APIConnectionException, CardException, APIException {
+    String url = String.format("%s%s", instanceURL(Transfer.class, this.getId()), "/transactions");
+    return requestCollection(url, params, TransferTransactionCollection.class, options);
   }
 
   public static TransferCollection list(Map<String, Object> params)
@@ -526,21 +542,5 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
       InvalidRequestException, APIConnectionException, CardException,
       APIException {
     return list(params, options);
-  }
-
-  @Deprecated
-  public TransferTransactionCollection transactions(
-      Map<String, Object> params, String apiKey)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return transactions(params, RequestOptions.builder().setApiKey(apiKey).build());
-  }
-
-  public TransferTransactionCollection transactions(
-      Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    String url = String.format("%s%s", instanceURL(Transfer.class, this.getId()), "/transactions");
-    return requestCollection(url, params, TransferTransactionCollection.class, options);
   }
 }


### PR DESCRIPTION
cc @stripe/api-libraries 

Regroup overloaded methods.

This is just moving some method declarations around so should be fairly safe.