### PR TITLE
Fix variable and method names

### DIFF
--- a/src/main/java/com/stripe/net/OAuth.java
+++ b/src/main/java/com/stripe/net/OAuth.java
@@ -66,7 +66,7 @@ public final class OAuth {
       throws AuthenticationException, InvalidRequestException, APIConnectionException, APIException,
       OAuthException {
     String url = Stripe.getConnectBase() + "/oauth/token";
-    return OAuth.stripeResponseGetter.oAuthRequest(APIResource.RequestMethod.POST, url, params,
+    return OAuth.stripeResponseGetter.oauthRequest(APIResource.RequestMethod.POST, url, params,
         TokenResponse.class, APIResource.RequestType.NORMAL, options);
   }
 
@@ -84,7 +84,7 @@ public final class OAuth {
       OAuthException {
     String url = Stripe.getConnectBase() + "/oauth/deauthorize";
     params.put("client_id", getClientId(params, options));
-    return OAuth.stripeResponseGetter.oAuthRequest(APIResource.RequestMethod.POST, url, params,
+    return OAuth.stripeResponseGetter.oauthRequest(APIResource.RequestMethod.POST, url, params,
         DeauthorizedAccount.class, APIResource.RequestType.NORMAL, options);
   }
 

--- a/src/main/java/com/stripe/net/StripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/StripeResponseGetter.java
@@ -20,7 +20,7 @@ public interface StripeResponseGetter {
       throws AuthenticationException, InvalidRequestException, APIConnectionException,
       CardException, APIException;
 
-  <T> T oAuthRequest(
+  <T> T oauthRequest(
       APIResource.RequestMethod method,
       String url,
       Map<String, Object> params,

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -149,7 +149,7 @@ public class BaseStripeTest {
   }
 
   public static <T> void stubOAuth(Class<T> clazz, String response) throws StripeException {
-    when(networkMock.oAuthRequest(
+    when(networkMock.oauthRequest(
         Mockito.any(APIResource.RequestMethod.class),
         Mockito.anyString(),
         Mockito.<Map<String, Object>>any(),

--- a/src/test/java/com/stripe/model/StandardizationTest.java
+++ b/src/test/java/com/stripe/model/StandardizationTest.java
@@ -47,10 +47,10 @@ public class StandardizationTest {
 
   @Test
   public void allNonDeprecatedMethodsTakeOptions() throws IOException, NoSuchMethodException {
-    for (Class aClass : getAllModels()) {
-      for (Method method : aClass.getMethods()) {
+    for (Class model : getAllModels()) {
+      for (Method method : model.getMethods()) {
         // Skip methods not declared on the base class.
-        if (method.getDeclaringClass() != aClass) {
+        if (method.getDeclaringClass() != model) {
           continue;
         }
         // Skip equals
@@ -73,7 +73,7 @@ public class StandardizationTest {
         // If more than one method with the same parameter types is declared in a class, and one of
         // these methods has a return type that is more specific than any of the others, that method
         // is returned; otherwise one of the methods is chosen arbitrarily.
-        Method mostSpecificMethod = aClass.getDeclaredMethod(method.getName(),
+        Method mostSpecificMethod = model.getDeclaredMethod(method.getName(),
             method.getParameterTypes());
         if (!method.equals(mostSpecificMethod)) {
           continue;
@@ -121,7 +121,7 @@ public class StandardizationTest {
         Assert.assertTrue(
             String.format(
                 "Methods on %ss like %s.%s should take a final parameter as a %s parameter.%n",
-                APIResource.class.getSimpleName(), aClass.getSimpleName(), method.getName(),
+                APIResource.class.getSimpleName(), model.getSimpleName(), method.getName(),
                 RequestOptions.class.getSimpleName()),
             RequestOptions.class.isAssignableFrom(finalParamType));
       }


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Under the new style rules, method and variable names must start with two lowercase letters, and not include underscores.