### PR TITLE
Update Bouncy Castle to 1.59

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   # Work around missing crypto in openjdk7
   - |
     if [ "$TRAVIS_JDK_VERSION" == "openjdk7" ]; then
-      sudo wget "https://bouncycastle.org/download/bcprov-ext-jdk15on-158.jar" -O "${JAVA_HOME}/jre/lib/ext/bcprov-ext-jdk15on-158.jar"
+      sudo wget "https://bouncycastle.org/download/bcprov-jdk15on-159.jar" -O "${JAVA_HOME}/jre/lib/ext/bcprov-jdk15on-159.jar"
       sudo perl -pi.bak -e 's/^(security\.provider\.)([0-9]+)/$1.($2+1)/ge' /etc/java-7-openjdk/security/java.security
       echo "security.provider.1=org.bouncycastle.jce.provider.BouncyCastleProvider" | sudo tee -a /etc/java-7-openjdk/security/java.security
     fi


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Looks like the cert issues are fixed, so let's update the dependency!
