### PR TITLE
Fix missing Javadoc linting issues

### DIFF
--- a/src/main/java/com/stripe/Stripe.java
+++ b/src/main/java/com/stripe/Stripe.java
@@ -71,6 +71,11 @@ public abstract class Stripe {
     return connectionProxy;
   }
 
+  /**
+   * Returns the connection timeout.
+   *
+   * @return timeout value in milliseconds
+   */
   public static int getConnectTimeout() {
     if (connectTimeout == -1) {
       return DEFAULT_CONNECT_TIMEOUT;
@@ -88,6 +93,11 @@ public abstract class Stripe {
     connectTimeout = timeout;
   }
 
+  /**
+   * Returns the read timeout.
+   *
+   * @return timeout value in milliseconds
+   */
   public static int getReadTimeout() {
     if (readTimeout == -1) {
       return DEFAULT_READ_TIMEOUT;
@@ -98,7 +108,7 @@ public abstract class Stripe {
   /**
    * Sets the timeout value that will be used when reading data from an
    * established connection to the Stripe API (in milliseconds).
-   * 
+   *
    * <p>Note that this value should be set conservatively because some API
    * requests can take time and a short timeout increases the likelihood of
    * causing a problem in the backend.
@@ -130,6 +140,13 @@ public abstract class Stripe {
     setAppInfo(name, version, null);
   }
 
+  /**
+   * Sets information about your application. The information is passed along to Stripe.
+   *
+   * @param name Name of your application (e.g. "MyAwesomeApp")
+   * @param version Version of your application (e.g. "1.2.34")
+   * @param url Website for your application (e.g. "https://myawesomeapp.info")
+   */
   public static void setAppInfo(String name, String version, String url) {
     if (appInfo == null) {
       appInfo = new HashMap<String, String>();

--- a/src/main/java/com/stripe/exception/APIException.java
+++ b/src/main/java/com/stripe/exception/APIException.java
@@ -4,6 +4,8 @@ public class APIException extends StripeException {
   private static final long serialVersionUID = 2L;
 
   /**
+   * Constructs a new API exception with the specified details.
+   *
    * @deprecated Use new constructor with `code` argument instead.
    */
   @Deprecated

--- a/src/main/java/com/stripe/exception/AuthenticationException.java
+++ b/src/main/java/com/stripe/exception/AuthenticationException.java
@@ -4,6 +4,8 @@ public class AuthenticationException extends StripeException {
   private static final long serialVersionUID = 2L;
 
   /**
+   * Constructs a new authentication exception with the specified details.
+   *
    * @deprecated Use new constructor with `code` argument instead.
    */
   @Deprecated

--- a/src/main/java/com/stripe/exception/CardException.java
+++ b/src/main/java/com/stripe/exception/CardException.java
@@ -7,6 +7,9 @@ public class CardException extends StripeException {
   private String declineCode;
   private String charge;
 
+  /**
+   * Constructs a new card exception with the specified details.
+   */
   public CardException(String message, String requestId, String code, String param,
       String declineCode, String charge, Integer statusCode, Throwable e) {
     super(message, requestId, code, statusCode, e);

--- a/src/main/java/com/stripe/exception/InvalidRequestException.java
+++ b/src/main/java/com/stripe/exception/InvalidRequestException.java
@@ -6,6 +6,8 @@ public class InvalidRequestException extends StripeException {
   private final String param;
 
   /**
+   * Constructs a new invalid request exception with the specified details.
+   *
    * @deprecated Use new constructor with `code` argument instead.
    */
   @Deprecated

--- a/src/main/java/com/stripe/exception/PermissionException.java
+++ b/src/main/java/com/stripe/exception/PermissionException.java
@@ -4,6 +4,8 @@ public class PermissionException extends AuthenticationException {
   private static final long serialVersionUID = 2L;
 
   /**
+   * Constructs a new permission exception with the specified details.
+   *
    * @deprecated Use new constructor with `code` argument instead.
    */
   @Deprecated

--- a/src/main/java/com/stripe/exception/RateLimitException.java
+++ b/src/main/java/com/stripe/exception/RateLimitException.java
@@ -4,6 +4,8 @@ public class RateLimitException extends InvalidRequestException {
   private static final long serialVersionUID = 2L;
 
   /**
+   * Constructs a new rate limit exception with the specified details.
+   *
    * @deprecated Use new constructor with `code` argument instead.
    */
   @Deprecated

--- a/src/main/java/com/stripe/exception/StripeException.java
+++ b/src/main/java/com/stripe/exception/StripeException.java
@@ -8,6 +8,8 @@ public abstract class StripeException extends Exception {
   private Integer statusCode;
 
   /**
+   * Constructs a new Stripe exception with the specified details.
+   *
    * @deprecated Use new constructor with `code` argument instead.
    */
   @Deprecated
@@ -17,6 +19,8 @@ public abstract class StripeException extends Exception {
   }
 
   /**
+   * Constructs a new Stripe exception with the specified details.
+   *
    * @deprecated Use new constructor with `code` argument instead.
    */
   @Deprecated
@@ -29,6 +33,9 @@ public abstract class StripeException extends Exception {
     this(message, requestId, code, statusCode, null);
   }
 
+  /**
+   * Constructs a new Stripe exception with the specified details.
+   */
   public StripeException(String message, String requestId, String code, Integer statusCode,
       Throwable e) {
     super(message, e);
@@ -49,6 +56,12 @@ public abstract class StripeException extends Exception {
     return statusCode;
   }
 
+  /**
+   * Returns a description of the exception, including the HTTP status code and request ID (if
+   * applicable).
+   *
+   * @return a string representation of the exception.
+   */
   public String toString() {
     String additionalInfo = "";
     if (code != null) {

--- a/src/main/java/com/stripe/model/Account.java
+++ b/src/main/java/com/stripe/model/Account.java
@@ -142,7 +142,11 @@ public class Account extends APIResource implements HasId, MetadataStore<Account
   }
 
   /**
-   * @deprecated Use getType() instead.
+   * Returns the {@code managed} attribute.
+   *
+   * @return the {@code managed} attribute
+   * @deprecated Prefer using the {@code type} attribute instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2017-05-25">API version 2017-05-25</a>
    */
   @Deprecated
   public Boolean getManaged() {
@@ -230,7 +234,12 @@ public class Account extends APIResource implements HasId, MetadataStore<Account
   }
 
   /**
-   * @deprecated Use the country_specs endpoint (https://stripe.com/docs/upgrades#2016-03-07)
+   * Returns the {@code currencies_supported} attribute.
+   *
+   * @return the {@code currencies_supported} attribute
+   * @deprecated Prefer using the {@link CountrySpec#getSupportedPaymentCurrencies()} method
+   *     instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2016-03-07">API version 2016-03-07</a>
    */
   @Deprecated
   public List<String> getCurrenciesSupported() {
@@ -301,12 +310,7 @@ public class Account extends APIResource implements HasId, MetadataStore<Account
   public static Account retrieve(RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
-    return request(
-        RequestMethod.GET,
-        singleClassURL(Account.class),
-        null,
-        Account.class,
-        options);
+    return request(RequestMethod.GET, singleClassURL(Account.class), null, Account.class, options);
   }
 
   public static Account retrieve(String id, RequestOptions options)

--- a/src/main/java/com/stripe/model/ApplicationFee.java
+++ b/src/main/java/com/stripe/model/ApplicationFee.java
@@ -46,10 +46,7 @@ public class ApplicationFee extends APIResource implements HasId {
   }
 
   public String getAccount() {
-    if (this.account == null) {
-      return null;
-    }
-    return this.account.getId();
+    return (this.account != null) ? this.account.getId() : null;
   }
 
   public void setAccount(String accountID) {
@@ -57,10 +54,7 @@ public class ApplicationFee extends APIResource implements HasId {
   }
 
   public Account getAccountObject() {
-    if (this.account == null) {
-      return null;
-    }
-    return this.account.getExpanded();
+    return (this.account != null) ? this.account.getExpanded() : null;
   }
 
   public void setAccountObject(Account c) {
@@ -84,10 +78,7 @@ public class ApplicationFee extends APIResource implements HasId {
   }
 
   public String getApplication() {
-    if (this.application == null) {
-      return null;
-    }
-    return this.application.getId();
+    return (this.application != null) ? this.application.getId() : null;
   }
 
   public void setApplication(String applicationID) {
@@ -95,10 +86,7 @@ public class ApplicationFee extends APIResource implements HasId {
   }
 
   public Application getApplicationObject() {
-    if (this.application == null) {
-      return null;
-    }
-    return this.application.getExpanded();
+    return (this.application != null) ? this.application.getExpanded() : null;
   }
 
   public void setApplicationObject(Application c) {
@@ -106,10 +94,7 @@ public class ApplicationFee extends APIResource implements HasId {
   }
 
   public String getBalanceTransaction() {
-    if (this.balanceTransaction == null) {
-      return null;
-    }
-    return this.balanceTransaction.getId();
+    return (this.balanceTransaction != null) ? this.balanceTransaction.getId() : null;
   }
 
   public void setBalanceTransaction(String balanceTransactionID) {
@@ -117,10 +102,7 @@ public class ApplicationFee extends APIResource implements HasId {
   }
 
   public BalanceTransaction getBalanceTransactionObject() {
-    if (this.balanceTransaction == null) {
-      return null;
-    }
-    return this.balanceTransaction.getExpanded();
+    return (this.balanceTransaction != null) ? this.balanceTransaction.getExpanded() : null;
   }
 
   public void setBalanceTransactionObject(BalanceTransaction c) {
@@ -128,10 +110,7 @@ public class ApplicationFee extends APIResource implements HasId {
   }
 
   public String getCharge() {
-    if (this.charge == null) {
-      return null;
-    }
-    return this.charge.getId();
+    return (this.charge != null) ? this.charge.getId() : null;
   }
 
   public void setCharge(String chargeID) {
@@ -139,10 +118,7 @@ public class ApplicationFee extends APIResource implements HasId {
   }
 
   public Charge getChargeObject() {
-    if (this.charge == null) {
-      return null;
-    }
-    return this.charge.getExpanded();
+    return (this.charge != null) ? this.charge.getExpanded() : null;
   }
 
   public void setChargeObject(Charge c) {
@@ -174,10 +150,7 @@ public class ApplicationFee extends APIResource implements HasId {
   }
 
   public String getOriginatingTransaction() {
-    if (this.originatingTransaction == null) {
-      return null;
-    }
-    return this.originatingTransaction.getId();
+    return (this.originatingTransaction != null) ? this.originatingTransaction.getId() : null;
   }
 
   public void setOriginatingTransaction(String originatingTransactionID) {
@@ -186,10 +159,7 @@ public class ApplicationFee extends APIResource implements HasId {
   }
 
   public Charge getOriginatingTransactionObject() {
-    if (this.originatingTransaction == null) {
-      return null;
-    }
-    return this.originatingTransaction.getExpanded();
+    return (this.originatingTransaction != null) ? this.originatingTransaction.getExpanded() : null;
   }
 
   public void setOriginatingTransactionObject(Charge c) {
@@ -204,6 +174,11 @@ public class ApplicationFee extends APIResource implements HasId {
     this.refunded = refunded;
   }
 
+  /**
+   * Returns the {@code refunds} list.
+   *
+   * @return the {@code refunds} list
+   */
   public FeeRefundCollection getRefunds() {
     // API versions 2014-07-26 and earlier render charge refunds as an array
     // instead of an object, meaning there is no sublist URL.
@@ -215,16 +190,17 @@ public class ApplicationFee extends APIResource implements HasId {
   }
 
   /**
-   * @deprecated Use `account` field (https://stripe.com/docs/upgrades#2013-12-03)
+   * Returns the {@code user} attribute.
+   *
+   * @return the {@code user} attribute
+   * @deprecated Prefer using the {@code account} attribute instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2013-12-03">API version 2013-12-03</a>
    */
   @Deprecated
   public String getUser() {
     return user;
   }
 
-  /**
-   * @deprecated Use `account` field (https://stripe.com/docs/upgrades#2013-12-03)
-   */
   @Deprecated
   public void setUser(String user) {
     this.user = user;

--- a/src/main/java/com/stripe/model/BalanceTransaction.java
+++ b/src/main/java/com/stripe/model/BalanceTransaction.java
@@ -110,20 +110,6 @@ public class BalanceTransaction extends APIResource implements HasId {
     this.net = net;
   }
 
-  /**
-   * @deprecated Recent API versions no longer return this field
-   *     (https://stripe.com/docs/upgrades#2017-01-27).
-   *     Prefer listing all transfers with the `transfer_group` parameter:
-   *     https://stripe.com/docs/api/java#list_transfers-transfer_group.
-   */
-  @Deprecated
-  public TransferCollection getSourcedTransfers() {
-    if (sourcedTransfers != null && sourcedTransfers.getURL() == null && getSource() != null) {
-      sourcedTransfers.setURL(String.format("/v1/transfers?source_transaction=%s", getSource()));
-    }
-    return sourcedTransfers;
-  }
-
   public String getStatus() {
     return status;
   }
@@ -141,10 +127,7 @@ public class BalanceTransaction extends APIResource implements HasId {
   }
 
   public String getSource() {
-    if (this.source == null) {
-      return null;
-    }
-    return this.source.getId();
+    return (this.source != null) ? this.source.getId() : null;
   }
 
   public void setSource(String sourceID) {
@@ -152,10 +135,7 @@ public class BalanceTransaction extends APIResource implements HasId {
   }
 
   public HasId getSourceObject() {
-    if (this.source == null) {
-      return null;
-    }
-    return this.source.getExpanded();
+    return (this.source != null) ? this.source.getExpanded() : null;
   }
 
   public void setSourceObject(HasId o) {
@@ -163,10 +143,23 @@ public class BalanceTransaction extends APIResource implements HasId {
   }
 
   public <O extends HasId> O getSourceObjectAs() {
-    if (this.source == null) {
-      return null;
+    return (this.source != null) ? (O) this.source.getExpanded() : null;
+  }
+
+  /**
+   * Returns the {@code sourced_transfers} attribute.
+   *
+   * @return the {@code sourced_transfers} attribute
+   * @deprecated Prefer using the {@link Transfer#list} method with the {@code transfer_group}
+   *     parameter.
+   * @see <a href="https://stripe.com/docs/upgrades#2017-01-27">API version 2017-01-27</a>
+   */
+  @Deprecated
+  public TransferCollection getSourcedTransfers() {
+    if (sourcedTransfers != null && sourcedTransfers.getURL() == null && getSource() != null) {
+      sourcedTransfers.setURL(String.format("/v1/transfers?source_transaction=%s", getSource()));
     }
-    return (O) this.source.getExpanded();
+    return sourcedTransfers;
   }
 
   public static BalanceTransaction retrieve(String id) throws AuthenticationException,

--- a/src/main/java/com/stripe/model/BitcoinReceiver.java
+++ b/src/main/java/com/stripe/model/BitcoinReceiver.java
@@ -211,7 +211,7 @@ public class BitcoinReceiver extends ExternalAccount {
     return retrieve(id, null);
   }
 
-  
+
   public static BitcoinReceiver retrieve(String id, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
@@ -247,16 +247,6 @@ public class BitcoinReceiver extends ExternalAccount {
   }
 
   @Override
-  public String getInstanceURL() {
-    String result = super.getInstanceURL();
-    if (result == null) {
-      return String.format("%s/%s/%s", Stripe.getApiBase(), "v1/bitcoin/receivers", this.getId());
-    } else {
-      return result;
-    }
-  }
-
-  @Override
   public BitcoinReceiver update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
@@ -284,5 +274,15 @@ public class BitcoinReceiver extends ExternalAccount {
       APIException {
     return request(RequestMethod.DELETE, this.getInstanceURL(), null, DeletedBitcoinReceiver.class,
         options);
+  }
+
+  @Override
+  protected String getInstanceURL() {
+    String result = super.getInstanceURL();
+    if (result == null) {
+      return String.format("%s/%s/%s", Stripe.getApiBase(), "v1/bitcoin/receivers", this.getId());
+    } else {
+      return result;
+    }
   }
 }

--- a/src/main/java/com/stripe/model/Card.java
+++ b/src/main/java/com/stripe/model/Card.java
@@ -271,16 +271,17 @@ public class Card extends ExternalAccount {
   }
 
   /**
-   * @deprecated Use `brand` field (https://stripe.com/docs/upgrades#2014-06-13)
+   * Returns the {@code type} attribute.
+   *
+   * @return the {@code type} attribute
+   * @deprecated Prefer using the {@code brand} attribute instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2014-06-13">API version 2014-06-13</a>
    */
   @Deprecated
   public String getType() {
     return type;
   }
 
-  /**
-   * @deprecated Use `brand` field (https://stripe.com/docs/upgrades#2014-06-13)
-   */
   @Deprecated
   public void setType(String type) {
     this.type = type;
@@ -325,7 +326,7 @@ public class Card extends ExternalAccount {
   }
 
   @Override
-  public String getInstanceURL() {
+  protected String getInstanceURL() {
     String result = super.getInstanceURL();
     if (result != null) {
       return result;

--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -53,9 +53,6 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
 
   @Deprecated
   Card card;
-  /**
-   * Legacy; use `dispute` field (https://stripe.com/docs/upgrades#2012-11-07)
-   */
   @Deprecated
   Boolean disputed;
   @Deprecated
@@ -103,10 +100,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   }
 
   public String getApplication() {
-    if (this.application == null) {
-      return null;
-    }
-    return this.application.getId();
+    return (this.application != null) ? this.application.getId() : null;
   }
 
   public void setApplication(String applicationID) {
@@ -114,10 +108,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   }
 
   public Application getApplicationObject() {
-    if (this.application == null) {
-      return null;
-    }
-    return this.application.getExpanded();
+    return (this.application != null) ? this.application.getExpanded() : null;
   }
 
   public void setApplicationObject(Application c) {
@@ -125,10 +116,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   }
 
   public String getApplicationFee() {
-    if (this.applicationFee == null) {
-      return null;
-    }
-    return this.applicationFee.getId();
+    return (this.applicationFee != null) ? this.applicationFee.getId() : null;
   }
 
   public void setApplicationFee(String applicationFeeID) {
@@ -136,10 +124,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   }
 
   public ApplicationFee getApplicationFeeObject() {
-    if (this.applicationFee == null) {
-      return null;
-    }
-    return this.applicationFee.getExpanded();
+    return (this.applicationFee != null) ? this.applicationFee.getExpanded() : null;
   }
 
   public void setApplicationFeeObject(ApplicationFee c) {
@@ -147,10 +132,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   }
 
   public String getBalanceTransaction() {
-    if (this.balanceTransaction == null) {
-      return null;
-    }
-    return this.balanceTransaction.getId();
+    return (this.balanceTransaction != null) ? this.balanceTransaction.getId() : null;
   }
 
   public void setBalanceTransaction(String balanceTransactionID) {
@@ -158,10 +140,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   }
 
   public BalanceTransaction getBalanceTransactionObject() {
-    if (this.balanceTransaction == null) {
-      return null;
-    }
-    return this.balanceTransaction.getExpanded();
+    return (this.balanceTransaction != null) ? this.balanceTransaction.getExpanded() : null;
   }
 
   public void setBalanceTransactionObject(BalanceTransaction c) {
@@ -193,10 +172,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   }
 
   public String getCustomer() {
-    if (this.customer == null) {
-      return null;
-    }
-    return this.customer.getId();
+    return (this.customer != null) ? this.customer.getId() : null;
   }
 
   public void setCustomer(String customerID) {
@@ -205,10 +181,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   }
 
   public Customer getCustomerObject() {
-    if (this.customer == null) {
-      return null;
-    }
-    return this.customer.getExpanded();
+    return (this.customer != null) ? this.customer.getExpanded() : null;
   }
 
   public void setCustomerObject(Customer c) {
@@ -224,10 +197,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   }
 
   public String getDestination() {
-    if (this.destination == null) {
-      return null;
-    }
-    return this.destination.getId();
+    return (this.destination != null) ? this.destination.getId() : null;
   }
 
   public void setDestination(String destinationID) {
@@ -235,10 +205,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   }
 
   public Account getDestinationObject() {
-    if (this.destination == null) {
-      return null;
-    }
-    return this.destination.getExpanded();
+    return (this.destination != null) ? this.destination.getExpanded() : null;
   }
 
   public void setDestinationObject(Account c) {
@@ -246,10 +213,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   }
 
   public String getDispute() {
-    if (dispute == null) {
-      return null;
-    }
-    return dispute.getId();
+    return (this.dispute != null) ? this.dispute.getId() : null;
   }
 
   public void setDispute(String dispute) {
@@ -257,10 +221,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   }
 
   public Dispute getDisputeObject() {
-    if (dispute == null) {
-      return null;
-    }
-    return this.dispute.getExpanded();
+    return (this.dispute != null) ? this.dispute.getExpanded() : null;
   }
 
   public void setDisputeObject(Dispute dispute) {
@@ -292,10 +253,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   }
 
   public String getInvoice() {
-    if (this.invoice == null) {
-      return null;
-    }
-    return this.invoice.getId();
+    return (this.invoice != null) ? this.invoice.getId() : null;
   }
 
   public void setInvoice(String invoiceID) {
@@ -303,10 +261,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   }
 
   public Invoice getInvoiceObject() {
-    if (this.invoice == null) {
-      return null;
-    }
-    return this.invoice.getExpanded();
+    return (this.invoice != null) ? this.invoice.getExpanded() : null;
   }
 
   public void setInvoiceObject(Invoice c) {
@@ -330,10 +285,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   }
 
   public String getOrder() {
-    if (this.order == null) {
-      return null;
-    }
-    return this.order.getId();
+    return (this.order != null) ? this.order.getId() : null;
   }
 
   public void setOrder(String orderID) {
@@ -341,10 +293,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   }
 
   public Order getOrderObject() {
-    if (this.order == null) {
-      return null;
-    }
-    return this.order.getExpanded();
+    return (this.order != null) ? this.order.getExpanded() : null;
   }
 
   public void setOrderObject(Order c) {
@@ -391,6 +340,11 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
     this.refunded = refunded;
   }
 
+  /**
+   * Returns the {@code refunds} list.
+   *
+   * @return the {@code refunds} list
+   */
   public ChargeRefundCollection getRefunds() {
     // API versions 2014-05-19 and earlier render charge refunds as an array
     // instead of an object, meaning there is no sublist URL.
@@ -401,10 +355,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   }
 
   public String getReview() {
-    if (this.review == null) {
-      return null;
-    }
-    return this.review.getId();
+    return (this.review != null) ? this.review.getId() : null;
   }
 
   public void setReview(String reviewID) {
@@ -412,10 +363,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   }
 
   public Review getReviewObject() {
-    if (this.review == null) {
-      return null;
-    }
-    return this.review.getExpanded();
+    return (this.review != null) ? this.review.getExpanded() : null;
   }
 
   public void setReviewObject(Review r) {
@@ -439,10 +387,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   }
 
   public String getSourceTransfer() {
-    if (this.sourceTransfer == null) {
-      return null;
-    }
-    return this.sourceTransfer.getId();
+    return (this.sourceTransfer != null) ? this.sourceTransfer.getId() : null;
   }
 
   public void setSourceTransfer(String sourceTransferID) {
@@ -450,10 +395,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   }
 
   public Transfer getSourceTransferObject() {
-    if (this.sourceTransfer == null) {
-      return null;
-    }
-    return this.sourceTransfer.getExpanded();
+    return (this.sourceTransfer != null) ? this.sourceTransfer.getExpanded() : null;
   }
 
   public void setSourceTransferObject(Transfer c) {
@@ -477,10 +419,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   }
 
   public String getTransfer() {
-    if (this.transfer == null) {
-      return null;
-    }
-    return this.transfer.getId();
+    return (this.transfer != null) ? this.transfer.getId() : null;
   }
 
   public void setTransfer(String transferID) {
@@ -496,10 +435,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   }
 
   public Transfer getTransferObject() {
-    if (this.transfer == null) {
-      return null;
-    }
-    return this.transfer.getExpanded();
+    return (this.transfer != null) ? this.transfer.getExpanded() : null;
   }
 
   public void setTransferObject(Transfer c) {
@@ -507,48 +443,51 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   }
 
   /**
-   * @deprecated Use `source` field (https://stripe.com/docs/upgrades#2015-02-18)
+   * Returns the {@code card} attribute.
+   *
+   * @return the {@code card} attribute
+   * @deprecated Prefer using the {@code source} attribute instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2015-02-18">API version 2015-02-18</a>
    */
   @Deprecated
   public Card getCard() {
     return card;
   }
 
-  /**
-   * @deprecated Use `source` field (https://stripe.com/docs/upgrades#2015-02-18)
-   */
   @Deprecated
   public void setCard(Card card) {
     this.card = card;
   }
 
   /**
-   * @deprecated Use `dispute` field (https://stripe.com/docs/upgrades#2012-11-07)
+   * Returns the {@code disputed} attribute.
+   *
+   * @return the {@code disputed} attribute
+   * @deprecated Prefer using the {@code dispute} attribute instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2012-11-07">API version 2012-11-07</a>
    */
   @Deprecated
   public Boolean getDisputed() {
     return disputed;
   }
 
-  /**
-   * @deprecated Use `dispute` field (https://stripe.com/docs/upgrades#2012-11-07)
-   */
   @Deprecated
   public void setDisputed(Boolean disputed) {
     this.disputed = disputed;
   }
 
   /**
-   * @deprecated Use `statement_descriptor` field (https://stripe.com/docs/upgrades#2014-12-17)
+   * Returns the {@code statement_description} attribute.
+   *
+   * @return the {@code statement_description} attribute
+   * @deprecated Prefer using the {@code statement_descriptor} attribute instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2014-12-17">API version 2014-12-17</a>
    */
   @Deprecated
   public String getStatementDescription() {
     return statementDescription;
   }
 
-  /**
-   * @deprecated Use `statement_descriptor` field (https://stripe.com/docs/upgrades#2014-12-17)
-   */
   @Deprecated
   public void setStatementDescription(String statementDescription) {
     this.statementDescription = statementDescription;
@@ -710,6 +649,11 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
     return updateDispute(params, RequestOptions.builder().setApiKey(apiKey).build());
   }
 
+  /**
+   * Updates the charge's dispute.
+   *
+   * @deprecated Prefer using the {@link Dispute#update} method instead.
+   */
   @Deprecated
   public Dispute updateDispute(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
@@ -733,6 +677,11 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
     return closeDispute(RequestOptions.builder().setApiKey(apiKey).build());
   }
 
+  /**
+   * Closes the charge's dispute.
+   *
+   * @deprecated Prefer using the {@link Dispute#close} method instead.
+   */
   @Deprecated
   public Dispute closeDispute(RequestOptions options)
       throws AuthenticationException, InvalidRequestException,

--- a/src/main/java/com/stripe/model/ChargeOutcome.java
+++ b/src/main/java/com/stripe/model/ChargeOutcome.java
@@ -30,26 +30,26 @@ public class ChargeOutcome extends APIResource {
     return type;
   }
 
+  /**
+   * Returns the {@code rule} object, if expanded. If not expanded, use {@link #getRuleId()} to get
+   * the ID.
+   *
+   * @return the {@code rule} ID
+   * @deprecated In recent API versions, this attribute is no longer automatically expanded. Prefer
+   *     using the {@link #getRuleId()} and {@link #getRuleObject()} methods instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2017-02-14">API version 2017-02-14</a>
+   */
   @Deprecated
   public ChargeOutcomeRule getRule() {
-    if (this.rule == null) {
-      return null;
-    }
-    return this.rule.getExpanded();
+    return (this.rule != null) ? this.rule.getExpanded() : null;
   }
 
   public String getRuleId() {
-    if (this.rule == null) {
-      return null;
-    }
-    return this.rule.getId();
+    return (this.rule != null) ? this.rule.getId() : null;
   }
 
   public ChargeOutcomeRule getRuleObject() {
-    if (this.rule == null) {
-      return null;
-    }
-    return this.rule.getExpanded();
+    return (this.rule != null) ? this.rule.getExpanded() : null;
   }
 
   public void setNetworkStatus(String networkStatus) {

--- a/src/main/java/com/stripe/model/ChargeRefundCollectionDeserializer.java
+++ b/src/main/java/com/stripe/model/ChargeRefundCollectionDeserializer.java
@@ -17,6 +17,9 @@ import java.util.List;
 public class ChargeRefundCollectionDeserializer
     implements JsonDeserializer<ChargeRefundCollection> {
 
+  /**
+   * Deserializes a refund list JSON payload into a {@link ChargeRefundCollection} object.
+   */
   public ChargeRefundCollection deserialize(JsonElement json, Type typeOfT,
       JsonDeserializationContext context)
       throws JsonParseException {

--- a/src/main/java/com/stripe/model/CountrySpec.java
+++ b/src/main/java/com/stripe/model/CountrySpec.java
@@ -86,12 +86,8 @@ public class CountrySpec extends APIResource implements HasId {
   public static CountrySpec retrieve(String country, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
-    return request(
-        RequestMethod.GET,
-        instanceURL(CountrySpec.class, country),
-        null,
-        CountrySpec.class,
-        options);
+    return request(RequestMethod.GET, instanceURL(CountrySpec.class, country), null,
+        CountrySpec.class, options);
   }
 
   public static CountrySpecCollection list(Map<String, Object> params)

--- a/src/main/java/com/stripe/model/Customer.java
+++ b/src/main/java/com/stripe/model/Customer.java
@@ -90,10 +90,7 @@ public class Customer extends APIResource implements MetadataStore<Customer>, Ha
   }
 
   public String getDefaultSource() {
-    if (this.defaultSource == null) {
-      return null;
-    }
-    return this.defaultSource.getId();
+    return (this.defaultSource != null) ? this.defaultSource.getId() : null;
   }
 
   public void setDefaultSource(String defaultSourceID) {
@@ -101,10 +98,7 @@ public class Customer extends APIResource implements MetadataStore<Customer>, Ha
   }
 
   public ExternalAccount getDefaultSourceObject() {
-    if (this.defaultSource == null) {
-      return null;
-    }
-    return this.defaultSource.getExpanded();
+    return (this.defaultSource != null) ? this.defaultSource.getExpanded() : null;
   }
 
   public void setDefaultSourceObject(ExternalAccount c) {
@@ -188,7 +182,11 @@ public class Customer extends APIResource implements MetadataStore<Customer>, Ha
   }
 
   /**
-   * @deprecated Use `sources` field (https://stripe.com/docs/upgrades#2015-02-18)
+   * Returns the {@code cards} attribute.
+   *
+   * @return the {@code cards} attribute
+   * @deprecated Prefer using the {@code sources} attribute instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2015-02-18">API version 2015-02-18</a>
    */
   @Deprecated
   public CustomerCardCollection getCards() {
@@ -196,64 +194,68 @@ public class Customer extends APIResource implements MetadataStore<Customer>, Ha
   }
 
   /**
-   * @deprecated Use `default_source` field (https://stripe.com/docs/upgrades#2015-02-18)
+   * Returns the {@code default_card} attribute.
+   *
+   * @return the {@code default_card} attribute
+   * @deprecated Prefer using the {@code default_source} attribute instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2015-02-18">API version 2015-02-18</a>
    */
   @Deprecated
   public String getDefaultCard() {
     return defaultCard;
   }
 
-  /**
-   * @deprecated Use `default_source` field (https://stripe.com/docs/upgrades#2015-02-18)
-   */
   @Deprecated
   public void setDefaultCard(String defaultCard) {
     this.defaultCard = defaultCard;
   }
 
   /**
-   * @deprecated Use the upcoming invoice endpoint (https://stripe.com/docs/upgrades#2012-03-25)
+   * Returns the {@code next_recurring_charge} attribute.
+   *
+   * @return the {@code next_recurring_charge} attribute
+   * @deprecated Prefer using the {@link Invoice#upcoming} method instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2012-03-25">API version 2012-03-25</a>
    */
   @Deprecated
   public NextRecurringCharge getNextRecurringCharge() {
     return nextRecurringCharge;
   }
 
-  /**
-   * @deprecated Use the upcoming invoice endpoint (https://stripe.com/docs/upgrades#2012-03-25)
-   */
   @Deprecated
   public void setNextRecurringCharge(NextRecurringCharge nextRecurringCharge) {
     this.nextRecurringCharge = nextRecurringCharge;
   }
 
   /**
-   * @deprecated Use `subscriptions` field (https://stripe.com/docs/upgrades#2014-01-31)
+   * Returns the {@code subscription} attribute.
+   *
+   * @return the {@code subscription} attribute
+   * @deprecated Prefer using the {@code subscriptions} attribute instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2014-01-31">API version 2014-01-31</a>
    */
   @Deprecated
   public Subscription getSubscription() {
     return subscription;
   }
 
-  /**
-   * @deprecated Use `subscriptions` field (https://stripe.com/docs/upgrades#2014-01-31)
-   */
   @Deprecated
   public void setSubscription(Subscription subscription) {
     this.subscription = subscription;
   }
 
   /**
-   * @deprecated Use `subscriptions` field (https://stripe.com/docs/upgrades#2014-01-31)
+   * Returns the {@code trial_end} attribute.
+   *
+   * @return the {@code trial_end} attribute
+   * @deprecated Prefer using the {@code subscriptions} attribute instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2014-01-31">API version 2014-01-31</a>
    */
   @Deprecated
   public Long getTrialEnd() {
     return trialEnd;
   }
 
-  /**
-   * @deprecated Use `subscriptions` field (https://stripe.com/docs/upgrades#2014-01-31)
-   */
   @Deprecated
   public void setTrialEnd(Long trialEnd) {
     this.trialEnd = trialEnd;
@@ -345,7 +347,6 @@ public class Customer extends APIResource implements MetadataStore<Customer>, Ha
         DeletedCustomer.class, options);
   }
 
-  // Use `(Card)customer.getSources().create(params)` instead.
   @Deprecated
   public Card createCard(String token, String apiKey) throws AuthenticationException,
       InvalidRequestException, APIConnectionException, CardException,
@@ -365,6 +366,14 @@ public class Customer extends APIResource implements MetadataStore<Customer>, Ha
     return createCard(params, (RequestOptions) null);
   }
 
+  /**
+   * Adds a card to the customer using a card token.
+   *
+   * @param token card token ({@code "tok_..."})
+   * @param options request options
+   * @return the new card object
+   * @deprecated Prefer using the {@code customer.getSources().create(params)} method instead.
+   */
   @Deprecated
   public Card createCard(String token, RequestOptions options) throws AuthenticationException,
       InvalidRequestException, APIConnectionException, CardException,
@@ -390,7 +399,6 @@ public class Customer extends APIResource implements MetadataStore<Customer>, Ha
         instanceURL(Customer.class, this.id)), params, Card.class, options);
   }
 
-  // Use `(BankAccount)customer.getSources().create(params)` instead.
   @Deprecated
   public BankAccount createBankAccount(String token) throws AuthenticationException,
       InvalidRequestException, APIConnectionException, CardException,
@@ -398,13 +406,20 @@ public class Customer extends APIResource implements MetadataStore<Customer>, Ha
     return createBankAccount(token, null);
   }
 
+  /**
+   * Adds a bank account to the customer using a bank account token.
+   *
+   * @param token bank account token ({@code "btok_..."})
+   * @param options request options
+   * @return the new bank account object
+   * @deprecated Prefer using the {@code customer.getSources().create(params)} method instead.
+   */
   @Deprecated
   public BankAccount createBankAccount(String token, RequestOptions options)
       throws AuthenticationException, InvalidRequestException, APIConnectionException,
       CardException, APIException {
     Map<String, Object> postParams = new HashMap<String, Object>();
     postParams.put("bank_account", token);
-
     return createBankAccount(postParams, options);
   }
 

--- a/src/main/java/com/stripe/model/CustomerSubscriptionCollection.java
+++ b/src/main/java/com/stripe/model/CustomerSubscriptionCollection.java
@@ -22,9 +22,8 @@ public class CustomerSubscriptionCollection extends StripeCollection<Subscriptio
                          RequestOptions options) throws AuthenticationException,
       InvalidRequestException, APIConnectionException, CardException,
       APIException {
-    String url = String.format("%s%s", Stripe.getApiBase(), this.getURL());
-    return APIResource.requestCollection(url, params, CustomerSubscriptionCollection.class,
-        options);
+    return APIResource.requestCollection(String.format("%s%s", Stripe.getApiBase(), this.getURL()),
+        params, CustomerSubscriptionCollection.class, options);
   }
 
   @Deprecated
@@ -66,9 +65,8 @@ public class CustomerSubscriptionCollection extends StripeCollection<Subscriptio
   public Subscription retrieve(String id, RequestOptions options) throws AuthenticationException,
       InvalidRequestException, APIConnectionException, CardException,
       APIException {
-    String url = String.format("%s%s/%s", Stripe.getApiBase(), this.getURL(), id);
-    return APIResource.request(APIResource.RequestMethod.GET, url, null, Subscription.class,
-        options);
+    return APIResource.request(APIResource.RequestMethod.GET, String.format("%s%s/%s",
+        Stripe.getApiBase(), this.getURL(), id), null, Subscription.class, options);
   }
 
   public Subscription create(Map<String, Object> params)
@@ -89,8 +87,7 @@ public class CustomerSubscriptionCollection extends StripeCollection<Subscriptio
                  RequestOptions options) throws AuthenticationException,
       InvalidRequestException, APIConnectionException, CardException,
       APIException {
-    String url = String.format("%s%s", Stripe.getApiBase(), this.getURL());
-    return APIResource.request(APIResource.RequestMethod.POST, url, params, Subscription.class,
-        options);
+    return APIResource.request(APIResource.RequestMethod.POST, String.format("%s%s",
+        Stripe.getApiBase(), this.getURL()), params, Subscription.class, options);
   }
 }

--- a/src/main/java/com/stripe/model/Dispute.java
+++ b/src/main/java/com/stripe/model/Dispute.java
@@ -77,10 +77,7 @@ public class Dispute extends APIResource implements HasId {
   }
 
   public String getCharge() {
-    if (charge == null) {
-      return null;
-    }
-    return charge.getId();
+    return (this.charge != null) ? this.charge.getId() : null;
   }
 
   public void setCharge(String chargeID) {
@@ -88,10 +85,7 @@ public class Dispute extends APIResource implements HasId {
   }
 
   public Charge getChargeObject() {
-    if (this.charge == null) {
-      return null;
-    }
-    return this.charge.getExpanded();
+    return (this.charge != null) ? this.charge.getExpanded() : null;
   }
 
   public void setChargeObject(Charge charge) {
@@ -182,48 +176,51 @@ public class Dispute extends APIResource implements HasId {
   }
 
   /**
-   * @deprecated Use `balance_transactions` field
+   * Returns the {@code balance_transaction} attribute.
+   *
+   * @return the {@code balance_transaction} attribute
+   * @deprecated Prefer using the {@code balance_transactions} attribute instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2014-08-20">API version 2014-08-20</a>
    */
   @Deprecated
   public String getBalanceTransaction() {
     return balanceTransaction;
   }
 
-  /**
-   * @deprecated Use `balance_transactions` field
-   */
   @Deprecated
   public void setBalanceTransaction(String balanceTransaction) {
     this.balanceTransaction = balanceTransaction;
   }
 
   /**
-   * @deprecated Use evidenceSubObject (https://stripe.com/docs/upgrades#2014-12-08)
+   * Returns the {@code evidence} String attribute.
+   *
+   * @return the {@code evidence} String attribute
+   * @deprecated Prefer using the {@link #getEvidenceSubObject} method instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2014-12-08">API version 2014-12-08</a>
    */
   @Deprecated
   public String getEvidence() {
     return evidence;
   }
 
-  /**
-   * @deprecated Use evidenceSubObject (https://stripe.com/docs/upgrades#2014-12-08)
-   */
   @Deprecated
   public void setEvidence(String evidence) {
     this.evidence = evidence;
   }
 
   /**
-   * @deprecated Use evidenceDetails.dueBy (https://stripe.com/docs/upgrades#2014-12-08)
+   * Returns the {@code evidence_due_by} attribute.
+   *
+   * @return the {@code evidence_due_by} attribute
+   * @deprecated Prefer using the {@code getEvidenceDetails().getDueBy()} method instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2014-12-08">API version 2014-12-08</a>
    */
   @Deprecated
   public Long getEvidenceDueBy() {
     return evidenceDueBy;
   }
 
-  /**
-   * @deprecated Use evidenceDetails.dueBy (https://stripe.com/docs/upgrades#2014-12-08)
-   */
   @Deprecated
   public void setEvidenceDueBy(Long evidenceDueBy) {
     this.evidenceDueBy = evidenceDueBy;
@@ -296,8 +293,7 @@ public class Dispute extends APIResource implements HasId {
   public Dispute close(RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
-    return request(RequestMethod.POST,
-        String.format("%s/close", instanceURL(Dispute.class, this.getId())),
-        null, Dispute.class, options);
+    return request(RequestMethod.POST, String.format("%s/close",
+        instanceURL(Dispute.class, this.getId())), null, Dispute.class, options);
   }
 }

--- a/src/main/java/com/stripe/model/DisputeDataDeserializer.java
+++ b/src/main/java/com/stripe/model/DisputeDataDeserializer.java
@@ -13,6 +13,9 @@ import com.google.gson.JsonPrimitive;
 import java.lang.reflect.Type;
 
 public class DisputeDataDeserializer implements JsonDeserializer<Dispute> {
+  /**
+   * Deserializes a dispute JSON payload into a {@link Dispute} object.
+   */
   public Dispute deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
       throws JsonParseException {
     Gson gson = new GsonBuilder()

--- a/src/main/java/com/stripe/model/EphemeralKey.java
+++ b/src/main/java/com/stripe/model/EphemeralKey.java
@@ -85,6 +85,14 @@ public class EphemeralKey extends APIResource implements HasId {
     this.rawJson = rawJson;
   }
 
+  /**
+   * Creates an ephemeral key.
+   *
+   * @param params request parameters
+   * @param options request options. {@code stripeVersion} is required when creating ephemeral
+   *     keys.
+   * @return the new ephemeral key
+   */
   public static EphemeralKey create(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/EphemeralKeyDeserializer.java
+++ b/src/main/java/com/stripe/model/EphemeralKeyDeserializer.java
@@ -11,6 +11,9 @@ import com.google.gson.JsonParseException;
 import java.lang.reflect.Type;
 
 public class EphemeralKeyDeserializer implements JsonDeserializer<EphemeralKey> {
+  /**
+   * Deserializes an ephemeral_key JSON payload into an {@link EphemeralKey} object.
+   */
   public EphemeralKey deserialize(JsonElement json, Type typeOfT,
       JsonDeserializationContext context)
       throws JsonParseException {

--- a/src/main/java/com/stripe/model/EventDataDeserializer.java
+++ b/src/main/java/com/stripe/model/EventDataDeserializer.java
@@ -113,6 +113,10 @@ public class EventDataDeserializer implements JsonDeserializer<EventData> {
     }
   }
 
+  /**
+   * Deserializes the JSON payload contained in an event's {@code data} attribute into an
+   * {@link EventData} instance.
+   */
   @SuppressWarnings("unchecked")
   public EventData deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
       throws JsonParseException {

--- a/src/main/java/com/stripe/model/EventRequestDeserializer.java
+++ b/src/main/java/com/stripe/model/EventRequestDeserializer.java
@@ -12,6 +12,10 @@ import java.lang.reflect.Type;
 
 public class EventRequestDeserializer implements JsonDeserializer<EventRequest> {
 
+  /**
+   * Deserializes the JSON payload contained in an event's {@code request} attribute into an
+   * {@link EventRequest} instance.
+   */
   public EventRequest deserialize(JsonElement json, Type typeOfT,
       JsonDeserializationContext context)
       throws JsonParseException {

--- a/src/main/java/com/stripe/model/ExchangeRate.java
+++ b/src/main/java/com/stripe/model/ExchangeRate.java
@@ -48,12 +48,8 @@ public class ExchangeRate extends APIResource implements HasId {
   public static ExchangeRate retrieve(String currency, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
-    return request(
-        RequestMethod.GET,
-        instanceURL(ExchangeRate.class, currency),
-        null,
-        ExchangeRate.class,
-        options);
+    return request(RequestMethod.GET, instanceURL(ExchangeRate.class, currency), null,
+        ExchangeRate.class, options);
   }
 
   public static ExchangeRateCollection list(Map<String, Object> params)

--- a/src/main/java/com/stripe/model/ExpandableFieldDeserializer.java
+++ b/src/main/java/com/stripe/model/ExpandableFieldDeserializer.java
@@ -11,6 +11,10 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 
 public class ExpandableFieldDeserializer implements JsonDeserializer<ExpandableField> {
+  /**
+   * Deserializes an expandable field JSON payload (i.e. either a string with just the ID, or a full
+   * JSON object) into an {@link ExpandableField} object.
+   */
   public ExpandableField deserialize(JsonElement json, Type typeOfT,
       JsonDeserializationContext context) throws JsonParseException {
     if (json.isJsonNull()) {

--- a/src/main/java/com/stripe/model/ExpandableFieldSerializer.java
+++ b/src/main/java/com/stripe/model/ExpandableFieldSerializer.java
@@ -8,6 +8,9 @@ import com.google.gson.JsonSerializer;
 import java.lang.reflect.Type;
 
 public class ExpandableFieldSerializer implements JsonSerializer<ExpandableField> {
+  /**
+   * Serializes an expandable attribute into a JSON string.
+   */
   public JsonElement serialize(ExpandableField src, Type typeOfSrc,
       JsonSerializationContext context) {
     if (src.isExpanded()) {

--- a/src/main/java/com/stripe/model/ExternalAccount.java
+++ b/src/main/java/com/stripe/model/ExternalAccount.java
@@ -59,24 +59,19 @@ public class ExternalAccount extends APIResource implements HasId, MetadataStore
     this.metadata = metadata;
   }
 
-  public String getInstanceURL() {
-    if (this.getCustomer() != null) {
-      return String.format("%s/%s/sources/%s", classURL(Customer.class), this.getCustomer(),
-          this.getId());
-    } else if (this.getAccount() != null) {
-      return String.format("%s/%s/external_accounts/%s", classURL(Account.class), this.getAccount(),
-          this.getId());
-    } else {
-      return null;
-    }
-  }
-
   public ExternalAccount verify(Map<String, Object> params) throws
       AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
     return verify(params, null);
   }
 
+  /**
+   * Verifies a bank account.
+   *
+   * @param params request parameters
+   * @param options request options
+   * @return the verified bank account
+   */
   public ExternalAccount verify(Map<String, Object> params, RequestOptions options) throws
       AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
@@ -114,5 +109,17 @@ public class ExternalAccount extends APIResource implements HasId, MetadataStore
       APIConnectionException, CardException, APIException {
     return request(RequestMethod.DELETE, this.getInstanceURL(), null, DeletedExternalAccount.class,
         options);
+  }
+
+  protected String getInstanceURL() {
+    if (this.getCustomer() != null) {
+      return String.format("%s/%s/sources/%s", classURL(Customer.class), this.getCustomer(),
+          this.getId());
+    } else if (this.getAccount() != null) {
+      return String.format("%s/%s/external_accounts/%s", classURL(Account.class), this.getAccount(),
+          this.getId());
+    } else {
+      return null;
+    }
   }
 }

--- a/src/main/java/com/stripe/model/ExternalAccountCollection.java
+++ b/src/main/java/com/stripe/model/ExternalAccountCollection.java
@@ -50,9 +50,8 @@ public class ExternalAccountCollection extends StripeCollection<ExternalAccount>
   public ExternalAccount retrieve(String id, RequestOptions options) throws AuthenticationException,
       InvalidRequestException, APIConnectionException, CardException,
       APIException {
-    String url = String.format("%s%s/%s", Stripe.getApiBase(), this.getURL(), id);
-    return APIResource.request(APIResource.RequestMethod.GET, url, null, ExternalAccount.class,
-        options);
+    return APIResource.request(APIResource.RequestMethod.GET, String.format("%s%s/%s",
+        Stripe.getApiBase(), this.getURL(), id), null, ExternalAccount.class, options);
   }
 
   public ExternalAccount create(Map<String, Object> params)
@@ -65,8 +64,7 @@ public class ExternalAccountCollection extends StripeCollection<ExternalAccount>
                   RequestOptions options) throws AuthenticationException,
       InvalidRequestException, APIConnectionException, CardException,
       APIException {
-    String url = String.format("%s%s", Stripe.getApiBase(), this.getURL());
-    return APIResource.request(APIResource.RequestMethod.POST, url, params, ExternalAccount.class,
-        options);
+    return APIResource.request(APIResource.RequestMethod.POST, String.format("%s%s",
+        Stripe.getApiBase(), this.getURL()), params, ExternalAccount.class, options);
   }
 }

--- a/src/main/java/com/stripe/model/ExternalAccountTypeAdapterFactory.java
+++ b/src/main/java/com/stripe/model/ExternalAccountTypeAdapterFactory.java
@@ -12,6 +12,10 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 
 public class ExternalAccountTypeAdapterFactory implements TypeAdapterFactory {
+  /**
+   * Creates the type adapter used to instantiate {@link ExternalAccount} subclasses from JSON
+   * payloads.
+   */
   public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
     if (!ExternalAccount.class.isAssignableFrom(type.getRawType())) {
       return null; // this class only serializes 'ExternalAccount' and its subtypes

--- a/src/main/java/com/stripe/model/FeeRefund.java
+++ b/src/main/java/com/stripe/model/FeeRefund.java
@@ -41,10 +41,7 @@ public class FeeRefund extends APIResource implements MetadataStore<ApplicationF
   }
 
   public String getBalanceTransaction() {
-    if (this.balanceTransaction == null) {
-      return null;
-    }
-    return this.balanceTransaction.getId();
+    return (this.balanceTransaction != null) ? this.balanceTransaction.getId() : null;
   }
 
   public void setBalanceTransaction(String balanceTransactionID) {
@@ -52,10 +49,7 @@ public class FeeRefund extends APIResource implements MetadataStore<ApplicationF
   }
 
   public BalanceTransaction getBalanceTransactionObject() {
-    if (this.balanceTransaction == null) {
-      return null;
-    }
-    return this.balanceTransaction.getExpanded();
+    return (this.balanceTransaction != null) ? this.balanceTransaction.getExpanded() : null;
   }
 
   public void setBalanceTransactionObject(BalanceTransaction c) {
@@ -79,10 +73,7 @@ public class FeeRefund extends APIResource implements MetadataStore<ApplicationF
   }
 
   public String getFee() {
-    if (this.fee == null) {
-      return null;
-    }
-    return this.fee.getId();
+    return (this.fee != null) ? this.fee.getId() : null;
   }
 
   public void setFee(String feeID) {
@@ -90,10 +81,7 @@ public class FeeRefund extends APIResource implements MetadataStore<ApplicationF
   }
 
   public ApplicationFee getFeeObject() {
-    if (this.fee == null) {
-      return null;
-    }
-    return this.fee.getExpanded();
+    return (this.fee != null) ? this.fee.getExpanded() : null;
   }
 
   public void setFeeObject(ApplicationFee c) {
@@ -127,7 +115,7 @@ public class FeeRefund extends APIResource implements MetadataStore<ApplicationF
     return request(RequestMethod.POST, this.getInstanceURL(), params, FeeRefund.class, options);
   }
 
-  public String getInstanceURL() {
+  protected String getInstanceURL() {
     if (this.fee != null) {
       return String.format("%s/%s/refunds/%s", classURL(ApplicationFee.class), this.fee,
           this.getId());

--- a/src/main/java/com/stripe/model/FeeRefundCollection.java
+++ b/src/main/java/com/stripe/model/FeeRefundCollection.java
@@ -87,8 +87,7 @@ public class FeeRefundCollection extends StripeCollection<FeeRefund> {
               RequestOptions options) throws AuthenticationException,
       InvalidRequestException, APIConnectionException, CardException,
       APIException {
-    String url = String.format("%s%s", Stripe.getApiBase(), this.getURL());
-    return APIResource.request(APIResource.RequestMethod.POST, url, params, FeeRefund.class,
-        options);
+    return APIResource.request(APIResource.RequestMethod.POST, String.format("%s%s",
+        Stripe.getApiBase(), this.getURL()), params, FeeRefund.class, options);
   }
 }

--- a/src/main/java/com/stripe/model/FeeRefundCollectionDeserializer.java
+++ b/src/main/java/com/stripe/model/FeeRefundCollectionDeserializer.java
@@ -19,6 +19,9 @@ public class FeeRefundCollectionDeserializer implements JsonDeserializer<FeeRefu
   public static final Type REFUND_LIST_TYPE = new TypeToken<List<FeeRefund>>() {
   }.getType();
 
+  /**
+   * Deserializes a fee_refund list JSON payload into a {@link FeeRefundCollection} object.
+   */
   public FeeRefundCollection deserialize(JsonElement json, Type typeOfT,
       JsonDeserializationContext context)
       throws JsonParseException {

--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -105,10 +105,7 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
   }
 
   public String getCharge() {
-    if (charge == null) {
-      return null;
-    }
-    return charge.getId();
+    return (this.charge != null) ? this.charge.getId() : null;
   }
 
   public void setCharge(String chargeID) {
@@ -116,10 +113,7 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
   }
 
   public Charge getChargeObject() {
-    if (this.charge == null) {
-      return null;
-    }
-    return this.charge.getExpanded();
+    return (this.charge != null) ? this.charge.getExpanded() : null;
   }
 
   public void setChargeObject(Charge charge) {
@@ -291,10 +285,7 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
   }
 
   public String getSubscription() {
-    if (subscription == null) {
-      return null;
-    }
-    return subscription.getId();
+    return (this.subscription != null) ? this.subscription.getId() : null;
   }
 
   public void setSubscription(String subscriptionID) {
@@ -302,10 +293,7 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
   }
 
   public Subscription getSubscriptionObject() {
-    if (this.subscription == null) {
-      return null;
-    }
-    return this.subscription.getExpanded();
+    return (this.subscription != null) ? this.subscription.getExpanded() : null;
   }
 
   public void setSubscriptionObject(Subscription subscription) {

--- a/src/main/java/com/stripe/model/InvoiceItem.java
+++ b/src/main/java/com/stripe/model/InvoiceItem.java
@@ -61,10 +61,7 @@ public class InvoiceItem extends APIResource implements MetadataStore<InvoiceIte
   }
 
   public String getCustomer() {
-    if (this.customer == null) {
-      return null;
-    }
-    return this.customer.getId();
+    return (this.customer != null) ? this.customer.getId() : null;
   }
 
   public void setCustomer(String customerID) {
@@ -73,10 +70,7 @@ public class InvoiceItem extends APIResource implements MetadataStore<InvoiceIte
   }
 
   public Customer getCustomerObject() {
-    if (this.customer == null) {
-      return null;
-    }
-    return this.customer.getExpanded();
+    return (this.customer != null) ? this.customer.getExpanded() : null;
   }
 
   public void setCustomerObject(Customer c) {
@@ -108,10 +102,7 @@ public class InvoiceItem extends APIResource implements MetadataStore<InvoiceIte
   }
 
   public String getInvoice() {
-    if (this.invoice == null) {
-      return null;
-    }
-    return this.invoice.getId();
+    return (this.invoice != null) ? this.invoice.getId() : null;
   }
 
   public void setInvoice(String invoiceID) {
@@ -120,10 +111,7 @@ public class InvoiceItem extends APIResource implements MetadataStore<InvoiceIte
   }
 
   public Invoice getInvoiceObject() {
-    if (this.invoice == null) {
-      return null;
-    }
-    return this.invoice.getExpanded();
+    return (this.invoice != null) ? this.invoice.getExpanded() : null;
   }
 
   public void setInvoiceObject(Invoice invoice) {
@@ -179,10 +167,7 @@ public class InvoiceItem extends APIResource implements MetadataStore<InvoiceIte
   }
 
   public String getSubscription() {
-    if (subscription == null) {
-      return null;
-    }
-    return subscription.getId();
+    return (this.subscription != null) ? this.subscription.getId() : null;
   }
 
   public void setSubscription(String subscriptionID) {
@@ -190,10 +175,7 @@ public class InvoiceItem extends APIResource implements MetadataStore<InvoiceIte
   }
 
   public Subscription getSubscriptionObject() {
-    if (this.subscription == null) {
-      return null;
-    }
-    return this.subscription.getExpanded();
+    return (this.subscription != null) ? this.subscription.getExpanded() : null;
   }
 
   public void setSubscriptionObject(Subscription subscription) {
@@ -263,7 +245,7 @@ public class InvoiceItem extends APIResource implements MetadataStore<InvoiceIte
   public InvoiceItem update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
-    return request(RequestMethod.POST, instanceURL(InvoiceItem.class, this.id), params, 
+    return request(RequestMethod.POST, instanceURL(InvoiceItem.class, this.id), params,
         InvoiceItem.class, options);
   }
 

--- a/src/main/java/com/stripe/model/Order.java
+++ b/src/main/java/com/stripe/model/Order.java
@@ -85,10 +85,7 @@ public class Order extends APIResource implements HasId, MetadataStore<Order> {
   }
 
   public String getCharge() {
-    if (this.charge == null) {
-      return null;
-    }
-    return this.charge.getId();
+    return (this.charge != null) ? this.charge.getId() : null;
   }
 
   public void setCharge(String chargeID) {
@@ -97,10 +94,7 @@ public class Order extends APIResource implements HasId, MetadataStore<Order> {
   }
 
   public Charge getChargeObject() {
-    if (this.charge == null) {
-      return null;
-    }
-    return this.charge.getExpanded();
+    return (this.charge != null) ? this.charge.getExpanded() : null;
   }
 
   public void setChargeObject(Charge charge) {
@@ -124,10 +118,7 @@ public class Order extends APIResource implements HasId, MetadataStore<Order> {
   }
 
   public String getCustomer() {
-    if (this.customer == null) {
-      return null;
-    }
-    return this.customer.getId();
+    return (this.customer != null) ? this.customer.getId() : null;
   }
 
   public void setCustomer(String customerID) {
@@ -135,10 +126,7 @@ public class Order extends APIResource implements HasId, MetadataStore<Order> {
   }
 
   public Customer getCustomerObject() {
-    if (this.customer == null) {
-      return null;
-    }
-    return this.customer.getExpanded();
+    return (this.customer != null) ? this.customer.getExpanded() : null;
   }
 
   public void setCustomerObject(Customer customer) {

--- a/src/main/java/com/stripe/model/OrderItem.java
+++ b/src/main/java/com/stripe/model/OrderItem.java
@@ -44,10 +44,7 @@ public class OrderItem extends APIResource {
   }
 
   public String getParent() {
-    if (this.parent == null) {
-      return null;
-    }
-    return this.parent.getId();
+    return (this.parent != null) ? this.parent.getId() : null;
   }
 
   public void setParent(String parentID) {
@@ -55,10 +52,7 @@ public class OrderItem extends APIResource {
   }
 
   public HasId getParentObject() {
-    if (this.parent == null) {
-      return null;
-    }
-    return this.parent.getExpanded();
+    return (this.parent != null) ? this.parent.getExpanded() : null;
   }
 
   public void setParentObject(HasId o) {
@@ -66,10 +60,7 @@ public class OrderItem extends APIResource {
   }
 
   public <O extends HasId> O getParentObjectAs() {
-    if (this.parent == null) {
-      return null;
-    }
-    return (O) this.parent.getExpanded();
+    return (this.parent != null) ? (O) this.parent.getExpanded() : null;
   }
 
   public Integer getQuantity() {

--- a/src/main/java/com/stripe/model/OrderReturn.java
+++ b/src/main/java/com/stripe/model/OrderReturn.java
@@ -79,10 +79,7 @@ public class OrderReturn extends APIResource implements HasId {
   }
 
   public String getOrder() {
-    if (order == null) {
-      return null;
-    }
-    return order.getId();
+    return (this.order != null) ? this.order.getId() : null;
   }
 
   public void setOrder(String orderID) {
@@ -90,10 +87,7 @@ public class OrderReturn extends APIResource implements HasId {
   }
 
   public Order getOrderObject() {
-    if (this.order == null) {
-      return null;
-    }
-    return this.order.getExpanded();
+    return (this.order != null) ? this.order.getExpanded() : null;
   }
 
   public void setOrderObject(Order order) {
@@ -101,10 +95,7 @@ public class OrderReturn extends APIResource implements HasId {
   }
 
   public String getRefund() {
-    if (refund == null) {
-      return null;
-    }
-    return refund.getId();
+    return (this.refund != null) ? this.refund.getId() : null;
   }
 
   public void setRefund(String refundID) {
@@ -112,10 +103,7 @@ public class OrderReturn extends APIResource implements HasId {
   }
 
   public Refund getRefundObject() {
-    if (this.refund == null) {
-      return null;
-    }
-    return this.refund.getExpanded();
+    return (this.refund != null) ? this.refund.getExpanded() : null;
   }
 
   public void setRefundObject(Refund refund) {

--- a/src/main/java/com/stripe/model/Payout.java
+++ b/src/main/java/com/stripe/model/Payout.java
@@ -72,10 +72,7 @@ public class Payout extends APIResource implements MetadataStore<Payout>, HasId 
   }
 
   public String getBalanceTransaction() {
-    if (this.balanceTransaction == null) {
-      return null;
-    }
-    return this.balanceTransaction.getId();
+    return (this.balanceTransaction != null) ? this.balanceTransaction.getId() : null;
   }
 
   public void setBalanceTransaction(String balanceTransactionID) {
@@ -83,10 +80,7 @@ public class Payout extends APIResource implements MetadataStore<Payout>, HasId 
   }
 
   public BalanceTransaction getBalanceTransactionObject() {
-    if (this.balanceTransaction == null) {
-      return null;
-    }
-    return this.balanceTransaction.getExpanded();
+    return (this.balanceTransaction != null) ? this.balanceTransaction.getExpanded() : null;
   }
 
   public void setBalanceTransactionObject(BalanceTransaction c) {
@@ -110,10 +104,7 @@ public class Payout extends APIResource implements MetadataStore<Payout>, HasId 
   }
 
   public String getDestination() {
-    if (this.destination == null) {
-      return null;
-    }
-    return this.destination.getId();
+    return (this.destination != null) ? this.destination.getId() : null;
   }
 
   public void setDestination(String destinationID) {
@@ -121,10 +112,7 @@ public class Payout extends APIResource implements MetadataStore<Payout>, HasId 
   }
 
   public ExternalAccount getDestinationObject() {
-    if (this.destination == null) {
-      return null;
-    }
-    return this.destination.getExpanded();
+    return (this.destination != null) ? this.destination.getExpanded() : null;
   }
 
   public void setDestinationObject(ExternalAccount c) {
@@ -132,10 +120,8 @@ public class Payout extends APIResource implements MetadataStore<Payout>, HasId 
   }
 
   public String getFailureBalanceTransaction() {
-    if (this.failureBalanceTransaction == null) {
-      return null;
-    }
-    return this.failureBalanceTransaction.getId();
+    return (this.failureBalanceTransaction != null) ? this.failureBalanceTransaction.getId()
+        : null;
   }
 
   public void setFailureBalanceTransaction(String failureBalanceTransactionID) {
@@ -144,10 +130,8 @@ public class Payout extends APIResource implements MetadataStore<Payout>, HasId 
   }
 
   public BalanceTransaction getFailureBalanceTransactionObject() {
-    if (this.failureBalanceTransaction == null) {
-      return null;
-    }
-    return this.failureBalanceTransaction.getExpanded();
+    return (this.failureBalanceTransaction != null) ? this.failureBalanceTransaction.getExpanded()
+        : null;
   }
 
   public void setFailureBalanceTransactionObject(BalanceTransaction c) {

--- a/src/main/java/com/stripe/model/Plan.java
+++ b/src/main/java/com/stripe/model/Plan.java
@@ -113,10 +113,7 @@ public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
   }
 
   public String getProduct() {
-    if (this.product == null) {
-      return null;
-    }
-    return this.product.getId();
+    return (this.product != null) ? this.product.getId() : null;
   }
 
   public void setProduct(String productID) {
@@ -124,10 +121,7 @@ public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
   }
 
   public Product getProductObject() {
-    if (this.product == null) {
-      return null;
-    }
-    return this.product.getExpanded();
+    return (this.product != null) ? this.product.getExpanded() : null;
   }
 
   public void setProductObject(Product product) {
@@ -135,7 +129,11 @@ public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
   }
 
   /**
-   *  @deprecated Prefer using the product field (https://stripe.com/docs/upgrades#2018-02-05)
+   * Returns the {@code name} attribute.
+   *
+   * @return the {@code name} attribute
+   * @deprecated Prefer using the {@code getProduct().getName()} method instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2018-02-05">API version 2018-02-05</a>
    */
   public String getName() {
     return name;
@@ -146,7 +144,11 @@ public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
   }
 
   /**
-   *  @deprecated Prefer using the product field (https://stripe.com/docs/upgrades#2018-02-05)
+   * Returns the {@code statement_descriptor} attribute.
+   *
+   * @return the {@code statement_descriptor} attribute
+   * @deprecated Prefer using the {@code getProduct().getStatementDescriptor()} method instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2018-02-05">API version 2018-02-05</a>
    */
   public String getStatementDescriptor() {
     return statementDescriptor;
@@ -157,7 +159,12 @@ public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
   }
 
   /**
-   *  @deprecated Prefer using the product field (https://stripe.com/docs/upgrades#2018-02-05)
+   * Returns the {@code trial_period_days} attribute.
+   *
+   * @return the {@code trial_period_days} attribute
+   * @deprecated Prefer using the {@link Subscription#create} method with the {@code trial_end}
+   *     parameter instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2018-02-05">API version 2018-02-05</a>
    */
   public Integer getTrialPeriodDays() {
     return trialPeriodDays;
@@ -168,16 +175,18 @@ public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
   }
 
   /**
-   * @deprecated Use `statement_descriptor` field (https://stripe.com/docs/upgrades#2014-12-17)
+   * Returns the {@code statement_description} attribute.
+   *
+   * @return the {@code statement_description} attribute
+   * @deprecated Prefer using the {@code getProduct().getStatementDescriptor()} method instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2014-12-17">API version 2014-12-17</a>
+   * @see <a href="https://stripe.com/docs/upgrades#2018-02-05">API version 2018-02-05</a>
    */
   @Deprecated
   public String getStatementDescription() {
     return statementDescription;
   }
 
-  /**
-   * @deprecated Use `statement_descriptor` field (https://stripe.com/docs/upgrades#2014-12-17)
-   */
   @Deprecated
   public void setStatementDescription(String statementDescription) {
     this.statementDescription = statementDescription;

--- a/src/main/java/com/stripe/model/Recipient.java
+++ b/src/main/java/com/stripe/model/Recipient.java
@@ -65,10 +65,7 @@ public class Recipient extends APIResource implements MetadataStore<Recipient>, 
   }
 
   public String getDefaultCard() {
-    if (this.defaultCard == null) {
-      return null;
-    }
-    return this.defaultCard.getId();
+    return (this.defaultCard != null) ? this.defaultCard.getId() : null;
   }
 
   public void setDefaultCard(String defaultCardID) {
@@ -76,10 +73,7 @@ public class Recipient extends APIResource implements MetadataStore<Recipient>, 
   }
 
   public Card getDefaultCardObject() {
-    if (this.defaultCard == null) {
-      return null;
-    }
-    return this.defaultCard.getExpanded();
+    return (this.defaultCard != null) ? this.defaultCard.getExpanded() : null;
   }
 
   public void setDefaultCardObject(Card c) {
@@ -123,10 +117,7 @@ public class Recipient extends APIResource implements MetadataStore<Recipient>, 
   }
 
   public String getMigratedTo() {
-    if (this.migratedTo == null) {
-      return null;
-    }
-    return this.migratedTo.getId();
+    return (this.migratedTo != null) ? this.migratedTo.getId() : null;
   }
 
   public void setMigratedTo(String migratedToID) {
@@ -134,10 +125,7 @@ public class Recipient extends APIResource implements MetadataStore<Recipient>, 
   }
 
   public Account getMigratedToObject() {
-    if (this.migratedTo == null) {
-      return null;
-    }
-    return this.migratedTo.getExpanded();
+    return (this.migratedTo != null) ? this.migratedTo.getExpanded() : null;
   }
 
   public void setMigratedToObject(Account c) {
@@ -273,6 +261,13 @@ public class Recipient extends APIResource implements MetadataStore<Recipient>, 
     return createCard(token, RequestOptions.builder().setApiKey(apiKey).build());
   }
 
+  /**
+   * Adds a card to the recipient using a card token.
+   *
+   * @param token card token ({@code "tok_..."})
+   * @param options request options
+   * @return the new card object
+   */
   public Card createCard(String token, RequestOptions options) throws AuthenticationException,
       InvalidRequestException, APIConnectionException, CardException,
       APIException {

--- a/src/main/java/com/stripe/model/RecipientCardCollection.java
+++ b/src/main/java/com/stripe/model/RecipientCardCollection.java
@@ -87,8 +87,7 @@ public class RecipientCardCollection extends StripeCollection<Card> {
                       RequestOptions options) throws AuthenticationException,
       InvalidRequestException, APIConnectionException, CardException,
       APIException {
-    String url = String.format("%s%s", Stripe.getApiBase(), this.getURL());
-    return APIResource.request(APIResource.RequestMethod.POST, url, params,
-        RecipientCardCollection.class, options);
+    return APIResource.request(APIResource.RequestMethod.POST, String.format("%s%s",
+        Stripe.getApiBase(), this.getURL()), params, RecipientCardCollection.class, options);
   }
 }

--- a/src/main/java/com/stripe/model/Refund.java
+++ b/src/main/java/com/stripe/model/Refund.java
@@ -49,10 +49,7 @@ public class Refund extends APIResource implements MetadataStore<Charge>, HasId 
   }
 
   public String getBalanceTransaction() {
-    if (this.balanceTransaction == null) {
-      return null;
-    }
-    return this.balanceTransaction.getId();
+    return (this.balanceTransaction != null) ? this.balanceTransaction.getId() : null;
   }
 
   public void setBalanceTransaction(String balanceTransactionID) {
@@ -60,10 +57,7 @@ public class Refund extends APIResource implements MetadataStore<Charge>, HasId 
   }
 
   public BalanceTransaction getBalanceTransactionObject() {
-    if (this.balanceTransaction == null) {
-      return null;
-    }
-    return this.balanceTransaction.getExpanded();
+    return (this.balanceTransaction != null) ? this.balanceTransaction.getExpanded() : null;
   }
 
   public void setBalanceTransactionObject(BalanceTransaction c) {
@@ -71,10 +65,7 @@ public class Refund extends APIResource implements MetadataStore<Charge>, HasId 
   }
 
   public String getCharge() {
-    if (this.charge == null) {
-      return null;
-    }
-    return this.charge.getId();
+    return (this.charge != null) ? this.charge.getId() : null;
   }
 
   public void setCharge(String chargeID) {
@@ -82,10 +73,7 @@ public class Refund extends APIResource implements MetadataStore<Charge>, HasId 
   }
 
   public Charge getChargeObject() {
-    if (this.charge == null) {
-      return null;
-    }
-    return this.charge.getExpanded();
+    return (this.charge != null) ? this.charge.getExpanded() : null;
   }
 
   public void setChargeObject(Charge c) {

--- a/src/main/java/com/stripe/model/Reversal.java
+++ b/src/main/java/com/stripe/model/Reversal.java
@@ -41,10 +41,7 @@ public class Reversal extends APIResource implements MetadataStore<Transfer>, Ha
   }
 
   public String getBalanceTransaction() {
-    if (this.balanceTransaction == null) {
-      return null;
-    }
-    return this.balanceTransaction.getId();
+    return (this.balanceTransaction != null) ? this.balanceTransaction.getId() : null;
   }
 
   public void setBalanceTransaction(String balanceTransactionID) {
@@ -52,10 +49,7 @@ public class Reversal extends APIResource implements MetadataStore<Transfer>, Ha
   }
 
   public BalanceTransaction getBalanceTransactionObject() {
-    if (this.balanceTransaction == null) {
-      return null;
-    }
-    return this.balanceTransaction.getExpanded();
+    return (this.balanceTransaction != null) ? this.balanceTransaction.getExpanded() : null;
   }
 
   public void setBalanceTransactionObject(BalanceTransaction c) {
@@ -87,10 +81,7 @@ public class Reversal extends APIResource implements MetadataStore<Transfer>, Ha
   }
 
   public String getTransfer() {
-    if (this.transfer == null) {
-      return null;
-    }
-    return this.transfer.getId();
+    return (this.transfer != null) ? this.transfer.getId() : null;
   }
 
   public void setTransfer(String transferID) {
@@ -98,10 +89,7 @@ public class Reversal extends APIResource implements MetadataStore<Transfer>, Ha
   }
 
   public Transfer getTransferObject() {
-    if (this.transfer == null) {
-      return null;
-    }
-    return this.transfer.getExpanded();
+    return (this.transfer != null) ? this.transfer.getExpanded() : null;
   }
 
   public void setTransferObject(Transfer c) {
@@ -127,7 +115,7 @@ public class Reversal extends APIResource implements MetadataStore<Transfer>, Ha
     return request(RequestMethod.POST, this.getInstanceURL(), params, Reversal.class, options);
   }
 
-  public String getInstanceURL() {
+  protected String getInstanceURL() {
     if (this.transfer != null) {
       return String.format("%s/%s/reversals/%s", classURL(Transfer.class), this.transfer,
           this.getId());

--- a/src/main/java/com/stripe/model/SKU.java
+++ b/src/main/java/com/stripe/model/SKU.java
@@ -123,10 +123,7 @@ public class SKU extends APIResource implements HasId, MetadataStore<SKU> {
   }
 
   public String getProduct() {
-    if (this.product == null) {
-      return null;
-    }
-    return this.product.getId();
+    return (this.product != null) ? this.product.getId() : null;
   }
 
   public void setProduct(String productID) {
@@ -135,10 +132,7 @@ public class SKU extends APIResource implements HasId, MetadataStore<SKU> {
   }
 
   public Product getProductObject() {
-    if (this.product == null) {
-      return null;
-    }
-    return this.product.getExpanded();
+    return (this.product != null) ? this.product.getExpanded() : null;
   }
 
   public void setProductObject(Product product) {

--- a/src/main/java/com/stripe/model/Source.java
+++ b/src/main/java/com/stripe/model/Source.java
@@ -210,6 +210,11 @@ public class Source extends ExternalAccount implements HasSourceTypeData {
     return request(RequestMethod.POST, this.getSourceInstanceURL(), params, Source.class, options);
   }
 
+  /**
+   * Source objects cannot be deleted. Calling this method will raise an
+   * {@link InvalidRequestException}. Call {@link #detach} to detach the source from a
+   * customer object.
+   */
   public DeletedExternalAccount delete(RequestOptions options) throws
       AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
@@ -231,6 +236,9 @@ public class Source extends ExternalAccount implements HasSourceTypeData {
     return detach(params, null);
   }
 
+  /**
+   * Detaches the source from its customer objects.
+   */
   public Source detach(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/SourceTypeDataDeserializer.java
+++ b/src/main/java/com/stripe/model/SourceTypeDataDeserializer.java
@@ -33,6 +33,9 @@ public class SourceTypeDataDeserializer<T extends HasSourceTypeData>
     }
   }
 
+  /**
+   * Deserializes the type-specific data of a {@link Source} or {@link SourceTransaction} object.
+   */
   public T deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
           throws JsonParseException {
     if (json.isJsonNull()) {

--- a/src/main/java/com/stripe/model/StripeCollection.java
+++ b/src/main/java/com/stripe/model/StripeCollection.java
@@ -8,10 +8,10 @@ import java.util.Map;
 /**
  * Provides a representation of a single page worth of data from the Stripe
  * API.
- * 
+ *
  * <p>The following code will have the effect of iterating through a single page
  * worth of invoice data retrieve from the API:
- * 
+ *
  * <p><pre>
  * {@code
  * foreach (Invoice invoice : Invoice.list(...).getData()) {
@@ -19,10 +19,10 @@ import java.util.Map;
  * }
  * }
  * </pre>
- * 
+ *
  * <p>The class also provides a helper for iterating over collections that may be
  * longer than a single page:
- * 
+ *
  * <p><pre>
  * {@code
  * foreach (Invoice invoice : Invoice.list(...).autoPagingIterable()) {
@@ -91,25 +91,26 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject
     this.count = count;
   }
 
-  /**
-   * Returns an iterable that can be used to iterate across all objects
-   * across all pages. As page boundaries are encountered, the next page will
-   * be fetched automatically for continued iteration.
-   */
   public Iterable<T> autoPagingIterable() {
     return new PagingIterable<T>(this);
   }
 
   public Iterable<T> autoPagingIterable(Map<String, Object> params) {
     this.setRequestParams(params);
-
     return new PagingIterable<T>(this);
   }
 
+  /**
+   * Constructs an iterable that can be used to iterate across all objects
+   * across all pages. As page boundaries are encountered, the next page will
+   * be fetched automatically for continued iteration.
+   *
+   * @param params request parameters (will override the parameters from the initial list request)
+   * @param options request options (will override the options from the initial list request)
+   */
   public Iterable<T> autoPagingIterable(Map<String, Object> params, RequestOptions options) {
     this.setRequestOptions(options);
     this.setRequestParams(params);
-
     return new PagingIterable<T>(this);
   }
 

--- a/src/main/java/com/stripe/model/StripeRawJsonObjectDeserializer.java
+++ b/src/main/java/com/stripe/model/StripeRawJsonObjectDeserializer.java
@@ -8,6 +8,9 @@ import com.google.gson.JsonParseException;
 import java.lang.reflect.Type;
 
 public class StripeRawJsonObjectDeserializer implements JsonDeserializer<StripeRawJsonObject> {
+  /**
+   * Deserializes a JSON payload into a {@link StripeRawJsonObject} object.
+   */
   public StripeRawJsonObject deserialize(JsonElement json, Type typeOfT,
       JsonDeserializationContext context)
       throws JsonParseException {

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -117,10 +117,7 @@ public class Subscription extends APIResource implements MetadataStore<Subscript
   }
 
   public String getCustomer() {
-    if (this.customer == null) {
-      return null;
-    }
-    return this.customer.getId();
+    return (this.customer != null) ? this.customer.getId() : null;
   }
 
   public void setCustomer(String customerID) {
@@ -128,10 +125,7 @@ public class Subscription extends APIResource implements MetadataStore<Subscript
   }
 
   public Customer getCustomerObject() {
-    if (this.customer == null) {
-      return null;
-    }
-    return this.customer.getExpanded();
+    return (this.customer != null) ? this.customer.getExpanded() : null;
   }
 
   public void setCustomerObject(Customer c) {
@@ -343,6 +337,11 @@ public class Subscription extends APIResource implements MetadataStore<Subscript
     deleteDiscount((RequestOptions) null);
   }
 
+  /**
+   * Deletes the subscription's discount.
+   *
+   * @deprecated Use {@link #deleteDiscount(RequestOptions)} instead.
+   */
   @Deprecated
   public void deleteDiscount(String apiKey) throws AuthenticationException,
       InvalidRequestException, APIConnectionException, CardException,

--- a/src/main/java/com/stripe/model/Topup.java
+++ b/src/main/java/com/stripe/model/Topup.java
@@ -53,10 +53,7 @@ public class Topup extends APIResource implements MetadataStore<Topup>, HasId {
   }
 
   public String getBalanceTransaction() {
-    if (this.balanceTransaction == null) {
-      return null;
-    }
-    return this.balanceTransaction.getId();
+    return (this.balanceTransaction != null) ? this.balanceTransaction.getId() : null;
   }
 
   public void setBalanceTransaction(String balanceTransactionID) {
@@ -64,10 +61,7 @@ public class Topup extends APIResource implements MetadataStore<Topup>, HasId {
   }
 
   public BalanceTransaction getBalanceTransactionObject() {
-    if (this.balanceTransaction == null) {
-      return null;
-    }
-    return this.balanceTransaction.getExpanded();
+    return (this.balanceTransaction != null) ? this.balanceTransaction.getExpanded() : null;
   }
 
   public void setBalanceTransactionObject(BalanceTransaction c) {

--- a/src/main/java/com/stripe/model/Transfer.java
+++ b/src/main/java/com/stripe/model/Transfer.java
@@ -92,10 +92,7 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
   }
 
   public String getBalanceTransaction() {
-    if (this.balanceTransaction == null) {
-      return null;
-    }
-    return this.balanceTransaction.getId();
+    return (this.balanceTransaction != null) ? this.balanceTransaction.getId() : null;
   }
 
   public void setBalanceTransaction(String balanceTransactionID) {
@@ -103,10 +100,7 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
   }
 
   public BalanceTransaction getBalanceTransactionObject() {
-    if (this.balanceTransaction == null) {
-      return null;
-    }
-    return this.balanceTransaction.getExpanded();
+    return (this.balanceTransaction != null) ? this.balanceTransaction.getExpanded() : null;
   }
 
   public void setBalanceTransactionObject(BalanceTransaction c) {
@@ -158,10 +152,7 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
   }
 
   public String getDestination() {
-    if (this.destination == null) {
-      return null;
-    }
-    return this.destination.getId();
+    return (this.destination != null) ? this.destination.getId() : null;
   }
 
   public void setDestination(String destinationID) {
@@ -169,10 +160,7 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
   }
 
   public Account getDestinationObject() {
-    if (this.destination == null) {
-      return null;
-    }
-    return this.destination.getExpanded();
+    return (this.destination != null) ? this.destination.getExpanded() : null;
   }
 
   public void setDestinationObject(Account c) {
@@ -180,22 +168,15 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
   }
 
   public String getDestinationPayment() {
-    if (this.destinationPayment == null) {
-      return null;
-    }
-    return this.destinationPayment.getId();
+    return (this.destinationPayment != null) ? this.destinationPayment.getId() : null;
   }
 
   public void setDestinationPayment(String destinationPaymentID) {
     this.destinationPayment = setExpandableFieldID(destinationPaymentID, this.destinationPayment);
-
   }
 
   public Charge getDestinationPaymentObject() {
-    if (this.destinationPayment == null) {
-      return null;
-    }
-    return this.destinationPayment.getExpanded();
+    return (this.destinationPayment != null) ? this.destinationPayment.getExpanded() : null;
   }
 
   public void setDestinationPaymentObject(Charge destinationPayment) {
@@ -239,6 +220,11 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
     this.metadata = metadata;
   }
 
+  /**
+   * Returns the {@code reversals} list.
+   *
+   * @return the {@code reversals} list
+   */
   public TransferReversalCollection getReversals() {
     if (reversals.getURL() == null) {
       reversals.setURL(String.format("/v1/transfers/%s/reversals", getId()));
@@ -255,10 +241,7 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
   }
 
   public String getSourceTransaction() {
-    if (this.sourceTransaction == null) {
-      return null;
-    }
-    return this.sourceTransaction.getId();
+    return (this.sourceTransaction != null) ? this.sourceTransaction.getId() : null;
   }
 
   public void setSourceTransaction(String sourceTransactionID) {
@@ -267,10 +250,7 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
   }
 
   public Charge getSourceTransactionObject() {
-    if (this.sourceTransaction == null) {
-      return null;
-    }
-    return this.sourceTransaction.getExpanded();
+    return (this.sourceTransaction != null) ? this.sourceTransaction.getExpanded() : null;
   }
 
   public void setSourceTransactionObject(Charge sourceTransaction) {
@@ -323,32 +303,34 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
   }
 
   /**
-   * @deprecated Use `bank_account` field (https://stripe.com/docs/upgrades#2014-05-19)
+   * Returns the {@code account} attribute.
+   *
+   * @return the {@code account} attribute
+   * @deprecated Prefer using the {@code bank_account} attribute instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2014-05-19">API version 2014-05-19</a>
    */
   @Deprecated
   public BankAccount getAccount() {
     return account;
   }
 
-  /**
-   * @deprecated Use `bank_account` field (https://stripe.com/docs/upgrades#2014-05-19)
-   */
   @Deprecated
   public void setAccount(BankAccount account) {
     this.account = account;
   }
 
   /**
-   * @deprecated Use the balance history endpoint (https://stripe.com/docs/upgrades#2014-08-04)
+   * Returns the {@code other_transfers} attribute.
+   *
+   * @return the {@code other_transfers} attribute
+   * @deprecated Prefer using the {@link BalanceTransaction#list} method instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2014-08-04">API version 2014-08-04</a>
    */
   @Deprecated
   public List<String> getOtherTransfers() {
     return otherTransfers;
   }
 
-  /**
-   * @deprecated Use the balance history endpoint (https://stripe.com/docs/upgrades#2014-08-04)
-   */
   @Deprecated
   public void setOtherTransfers(List<String> otherTransfers) {
     this.otherTransfers = otherTransfers;
@@ -365,32 +347,34 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
   }
 
   /**
-   * @deprecated Use `statement_descriptor` field (https://stripe.com/docs/upgrades#2014-12-17)
+   * Returns the {@code statement_description} attribute.
+   *
+   * @return the {@code statement_description} attribute
+   * @deprecated Prefer using the {@code statement_descriptor} attribute instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2014-12-17">API version 2014-12-17</a>
    */
   @Deprecated
   public String getStatementDescription() {
     return statementDescription;
   }
 
-  /**
-   * @deprecated Use `statement_descriptor` field (https://stripe.com/docs/upgrades#2014-12-17)
-   */
   @Deprecated
   public void setStatementDescription(String statementDescription) {
     this.statementDescription = statementDescription;
   }
 
   /**
-   * @deprecated Use the balance history endpoint (https://stripe.com/docs/upgrades#2014-08-04)
+   * Returns the {@code summary} attribute.
+   *
+   * @return the {@code summary} attribute
+   * @deprecated Prefer using the {@link BalanceTransaction#list} method instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2014-08-04">API version 2014-08-04</a>
    */
   @Deprecated
   public Summary getSummary() {
     return summary;
   }
 
-  /**
-   * @deprecated Use the balance history endpoint (https://stripe.com/docs/upgrades#2014-08-04)
-   */
   @Deprecated
   public void setSummary(Summary summary) {
     this.summary = summary;
@@ -443,7 +427,10 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
   }
 
   /**
-   * @deprecated Use Transfer.getReversals().create() instead of Transfer.cancel().
+   * Returns the {@code summary} attribute.
+   *
+   * @return the {@code summary} attribute
+   * @deprecated Prefer using the {@code transfers.getReversals().create(params)} method instead.
    */
   @Deprecated
   public Transfer cancel()

--- a/src/main/java/com/stripe/model/TransferReversalCollection.java
+++ b/src/main/java/com/stripe/model/TransferReversalCollection.java
@@ -71,9 +71,7 @@ public class TransferReversalCollection extends StripeCollection<Reversal> {
                RequestOptions options) throws AuthenticationException,
       InvalidRequestException, APIConnectionException, CardException,
       APIException {
-    String url = String.format("%s%s", Stripe.getApiBase(), this.getURL());
-    return APIResource.request(APIResource.RequestMethod.POST, url, params, Reversal.class,
-        options);
+    return APIResource.request(APIResource.RequestMethod.POST, String.format("%s%s",
+        Stripe.getApiBase(), this.getURL()), params, Reversal.class, options);
   }
 }
-

--- a/src/main/java/com/stripe/net/APIResource.java
+++ b/src/main/java/com/stripe/net/APIResource.java
@@ -145,6 +145,9 @@ public abstract class APIResource extends StripeObject {
     NORMAL, MULTIPART
   }
 
+  /**
+   * URL-encodes a string.
+   */
   public static String urlEncode(String str) throws UnsupportedEncodingException {
     // Preserve original behavior that passing null for an object id will lead
     // to us actually making a request to /v1/foo/null
@@ -181,7 +184,7 @@ public abstract class APIResource extends StripeObject {
   /**
    * Similar to #request, but specific for use with collection types that
    * come from the API (i.e. lists of resources).
-   * 
+   *
    * <p>Collections need a little extra work because we need to plumb request
    * options and params through so that we can iterate to the next page if
    * necessary.

--- a/src/main/java/com/stripe/net/MultipartProcessor.java
+++ b/src/main/java/com/stripe/net/MultipartProcessor.java
@@ -17,12 +17,20 @@ public class MultipartProcessor {
   private String charset;
   private java.net.HttpURLConnection conn;
 
+  /**
+   * Generates a random MIME multipart boundary.
+   *
+   * @return boundary value
+   */
   public static String getBoundary() {
     Random random = new Random();
     Long positiveRandomLong = Math.abs(random.nextLong());
     return String.valueOf(positiveRandomLong);
   }
 
+  /**
+   * Constructs a new multipart body builder.
+   */
   public MultipartProcessor(java.net.HttpURLConnection conn, String boundary, String charset)
       throws IOException {
     this.boundary = boundary;
@@ -30,10 +38,15 @@ public class MultipartProcessor {
     this.conn = conn;
 
     this.outputStream = conn.getOutputStream();
-    this.writer = new PrintWriter(new OutputStreamWriter(outputStream,
-        charset), true);
+    this.writer = new PrintWriter(new OutputStreamWriter(outputStream, charset), true);
   }
 
+  /**
+   * Adds a form field to the multipart message.
+   *
+   * @param name field name
+   * @param value field value
+   */
   public void addFormField(String name, String value) {
     writer.append("--" + boundary).append(LINE_BREAK);
     writer.append("Content-Disposition: form-data; name=\"" + name + "\"")
@@ -43,6 +56,12 @@ public class MultipartProcessor {
     writer.flush();
   }
 
+  /**
+   * Adds a file field to the multipart message.
+   *
+   * @param name field name
+   * @param file File instance
+   */
   public void addFileField(String name, File file) throws IOException {
     String fileName = file.getName();
     writer.append("--" + boundary).append(LINE_BREAK);
@@ -51,10 +70,8 @@ public class MultipartProcessor {
             + "\"; filename=\"" + fileName + "\"").append(
         LINE_BREAK);
 
-    String probableContentType = URLConnection
-        .guessContentTypeFromName(fileName);
-    writer.append("Content-Type: " + probableContentType)
-        .append(LINE_BREAK);
+    String probableContentType = URLConnection.guessContentTypeFromName(fileName);
+    writer.append("Content-Type: " + probableContentType).append(LINE_BREAK);
     writer.append("Content-Transfer-Encoding: binary").append(LINE_BREAK);
     writer.append(LINE_BREAK);
     writer.flush();
@@ -75,6 +92,9 @@ public class MultipartProcessor {
     writer.flush();
   }
 
+  /**
+   * Adds the final boundary to the multipart message and closes streams.
+   */
   public void finish() throws IOException {
     writer.append("--" + boundary + "--").append(LINE_BREAK);
     writer.flush();
@@ -82,5 +102,4 @@ public class MultipartProcessor {
     outputStream.flush();
     outputStream.close();
   }
-
 }

--- a/src/main/java/com/stripe/net/RequestOptions.java
+++ b/src/main/java/com/stripe/net/RequestOptions.java
@@ -117,6 +117,10 @@ public class RequestOptions {
     private int connectTimeout;
     private int readTimeout;
 
+    /**
+     * Constructs a request options builder with the global parameters (API key, client ID and
+     * API version) as default values.
+     */
     public RequestOptionsBuilder() {
       this.apiKey = Stripe.apiKey;
       this.clientId = Stripe.clientId;
@@ -178,7 +182,7 @@ public class RequestOptions {
     /**
      * Sets the timeout value that will be used when reading data from an
      * established connection to the Stripe API (in milliseconds).
-     * 
+     *
      * <p>Note that this value should be set conservatively because some API
      * requests can take time and a short timeout increases the likelihood
      * of causing a problem in the backend.
@@ -212,6 +216,9 @@ public class RequestOptions {
       return setStripeAccount(null);
     }
 
+    /**
+     * Constructs a {@link RequestOptions} with the specified values.
+     */
     public RequestOptions build() {
       return new RequestOptions(
           normalizeApiKey(this.apiKey),

--- a/src/main/java/com/stripe/net/StripeResponse.java
+++ b/src/main/java/com/stripe/net/StripeResponse.java
@@ -9,12 +9,18 @@ public class StripeResponse {
   String body;
   StripeHeaders headers;
 
+  /**
+   * Constructs a Stripe response with the specified status code and body.
+   */
   public StripeResponse(int code, String body) {
     this.code = code;
     this.body = body;
     this.headers = null;
   }
 
+  /**
+   * Constructs a Stripe response with the specified status code, body and headers.
+   */
   public StripeResponse(int code, String body, Map<String, List<String>> headers) {
     this.code = code;
     this.body = body;
@@ -34,16 +40,10 @@ public class StripeResponse {
   }
 
   public String idempotencyKey() {
-    if (headers == null) {
-      return null;
-    }
-    return headers.get("Idempotency-Key");
+    return (headers != null) ? headers.get("Idempotency-Key") : null;
   }
 
   public String requestId() {
-    if (headers == null) {
-      return null;
-    }
-    return headers.get("Request-Id");
+    return (headers != null) ? headers.get("Request-Id") : null;
   }
 }

--- a/src/main/java/com/stripe/net/StripeSSLSocketFactory.java
+++ b/src/main/java/com/stripe/net/StripeSSLSocketFactory.java
@@ -23,6 +23,9 @@ public class StripeSSLSocketFactory extends SSLSocketFactory {
   private static final String TLSv11Proto = "TLSv1.1";
   private static final String TLSv12Proto = "TLSv1.2";
 
+  /**
+   * Constructs a new SSL socket factory.
+   */
   public StripeSSLSocketFactory() {
     this.under = HttpsURLConnection.getDefaultSSLSocketFactory();
 

--- a/src/test/java/com/stripe/BaseStripeFunctionalTest.java
+++ b/src/test/java/com/stripe/BaseStripeFunctionalTest.java
@@ -36,7 +36,9 @@ public class BaseStripeFunctionalTest {
   public static RequestOptions supportedRequestOptions;
   public static StripeResponseGetter networkMock;
 
-
+  /**
+   * Returns a string containing next year.
+   */
   public static String getYear() {
     Date date = new Date(); //Get current date
     Calendar calendar = new GregorianCalendar();
@@ -56,6 +58,9 @@ public class BaseStripeFunctionalTest {
     return String.format("MY-J-COUPON-%s", UUID.randomUUID().toString().substring(24));
   }
 
+  /**
+   * Returns the parameters to create a new unique plan.
+   */
   public static Map<String, Object> getUniquePlanParams() {
     Map<String, Object> uniqueParams = new HashMap<String, Object>();
     uniqueParams.putAll(defaultPlanParams);
@@ -63,6 +68,9 @@ public class BaseStripeFunctionalTest {
     return uniqueParams;
   }
 
+  /**
+   * Creates a new customer object with a subscription to the given plan.
+   */
   public static Customer createDefaultCustomerWithPlan(Plan plan)
       throws StripeException {
     Map<String, Object> customerWithPlanParams = new HashMap<String, Object>();
@@ -71,6 +79,9 @@ public class BaseStripeFunctionalTest {
     return Customer.create(customerWithPlanParams);
   }
 
+  /**
+   * Prepares a Stripe functional test: sets the API key and version, sets default params fixtures.
+   */
   @BeforeClass
   public static void setUp() {
     Stripe.apiKey = "tGN0bIwXnHdwOa85VABjPdSn8nWY7G7I"; // stripe public
@@ -133,7 +144,7 @@ public class BaseStripeFunctionalTest {
     Stripe.apiVersion = null;
   }
 
-  public void testMetadata(MetadataStore<?> object) throws StripeException {
+  protected void testMetadata(MetadataStore<?> object) throws StripeException {
     assertTrue(object.getMetadata().isEmpty());
 
     Map<String, String> initialMetadata = new HashMap<String, String>();

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -122,6 +122,9 @@ public class BaseStripeTest {
         APIResource.RequestType.NORMAL, RequestOptions.getDefault());
   }
 
+  /**
+   * Verifies that the specified request occurred.
+   */
   public static <T> void verifyRequest(
       APIResource.RequestMethod method,
       Class<T> clazz,
@@ -138,6 +141,9 @@ public class BaseStripeTest {
         argThat(new RequestOptionsMatcher(options)));
   }
 
+  /**
+   * Stubs the next API request and return the provided response.
+   */
   public static <T> void stubNetwork(Class<T> clazz, String response) throws StripeException {
     when(networkMock.request(
         Mockito.any(APIResource.RequestMethod.class),
@@ -148,6 +154,9 @@ public class BaseStripeTest {
         Mockito.<RequestOptions>any())).thenReturn(APIResource.GSON.fromJson(response, clazz));
   }
 
+  /**
+   * Stubs the next OAuth request and return the provided response.
+   */
   public static <T> void stubOAuth(Class<T> clazz, String response) throws StripeException {
     when(networkMock.oauthRequest(
         Mockito.any(APIResource.RequestMethod.class),
@@ -165,8 +174,11 @@ public class BaseStripeTest {
       this.other = other;
     }
 
-    /* Treat null references as equal to empty maps */
+    /**
+     * Informs if this matcher accepts the given argument.
+     */
     public boolean matches(Map<String,Object> paramMap) {
+      // Treat null references as equal to empty maps
       if (paramMap == null) {
         return this.other == null || this.other.isEmpty();
       } else {
@@ -186,8 +198,11 @@ public class BaseStripeTest {
       this.other = other;
     }
 
-    /* Treat null reference as RequestOptions.getDefault() */
+    /**
+     * Informs if this matcher accepts the given argument.
+     */
     public boolean matches(RequestOptions requestOptions) {
+      // Treat null reference as RequestOptions.getDefault()
       RequestOptions defaultOptions = RequestOptions.getDefault();
       if (requestOptions == null) {
         return this.other == null || this.other.equals(defaultOptions);

--- a/src/test/java/com/stripe/model/ChargeOutcomeTest.java
+++ b/src/test/java/com/stripe/model/ChargeOutcomeTest.java
@@ -25,6 +25,7 @@ public class ChargeOutcomeTest extends BaseStripeTest {
     assertEquals("authorized", outcome.getType());
   }
 
+  @Test
   public void testDeserializeWithRule() throws StripeException, IOException {
     String json = resource("charge_outcome_expansions.json");
     ChargeOutcome outcome = APIResource.GSON.fromJson(json, ChargeOutcome.class);

--- a/src/test/java/com/stripe/model/ChargeTest.java
+++ b/src/test/java/com/stripe/model/ChargeTest.java
@@ -15,6 +15,9 @@ public class ChargeTest extends BaseStripeTest {
   Charge basicCharge;
   Charge expandedCharge;
 
+  /**
+   * Sets the {@link Charge} fixtures.
+   */
   @Before
   public void deserializeCharges() throws IOException {
     String json = resource("charge.json");

--- a/src/test/java/com/stripe/model/InvoiceTest.java
+++ b/src/test/java/com/stripe/model/InvoiceTest.java
@@ -35,6 +35,9 @@ public class InvoiceTest extends BaseStripeTest {
     APIResource.setStripeResponseGetter(new LiveStripeResponseGetter());
   }
 
+  /**
+   * Sets the {@link Invoice} fixtures.
+   */
   @Before
   public void deserialize() throws IOException {
     String json = resource("invoice.json");

--- a/src/test/java/com/stripe/model/PagingIteratorTest.java
+++ b/src/test/java/com/stripe/model/PagingIteratorTest.java
@@ -65,6 +65,9 @@ public class PagingIteratorTest extends BaseStripeTest {
     APIResource.setStripeResponseGetter(new LiveStripeResponseGetter());
   }
 
+  /**
+   * Sets the mock page fixtures.
+   */
   @Before
   public void setUpMockPages() throws IOException, StripeException {
     final List<String> pages = new ArrayList<String>();

--- a/src/test/java/com/stripe/model/StandardizationTest.java
+++ b/src/test/java/com/stripe/model/StandardizationTest.java
@@ -24,27 +24,6 @@ import org.junit.Test;
  * Simple test to make sure stripe-java provides consistent bindings.
  */
 public class StandardizationTest {
-  public Collection<Class> getAllModels() throws IOException {
-    Class<Charge> chargeClass = Charge.class;
-    ClassPath classPath = ClassPath.from(chargeClass.getClassLoader());
-    ImmutableSet<ClassPath.ClassInfo> topLevelClasses
-        = classPath.getTopLevelClasses(chargeClass.getPackage().getName());
-    List<Class> classList = Lists.newArrayListWithExpectedSize(topLevelClasses.size());
-    for (ClassPath.ClassInfo classInfo : topLevelClasses) {
-      Class c = classInfo.load();
-      // Skip things that aren't APIResources
-      if (!APIResource.class.isAssignableFrom(c)) {
-        continue;
-      }
-      // Skip the APIResource itself
-      if (APIResource.class == c) {
-        continue;
-      }
-      classList.add(classInfo.load());
-    }
-    return classList;
-  }
-
   @Test
   public void allNonDeprecatedMethodsTakeOptions() throws IOException, NoSuchMethodException {
     for (Class model : getAllModels()) {
@@ -126,5 +105,26 @@ public class StandardizationTest {
             RequestOptions.class.isAssignableFrom(finalParamType));
       }
     }
+  }
+
+  private Collection<Class> getAllModels() throws IOException {
+    Class<Charge> chargeClass = Charge.class;
+    ClassPath classPath = ClassPath.from(chargeClass.getClassLoader());
+    ImmutableSet<ClassPath.ClassInfo> topLevelClasses
+        = classPath.getTopLevelClasses(chargeClass.getPackage().getName());
+    List<Class> classList = Lists.newArrayListWithExpectedSize(topLevelClasses.size());
+    for (ClassPath.ClassInfo classInfo : topLevelClasses) {
+      Class c = classInfo.load();
+      // Skip things that aren't APIResources
+      if (!APIResource.class.isAssignableFrom(c)) {
+        continue;
+      }
+      // Skip the APIResource itself
+      if (APIResource.class == c) {
+        continue;
+      }
+      classList.add(classInfo.load());
+    }
+    return classList;
   }
 }

--- a/src/test/java/com/stripe/net/WebhookTest.java
+++ b/src/test/java/com/stripe/net/WebhookTest.java
@@ -38,6 +38,12 @@ public class WebhookTest extends BaseStripeTest {
     return generateSigHeader(options);
   }
 
+  /**
+   * Generates a {@code Stripe-Signature} header.
+   *
+   * @param options Options map to override default values
+   * @return The contents of the generated header
+   */
   public String generateSigHeader(Map<String, Object> options) throws UnsupportedEncodingException,
       NoSuchAlgorithmException, InvalidKeyException {
     long timestamp = (options.get("timestamp") != null)


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Fixes the missing Javadoc linting issues.

The style rules requires that all public methods with a body longer than 2 lines have a Javadoc summary.

I fixed this in a few different ways:
- reworking bodies so that they're under 2 lines :P (mostly for the expandable field getters)
- changing the method visibilities (there were a few public methods that really should have been protected or private)
- occasionally, adding Javadoc :)

This PR brings the number of Checkstyle issues to zero! So once this is merged, we can start enforcing the rules as part of the build process.
