### PR TITLE
Fix testSourceCreateRead

### DIFF
--- a/src/test/java/com/stripe/functional/SourceTest.java
+++ b/src/test/java/com/stripe/functional/SourceTest.java
@@ -23,21 +23,16 @@ public class SourceTest extends BaseStripeFunctionalTest {
     ownerParams.put("email", "payinguser+fill_now@example.com");
 
     Map<String, Object> sourceCreateParams = new HashMap<String, Object>();
-    sourceCreateParams.put("type", "bitcoin");
+    sourceCreateParams.put("type", "ach_credit_transfer");
     sourceCreateParams.put("currency", "usd");
-    sourceCreateParams.put("amount", 1000);
     sourceCreateParams.put("owner", ownerParams);
 
     Source created = Source.create(sourceCreateParams, sourceRequestOptions);
 
-    assertEquals("bitcoin", created.getType());
+    assertEquals("ach_credit_transfer", created.getType());
     assertEquals("receiver", created.getFlow());
 
-    // TODO: It's obviously very unpleasant to have all strings
-    // here. The plan is to type-check these once any method makes
-    // it to public beta. For now, unfortunately, the user will have
-    // to actually cast the data to what they want.
-    assertEquals(0, Long.parseLong(created.getTypeData().get("amount_charged")));
+    assertEquals(false, created.getTypeData().isEmpty());
 
     Source retrieved = Source.retrieve(created.getId(), sourceRequestOptions);
     assertEquals(created.getId(), retrieved.getId());

--- a/src/test/java/com/stripe/model/SourceTest.java
+++ b/src/test/java/com/stripe/model/SourceTest.java
@@ -34,8 +34,7 @@ public class SourceTest extends BaseStripeTest {
     ownerParams.put("email", "jenny.rosen@example.com");
 
     HashMap<String, Object> params = new HashMap<String, Object>();
-    params.put("type", "bitcoin");
-    params.put("amount", 1000);
+    params.put("type", "ach_credit_transfer");
     params.put("currency", "usd");
     params.put("owner", ownerParams);
 


### PR DESCRIPTION
Bitcoin is no longer supported, so use ach_credit_transfer as the example source in this functional test.

r? @brandur-stripe 