### PR TITLE
Fix invoice test

### DIFF
--- a/src/test/java/com/stripe/functional/InvoiceTest.java
+++ b/src/test/java/com/stripe/functional/InvoiceTest.java
@@ -101,6 +101,7 @@ public class InvoiceTest extends BaseStripeFunctionalTest {
     Invoice retrievedInvoice = Invoice.retrieve(createdInvoice.getId());
     assertEquals(createdInvoice.getId(), retrievedInvoice.getId());
 
+    listParams.remove("subscription");
     InvoiceLineItemCollection lines = retrievedInvoice.getLines().all(
         listParams);
     assertNotNull(lines);


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

The test suite has been broken for the past 17 days because of an upstream change. The ["list invoice lines"](https://stripe.com/docs/api#invoice_lines) endpoint (`/v1/invoices/<INVOICE_ID>/lines`) now only accepts pagination parameters and nothing else. 

For context: previously, the endpoint accepted (and ignored) more parameters due to the implementation being shared with the ["list upcoming invoice lines"](https://stripe.com/docs/api#upcoming_invoice_lines) endpoint (`/v1/invoices/upcoming/lines`).

This caused one of the tests in the suite to fail because it was sending a `subscription` parameter that is now rejected by the API. Removing the parameter fixes the test.
