### PR TITLE
Test more Java versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,9 @@ addons:
     - short-hostname
   hostname: short-hostname
 
-jdk:
-  - openjdk7
-  - openjdk8
-  - oraclejdk8
-  - oraclejdk9
-
 before_install:
+  # Install script for missing JDKs
+  - wget https://github.com/sormuras/bach/raw/master/install-jdk.sh
   # Work around missing crypto in openjdk7
   - |
     if [ "$TRAVIS_JDK_VERSION" == "openjdk7" ]; then
@@ -22,11 +18,33 @@ before_install:
       echo "security.provider.1=org.bouncycastle.jce.provider.BouncyCastleProvider" | sudo tee -a /etc/java-7-openjdk/security/java.security
     fi
 
+matrix:
+  include:
+# 7
+    - env: JDK='OpenJDK 7'
+      jdk: openjdk7
+# 8
+    - env: JDK='Oracle JDK 8'
+      jdk: oraclejdk8
+    - env: JDK='OpenJDK 8'
+      jdk: openjdk8
+# 9
+    - env: JDK='Oracle JDK 9'
+      jdk: oraclejdk9
+    - env: JDK='OpenJDK 9'
+      install: . ./install-jdk.sh -F 9 -L GPL
+# 10
+    - env: JDK='Oracle JDK 10'
+      install: . ./install-jdk.sh -F 10 -L BCL
+    - env: JDK='OpenJDK 10'
+      install: . ./install-jdk.sh -F 10 -L GPL
+
 notifications:
   email:
     on_success: never
 
 script:
+  - ./gradlew --version
   - ./gradlew clean
   - if [ "$TRAVIS_JDK_VERSION" == "oraclejdk9" ]; then ./gradlew check; fi
   - ./gradlew cobertura coveralls


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Java is moving to a faster development cycle where a new major version will be released every 6 months (and one LTS version every 3 years). Java 10 was released a few weeks back.

Travis has been fairly slow in adding support for these new versions, so someone wrote a script to install the missing JDKs. This PR uses the script in order to test the following versions that are not natively supported by Travis:
- OpenJDK 9
- Oracle JDK 10
- OpenJDK 10

(The script also supports the "early access" versions of Java 11, but then Gradle doesn't yet support Java 11 so there's not much point in adding those versions for now.)

References:
- https://adtmag.com/articles/2018/03/21/java-10.aspx
- https://github.com/travis-ci/travis-ci/issues/9368
- https://sormuras.github.io/blog/2017-12-08-install-jdk-on-travis.html
