### PR TITLE
Implement Google's Error Prone in the build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ out/*
 # compiler output
 bin/
 
+/.gradle/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ addons:
   hostname: short-hostname
 
 jdk:
-  - openjdk7
   - openjdk8
   - oraclejdk8
   - oraclejdk9

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ plugins {
     id 'net.saliman.cobertura' version '2.5.2'
     id 'com.github.kt3k.coveralls' version '2.8.2'
     id 'osgi'
+    id 'net.ltgt.errorprone' version '0.0.13'   
 }
 
 sourceCompatibility = 1.7
@@ -41,6 +42,7 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version:'4.12'
     testCompile group: 'org.mockito', name: 'mockito-core', version:'2.12.0'
     testRuntime group: 'org.slf4j', name: 'slf4j-api', version: '1.7.10'
+    errorprone 'com.google.errorprone:error_prone_core:2.2.0'
 }
 
 jar {

--- a/formatters/eclipse-java-stripe.xml
+++ b/formatters/eclipse-java-stripe.xml
@@ -1,0 +1,315 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="13">
+<profile kind="CodeFormatterProfile" name="Stripe" version="13">
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_annotation_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_for_statment" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_invocation" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_switch_statement" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_enum_constant_declaration" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_anonymous_type_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
+<setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_binary_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_if_while_statement" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_before_or_operator_multicatch" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="@formatter:on"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.count_line_length_from_starting_position" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameterized_type_references" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_enum_constant" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column" value="false"/>
+<setting id="org.eclipse.jdt.core.compiler.problem.enumIdentifier" value="error"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="100"/>
+<setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_union_type_in_multicatch" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_catch_clause" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_lambda_body" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.compact_else_if" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_type_parameters" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.compiler.problem.assertIdentifier" value="error"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_try" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_binary_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="3"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_annotation" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_try_resources" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_module_statements" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_method_body" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="80"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
+<setting id="org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode" value="enabled"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_before_conditional_operator" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.align_fields_grouping_blank_lines" value="2147483647"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80"/>
+<setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_try_clause" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
+<setting id="org.eclipse.jdt.core.compiler.source" value="9"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_try" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_try_resources" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_before_assignment_operator" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="9"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_type_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_delcaration" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_type_arguments" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_label" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_try" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_lambda_arrow" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_before_binary_operator" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.compiler.compliance" value="9"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_lambda_declaration" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_for_loop_header" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_lambda_arrow" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.lineSplit" value="100"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
+</profile>
+</profiles>

--- a/src/main/java/com/stripe/Stripe.java
+++ b/src/main/java/com/stripe/Stripe.java
@@ -2,13 +2,15 @@ package com.stripe;
 
 import java.net.PasswordAuthentication;
 import java.net.Proxy;
-
+import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 
 public abstract class Stripe {
   private static final int DEFAULT_CONNECT_TIMEOUT = 30 * 1000;
   private static final int DEFAULT_READ_TIMEOUT = 80 * 1000;
+  
+  public static final Charset UTF_8 = Charset.forName("UTF-8");
 
   public static final String UPLOAD_API_BASE = "https://uploads.stripe.com";
   public static final String LIVE_API_BASE = "https://api.stripe.com";

--- a/src/main/java/com/stripe/exception/RateLimitException.java
+++ b/src/main/java/com/stripe/exception/RateLimitException.java
@@ -12,11 +12,11 @@ public class RateLimitException extends InvalidRequestException {
   // TODO: remove this constructor in next major version bump
   public RateLimitException(String message, String param, String requestId, Integer statusCode,
       Throwable e) {
-    this(message, param, null, requestId, statusCode, e);
+    this(message, param, requestId, null, statusCode, e);
   }
 
   public RateLimitException(String message, String param, String requestId, String code,
       Integer statusCode, Throwable e) {
-    super(message, param, code, requestId, statusCode, e);
+    super(message, param, requestId, code, statusCode, e);
   }
 }

--- a/src/main/java/com/stripe/exception/StripeException.java
+++ b/src/main/java/com/stripe/exception/StripeException.java
@@ -62,6 +62,7 @@ public abstract class StripeException extends Exception {
    *
    * @return a string representation of the exception.
    */
+  @Override
   public String toString() {
     String additionalInfo = "";
     if (code != null) {

--- a/src/main/java/com/stripe/model/Account.java
+++ b/src/main/java/com/stripe/model/Account.java
@@ -53,6 +53,7 @@ public class Account extends APIResource implements HasId, MetadataStore<Account
   @Deprecated
   List<String> currenciesSupported;
 
+  @Override
   public String getId() {
     return id;
   }
@@ -153,6 +154,7 @@ public class Account extends APIResource implements HasId, MetadataStore<Account
     return managed;
   }
 
+  @Override
   public Map<String, String> getMetadata() {
     return metadata;
   }
@@ -326,12 +328,14 @@ public class Account extends APIResource implements HasId, MetadataStore<Account
         options);
   }
 
+  @Override
   public Account update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
     return update(params, null);
   }
 
+  @Override
   public Account update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
@@ -399,6 +403,11 @@ public class Account extends APIResource implements HasId, MetadataStore<Account
       return fieldsNeeded;
     }
 
+    @Override
+    public int hashCode() {
+      return 42;
+    }
+    
     @Override
     public boolean equals(Object o) {
       if (this == o) {

--- a/src/main/java/com/stripe/model/AccountPayoutSchedule.java
+++ b/src/main/java/com/stripe/model/AccountPayoutSchedule.java
@@ -39,6 +39,11 @@ public class AccountPayoutSchedule extends StripeObject {
   }
 
   @Override
+  public int hashCode() {
+    return 42;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;
@@ -48,8 +53,7 @@ public class AccountPayoutSchedule extends StripeObject {
     }
 
     AccountPayoutSchedule schedule = (AccountPayoutSchedule) o;
-    return equals(delayDays, schedule.delayDays)
-        && equals(interval, schedule.interval)
+    return equals(delayDays, schedule.delayDays) && equals(interval, schedule.interval)
         && equals(monthlyAnchor, schedule.monthlyAnchor)
         && equals(weeklyAnchor, schedule.weeklyAnchor);
   }

--- a/src/main/java/com/stripe/model/AlipayAccount.java
+++ b/src/main/java/com/stripe/model/AlipayAccount.java
@@ -92,24 +92,28 @@ public class AlipayAccount extends ExternalAccount {
     this.status = status;
   }
 
+  @Override
   public AlipayAccount update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
     return update(params, null);
   }
 
+  @Override
   public AlipayAccount update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
     return request(RequestMethod.POST, this.getInstanceURL(), params, AlipayAccount.class, options);
   }
 
+  @Override
   public DeletedAlipayAccount delete() throws AuthenticationException,
       InvalidRequestException, APIConnectionException, CardException,
       APIException {
     return delete(null);
   }
 
+  @Override
   public DeletedAlipayAccount delete(RequestOptions options) throws AuthenticationException,
       InvalidRequestException, APIConnectionException, CardException,
       APIException {

--- a/src/main/java/com/stripe/model/ApplePayDomain.java
+++ b/src/main/java/com/stripe/model/ApplePayDomain.java
@@ -18,6 +18,7 @@ public class ApplePayDomain extends APIResource implements HasId {
   String domainName;
   Boolean livemode;
 
+  @Override
   public String getId() {
     return id;
   }

--- a/src/main/java/com/stripe/model/Application.java
+++ b/src/main/java/com/stripe/model/Application.java
@@ -4,6 +4,7 @@ public class Application extends StripeObject implements HasId {
   String id;
   String name;
 
+  @Override
   public String getId() {
     return id;
   }

--- a/src/main/java/com/stripe/model/ApplicationFee.java
+++ b/src/main/java/com/stripe/model/ApplicationFee.java
@@ -29,6 +29,7 @@ public class ApplicationFee extends APIResource implements HasId {
   @Deprecated
   String user;
 
+  @Override
   public String getId() {
     return id;
   }

--- a/src/main/java/com/stripe/model/BalanceTransaction.java
+++ b/src/main/java/com/stripe/model/BalanceTransaction.java
@@ -8,7 +8,6 @@ import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
 import com.stripe.net.APIResource;
 import com.stripe.net.RequestOptions;
-
 import java.util.List;
 import java.util.Map;
 
@@ -30,6 +29,7 @@ public class BalanceTransaction extends APIResource implements HasId {
   @Deprecated
   TransferCollection sourcedTransfers;
 
+  @Override
   public String getId() {
     return id;
   }
@@ -142,8 +142,8 @@ public class BalanceTransaction extends APIResource implements HasId {
     this.source = new ExpandableField<HasId>(o.getId(), o);
   }
 
-  public <O extends HasId> O getSourceObjectAs() {
-    return (this.source != null) ? (O) this.source.getExpanded() : null;
+  public HasId getSourceObjectAs() {
+    return (this.source != null) ? this.source.getExpanded() : null;
   }
 
   /**
@@ -163,34 +163,32 @@ public class BalanceTransaction extends APIResource implements HasId {
   }
 
   public static BalanceTransaction retrieve(String id) throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
+      InvalidRequestException, APIConnectionException, CardException, APIException {
     return retrieve(id, (RequestOptions) null);
   }
 
   @Deprecated
   public static BalanceTransaction retrieve(String id, String apiKey)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
+      throws AuthenticationException, InvalidRequestException, APIConnectionException,
+      CardException, APIException {
     return retrieve(id, RequestOptions.builder().setApiKey(apiKey).build());
   }
 
   public static BalanceTransaction retrieve(String id, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
+      throws AuthenticationException, InvalidRequestException, APIConnectionException,
+      CardException, APIException {
     String url = String.format("%s/%s/%s", Stripe.getApiBase(), "v1/balance/history", id);
     return request(RequestMethod.GET, url, null, BalanceTransaction.class, options);
   }
 
   public static BalanceTransactionCollection list(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
+      throws AuthenticationException, InvalidRequestException, APIConnectionException,
+      CardException, APIException {
     return list(params, null);
   }
 
   public static BalanceTransactionCollection list(Map<String, Object> params,
-      RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
+      RequestOptions options) throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
     String url = String.format("%s/%s", Stripe.getApiBase(), "v1/balance/history");
     return requestCollection(url, params, BalanceTransactionCollection.class, options);
@@ -198,22 +196,22 @@ public class BalanceTransaction extends APIResource implements HasId {
 
   @Deprecated
   public static BalanceTransactionCollection all(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
+      throws AuthenticationException, InvalidRequestException, APIConnectionException,
+      CardException, APIException {
     return list(params, null);
   }
 
   @Deprecated
   public static BalanceTransactionCollection all(Map<String, Object> params, String apiKey)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
+      throws AuthenticationException, InvalidRequestException, APIConnectionException,
+      CardException, APIException {
     return list(params, RequestOptions.builder().setApiKey(apiKey).build());
   }
 
   @Deprecated
   public static BalanceTransactionCollection all(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
+      throws AuthenticationException, InvalidRequestException, APIConnectionException,
+      CardException, APIException {
     return list(params, options);
   }
 

--- a/src/main/java/com/stripe/model/BankAccount.java
+++ b/src/main/java/com/stripe/model/BankAccount.java
@@ -110,24 +110,28 @@ public class BankAccount extends ExternalAccount {
     this.validated = validated;
   }
 
+  @Override
   public BankAccount update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException, APIConnectionException,
       CardException, APIException {
     return update(params, null);
   }
 
+  @Override
   public BankAccount update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException, APIConnectionException,
       CardException, APIException {
     return request(RequestMethod.POST, this.getInstanceURL(), params, BankAccount.class, options);
   }
 
+  @Override
   public DeletedBankAccount delete()
       throws AuthenticationException, InvalidRequestException, APIConnectionException,
       CardException, APIException {
     return delete(null);
   }
 
+  @Override
   public DeletedBankAccount delete(RequestOptions options)
       throws AuthenticationException, InvalidRequestException, APIConnectionException,
       CardException, APIException {

--- a/src/main/java/com/stripe/model/BitcoinTransaction.java
+++ b/src/main/java/com/stripe/model/BitcoinTransaction.java
@@ -11,6 +11,7 @@ public class BitcoinTransaction extends APIResource implements HasId {
   String customer;
   String receiver;
 
+  @Override
   public String getId() {
     return id;
   }

--- a/src/main/java/com/stripe/model/Card.java
+++ b/src/main/java/com/stripe/model/Card.java
@@ -287,6 +287,7 @@ public class Card extends ExternalAccount {
     this.type = type;
   }
 
+  @Override
   public Card update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
@@ -300,12 +301,14 @@ public class Card extends ExternalAccount {
     return update(params, RequestOptions.builder().setApiKey(apiKey).build());
   }
 
+  @Override
   public Card update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
     return request(RequestMethod.POST, this.getInstanceURL(), params, Card.class, options);
   }
 
+  @Override
   public DeletedCard delete()
       throws AuthenticationException, InvalidRequestException, APIConnectionException,
       CardException, APIException {
@@ -319,6 +322,7 @@ public class Card extends ExternalAccount {
     return delete(RequestOptions.builder().setApiKey(apiKey).build());
   }
 
+  @Override
   public DeletedCard delete(RequestOptions options)
       throws AuthenticationException, InvalidRequestException, APIConnectionException,
       CardException, APIException {

--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -58,6 +58,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   @Deprecated
   String statementDescription;
 
+  @Override
   public String getId() {
     return id;
   }
@@ -276,6 +277,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
     this.livemode = livemode;
   }
 
+  @Override
   public Map<String, String> getMetadata() {
     return metadata;
   }
@@ -537,6 +539,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
     return request(RequestMethod.GET, instanceURL(Charge.class, id), params, Charge.class, options);
   }
 
+  @Override
   public Charge update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
@@ -550,6 +553,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
     return update(params, RequestOptions.builder().setApiKey(apiKey).build());
   }
 
+  @Override
   public Charge update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/ChargeOutcomeRule.java
+++ b/src/main/java/com/stripe/model/ChargeOutcomeRule.java
@@ -9,6 +9,7 @@ public class ChargeOutcomeRule extends StripeObject implements HasId {
     return action;
   }
 
+  @Override
   public String getId() {
     return id;
   }

--- a/src/main/java/com/stripe/model/ChargeRefundCollectionDeserializer.java
+++ b/src/main/java/com/stripe/model/ChargeRefundCollectionDeserializer.java
@@ -20,6 +20,7 @@ public class ChargeRefundCollectionDeserializer
   /**
    * Deserializes a refund list JSON payload into a {@link ChargeRefundCollection} object.
    */
+  @Override
   public ChargeRefundCollection deserialize(JsonElement json, Type typeOfT,
       JsonDeserializationContext context)
       throws JsonParseException {

--- a/src/main/java/com/stripe/model/CountrySpec.java
+++ b/src/main/java/com/stripe/model/CountrySpec.java
@@ -20,6 +20,7 @@ public class CountrySpec extends APIResource implements HasId {
   List<String> supportedPaymentMethods;
   VerificationFields verificationFields;
 
+  @Override
   public String getId() {
     return id;
   }

--- a/src/main/java/com/stripe/model/Coupon.java
+++ b/src/main/java/com/stripe/model/Coupon.java
@@ -26,6 +26,7 @@ public class Coupon extends APIResource implements MetadataStore<Coupon>, HasId 
   Integer timesRedeemed;
   Boolean valid;
 
+  @Override
   public String getId() {
     return id;
   }
@@ -98,6 +99,7 @@ public class Coupon extends APIResource implements MetadataStore<Coupon>, HasId 
     this.maxRedemptions = maxRedemptions;
   }
 
+  @Override
   public Map<String, String> getMetadata() {
     return metadata;
   }
@@ -176,6 +178,7 @@ public class Coupon extends APIResource implements MetadataStore<Coupon>, HasId 
     return request(RequestMethod.GET, instanceURL(Coupon.class, id), null, Coupon.class, options);
   }
 
+  @Override
   public Coupon update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException, APIConnectionException,
       CardException, APIException {
@@ -189,6 +192,7 @@ public class Coupon extends APIResource implements MetadataStore<Coupon>, HasId 
     return update(params, RequestOptions.builder().setApiKey(apiKey).build());
   }
 
+  @Override
   public Coupon update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException, APIConnectionException,
       CardException, APIException {

--- a/src/main/java/com/stripe/model/Customer.java
+++ b/src/main/java/com/stripe/model/Customer.java
@@ -41,6 +41,7 @@ public class Customer extends APIResource implements MetadataStore<Customer>, Ha
   @Deprecated
   Long trialEnd;
 
+  @Override
   public String getId() {
     return id;
   }
@@ -149,6 +150,7 @@ public class Customer extends APIResource implements MetadataStore<Customer>, Ha
     this.livemode = livemode;
   }
 
+  @Override
   public Map<String, String> getMetadata() {
     return metadata;
   }
@@ -307,6 +309,7 @@ public class Customer extends APIResource implements MetadataStore<Customer>, Ha
         options);
   }
 
+  @Override
   public Customer update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
@@ -320,6 +323,7 @@ public class Customer extends APIResource implements MetadataStore<Customer>, Ha
     return update(params, RequestOptions.builder().setApiKey(apiKey).build());
   }
 
+  @Override
   public Customer update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/DeletedAccount.java
+++ b/src/main/java/com/stripe/model/DeletedAccount.java
@@ -5,18 +5,22 @@ public class DeletedAccount extends StripeObject implements DeletedStripeObject 
   String id;
   Boolean deleted;
 
+  @Override
   public String getId() {
     return id;
   }
 
+  @Override
   public void setId(String id) {
     this.id = id;
   }
 
+  @Override
   public Boolean getDeleted() {
     return deleted;
   }
 
+  @Override
   public void setDeleted(Boolean deleted) {
     this.deleted = deleted;
   }

--- a/src/main/java/com/stripe/model/DeletedApplePayDomain.java
+++ b/src/main/java/com/stripe/model/DeletedApplePayDomain.java
@@ -4,18 +4,22 @@ public class DeletedApplePayDomain extends StripeObject implements DeletedStripe
   String id;
   Boolean deleted;
 
+  @Override
   public String getId() {
     return id;
   }
 
+  @Override
   public void setId(String id) {
     this.id = id;
   }
 
+  @Override
   public Boolean getDeleted() {
     return deleted;
   }
 
+  @Override
   public void setDeleted(Boolean deleted) {
     this.deleted = deleted;
   }

--- a/src/main/java/com/stripe/model/DeletedCoupon.java
+++ b/src/main/java/com/stripe/model/DeletedCoupon.java
@@ -5,18 +5,22 @@ public class DeletedCoupon extends StripeObject implements DeletedStripeObject {
   String id;
   Boolean deleted;
 
+  @Override
   public String getId() {
     return id;
   }
 
+  @Override
   public void setId(String id) {
     this.id = id;
   }
 
+  @Override
   public Boolean getDeleted() {
     return deleted;
   }
 
+  @Override
   public void setDeleted(Boolean deleted) {
     this.deleted = deleted;
   }

--- a/src/main/java/com/stripe/model/DeletedCustomer.java
+++ b/src/main/java/com/stripe/model/DeletedCustomer.java
@@ -5,18 +5,22 @@ public class DeletedCustomer extends StripeObject implements DeletedStripeObject
   String id;
   Boolean deleted;
 
+  @Override
   public String getId() {
     return id;
   }
 
+  @Override
   public void setId(String id) {
     this.id = id;
   }
 
+  @Override
   public Boolean getDeleted() {
     return deleted;
   }
 
+  @Override
   public void setDeleted(Boolean deleted) {
     this.deleted = deleted;
   }

--- a/src/main/java/com/stripe/model/DeletedExternalAccount.java
+++ b/src/main/java/com/stripe/model/DeletedExternalAccount.java
@@ -5,18 +5,22 @@ public class DeletedExternalAccount extends StripeObject implements DeletedStrip
   String id;
   Boolean deleted;
 
+  @Override
   public String getId() {
     return id;
   }
 
+  @Override
   public void setId(String id) {
     this.id = id;
   }
 
+  @Override
   public Boolean getDeleted() {
     return deleted;
   }
 
+  @Override
   public void setDeleted(Boolean deleted) {
     this.deleted = deleted;
   }

--- a/src/main/java/com/stripe/model/DeletedInvoiceItem.java
+++ b/src/main/java/com/stripe/model/DeletedInvoiceItem.java
@@ -5,18 +5,22 @@ public class DeletedInvoiceItem extends StripeObject implements DeletedStripeObj
   String id;
   Boolean deleted;
 
+  @Override
   public String getId() {
     return id;
   }
 
+  @Override
   public void setId(String id) {
     this.id = id;
   }
 
+  @Override
   public Boolean getDeleted() {
     return deleted;
   }
 
+  @Override
   public void setDeleted(Boolean deleted) {
     this.deleted = deleted;
   }

--- a/src/main/java/com/stripe/model/DeletedPlan.java
+++ b/src/main/java/com/stripe/model/DeletedPlan.java
@@ -5,18 +5,22 @@ public class DeletedPlan extends StripeObject implements DeletedStripeObject {
   String id;
   Boolean deleted;
 
+  @Override
   public String getId() {
     return id;
   }
 
+  @Override
   public void setId(String id) {
     this.id = id;
   }
 
+  @Override
   public Boolean getDeleted() {
     return deleted;
   }
 
+  @Override
   public void setDeleted(Boolean deleted) {
     this.deleted = deleted;
   }

--- a/src/main/java/com/stripe/model/DeletedProduct.java
+++ b/src/main/java/com/stripe/model/DeletedProduct.java
@@ -5,18 +5,22 @@ public class DeletedProduct extends StripeObject implements DeletedStripeObject 
   String id;
   Boolean deleted;
 
+  @Override
   public String getId() {
     return id;
   }
 
+  @Override
   public void setId(String id) {
     this.id = id;
   }
-
+  
+  @Override
   public Boolean getDeleted() {
     return deleted;
   }
 
+  @Override
   public void setDeleted(Boolean deleted) {
     this.deleted = deleted;
   }

--- a/src/main/java/com/stripe/model/DeletedRecipient.java
+++ b/src/main/java/com/stripe/model/DeletedRecipient.java
@@ -5,18 +5,22 @@ public class DeletedRecipient extends StripeObject implements DeletedStripeObjec
   String id;
   Boolean deleted;
 
+  @Override
   public String getId() {
     return id;
   }
 
+  @Override
   public void setId(String id) {
     this.id = id;
   }
 
+  @Override
   public Boolean getDeleted() {
     return deleted;
   }
 
+  @Override
   public void setDeleted(Boolean deleted) {
     this.deleted = deleted;
   }

--- a/src/main/java/com/stripe/model/DeletedSKU.java
+++ b/src/main/java/com/stripe/model/DeletedSKU.java
@@ -5,18 +5,22 @@ public class DeletedSKU extends StripeObject implements DeletedStripeObject {
   String id;
   Boolean deleted;
 
+  @Override
   public String getId() {
     return id;
   }
 
+  @Override
   public void setId(String id) {
     this.id = id;
   }
 
+  @Override
   public Boolean getDeleted() {
     return deleted;
   }
 
+  @Override
   public void setDeleted(Boolean deleted) {
     this.deleted = deleted;
   }

--- a/src/main/java/com/stripe/model/DeletedSubscriptionItem.java
+++ b/src/main/java/com/stripe/model/DeletedSubscriptionItem.java
@@ -5,18 +5,22 @@ public class DeletedSubscriptionItem extends StripeObject implements DeletedStri
   String id;
   Boolean deleted;
 
+  @Override
   public String getId() {
     return id;
   }
 
+  @Override
   public void setId(String id) {
     this.id = id;
   }
 
+  @Override
   public Boolean getDeleted() {
     return deleted;
   }
 
+  @Override
   public void setDeleted(Boolean deleted) {
     this.deleted = deleted;
   }

--- a/src/main/java/com/stripe/model/Dispute.java
+++ b/src/main/java/com/stripe/model/Dispute.java
@@ -44,6 +44,7 @@ public class Dispute extends APIResource implements HasId {
   @Deprecated
   Long evidenceDueBy;
 
+  @Override
   public String getId() {
     return id;
   }

--- a/src/main/java/com/stripe/model/DisputeDataDeserializer.java
+++ b/src/main/java/com/stripe/model/DisputeDataDeserializer.java
@@ -16,6 +16,7 @@ public class DisputeDataDeserializer implements JsonDeserializer<Dispute> {
   /**
    * Deserializes a dispute JSON payload into a {@link Dispute} object.
    */
+  @Override
   public Dispute deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
       throws JsonParseException {
     Gson gson = new GsonBuilder()

--- a/src/main/java/com/stripe/model/EphemeralKey.java
+++ b/src/main/java/com/stripe/model/EphemeralKey.java
@@ -21,6 +21,7 @@ public class EphemeralKey extends APIResource implements HasId {
   List<EphemeralKeyAssociatedObject> associatedObjects;
   transient String rawJson;
 
+  @Override
   public String getId() {
     return id;
   }

--- a/src/main/java/com/stripe/model/EphemeralKeyAssociatedObject.java
+++ b/src/main/java/com/stripe/model/EphemeralKeyAssociatedObject.java
@@ -12,6 +12,7 @@ public class EphemeralKeyAssociatedObject extends StripeObject implements HasId 
     this.type = type;
   }
 
+  @Override
   public String getId() {
     return id;
   }

--- a/src/main/java/com/stripe/model/EphemeralKeyDeserializer.java
+++ b/src/main/java/com/stripe/model/EphemeralKeyDeserializer.java
@@ -14,6 +14,7 @@ public class EphemeralKeyDeserializer implements JsonDeserializer<EphemeralKey> 
   /**
    * Deserializes an ephemeral_key JSON payload into an {@link EphemeralKey} object.
    */
+  @Override
   public EphemeralKey deserialize(JsonElement json, Type typeOfT,
       JsonDeserializationContext context)
       throws JsonParseException {

--- a/src/main/java/com/stripe/model/Event.java
+++ b/src/main/java/com/stripe/model/Event.java
@@ -23,6 +23,7 @@ public class Event extends APIResource implements HasId {
   String type;
   String userId;
 
+  @Override
   public String getId() {
     return id;
   }

--- a/src/main/java/com/stripe/model/EventDataDeserializer.java
+++ b/src/main/java/com/stripe/model/EventDataDeserializer.java
@@ -117,6 +117,7 @@ public class EventDataDeserializer implements JsonDeserializer<EventData> {
    * Deserializes the JSON payload contained in an event's {@code data} attribute into an
    * {@link EventData} instance.
    */
+  @Override
   @SuppressWarnings("unchecked")
   public EventData deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
       throws JsonParseException {
@@ -136,8 +137,8 @@ public class EventDataDeserializer implements JsonDeserializer<EventData> {
       } else if ("object".equals(key)) {
         String type = element.getAsJsonObject().get("object").getAsString();
         Class<StripeObject> cl = objectMap.get(type);
-        StripeObject object = APIResource.GSON.fromJson(
-            entry.getValue(), cl != null ? cl : StripeRawJsonObject.class);
+        StripeObject object = APIResource.GSON.fromJson(entry.getValue(),
+            cl != null ? cl : StripeRawJsonObject.class);
         eventData.setObject(object);
       }
     }

--- a/src/main/java/com/stripe/model/EventRequestDeserializer.java
+++ b/src/main/java/com/stripe/model/EventRequestDeserializer.java
@@ -16,6 +16,7 @@ public class EventRequestDeserializer implements JsonDeserializer<EventRequest> 
    * Deserializes the JSON payload contained in an event's {@code request} attribute into an
    * {@link EventRequest} instance.
    */
+  @Override
   public EventRequest deserialize(JsonElement json, Type typeOfT,
       JsonDeserializationContext context)
       throws JsonParseException {

--- a/src/main/java/com/stripe/model/ExchangeRate.java
+++ b/src/main/java/com/stripe/model/ExchangeRate.java
@@ -15,6 +15,7 @@ public class ExchangeRate extends APIResource implements HasId {
   String object;
   Map<String, Float> rates;
 
+  @Override
   public String getId() {
     return id;
   }

--- a/src/main/java/com/stripe/model/ExpandableFieldDeserializer.java
+++ b/src/main/java/com/stripe/model/ExpandableFieldDeserializer.java
@@ -15,6 +15,7 @@ public class ExpandableFieldDeserializer implements JsonDeserializer<ExpandableF
    * Deserializes an expandable field JSON payload (i.e. either a string with just the ID, or a full
    * JSON object) into an {@link ExpandableField} object.
    */
+  @Override
   public ExpandableField deserialize(JsonElement json, Type typeOfT,
       JsonDeserializationContext context) throws JsonParseException {
     if (json.isJsonNull()) {

--- a/src/main/java/com/stripe/model/ExpandableFieldSerializer.java
+++ b/src/main/java/com/stripe/model/ExpandableFieldSerializer.java
@@ -11,6 +11,7 @@ public class ExpandableFieldSerializer implements JsonSerializer<ExpandableField
   /**
    * Serializes an expandable attribute into a JSON string.
    */
+  @Override
   public JsonElement serialize(ExpandableField src, Type typeOfSrc,
       JsonSerializationContext context) {
     if (src.isExpanded()) {

--- a/src/main/java/com/stripe/model/ExternalAccount.java
+++ b/src/main/java/com/stripe/model/ExternalAccount.java
@@ -17,6 +17,7 @@ public class ExternalAccount extends APIResource implements HasId, MetadataStore
   String customer;
   Map<String, String> metadata;
 
+  @Override
   public String getId() {
     return id;
   }
@@ -51,6 +52,7 @@ public class ExternalAccount extends APIResource implements HasId, MetadataStore
     this.customer = customer;
   }
 
+  @Override
   public Map<String, String> getMetadata() {
     return metadata;
   }
@@ -85,12 +87,14 @@ public class ExternalAccount extends APIResource implements HasId, MetadataStore
     }
   }
 
+  @Override
   public ExternalAccount update(Map<String, Object> params) throws
       AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
     return update(params, null);
   }
 
+  @Override
   public ExternalAccount update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/ExternalAccountTypeAdapterFactory.java
+++ b/src/main/java/com/stripe/model/ExternalAccountTypeAdapterFactory.java
@@ -16,6 +16,7 @@ public class ExternalAccountTypeAdapterFactory implements TypeAdapterFactory {
    * Creates the type adapter used to instantiate {@link ExternalAccount} subclasses from JSON
    * payloads.
    */
+  @Override
   public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
     if (!ExternalAccount.class.isAssignableFrom(type.getRawType())) {
       return null; // this class only serializes 'ExternalAccount' and its subtypes
@@ -38,11 +39,13 @@ public class ExternalAccountTypeAdapterFactory implements TypeAdapterFactory {
         = gson.getDelegateAdapter(this, TypeToken.get(Source.class));
 
     TypeAdapter<ExternalAccount> result = new TypeAdapter<ExternalAccount>() {
+      @Override
       public void write(JsonWriter out, ExternalAccount value) throws IOException {
         // TODO: check instance of for correct writer
         externalAccountAdapter.write(out, value);
       }
 
+      @Override
       public ExternalAccount read(JsonReader in) throws IOException {
         JsonObject object = elementAdapter.read(in).getAsJsonObject();
         String sourceObject = object.getAsJsonPrimitive(sourceObjectProp).getAsString();

--- a/src/main/java/com/stripe/model/FeeRefund.java
+++ b/src/main/java/com/stripe/model/FeeRefund.java
@@ -20,6 +20,7 @@ public class FeeRefund extends APIResource implements MetadataStore<ApplicationF
   ExpandableField<ApplicationFee> fee;
   Map<String, String> metadata;
 
+  @Override
   public String getId() {
     return id;
   }
@@ -88,6 +89,7 @@ public class FeeRefund extends APIResource implements MetadataStore<ApplicationF
     this.fee = new ExpandableField<ApplicationFee>(c.getId(), c);
   }
 
+  @Override
   public Map<String, String> getMetadata() {
     return metadata;
   }
@@ -96,6 +98,7 @@ public class FeeRefund extends APIResource implements MetadataStore<ApplicationF
     this.metadata = metadata;
   }
 
+  @Override
   public FeeRefund update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
@@ -109,6 +112,7 @@ public class FeeRefund extends APIResource implements MetadataStore<ApplicationF
     return update(params, RequestOptions.builder().setApiKey(apiKey).build());
   }
 
+  @Override
   public FeeRefund update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/FeeRefundCollectionDeserializer.java
+++ b/src/main/java/com/stripe/model/FeeRefundCollectionDeserializer.java
@@ -22,6 +22,7 @@ public class FeeRefundCollectionDeserializer implements JsonDeserializer<FeeRefu
   /**
    * Deserializes a fee_refund list JSON payload into a {@link FeeRefundCollection} object.
    */
+  @Override
   public FeeRefundCollection deserialize(JsonElement json, Type typeOfT,
       JsonDeserializationContext context)
       throws JsonParseException {

--- a/src/main/java/com/stripe/model/FileUpload.java
+++ b/src/main/java/com/stripe/model/FileUpload.java
@@ -20,6 +20,7 @@ public class FileUpload extends APIResource implements HasId {
   String type;
   String url;
 
+  @Override
   public String getId() {
     return id;
   }

--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -48,6 +48,7 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
   Long total;
   Long webhooksDeliveredAt;
 
+  @Override
   public String getId() {
     return id;
   }
@@ -212,6 +213,7 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
     this.livemode = livemode;
   }
 
+  @Override
   public Map<String, String> getMetadata() {
     return metadata;
   }
@@ -446,6 +448,7 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
         instanceURL(Invoice.class, this.getId())), params, Invoice.class, options);
   }
 
+  @Override
   public Invoice update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
@@ -459,6 +462,7 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
     return update(params, RequestOptions.builder().setApiKey(apiKey).build());
   }
 
+  @Override
   public Invoice update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/InvoiceItem.java
+++ b/src/main/java/com/stripe/model/InvoiceItem.java
@@ -28,6 +28,7 @@ public class InvoiceItem extends APIResource implements MetadataStore<InvoiceIte
   Integer quantity;
   ExpandableField<Subscription> subscription;
 
+  @Override
   public String getId() {
     return id;
   }
@@ -126,6 +127,7 @@ public class InvoiceItem extends APIResource implements MetadataStore<InvoiceIte
     this.livemode = livemode;
   }
 
+  @Override
   public Map<String, String> getMetadata() {
     return metadata;
   }
@@ -229,6 +231,7 @@ public class InvoiceItem extends APIResource implements MetadataStore<InvoiceIte
         options);
   }
 
+  @Override
   public InvoiceItem update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
@@ -242,6 +245,7 @@ public class InvoiceItem extends APIResource implements MetadataStore<InvoiceIte
     return update(params, RequestOptions.builder().setApiKey(apiKey).build());
   }
 
+  @Override
   public InvoiceItem update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/InvoiceLineItem.java
+++ b/src/main/java/com/stripe/model/InvoiceLineItem.java
@@ -18,6 +18,7 @@ public class InvoiceLineItem extends StripeObject implements HasId {
   String subscription;
   String type;
 
+  @Override
   public String getId() {
     return this.id;
   }

--- a/src/main/java/com/stripe/model/LegalEntity.java
+++ b/src/main/java/com/stripe/model/LegalEntity.java
@@ -3,6 +3,7 @@ package com.stripe.model;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.List;
+import java.util.Objects;
 
 public class LegalEntity extends StripeObject {
   List<Owner> additionalOwners;
@@ -80,6 +81,11 @@ public class LegalEntity extends StripeObject {
   }
 
   @Override
+  public int hashCode() {
+    return 42;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;
@@ -89,16 +95,12 @@ public class LegalEntity extends StripeObject {
     }
 
     LegalEntity le = (LegalEntity) o;
-    return equals(additionalOwners, le.additionalOwners)
-        && equals(address, le.address)
-        && equals(businessName, le.businessName)
-        && equals(dob, le.dob)
-        && equals(firstName, le.firstName)
-        && equals(lastName, le.lastName)
+    return equals(additionalOwners, le.additionalOwners) && equals(address, le.address)
+        && equals(businessName, le.businessName) && equals(dob, le.dob)
+        && equals(firstName, le.firstName) && equals(lastName, le.lastName)
         && equals(personalAddress, le.personalAddress)
         && equals(personalIdNumberProvided, le.personalIdNumberProvided)
-        && equals(ssnLast4Provided, le.ssnLast4Provided)
-        && equals(type, le.type)
+        && equals(ssnLast4Provided, le.ssnLast4Provided) && equals(type, le.type)
         && equals(verification, le.verification);
   }
 
@@ -120,6 +122,11 @@ public class LegalEntity extends StripeObject {
     }
 
     @Override
+    public int hashCode() {
+      return Objects.hash(day, month, year);
+    }
+
+    @Override
     public boolean equals(Object o) {
       if (this == o) {
         return true;
@@ -129,9 +136,7 @@ public class LegalEntity extends StripeObject {
       }
 
       DateOfBirth dob = (DateOfBirth) o;
-      return equals(day, dob.day)
-          && equals(month, dob.month)
-          && equals(year, dob.year);
+      return equals(day, dob.day) && equals(month, dob.month) && equals(year, dob.year);
     }
   }
 
@@ -158,6 +163,11 @@ public class LegalEntity extends StripeObject {
     }
 
     @Override
+    public int hashCode() {
+      return 42;
+    }
+
+    @Override
     public boolean equals(Object o) {
       if (this == o) {
         return true;
@@ -167,10 +177,8 @@ public class LegalEntity extends StripeObject {
       }
 
       Verification verification = (Verification) o;
-      return equals(details, verification.details)
-          && equals(detailsCode, verification.detailsCode)
-          && equals(document, verification.document)
-          && equals(status, verification.status);
+      return equals(details, verification.details) && equals(detailsCode, verification.detailsCode)
+          && equals(document, verification.document) && equals(status, verification.status);
     }
   }
 
@@ -202,6 +210,11 @@ public class LegalEntity extends StripeObject {
     }
 
     @Override
+    public int hashCode() {
+      return 42;
+    }
+
+    @Override
     public boolean equals(Object o) {
       if (this == o) {
         return true;
@@ -211,10 +224,8 @@ public class LegalEntity extends StripeObject {
       }
 
       Owner owner = (Owner) o;
-      return equals(address, owner.address)
-          && equals(dob, owner.dob)
-          && equals(firstName, owner.firstName)
-          && equals(lastName, owner.lastName)
+      return equals(address, owner.address) && equals(dob, owner.dob)
+          && equals(firstName, owner.firstName) && equals(lastName, owner.lastName)
           && equals(verification, owner.verification);
     }
   }

--- a/src/main/java/com/stripe/model/LoginLink.java
+++ b/src/main/java/com/stripe/model/LoginLink.java
@@ -7,6 +7,7 @@ public class LoginLink extends APIResource implements HasId {
   Long created;
   String url;
 
+  @Override
   public String getId() {
     throw new UnsupportedOperationException(
         "Login links are ephemeral and do not have an identifier");

--- a/src/main/java/com/stripe/model/Money.java
+++ b/src/main/java/com/stripe/model/Money.java
@@ -68,6 +68,11 @@ public class Money extends StripeObject {
     }
 
     @Override
+    public int hashCode() {
+      return 42;
+    }
+
+    @Override
     public boolean equals(Object o) {
       if (this == o) {
         return true;
@@ -77,10 +82,8 @@ public class Money extends StripeObject {
       }
 
       SourceTypes st = (SourceTypes) o;
-      return equals(alipayAccount, st.alipayAccount)
-          && equals(bankAccount, st.bankAccount)
-          && equals(bitcoinReceiver, st.bitcoinReceiver)
-          && equals(card, st.card);
+      return equals(alipayAccount, st.alipayAccount) && equals(bankAccount, st.bankAccount)
+          && equals(bitcoinReceiver, st.bitcoinReceiver) && equals(card, st.card);
     }
   }
 }

--- a/src/main/java/com/stripe/model/Order.java
+++ b/src/main/java/com/stripe/model/Order.java
@@ -36,6 +36,7 @@ public class Order extends APIResource implements HasId, MetadataStore<Order> {
   Long updated;
   String upstreamId;
 
+  @Override
   public String getId() {
     return id;
   }
@@ -165,6 +166,7 @@ public class Order extends APIResource implements HasId, MetadataStore<Order> {
     this.livemode = livemode;
   }
 
+  @Override
   public Map<String, String> getMetadata() {
     return metadata;
   }
@@ -267,12 +269,14 @@ public class Order extends APIResource implements HasId, MetadataStore<Order> {
     return request(RequestMethod.GET, instanceURL(Order.class, id), params, Order.class, options);
   }
 
+  @Override
   public Order update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
     return update(params, null);
   }
 
+  @Override
   @Deprecated
   public Order update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,

--- a/src/main/java/com/stripe/model/OrderItem.java
+++ b/src/main/java/com/stripe/model/OrderItem.java
@@ -59,8 +59,8 @@ public class OrderItem extends APIResource {
     this.parent = new ExpandableField<HasId>(o.getId(), o);
   }
 
-  public <O extends HasId> O getParentObjectAs() {
-    return (this.parent != null) ? (O) this.parent.getExpanded() : null;
+  public HasId getParentObjectAs() {
+    return (this.parent != null) ? this.parent.getExpanded() : null;
   }
 
   public Integer getQuantity() {

--- a/src/main/java/com/stripe/model/OrderReturn.java
+++ b/src/main/java/com/stripe/model/OrderReturn.java
@@ -22,6 +22,7 @@ public class OrderReturn extends APIResource implements HasId {
   ExpandableField<Order> order;
   ExpandableField<Refund> refund;
 
+  @Override
   public String getId() {
     return id;
   }

--- a/src/main/java/com/stripe/model/PagingIterable.java
+++ b/src/main/java/com/stripe/model/PagingIterable.java
@@ -14,6 +14,7 @@ public class PagingIterable<T extends HasId> implements Iterable<T> {
     this.page = page;
   }
 
+  @Override
   public Iterator<T> iterator() {
     return new PagingIterator<T>(page);
   }

--- a/src/main/java/com/stripe/model/Payout.java
+++ b/src/main/java/com/stripe/model/Payout.java
@@ -31,6 +31,7 @@ public class Payout extends APIResource implements MetadataStore<Payout>, HasId 
   String status;
   String type;
 
+  @Override
   public String getId() {
     return id;
   }
@@ -162,6 +163,7 @@ public class Payout extends APIResource implements MetadataStore<Payout>, HasId 
     this.livemode = livemode;
   }
 
+  @Override
   public Map<String, String> getMetadata() {
     return metadata;
   }
@@ -265,12 +267,14 @@ public class Payout extends APIResource implements MetadataStore<Payout>, HasId 
     return request(RequestMethod.GET, instanceURL(Payout.class, id), params, Payout.class, options);
   }
 
+  @Override
   public Payout update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
     return update(params, null);
   }
 
+  @Override
   public Payout update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/Plan.java
+++ b/src/main/java/com/stripe/model/Plan.java
@@ -38,6 +38,7 @@ public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
   @Deprecated
   String statementDescriptor;
 
+  @Override
   public String getId() {
     return id;
   }
@@ -110,6 +111,7 @@ public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
     this.livemode = livemode;
   }
 
+  @Override
   public Map<String, String> getMetadata() {
     return metadata;
   }
@@ -276,6 +278,7 @@ public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
     return request(RequestMethod.GET, instanceURL(Plan.class, id), null, Plan.class, options);
   }
 
+  @Override
   public Plan update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
@@ -289,6 +292,7 @@ public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
     return update(params, RequestOptions.builder().setApiKey(apiKey).build());
   }
 
+  @Override
   public Plan update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/Product.java
+++ b/src/main/java/com/stripe/model/Product.java
@@ -32,6 +32,7 @@ public class Product extends APIResource implements HasId, MetadataStore<Product
   Long updated;
   String url;
 
+  @Override
   public String getId() {
     return id;
   }
@@ -112,6 +113,7 @@ public class Product extends APIResource implements HasId, MetadataStore<Product
     this.livemode = livemode;
   }
 
+  @Override
   public Map<String, String> getMetadata() {
     return metadata;
   }
@@ -208,12 +210,14 @@ public class Product extends APIResource implements HasId, MetadataStore<Product
     return request(RequestMethod.GET, instanceURL(Product.class, id), null, Product.class, options);
   }
 
+  @Override
   public Product update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
     return update(params, null);
   }
 
+  @Override
   public Product update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/Recipient.java
+++ b/src/main/java/com/stripe/model/Recipient.java
@@ -28,6 +28,7 @@ public class Recipient extends APIResource implements MetadataStore<Recipient>, 
   String type;
   Boolean verified;
 
+  @Override
   public String getId() {
     return id;
   }
@@ -108,6 +109,7 @@ public class Recipient extends APIResource implements MetadataStore<Recipient>, 
     this.livemode = livemode;
   }
 
+  @Override
   public Map<String, String> getMetadata() {
     return metadata;
   }
@@ -202,6 +204,7 @@ public class Recipient extends APIResource implements MetadataStore<Recipient>, 
         options);
   }
 
+  @Override
   public Recipient update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
@@ -215,6 +218,7 @@ public class Recipient extends APIResource implements MetadataStore<Recipient>, 
     return update(params, RequestOptions.builder().setApiKey(apiKey).build());
   }
 
+  @Override
   public Recipient update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/Refund.java
+++ b/src/main/java/com/stripe/model/Refund.java
@@ -24,6 +24,7 @@ public class Refund extends APIResource implements MetadataStore<Charge>, HasId 
   String receiptNumber;
   String status;
 
+  @Override
   public String getId() {
     return id;
   }
@@ -104,6 +105,7 @@ public class Refund extends APIResource implements MetadataStore<Charge>, HasId 
     this.description = description;
   }
 
+  @Override
   public Map<String, String> getMetadata() {
     return metadata;
   }
@@ -136,6 +138,7 @@ public class Refund extends APIResource implements MetadataStore<Charge>, HasId 
     this.status = status;
   }
 
+  @Override
   public Refund update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
@@ -149,6 +152,7 @@ public class Refund extends APIResource implements MetadataStore<Charge>, HasId 
     return update(params, RequestOptions.builder().setApiKey(apiKey).build());
   }
 
+  @Override
   public Refund update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/Reversal.java
+++ b/src/main/java/com/stripe/model/Reversal.java
@@ -20,6 +20,7 @@ public class Reversal extends APIResource implements MetadataStore<Transfer>, Ha
   Map<String, String> metadata;
   ExpandableField<Transfer> transfer;
 
+  @Override
   public String getId() {
     return id;
   }
@@ -72,6 +73,7 @@ public class Reversal extends APIResource implements MetadataStore<Transfer>, Ha
     this.currency = currency;
   }
 
+  @Override
   public Map<String, String> getMetadata() {
     return metadata;
   }
@@ -96,6 +98,7 @@ public class Reversal extends APIResource implements MetadataStore<Transfer>, Ha
     this.transfer = new ExpandableField<Transfer>(c.getId(), c);
   }
 
+  @Override
   public Reversal update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
@@ -109,6 +112,7 @@ public class Reversal extends APIResource implements MetadataStore<Transfer>, Ha
     return update(params, RequestOptions.builder().setApiKey(apiKey).build());
   }
 
+  @Override
   public Reversal update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/Review.java
+++ b/src/main/java/com/stripe/model/Review.java
@@ -9,6 +9,7 @@ public class Review extends StripeObject implements HasId {
   Boolean open;
   String reason;
 
+  @Override
   public String getId() {
     return id;
   }

--- a/src/main/java/com/stripe/model/SKU.java
+++ b/src/main/java/com/stripe/model/SKU.java
@@ -26,6 +26,7 @@ public class SKU extends APIResource implements HasId, MetadataStore<SKU> {
   ExpandableField<Product> product;
   Long updated;
 
+  @Override
   public String getId() {
     return id;
   }
@@ -98,6 +99,7 @@ public class SKU extends APIResource implements HasId, MetadataStore<SKU> {
     this.livemode = livemode;
   }
 
+  @Override
   public Map<String, String> getMetadata() {
     return metadata;
   }
@@ -177,12 +179,14 @@ public class SKU extends APIResource implements HasId, MetadataStore<SKU> {
     return request(RequestMethod.GET, instanceURL(SKU.class, id), params, SKU.class, options);
   }
 
+  @Override
   public SKU update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
     return update(params, null);
   }
 
+  @Override
   public SKU update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/Source.java
+++ b/src/main/java/com/stripe/model/Source.java
@@ -142,10 +142,12 @@ public class Source extends ExternalAccount implements HasSourceTypeData {
 
   // Type-specific getters/setters
 
+  @Override
   public Map<String, String> getTypeData() {
     return typeData;
   }
 
+  @Override
   public void setTypeData(Map<String, String> typeData) {
     this.typeData = typeData;
   }
@@ -215,6 +217,7 @@ public class Source extends ExternalAccount implements HasSourceTypeData {
    * {@link InvalidRequestException}. Call {@link #detach} to detach the source from a
    * customer object.
    */
+  @Override
   public DeletedExternalAccount delete(RequestOptions options) throws
       AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/SourceMandateNotification.java
+++ b/src/main/java/com/stripe/model/SourceMandateNotification.java
@@ -18,6 +18,7 @@ public class SourceMandateNotification extends APIResource implements HasId, Has
   // Type-specific properties
   Map<String, String> typeData;
 
+  @Override
   public String getId() {
     return id;
   }
@@ -92,10 +93,12 @@ public class SourceMandateNotification extends APIResource implements HasId, Has
 
   // Type-specific getters/setters
 
+  @Override
   public Map<String, String> getTypeData() {
     return typeData;
   }
 
+  @Override
   public void setTypeData(Map<String, String> typeData) {
     this.typeData = typeData;
   }

--- a/src/main/java/com/stripe/model/SourceTransaction.java
+++ b/src/main/java/com/stripe/model/SourceTransaction.java
@@ -18,6 +18,7 @@ public class SourceTransaction extends APIResource implements HasId, HasSourceTy
   // Type-specific properties
   Map<String, String> typeData;
 
+  @Override
   public String getId() {
     return id;
   }
@@ -92,10 +93,12 @@ public class SourceTransaction extends APIResource implements HasId, HasSourceTy
 
   // Type-specific getters/setters
 
+  @Override
   public Map<String, String> getTypeData() {
     return typeData;
   }
 
+  @Override
   public void setTypeData(Map<String, String> typeData) {
     this.typeData = typeData;
   }

--- a/src/main/java/com/stripe/model/SourceTypeDataDeserializer.java
+++ b/src/main/java/com/stripe/model/SourceTypeDataDeserializer.java
@@ -36,6 +36,7 @@ public class SourceTypeDataDeserializer<T extends HasSourceTypeData>
   /**
    * Deserializes the type-specific data of a {@link Source} or {@link SourceTransaction} object.
    */
+  @Override
   public T deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
           throws JsonParseException {
     if (json.isJsonNull()) {

--- a/src/main/java/com/stripe/model/StripeCollection.java
+++ b/src/main/java/com/stripe/model/StripeCollection.java
@@ -45,6 +45,7 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject
    */
   Integer count;
 
+  @Override
   public List<T> getData() {
     return data;
   }
@@ -53,6 +54,7 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject
     this.data = data;
   }
 
+  @Override
   public Integer getTotalCount() {
     return totalCount;
   }
@@ -61,6 +63,7 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject
     this.totalCount = totalCount;
   }
 
+  @Override
   public Boolean getHasMore() {
     return hasMore;
   }
@@ -69,6 +72,7 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject
     this.hasMore = hasMore;
   }
 
+  @Override
   public String getURL() {
     return url;
   }
@@ -114,18 +118,22 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject
     return new PagingIterable<T>(this);
   }
 
+  @Override
   public RequestOptions getRequestOptions() {
     return this.requestOptions;
   }
 
+  @Override
   public Map<String, Object> getRequestParams() {
     return this.requestParams;
   }
 
+  @Override
   public void setRequestOptions(RequestOptions requestOptions) {
     this.requestOptions = requestOptions;
   }
 
+  @Override
   public void setRequestParams(Map<String, Object> requestParams) {
     this.requestParams = requestParams;
   }

--- a/src/main/java/com/stripe/model/StripeRawJsonObjectDeserializer.java
+++ b/src/main/java/com/stripe/model/StripeRawJsonObjectDeserializer.java
@@ -11,6 +11,7 @@ public class StripeRawJsonObjectDeserializer implements JsonDeserializer<StripeR
   /**
    * Deserializes a JSON payload into a {@link StripeRawJsonObject} object.
    */
+  @Override
   public StripeRawJsonObject deserialize(JsonElement json, Type typeOfT,
       JsonDeserializationContext context)
       throws JsonParseException {

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -36,6 +36,7 @@ public class Subscription extends APIResource implements MetadataStore<Subscript
   Long trialEnd;
   Long trialStart;
 
+  @Override
   public String getId() {
     return id;
   }
@@ -156,6 +157,7 @@ public class Subscription extends APIResource implements MetadataStore<Subscript
     this.endedAt = endedAt;
   }
 
+  @Override
   public Map<String, String> getMetadata() {
     return metadata;
   }
@@ -291,6 +293,7 @@ public class Subscription extends APIResource implements MetadataStore<Subscript
         Subscription.class, options);
   }
 
+  @Override
   public Subscription update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
@@ -304,6 +307,7 @@ public class Subscription extends APIResource implements MetadataStore<Subscript
     return update(params, RequestOptions.builder().setApiKey(apiKey).build());
   }
 
+  @Override
   public Subscription update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/SubscriptionItem.java
+++ b/src/main/java/com/stripe/model/SubscriptionItem.java
@@ -18,6 +18,7 @@ public class SubscriptionItem extends APIResource implements HasId {
   Plan plan;
   Integer quantity;
 
+  @Override
   public String getId() {
     return id;
   }

--- a/src/main/java/com/stripe/model/ThreeDSecure.java
+++ b/src/main/java/com/stripe/model/ThreeDSecure.java
@@ -26,6 +26,7 @@ public class ThreeDSecure extends APIResource implements HasId {
   String redirectURL;
   String status;
 
+  @Override
   public String getId() {
     return id;
   }

--- a/src/main/java/com/stripe/model/Token.java
+++ b/src/main/java/com/stripe/model/Token.java
@@ -24,6 +24,7 @@ public class Token extends APIResource implements HasId {
   String type;
   Boolean used;
 
+  @Override
   public String getId() {
     return id;
   }

--- a/src/main/java/com/stripe/model/Transfer.java
+++ b/src/main/java/com/stripe/model/Transfer.java
@@ -49,6 +49,7 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
   @Deprecated
   Summary summary;
 
+  @Override
   public String getId() {
     return id;
   }
@@ -212,6 +213,7 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
     this.livemode = livemode;
   }
 
+  @Override
   public Map<String, String> getMetadata() {
     return metadata;
   }
@@ -453,6 +455,7 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
         Transfer.class, options);
   }
 
+  @Override
   public Transfer update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
@@ -466,6 +469,7 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
     return update(params, RequestOptions.builder().setApiKey(apiKey).build());
   }
 
+  @Override
   public Transfer update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/TransferTransaction.java
+++ b/src/main/java/com/stripe/model/TransferTransaction.java
@@ -10,6 +10,7 @@ public class TransferTransaction extends StripeObject implements HasId {
   String description;
   Long fee;
 
+  @Override
   public String getId() {
     return id;
   }

--- a/src/main/java/com/stripe/model/VerificationFields.java
+++ b/src/main/java/com/stripe/model/VerificationFields.java
@@ -23,6 +23,11 @@ public final class VerificationFields extends StripeObject {
   }
 
   @Override
+  public int hashCode() {
+    return 42;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/src/main/java/com/stripe/model/VerificationFieldsDetails.java
+++ b/src/main/java/com/stripe/model/VerificationFieldsDetails.java
@@ -25,6 +25,12 @@ public final class VerificationFieldsDetails extends StripeObject {
   }
 
   @Override
+  public int hashCode() {
+    // TODO Auto-generated method stub
+    return super.hashCode();
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/src/main/java/com/stripe/net/APIResource.java
+++ b/src/main/java/com/stripe/net/APIResource.java
@@ -3,7 +3,6 @@ package com.stripe.net;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-
 import com.stripe.Stripe;
 import com.stripe.exception.APIConnectionException;
 import com.stripe.exception.APIException;
@@ -38,7 +37,6 @@ import com.stripe.model.StripeCollectionInterface;
 import com.stripe.model.StripeObject;
 import com.stripe.model.StripeRawJsonObject;
 import com.stripe.model.StripeRawJsonObjectDeserializer;
-
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Map;
@@ -67,8 +65,7 @@ public abstract class APIResource extends StripeObject {
       .registerTypeAdapter(SourceTransaction.class,
           new SourceTypeDataDeserializer<SourceTransaction>())
       .registerTypeAdapter(StripeRawJsonObject.class, new StripeRawJsonObjectDeserializer())
-      .registerTypeAdapterFactory(new ExternalAccountTypeAdapterFactory())
-      .create();
+      .registerTypeAdapterFactory(new ExternalAccountTypeAdapterFactory()).create();
 
   private static String className(Class<?> clazz) {
     String className = clazz.getSimpleName().toLowerCase().replace("$", " ");
@@ -120,8 +117,7 @@ public abstract class APIResource extends StripeObject {
     return String.format("%ss", singleClassURL(clazz, apiBase));
   }
 
-  protected static String instanceURL(Class<?> clazz, String id)
-      throws InvalidRequestException {
+  protected static String instanceURL(Class<?> clazz, String id) throws InvalidRequestException {
     return instanceURL(clazz, id, Stripe.getApiBase());
   }
 
@@ -130,10 +126,8 @@ public abstract class APIResource extends StripeObject {
     try {
       return String.format("%s/%s", classURL(clazz, apiBase), urlEncode(id));
     } catch (UnsupportedEncodingException e) {
-      throw new InvalidRequestException("Unable to encode parameters to "
-          + CHARSET
-          + ". Please contact support@stripe.com for assistance.",
-          null, null, null, 0, e);
+      throw new InvalidRequestException("Unable to encode parameters to " + CHARSET
+          + ". Please contact support@stripe.com for assistance.", null, null, null, 0, e);
     }
   }
 
@@ -146,13 +140,11 @@ public abstract class APIResource extends StripeObject {
   private static String subresourceURL(Class<?> clazz, String id, Class<?> subClazz, String apiBase)
       throws InvalidRequestException {
     try {
-      return String.format("%s/%s/%ss", classURL(clazz, apiBase),
-              urlEncode(id), className(subClazz));
+      return String.format("%s/%s/%ss", classURL(clazz, apiBase), urlEncode(id),
+          className(subClazz));
     } catch (UnsupportedEncodingException e) {
-      throw new InvalidRequestException("Unable to encode parameters to "
-              + CHARSET
-              + ". Please contact support@stripe.com for assistance.",
-              null, null, null, 0, e);
+      throw new InvalidRequestException("Unable to encode parameters to " + CHARSET
+          + ". Please contact support@stripe.com for assistance.", null, null, null, 0, e);
     }
   }
 
@@ -178,43 +170,37 @@ public abstract class APIResource extends StripeObject {
       // Don't use strict form encoding by changing the square bracket control
       // characters back to their literals. This is fine by the server, and
       // makes these parameter strings easier to read.
-      return URLEncoder.encode(str, CHARSET)
-        .replaceAll("%5B", "[")
-        .replaceAll("%5D", "]");
+      return URLEncoder.encode(str, CHARSET).replaceAll("%5B", "[").replaceAll("%5D", "]");
     }
   }
 
-  public static <T> T multipartRequest(APIResource.RequestMethod method,
-                     String url, Map<String, Object> params, Class<T> clazz,
-                     RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
+  public static <T> T multipartRequest(APIResource.RequestMethod method, String url,
+      Map<String, Object> params, Class<T> clazz, RequestOptions options)
+      throws AuthenticationException, InvalidRequestException, APIConnectionException,
+      CardException, APIException {
     return APIResource.stripeResponseGetter.request(method, url, params, clazz,
         APIResource.RequestType.MULTIPART, options);
   }
 
-  public static <T> T request(APIResource.RequestMethod method,
-                String url, Map<String, Object> params, Class<T> clazz,
-                RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, APIConnectionException, CardException,
-      APIException {
+  public static <T> T request(APIResource.RequestMethod method, String url,
+      Map<String, Object> params, Class<T> clazz, RequestOptions options)
+      throws AuthenticationException, InvalidRequestException, APIConnectionException,
+      CardException, APIException {
     return APIResource.stripeResponseGetter.request(method, url, params, clazz,
         APIResource.RequestType.NORMAL, options);
   }
 
   /**
-   * Similar to #request, but specific for use with collection types that
-   * come from the API (i.e. lists of resources).
-   *
-   * <p>Collections need a little extra work because we need to plumb request
-   * options and params through so that we can iterate to the next page if
-   * necessary.
+   * Similar to #request, but specific for use with collection types that come from the API (i.e.
+   * lists of resources).
+   * 
+   * <p>Collections need a little extra work because we need to plumb request options and params
+   * through so that we can iterate to the next page if necessary.
    */
-  public static <T extends StripeCollectionInterface> T requestCollection(
-      String url, Map<String, Object> params, Class<T> clazz,
-      RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      APIConnectionException, CardException, APIException {
+  public static <T extends StripeCollectionInterface> T requestCollection(String url,
+      Map<String, Object> params, Class<T> clazz, RequestOptions options)
+      throws AuthenticationException, InvalidRequestException, APIConnectionException,
+      CardException, APIException {
     T collection = request(RequestMethod.GET, url, params, clazz, options);
 
     if (collection != null) {
@@ -232,7 +218,8 @@ public abstract class APIResource extends StripeObject {
    */
   public static <T extends HasId> ExpandableField<T> setExpandableFieldID(String newId,
       ExpandableField<T> currentObject) {
-    if (currentObject == null || (currentObject.isExpanded() && (currentObject.getId() != newId))) {
+    if (currentObject == null
+        || (currentObject.isExpanded() && !currentObject.getId().equals(newId))) {
       return new ExpandableField<T>(newId, null);
     }
 

--- a/src/main/java/com/stripe/net/MultipartProcessor.java
+++ b/src/main/java/com/stripe/net/MultipartProcessor.java
@@ -14,8 +14,6 @@ public class MultipartProcessor {
   private static final String LINE_BREAK = "\r\n";
   private OutputStream outputStream;
   private PrintWriter writer;
-  private String charset;
-  private java.net.HttpURLConnection conn;
 
   /**
    * Generates a random MIME multipart boundary.
@@ -34,9 +32,6 @@ public class MultipartProcessor {
   public MultipartProcessor(java.net.HttpURLConnection conn, String boundary, String charset)
       throws IOException {
     this.boundary = boundary;
-    this.charset = charset;
-    this.conn = conn;
-
     this.outputStream = conn.getOutputStream();
     this.writer = new PrintWriter(new OutputStreamWriter(outputStream, charset), true);
   }
@@ -76,16 +71,13 @@ public class MultipartProcessor {
     writer.append(LINE_BREAK);
     writer.flush();
 
-    FileInputStream inputStream = new FileInputStream(file);
-    try {
+    try (FileInputStream inputStream = new FileInputStream(file)) {
       byte[] buffer = new byte[4096];
       int bytesRead = -1;
       while ((bytesRead = inputStream.read(buffer)) != -1) {
         outputStream.write(buffer, 0, bytesRead);
       }
       outputStream.flush();
-    } finally {
-      inputStream.close();
     }
 
     writer.append(LINE_BREAK);

--- a/src/main/java/com/stripe/net/Webhook.java
+++ b/src/main/java/com/stripe/net/Webhook.java
@@ -1,5 +1,6 @@
 package com.stripe.net;
 
+import com.stripe.Stripe;
 import com.stripe.exception.SignatureVerificationException;
 import com.stripe.model.Event;
 
@@ -9,6 +10,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 
@@ -119,7 +121,7 @@ public final class Webhook {
      * @return the timestamp contained in the header.
      */
     private static long getTimestamp(String sigHeader) {
-      String[] items = sigHeader.split(",");
+      String[] items = sigHeader.split(",", -1);
 
       for (String item : items) {
         String[] itemParts = item.split("=", 2);
@@ -140,7 +142,7 @@ public final class Webhook {
      */
     private static List<String> getSignatures(String sigHeader, String scheme) {
       List<String> signatures = new ArrayList<String>();
-      String[] items = sigHeader.split(",");
+      String[] items = sigHeader.split(",", -1);
 
       for (String item : items) {
         String[] itemParts = item.split("=", 2);
@@ -196,8 +198,8 @@ public final class Webhook {
      * @return true if the strings are equal, false otherwise.
      */
     public static boolean secureCompare(String a, String b) {
-      byte[] digesta = a.getBytes();
-      byte[] digestb = b.getBytes();
+      byte[] digesta = a.getBytes(Stripe.UTF_8);
+      byte[] digestb = b.getBytes(Stripe.UTF_8);
 
       return MessageDigest.isEqual(digesta, digestb);
     }

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -1,7 +1,7 @@
 package com.stripe;
 
-import static org.mockito.Mockito.argThat;
-import static org.mockito.Mockito.eq;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -14,110 +14,81 @@ import com.stripe.net.StripeResponseGetter;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
-
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 
 public class BaseStripeTest {
   public static StripeResponseGetter networkMock;
 
-  public static <T> void verifyGet(
-      Class<T> clazz,
-      String url) throws StripeException {
-    verifyRequest(APIResource.RequestMethod.GET, clazz, url, null,
-        APIResource.RequestType.NORMAL, RequestOptions.getDefault());
+  public static <T> void verifyGet(Class<T> clazz, String url) throws StripeException {
+    verifyRequest(APIResource.RequestMethod.GET, clazz, url, null, APIResource.RequestType.NORMAL,
+        RequestOptions.getDefault());
   }
 
-  public static <T> void verifyGet(
-      Class<T> clazz,
-      String url,
-      Map<String, Object> params) throws StripeException {
-    verifyRequest(APIResource.RequestMethod.GET, clazz, url, params,
-        APIResource.RequestType.NORMAL, RequestOptions.getDefault());
+  public static <T> void verifyGet(Class<T> clazz, String url, Map<String, Object> params)
+      throws StripeException {
+    verifyRequest(APIResource.RequestMethod.GET, clazz, url, params, APIResource.RequestType.NORMAL,
+        RequestOptions.getDefault());
   }
 
-  public static <T> void verifyGet(
-      Class<T> clazz,
-      String url,
+  public static <T> void verifyGet(Class<T> clazz, String url, RequestOptions requestOptions)
+      throws StripeException {
+    verifyRequest(APIResource.RequestMethod.GET, clazz, url, null, APIResource.RequestType.NORMAL,
+        requestOptions);
+  }
+
+  public static <T> void verifyGet(Class<T> clazz, String url, Map<String, Object> params,
       RequestOptions requestOptions) throws StripeException {
-    verifyRequest(APIResource.RequestMethod.GET, clazz, url, null,
-        APIResource.RequestType.NORMAL, requestOptions);
+    verifyRequest(APIResource.RequestMethod.GET, clazz, url, params, APIResource.RequestType.NORMAL,
+        requestOptions);
   }
 
-  public static <T> void verifyGet(
-      Class<T> clazz,
-      String url,
-      Map<String, Object> params,
-      RequestOptions requestOptions) throws StripeException {
-    verifyRequest(APIResource.RequestMethod.GET, clazz, url, params,
-        APIResource.RequestType.NORMAL, requestOptions);
+  public static <T> void verifyPost(Class<T> clazz, String url) throws StripeException {
+    verifyRequest(APIResource.RequestMethod.POST, clazz, url, null, APIResource.RequestType.NORMAL,
+        RequestOptions.getDefault());
   }
 
-  public static <T> void verifyPost(
-      Class<T> clazz,
-      String url) throws StripeException {
-    verifyRequest(APIResource.RequestMethod.POST, clazz, url, null,
-        APIResource.RequestType.NORMAL, RequestOptions.getDefault());
-  }
-
-  public static <T> void verifyPost(
-      Class<T> clazz,
-      String url,
-      Map<String, Object> params) throws StripeException {
+  public static <T> void verifyPost(Class<T> clazz, String url, Map<String, Object> params)
+      throws StripeException {
     verifyRequest(APIResource.RequestMethod.POST, clazz, url, params,
         APIResource.RequestType.NORMAL, RequestOptions.getDefault());
   }
 
-  public static <T> void verifyPost(
-      Class<T> clazz,
-      String url,
-      RequestOptions requestOptions) throws StripeException {
-    verifyRequest(APIResource.RequestMethod.POST, clazz, url, null,
-        APIResource.RequestType.NORMAL, requestOptions);
+  public static <T> void verifyPost(Class<T> clazz, String url, RequestOptions requestOptions)
+      throws StripeException {
+    verifyRequest(APIResource.RequestMethod.POST, clazz, url, null, APIResource.RequestType.NORMAL,
+        requestOptions);
   }
 
-  public static <T> void verifyPost(
-      Class<T> clazz,
-      String url,
-      Map<String, Object> params,
+  public static <T> void verifyPost(Class<T> clazz, String url, Map<String, Object> params,
       RequestOptions requestOptions) throws StripeException {
     verifyRequest(APIResource.RequestMethod.POST, clazz, url, params,
         APIResource.RequestType.NORMAL, requestOptions);
   }
 
-  public static <T> void verifyDelete(
-      Class<T> clazz,
-      String url,
-      Map<String, Object> params) throws StripeException {
+  public static <T> void verifyDelete(Class<T> clazz, String url, Map<String, Object> params)
+      throws StripeException {
     verifyRequest(APIResource.RequestMethod.DELETE, clazz, url, params,
         APIResource.RequestType.NORMAL, RequestOptions.getDefault());
   }
 
-  public static <T> void verifyDelete(
-      Class<T> clazz,
-      String url,
-      RequestOptions requestOptions) throws StripeException {
+  public static <T> void verifyDelete(Class<T> clazz, String url, RequestOptions requestOptions)
+      throws StripeException {
     verifyRequest(APIResource.RequestMethod.DELETE, clazz, url, null,
         APIResource.RequestType.NORMAL, requestOptions);
   }
 
-  public static <T> void verifyDelete(
-      Class<T> clazz,
-      String url,
-      Map<String, Object> params,
+  public static <T> void verifyDelete(Class<T> clazz, String url, Map<String, Object> params,
       RequestOptions requestOptions) throws StripeException {
     verifyRequest(APIResource.RequestMethod.DELETE, clazz, url, params,
         APIResource.RequestType.NORMAL, requestOptions);
   }
 
-  public static <T> void verifyDelete(
-      Class<T> clazz,
-      String url) throws StripeException {
+  public static <T> void verifyDelete(Class<T> clazz, String url) throws StripeException {
     verifyRequest(APIResource.RequestMethod.DELETE, clazz, url, null,
         APIResource.RequestType.NORMAL, RequestOptions.getDefault());
   }
@@ -125,46 +96,31 @@ public class BaseStripeTest {
   /**
    * Verifies that the specified request occurred.
    */
-  public static <T> void verifyRequest(
-      APIResource.RequestMethod method,
-      Class<T> clazz,
-      String url,
-      Map<String, Object> params,
-      APIResource.RequestType requestType,
-      RequestOptions options) throws StripeException {
-    verify(networkMock).request(
-        eq(method),
-        eq(url),
-        argThat(new ParamMapMatcher(params)),
-        eq(clazz),
-        eq(requestType),
-        argThat(new RequestOptionsMatcher(options)));
+  public static <T> void verifyRequest(APIResource.RequestMethod method, Class<T> clazz, String url,
+      Map<String, Object> params, APIResource.RequestType requestType, RequestOptions options)
+      throws StripeException {
+    verify(networkMock).request(eq(method), eq(url), argThat(new ParamMapMatcher(params)),
+        eq(clazz), eq(requestType), argThat(new RequestOptionsMatcher(options)));
   }
 
   /**
    * Stubs the next API request and return the provided response.
    */
   public static <T> void stubNetwork(Class<T> clazz, String response) throws StripeException {
-    when(networkMock.request(
-        Mockito.any(APIResource.RequestMethod.class),
-        Mockito.anyString(),
-        Mockito.<Map<String, Object>>any(),
-        Mockito.<Class<T>>any(),
-        Mockito.any(APIResource.RequestType.class),
-        Mockito.<RequestOptions>any())).thenReturn(APIResource.GSON.fromJson(response, clazz));
+    when(networkMock.request(Mockito.any(APIResource.RequestMethod.class), Mockito.anyString(),
+        Mockito.<Map<String, Object>>any(), Mockito.<Class<T>>any(),
+        Mockito.any(APIResource.RequestType.class), Mockito.<RequestOptions>any()))
+            .thenReturn(APIResource.GSON.fromJson(response, clazz));
   }
 
   /**
    * Stubs the next OAuth request and return the provided response.
    */
   public static <T> void stubOAuth(Class<T> clazz, String response) throws StripeException {
-    when(networkMock.oauthRequest(
-        Mockito.any(APIResource.RequestMethod.class),
-        Mockito.anyString(),
-        Mockito.<Map<String, Object>>any(),
-        Mockito.<Class<T>>any(),
-        Mockito.any(APIResource.RequestType.class),
-        Mockito.<RequestOptions>any())).thenReturn(APIResource.GSON.fromJson(response, clazz));
+    when(networkMock.oauthRequest(Mockito.any(APIResource.RequestMethod.class), Mockito.anyString(),
+        Mockito.<Map<String, Object>>any(), Mockito.<Class<T>>any(),
+        Mockito.any(APIResource.RequestType.class), Mockito.<RequestOptions>any()))
+            .thenReturn(APIResource.GSON.fromJson(response, clazz));
   }
 
   public static class ParamMapMatcher implements ArgumentMatcher<Map<String, Object>> {
@@ -177,7 +133,8 @@ public class BaseStripeTest {
     /**
      * Informs if this matcher accepts the given argument.
      */
-    public boolean matches(Map<String,Object> paramMap) {
+    @Override
+    public boolean matches(Map<String, Object> paramMap) {
       // Treat null references as equal to empty maps
       if (paramMap == null) {
         return this.other == null || this.other.isEmpty();
@@ -201,6 +158,7 @@ public class BaseStripeTest {
     /**
      * Informs if this matcher accepts the given argument.
      */
+    @Override
     public boolean matches(RequestOptions requestOptions) {
       // Treat null reference as RequestOptions.getDefault()
       RequestOptions defaultOptions = RequestOptions.getDefault();
@@ -229,14 +187,14 @@ public class BaseStripeTest {
   protected String resource(String path) throws IOException {
     InputStream resource = getClass().getResourceAsStream(path);
 
-    ByteArrayOutputStream os = new ByteArrayOutputStream(1024);
-    byte[] buf = new byte[1024];
+    try (ByteArrayOutputStream os = new ByteArrayOutputStream(1024)) {
+      byte[] buf = new byte[1024];
 
-    for (int i = resource.read(buf); i > 0; i = resource.read(buf)) {
-      os.write(buf, 0, i);
+      for (int i = resource.read(buf); i > 0; i = resource.read(buf)) {
+        os.write(buf, 0, i);
+      }
+
+      return os.toString("utf8");
     }
-
-    return os.toString("utf8");
-
   }
 }

--- a/src/test/java/com/stripe/DocumentationTest.java
+++ b/src/test/java/com/stripe/DocumentationTest.java
@@ -1,14 +1,16 @@
 package com.stripe;
 
+import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Calendar;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -28,77 +30,84 @@ public class DocumentationTest {
   @Test
   public void testChangeLogContainsStaticVersion() throws IOException {
     File changelogFile = new File("CHANGELOG.md").getAbsoluteFile();
-    Assert.assertTrue(String.format(
-        "Expected CHANGELOG file to exist, but it doesn't. (path is %s).",
-        changelogFile.getAbsolutePath()), changelogFile.exists());
-    Assert.assertTrue(String.format(
-        "Expected CHANGELOG to be a file, but it doesn't. (path is %s).",
-        changelogFile.getAbsolutePath()), changelogFile.isFile());
-    BufferedReader reader = new BufferedReader(new FileReader(changelogFile));
-    String expectedLine = formatDateTime();
-    String line;
-    List<String> closeMatches = new LinkedList<String>();
-    while ((line = reader.readLine()) != null) {
-      if (line.contains(Stripe.VERSION)) {
-        if (Pattern.matches(String.format(
-            "^## %s - 20[12][0-9]-(0[1-9]|1[0-2])-(0[1-9]|1[0-9]|2[0-9]|3[0-1])$", Stripe.VERSION),
-            line)) {
-          return;
+    Assert
+        .assertTrue(String.format("Expected CHANGELOG file to exist, but it doesn't. (path is %s).",
+            changelogFile.getAbsolutePath()), changelogFile.exists());
+    Assert
+        .assertTrue(String.format("Expected CHANGELOG to be a file, but it doesn't. (path is %s).",
+            changelogFile.getAbsolutePath()), changelogFile.isFile());
+    try (BufferedReader reader = Files.newBufferedReader(changelogFile.toPath(), Charsets.UTF_8)) {
+      String expectedLine = formatDateTime();
+      String line;
+      List<String> closeMatches = new ArrayList<String>();
+      while ((line = reader.readLine()) != null) {
+        if (line.contains(Stripe.VERSION)) {
+          if (Pattern.matches(
+              String.format("^## %s - 20[12][0-9]-(0[1-9]|1[0-2])-(0[1-9]|1[0-9]|2[0-9]|3[0-1])$",
+                  Stripe.VERSION),
+              line)) {
+            return;
+          }
+          closeMatches.add(line);
         }
-        closeMatches.add(line);
       }
+      Assert.fail(String.format(
+          "Expected a line of the format '%s' in the CHANGELOG, but didn't find one.%n"
+              + "The following lines were close, but didn't match exactly:%n'%s'",
+          expectedLine, Joiner.on(", ").join(closeMatches)));
     }
-    Assert.fail(String.format(
-        "Expected a line of the format '%s' in the CHANGELOG, but didn't find one.%nThe following "
-        + "lines were close, but didn't match exactly:%n'%s'",
-        expectedLine, Joiner.on(", ").join(closeMatches)));
   }
 
   @Test
   public void testReadMeContainsStripeVersionThatMatches() throws IOException {
     // this will be very flaky, but we want to ensure that the readme is correct.
     File readmeFile = new File("README.md").getAbsoluteFile();
-    Assert.assertTrue(String.format(
-        "Expected README.md file to exist, but it doesn't. (path is %s).",
-        readmeFile.getAbsolutePath()), readmeFile.exists());
-    Assert.assertTrue(String.format(
-        "Expected README.md to be a file, but it doesn't. (path is %s).",
-        readmeFile.getAbsolutePath()), readmeFile.isFile());
-    BufferedReader reader = new BufferedReader(new FileReader(readmeFile));
-    int expectedMentionsOfVersion = 2;
-    // Currently two places mention the Stripe version: the sample pom and gradle files.
-    String line;
-    List<String> mentioningLines = new LinkedList<String>();
-    while ((line = reader.readLine()) != null) {
-      if (line.contains(Stripe.VERSION)) {
-        mentioningLines.add(line);
+    Assert
+        .assertTrue(String.format("Expected README.md file to exist, but it doesn't. (path is %s).",
+            readmeFile.getAbsolutePath()), readmeFile.exists());
+    Assert
+        .assertTrue(String.format("Expected README.md to be a file, but it doesn't. (path is %s).",
+            readmeFile.getAbsolutePath()), readmeFile.isFile());
+    try (BufferedReader reader = Files.newBufferedReader(readmeFile.toPath(), Charsets.UTF_8)) {
+      int expectedMentionsOfVersion = 2;
+      // Currently two places mention the Stripe version: the sample pom and gradle files.
+      String line;
+      List<String> mentioningLines = new ArrayList<String>();
+      while ((line = reader.readLine()) != null) {
+        if (line.contains(Stripe.VERSION)) {
+          mentioningLines.add(line);
+        }
       }
+      String message = String.format(
+          "Expected %d mentions of the stripe-java version in the Readme, but found %d:%n%s",
+          expectedMentionsOfVersion, mentioningLines.size(), Joiner.on(", ").join(mentioningLines));
+      Assert.assertSame(message, expectedMentionsOfVersion, mentioningLines.size());
     }
-    String message = String.format(
-        "Expected %d mentions of the stripe-java version in the Readme, but found %d:%n%s",
-        expectedMentionsOfVersion, mentioningLines.size(), Joiner.on(", ").join(mentioningLines));
-    Assert.assertSame(message, expectedMentionsOfVersion, mentioningLines.size());
   }
 
   @Test
   public void testGradlePropertiesContainsVersionThatMatches() throws IOException {
     // we want to ensure that the pom's version matches the static version.
     File readmeFile = new File("gradle.properties").getAbsoluteFile();
-    Assert.assertTrue(String.format(
-        "Expected gradle.properties file to exist, but it doesn't. (path is %s).",
-        readmeFile.getAbsolutePath()), readmeFile.exists());
-    Assert.assertTrue(String.format(
-        "Expected gradle.properties to be a file, but it doesn't. (path is %s).",
-        readmeFile.getAbsolutePath()), readmeFile.isFile());
-    BufferedReader reader = new BufferedReader(new FileReader(readmeFile));
-    String line;
-    while ((line = reader.readLine()) != null) {
-      if (line.contains(Stripe.VERSION)) {
-        return;
+    Assert.assertTrue(
+        String.format("Expected gradle.properties file to exist, but it doesn't. (path is %s).",
+            readmeFile.getAbsolutePath()),
+        readmeFile.exists());
+    Assert.assertTrue(
+        String.format("Expected gradle.properties to be a file, but it doesn't. (path is %s).",
+            readmeFile.getAbsolutePath()),
+        readmeFile.isFile());
+    try (BufferedReader reader =
+        Files.newBufferedReader(readmeFile.toPath(), Charset.forName("UTF-8"))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        if (line.contains(Stripe.VERSION)) {
+          return;
+        }
       }
+      Assert.fail(
+          String.format("Expected the Stripe.VERSION (%s) to match up with the one listed in the "
+              + "gradle.properties file. It wasn't found.", Stripe.VERSION));
     }
-    Assert.fail(String.format(
-        "Expected the Stripe.VERSION (%s) to match up with the one listed in the gradle.properties "
-        + "file. It wasn't found.", Stripe.VERSION));
   }
 }

--- a/src/test/java/com/stripe/functional/ChargeTest.java
+++ b/src/test/java/com/stripe/functional/ChargeTest.java
@@ -171,7 +171,7 @@ public class ChargeTest extends BaseStripeFunctionalTest {
     Charge.create(invalidChargeParams);
   }
 
-  @Test
+  @Test(expected = CardException.class)
   public void testDeclinedCard() throws StripeException {
     Map<String, Object> declinedChargeParams = new HashMap<String, Object>();
     declinedChargeParams.putAll(defaultChargeParams);
@@ -182,6 +182,7 @@ public class ChargeTest extends BaseStripeFunctionalTest {
     } catch (CardException e) {
       assertEquals("card_declined", e.getCode());
       assertNotNull(e.getCharge());
+      throw e;
     }
   }
 

--- a/src/test/java/com/stripe/functional/CountrySpecTest.java
+++ b/src/test/java/com/stripe/functional/CountrySpecTest.java
@@ -47,11 +47,11 @@ public class CountrySpecTest extends BaseStripeFunctionalTest {
 
     CountrySpec retrievedCountrySpec2 = CountrySpec.retrieve(country);
     VerificationFields verificationFields2 = retrievedCountrySpec2.getVerificationFields();
-    assert (verificationFields2.equals(verificationFields));
+    assertTrue(verificationFields2.equals(verificationFields));
 
     CountrySpec retrievedCountrySpecFR = CountrySpec.retrieve("FR");
     VerificationFields verificationFieldsFR = retrievedCountrySpecFR.getVerificationFields();
-    assert (!verificationFieldsFR.equals(verificationFields));
+    assertTrue(!verificationFieldsFR.equals(verificationFields));
   }
 
   @Test

--- a/src/test/java/com/stripe/functional/CustomerTest.java
+++ b/src/test/java/com/stripe/functional/CustomerTest.java
@@ -26,8 +26,8 @@ import com.stripe.model.ExternalAccountCollection;
 import com.stripe.model.Plan;
 import com.stripe.model.ShippingDetails;
 
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -132,9 +132,9 @@ public class CustomerTest extends BaseStripeFunctionalTest {
     List<ExternalAccount> customerSourceList = customer.getSources().all(listParams).getData();
 
     assertEquals(2, customerSourceList.size());
-    assert (customerSourceList.get(0) instanceof Card);
+    assertTrue(customerSourceList.get(0) instanceof Card);
     assertEquals("4242", ((Card) customerSourceList.get(0)).getLast4());
-    assert (customerSourceList.get(1) instanceof BankAccount);
+    assertTrue(customerSourceList.get(1) instanceof BankAccount);
     assertEquals("6789", ((BankAccount) customerSourceList.get(1)).getLast4());
   }
 
@@ -152,7 +152,7 @@ public class CustomerTest extends BaseStripeFunctionalTest {
   public void testCustomerSourceRetrieveWithExpand() throws StripeException {
     Customer customer = Customer.create(defaultCustomerParams);
 
-    List<String> expandList = new LinkedList<String>();
+    List<String> expandList = new ArrayList<>();
     expandList.add("default_source");
     Map<String, Object> retrieveParams = new HashMap<String, Object>();
     retrieveParams.put("expand", expandList);
@@ -171,7 +171,7 @@ public class CustomerTest extends BaseStripeFunctionalTest {
     assertNotNull(customer);
     assertNotNull(customer.getId());
     assertNotNull(customer.getSources());
-    assert (customer.getSources().getData().get(0) instanceof Card);
+    assertTrue(customer.getSources().getData().get(0) instanceof Card);
     assertNotNull(customer.getDefaultSource());
     ExternalAccount card = customer.getSources().retrieve(customer.getDefaultSource());
     assertEquals(card.getId(), customer.getDefaultSource());
@@ -182,7 +182,7 @@ public class CustomerTest extends BaseStripeFunctionalTest {
     Customer customer = Customer.create(defaultCustomerParams);
     ExternalAccountCollection customerSources = customer.getSources();
     ExternalAccount paymentSource = customerSources.getData().get(0);
-    assert (paymentSource instanceof Card);
+    assertTrue(paymentSource instanceof Card);
     Card card = (Card) paymentSource;
 
     HashMap<String, Object> updateParams = new HashMap<String, Object>();

--- a/src/test/java/com/stripe/functional/DisputeTest.java
+++ b/src/test/java/com/stripe/functional/DisputeTest.java
@@ -26,8 +26,8 @@ import com.stripe.net.RequestOptions;
 import java.io.File;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -79,7 +79,7 @@ public class DisputeTest extends BaseStripeFunctionalTest {
     Charge disputedCharge = createDisputedCharge(chargeValueCents, null);
     Dispute dispute = disputedCharge.getDisputeObject();
 
-    List<String> expandList = new LinkedList<String>();
+    List<String> expandList = new ArrayList<>();
     expandList.add("charge");
 
     Map<String, Object> retrieveParams = new HashMap<String, Object>();

--- a/src/test/java/com/stripe/functional/PlanTest.java
+++ b/src/test/java/com/stripe/functional/PlanTest.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.junit.Test;
 
@@ -158,10 +159,10 @@ public class PlanTest extends BaseStripeFunctionalTest {
     assertEquals("volume", plan.getTiersMode());
     List<PlanTier> tierConfig = plan.getTiers();
     assertEquals(2, tierConfig.size());
-    assertEquals(new Long(1000), tierConfig.get(0).getAmount());
-    assertEquals(new Long(1000), tierConfig.get(0).getUpTo());
+    assertTrue(Objects.equals(1000L, tierConfig.get(0).getAmount()));
+    assertTrue(Objects.equals(1000L, tierConfig.get(0).getUpTo()));
     assertEquals(null, tierConfig.get(1).getUpTo());
-    assertEquals(new Long(2000), tierConfig.get(1).getAmount());
+    assertTrue(Objects.equals(2000L, tierConfig.get(1).getAmount()));
   }
 
   @Test
@@ -181,10 +182,10 @@ public class PlanTest extends BaseStripeFunctionalTest {
     params.put("transform_usage", transformUsage);
 
     Plan plan = Plan.create(params);
-    assertEquals(new Long(100), plan.getAmount());
+    assertTrue(Objects.equals(100L, plan.getAmount()));
 
     PlanTransformUsage planTransformUsage = plan.getTransformUsage();
-    assertEquals(new Long(1000), planTransformUsage.getDivideBy());
+    assertTrue(Objects.equals(1000L, planTransformUsage.getDivideBy()));
     assertEquals("up", planTransformUsage.getRound());
   }
 

--- a/src/test/java/com/stripe/functional/RefundTest.java
+++ b/src/test/java/com/stripe/functional/RefundTest.java
@@ -13,8 +13,8 @@ import com.stripe.model.Charge;
 import com.stripe.model.ChargeRefundCollection;
 import com.stripe.model.Refund;
 
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -111,7 +111,7 @@ public class RefundTest extends BaseStripeFunctionalTest {
     Charge ch = Charge.create(defaultChargeParams);
     ch = ch.refund();
 
-    List<String> expandList = new LinkedList<String>();
+    List<String> expandList = new ArrayList<>();
     expandList.add("data.balance_transaction");
     expandList.add("data.balance_transaction.source");
     expandList.add("data.charge");

--- a/src/test/java/com/stripe/functional/UsageRecordTest.java
+++ b/src/test/java/com/stripe/functional/UsageRecordTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.stripe.BaseStripeFunctionalTest;
 import com.stripe.exception.StripeException;
@@ -13,6 +13,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+
 import org.junit.Test;
 
 public class UsageRecordTest extends BaseStripeFunctionalTest {
@@ -30,8 +32,8 @@ public class UsageRecordTest extends BaseStripeFunctionalTest {
 
     UsageRecord ur = UsageRecord.create(params, null);
 
-    assertEquals(new Long(1000), ur.getQuantity());
-    assertEquals(new Long(unixTime), ur.getTimestamp());
+    assertTrue(Objects.equals(1000L, ur.getQuantity()));
+    assertTrue(Objects.equals(unixTime, ur.getTimestamp()));
   }
 
   private Plan createMeteredPlan() throws StripeException {

--- a/src/test/java/com/stripe/model/AccountTest.java
+++ b/src/test/java/com/stripe/model/AccountTest.java
@@ -11,8 +11,9 @@ import com.stripe.net.RequestOptions;
 import com.stripe.net.RequestOptions.RequestOptionsBuilder;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.After;
@@ -43,7 +44,7 @@ public class AccountTest extends BaseStripeTest {
     assertEquals("http://www.business.com", acc.getBusinessURL());
     assertEquals("http://support.business.com", acc.getSupportURL());
 
-    LinkedList<String> cs = new LinkedList<String>();
+    List<String> cs = new ArrayList<String>();
     cs.add("usd");
     cs.add("aud");
     assertEquals(cs, acc.getCurrenciesSupported());
@@ -70,7 +71,7 @@ public class AccountTest extends BaseStripeTest {
     Account.Verification verif = new Account.Verification();
     verif.disabledReason = "fields_needed";
     verif.dueBy = (long) 1457913600;
-    LinkedList<String> fn = new LinkedList<String>();
+    List<String> fn = new ArrayList<String>();
     fn.add("legal_entity.first_name");
     fn.add("legal_entity.last_name");
     verif.fieldsNeeded = fn;

--- a/src/test/java/com/stripe/model/BalanceTransactionTest.java
+++ b/src/test/java/com/stripe/model/BalanceTransactionTest.java
@@ -25,7 +25,7 @@ public class BalanceTransactionTest extends BaseStripeTest {
     BalanceTransaction transaction = APIResource.GSON.fromJson(json, BalanceTransaction.class);
     assertEquals("txn_1AF5AmKac2qaDcCZm8tBQt6I", transaction.getId());
 
-    Dispute dp = transaction.getSourceObjectAs();
+    Dispute dp = (Dispute) transaction.getSourceObjectAs();
     assertNotNull(dp);
     assertEquals("dp_1AF5AmKac2qaDcCZHvOjyrDo", dp.getId());
   }

--- a/src/test/java/com/stripe/model/ExpandableFieldDeserializerTest.java
+++ b/src/test/java/com/stripe/model/ExpandableFieldDeserializerTest.java
@@ -20,10 +20,11 @@ public class ExpandableFieldDeserializerTest extends BaseStripeTest {
 
   private static Gson gson = APIResource.GSON;
 
-  private class TestObject implements HasId {
+  private static class TestObject implements HasId {
     String id;
     int bar;
 
+    @Override
     public String getId() {
       return id;
     }
@@ -34,7 +35,7 @@ public class ExpandableFieldDeserializerTest extends BaseStripeTest {
     String json = gson.toJson(null);
     // Gson also uses TypeTokens internally to get around Type Erasure for generic types, simulate
     // that here:
-    ExpandableField out = gson.fromJson(json,
+    ExpandableField<TestObject> out = gson.fromJson(json,
         new TypeToken<ExpandableField<TestObject>>() {}.getType());
     assertNull(out);
   }

--- a/src/test/java/com/stripe/model/ExpandableFieldSerializerTest.java
+++ b/src/test/java/com/stripe/model/ExpandableFieldSerializerTest.java
@@ -11,16 +11,17 @@ import org.junit.Test;
 
 public class ExpandableFieldSerializerTest extends BaseStripeTest {
 
-  private class TestNestedObject implements HasId {
+  private static class TestNestedObject implements HasId {
     String id;
     int bar;
 
+    @Override
     public String getId() {
       return id;
     }
   }
 
-  private class TestTopLevelObject extends StripeObject {
+  private static class TestTopLevelObject extends StripeObject {
     ExpandableField<TestNestedObject> nested;
   }
 

--- a/src/test/java/com/stripe/model/LegalEntityTest.java
+++ b/src/test/java/com/stripe/model/LegalEntityTest.java
@@ -1,6 +1,7 @@
 package com.stripe.model;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -8,7 +9,8 @@ import com.stripe.model.LegalEntity;
 import com.stripe.net.APIResource;
 
 import java.io.IOException;
-import java.util.LinkedList;
+import java.util.ArrayList;
+import java.util.Objects;
 
 import org.junit.Test;
 
@@ -28,10 +30,10 @@ public class LegalEntityTest extends BaseStripeTest {
     assertEquals("US", le.getAddress().getCountry());
     assertEquals("Monica", le.getFirstName());
     assertEquals("Geller", le.getLastName());
-    assertEquals(new Integer(4), le.getDob().getDay());
-    assertEquals(new Integer(4), le.getDob().getMonth());
-    assertEquals(new Integer(1969), le.getDob().getYear());
-    assertEquals(new LinkedList<Object>(), le.getAdditionalOwners());
+    assertTrue(Objects.equals(4, le.getDob().getDay()));
+    assertTrue(Objects.equals(4, le.getDob().getMonth()));
+    assertTrue(Objects.equals(1969, le.getDob().getYear()));
+    assertEquals(new ArrayList<Object>(), le.getAdditionalOwners());
     assertEquals("verified", le.getVerification().getStatus());
     assertEquals(null, le.getVerification().getDocument());
     assertEquals(null, le.getVerification().getDetails());

--- a/src/test/java/com/stripe/model/OrderTest.java
+++ b/src/test/java/com/stripe/model/OrderTest.java
@@ -10,8 +10,8 @@ import com.stripe.net.APIResource;
 import com.stripe.net.LiveStripeResponseGetter;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -43,7 +43,7 @@ public class OrderTest extends BaseStripeTest {
   public void testCreate() throws StripeException {
     Map<String, Object> params = new HashMap<String, Object>();
     params.put("currency", "usd");
-    List<Object> itemsList = new LinkedList<Object>();
+    List<Object> itemsList = new ArrayList<Object>();
     Map<String, Object> item1Params = new HashMap<String, Object>();
     item1Params.put("type", "sku");
     item1Params.put("parent", "sku_test");
@@ -77,7 +77,7 @@ public class OrderTest extends BaseStripeTest {
 
   @Test
   public void testRetrieveWithExpand() throws StripeException {
-    List<String> expandList = new LinkedList<String>();
+    List<String> expandList = new ArrayList<String>();
     expandList.add("charge");
     expandList.add("customer");
 
@@ -136,7 +136,7 @@ public class OrderTest extends BaseStripeTest {
     assertEquals("or_1ATvaEKCFFPkgtRhFtMgtnLF", order.getId());
 
     OrderItem item = order.getItems().get(0);
-    SKU parent = item.getParentObjectAs();
+    SKU parent = (SKU) item.getParentObjectAs();
     assertNotNull(parent);
     assertEquals("silence_mp3", parent.getId());
   }

--- a/src/test/java/com/stripe/model/PagingIteratorTest.java
+++ b/src/test/java/com/stripe/model/PagingIteratorTest.java
@@ -46,6 +46,7 @@ public class PagingIteratorTest extends BaseStripeTest {
           PageableModelCollection.class, options);
     }
 
+    @Override
     public String getId() {
       return id;
     }
@@ -88,6 +89,7 @@ public class PagingIteratorTest extends BaseStripeTest {
       // essentially all we're doing here is returning the first page of
       // results on the first request and the second page of results on
       // the second
+      @Override
       public Object answer(InvocationOnMock invocation) {
         if (count >= pages.size()) {
           throw new RuntimeException("Page out of bounds");

--- a/src/test/java/com/stripe/model/UsageRecordTest.java
+++ b/src/test/java/com/stripe/model/UsageRecordTest.java
@@ -35,7 +35,7 @@ public class UsageRecordTest extends BaseStripeTest {
     params.put("livemode", true);
     params.put("subscription_item", "si_abc");
 
-    UsageRecord ur = UsageRecord.create(params, null);
+    UsageRecord.create(params, null);
 
     Map<String, Object> apiParams = new HashMap<>();
     apiParams.put("quantity", 1000);
@@ -43,8 +43,7 @@ public class UsageRecordTest extends BaseStripeTest {
     apiParams.put("livemode", true);
 
     verifyPost(UsageRecord.class,
-            "https://api.stripe.com/v1/subscription_items/si_abc/usage_records",
-            apiParams);
+        "https://api.stripe.com/v1/subscription_items/si_abc/usage_records", apiParams);
     verifyNoMoreInteractions(networkMock);
   }
 

--- a/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
+++ b/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
@@ -13,9 +13,9 @@ import com.stripe.net.RequestOptions;
 import com.stripe.net.RequestOptions.RequestOptionsBuilder;
 
 import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -54,7 +54,7 @@ public class LiveStripeResponseGetterTest {
   @Test
   public void testCreateQueryWithListParams() throws StripeException, UnsupportedEncodingException {
 
-    List<String> nested = new LinkedList<String>();
+    List<String> nested = new ArrayList<String>();
     nested.add("A");
     nested.add("B");
     nested.add("C");
@@ -96,7 +96,7 @@ public class LiveStripeResponseGetterTest {
     deepNestedMap2.put("A", "A-2");
     deepNestedMap2.put("B", "B-2");
 
-    List<Object> nested = new LinkedList<Object>();
+    List<Object> nested = new ArrayList<Object>();
     nested.add(deepNestedMap1);
     nested.add(deepNestedMap2);
 
@@ -111,7 +111,7 @@ public class LiveStripeResponseGetterTest {
   @Test
   public void testCreateQueryWithEmptyList() throws StripeException, UnsupportedEncodingException {
     Map<String, Object> params = new HashMap<String, Object>();
-    params.put("a", new LinkedList<String>());
+    params.put("a", new ArrayList<String>());
     assertEquals("a=", LiveStripeResponseGetter.createQuery(params));
   }
 
@@ -136,7 +136,7 @@ public class LiveStripeResponseGetterTest {
     Map<String, String> ownerParams = new HashMap<String, String>();
     ownerParams.put("first_name", "Stripe");
 
-    List<Object> additionalOwners = new LinkedList<Object>();
+    List<Object> additionalOwners = new ArrayList<Object>();
     additionalOwners.add(ownerParams);
 
     Map<String, Object> legalEntityParams = new HashMap<String, Object>();

--- a/src/test/java/com/stripe/net/OAuthTest.java
+++ b/src/test/java/com/stripe/net/OAuthTest.java
@@ -2,6 +2,7 @@ package com.stripe.net;
 
 import static org.junit.Assert.assertEquals;
 
+import com.google.common.base.Splitter;
 import com.stripe.BaseStripeTest;
 import com.stripe.Stripe;
 import com.stripe.exception.AuthenticationException;
@@ -17,6 +18,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.After;
@@ -38,7 +40,7 @@ public class OAuthTest extends BaseStripeTest {
 
   private static Map<String, String> splitQuery(String query) throws UnsupportedEncodingException {
     Map<String, String> queryPairs = new HashMap<String, String>();
-    String[] pairs = query.split("&");
+    List<String> pairs = Splitter.on("&").splitToList(query);
     for (String pair : pairs) {
       int idx = pair.indexOf("=");
       queryPairs.put(URLDecoder.decode(pair.substring(0, idx), "UTF8"),


### PR DESCRIPTION
This PR implements Googles Error Prone code analysis http://errorprone.info/

I’ve gone through and corrected the raised errors.

Error Prone cannot run on Java 7 and, as I am not a Gradle person, I don’t know how to conditionally run it. Thus the travis step for Java 7 is currently REMOVED. I would imagine that, like Checkstyle, you can configure this to only run for the Java 9 (or current latest) build.

http://errorprone.info/docs/installation

Per Google’s recommendation this is the Gradle plugin used:

https://github.com/tbroyer/Gradle-errorprone-plugin 

I’ve also added an Eclipse Java style file that is based off Google’s Java style and tweaked to conform to your Checkstyle. It works for everything I’ve run into, so it’s probably a good starting point.

I would also recommend configuring error prone to fail on warning so that small issues don't creep in over time.
