### PR TITLE
Fix linting issue about having multiple top-level classes in same file

### DIFF
--- a/src/test/java/com/stripe/model/PagingIteratorTest.java
+++ b/src/test/java/com/stripe/model/PagingIteratorTest.java
@@ -31,6 +31,29 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 public class PagingIteratorTest extends BaseStripeTest {
+  /**
+   * The most simple possible model. Handy for eliminating other variables while
+   * we test some of the nitty gritty of pagination.
+   */
+  private static class PageableModel extends APIResource implements HasId {
+    String id;
+
+    public static PageableModelCollection list(Map<String, Object> params,
+        RequestOptions options)
+        throws AuthenticationException, InvalidRequestException,
+        APIConnectionException, CardException, APIException {
+      return requestCollection(classURL(PageableModel.class), params,
+          PageableModelCollection.class, options);
+    }
+
+    public String getId() {
+      return id;
+    }
+  }
+
+  private static class PageableModelCollection extends StripeCollection<PageableModel> {
+  }
+
   @Before
   public void mockStripeResponseGetter() {
     APIResource.setStripeResponseGetter(networkMock);
@@ -153,27 +176,4 @@ public class PagingIteratorTest extends BaseStripeTest {
         page2Params, options);
     verifyNoMoreInteractions(networkMock);
   }
-}
-
-/**
- * The most simple possible model. Handy for eliminating other variables while
- * we test some of the nitty gritty of pagination.
- */
-class PageableModel extends APIResource implements HasId {
-  String id;
-
-  public static PageableModelCollection list(Map<String, Object> params,
-                         RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
-    return requestCollection(classURL(PageableModel.class), params,
-        PageableModelCollection.class, options);
-  }
-
-  public String getId() {
-    return id;
-  }
-}
-
-class PageableModelCollection extends StripeCollection<PageableModel> {
 }


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

The rules enforce having one dedicated file per top-level class. The only offense was in `PagingIteratorTest` which defines a couple of classes for testing. I turned the classes into nested static classes to fix the issue.

