### PR TITLE
Fix net setter method name

### DIFF
--- a/src/main/java/com/stripe/model/Summary.java
+++ b/src/main/java/com/stripe/model/Summary.java
@@ -57,7 +57,7 @@ public class Summary extends StripeObject {
     return net;
   }
 
-  public void set(Long net) {
+  public void setNet(Long net) {
     this.net = net;
   }
 


### PR DESCRIPTION
cc @stripe/api-libraries 

Fixes the setter's name for `net` from `set` to `setNet`.
