### PR TITLE
Fix update() methods for FeeRefund and Reversal

### DIFF
--- a/src/main/java/com/stripe/model/FeeRefund.java
+++ b/src/main/java/com/stripe/model/FeeRefund.java
@@ -86,7 +86,7 @@ public class FeeRefund extends APIResource implements MetadataStore<ApplicationF
 
   protected String getInstanceURL() {
     if (this.fee != null) {
-      return String.format("%s/%s/refunds/%s", classURL(ApplicationFee.class), this.fee,
+      return String.format("%s/%s/refunds/%s", classURL(ApplicationFee.class), this.getFee(),
           this.getId());
     }
     return null;

--- a/src/main/java/com/stripe/model/Reversal.java
+++ b/src/main/java/com/stripe/model/Reversal.java
@@ -86,7 +86,7 @@ public class Reversal extends APIResource implements MetadataStore<Transfer>, Ha
 
   protected String getInstanceURL() {
     if (this.transfer != null) {
-      return String.format("%s/%s/reversals/%s", classURL(Transfer.class), this.transfer,
+      return String.format("%s/%s/reversals/%s", classURL(Transfer.class), this.getTransfer(),
           this.getId());
     }
     return null;


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Currently, trying to update a `FeeRefund` or `Reversal` instance will fail because the URL is formed with `this.fee` / `this.transfer` to find the ID of the owner. Because these fields are expandable, accessing the attributes directly results in URLs like `/v1/application_fees/com.stripe.model.ExpandableField@792bbc74/refunds/fr_123`.

The fix is simply to use the getter, which will return the proper ID of the owner resource.

No tests in this PR, but there are tests for this in #452 and I've verified that this fix makes the tests pass.
