### PR TITLE
Fix all warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ group = GROUP
 version = VERSION_NAME
 
 tasks.withType(JavaCompile) {
+    options.compilerArgs << "-Xlint:all" << "-Xlint:-options" << "-Xlint:-processing" << "-Werror"
     options.encoding = 'UTF-8'
 }
 

--- a/src/main/java/com/stripe/model/BalanceTransaction.java
+++ b/src/main/java/com/stripe/model/BalanceTransaction.java
@@ -62,6 +62,7 @@ public class BalanceTransaction extends APIResource implements HasId {
     this.source = new ExpandableField<HasId>(o.getId(), o);
   }
 
+  @SuppressWarnings("unchecked")
   public <O extends HasId> O getSourceObjectAs() {
     return (this.source != null) ? (O) this.source.getExpanded() : null;
   }

--- a/src/main/java/com/stripe/model/BalanceTransactionDeserializer.java
+++ b/src/main/java/com/stripe/model/BalanceTransactionDeserializer.java
@@ -16,8 +16,8 @@ import java.util.Map;
 
 public class BalanceTransactionDeserializer implements JsonDeserializer<BalanceTransaction> {
 
-  @SuppressWarnings("rawtypes")
-  static final Map<String, Class> sourceObjMap = new HashMap<String, Class>();
+  static final Map<String, Class<? extends HasId>> sourceObjMap =
+      new HashMap<String, Class<? extends HasId>>();
 
   static {
     sourceObjMap.put("application_fee", ApplicationFee.class);

--- a/src/main/java/com/stripe/model/DeletedApplePayDomain.java
+++ b/src/main/java/com/stripe/model/DeletedApplePayDomain.java
@@ -1,6 +1,5 @@
 package com.stripe.model;
 
-import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/stripe/model/DisputeDataDeserializer.java
+++ b/src/main/java/com/stripe/model/DisputeDataDeserializer.java
@@ -31,7 +31,7 @@ public class DisputeDataDeserializer implements JsonDeserializer<Dispute> {
     if (!json.isJsonObject()) {
       throw new JsonParseException("Dispute type was not an object, which is problematic.");
     }
-    // API Versions 2014-12-TODO and earlier use a string for evidence, and we've renamed that to
+    // API Versions 2014-12-08 and earlier use a string for evidence, and we've renamed that to
     // evidenceString.
     JsonObject disputeAsJsonObject = json.getAsJsonObject();
 

--- a/src/main/java/com/stripe/model/DisputeDataDeserializer.java
+++ b/src/main/java/com/stripe/model/DisputeDataDeserializer.java
@@ -56,9 +56,14 @@ public class DisputeDataDeserializer implements JsonDeserializer<Dispute> {
     }
     disputeAsJsonObject.remove("evidence");
     Dispute parsedData = gson.fromJson(json, typeOfT);
-    parsedData.setEvidence(evidenceString);
+    setEvidenceString(parsedData, evidenceString);
     parsedData.setEvidenceSubObject(evidenceSubObject);
 
     return parsedData;
+  }
+
+  @SuppressWarnings("deprecation")
+  private static void setEvidenceString(Dispute dispute, String evidenceString) {
+    dispute.setEvidence(evidenceString);
   }
 }

--- a/src/main/java/com/stripe/model/EventDataDeserializer.java
+++ b/src/main/java/com/stripe/model/EventDataDeserializer.java
@@ -16,8 +16,8 @@ import java.util.Map;
 
 public class EventDataDeserializer implements JsonDeserializer<EventData> {
 
-  @SuppressWarnings("rawtypes")
-  static final Map<String, Class> objectMap = new HashMap<String, Class>();
+  static final Map<String, Class<? extends StripeObject>> objectMap =
+      new HashMap<String, Class<? extends StripeObject>>();
 
   static {
     objectMap.put("account", Account.class);
@@ -117,7 +117,6 @@ public class EventDataDeserializer implements JsonDeserializer<EventData> {
    * Deserializes the JSON payload contained in an event's {@code data} attribute into an
    * {@link EventData} instance.
    */
-  @SuppressWarnings("unchecked")
   public EventData deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
       throws JsonParseException {
     EventData eventData = new EventData();
@@ -135,7 +134,7 @@ public class EventDataDeserializer implements JsonDeserializer<EventData> {
         }
       } else if ("object".equals(key)) {
         String type = element.getAsJsonObject().get("object").getAsString();
-        Class<StripeObject> cl = objectMap.get(type);
+        Class<? extends StripeObject> cl = objectMap.get(type);
         StripeObject object = APIResource.GSON.fromJson(
             entry.getValue(), cl != null ? cl : StripeRawJsonObject.class);
         eventData.setObject(object);

--- a/src/main/java/com/stripe/model/ExpandableFieldDeserializer.java
+++ b/src/main/java/com/stripe/model/ExpandableFieldDeserializer.java
@@ -10,25 +10,25 @@ import com.google.gson.JsonPrimitive;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 
-public class ExpandableFieldDeserializer implements JsonDeserializer<ExpandableField> {
+public class ExpandableFieldDeserializer implements JsonDeserializer<ExpandableField<?>> {
   /**
    * Deserializes an expandable field JSON payload (i.e. either a string with just the ID, or a full
    * JSON object) into an {@link ExpandableField} object.
    */
-  public ExpandableField deserialize(JsonElement json, Type typeOfT,
+  public ExpandableField<?> deserialize(JsonElement json, Type typeOfT,
       JsonDeserializationContext context) throws JsonParseException {
     if (json.isJsonNull()) {
       return null;
     }
 
-    ExpandableField expandableField;
+    ExpandableField<?> expandableField;
 
     // Check if json is a String ID. If so, the field has not been expanded, so we only need to
     // serialize a String and create a new ExpandableField with the String id only.
     if (json.isJsonPrimitive()) {
       JsonPrimitive jsonPrimitive = json.getAsJsonPrimitive();
       if (jsonPrimitive.isString()) {
-        expandableField = new ExpandableField(jsonPrimitive.getAsString(), null);
+        expandableField = new ExpandableField<HasId>(jsonPrimitive.getAsString(), null);
         return expandableField;
       } else {
         throw new JsonParseException("ExpandableField is a non-string primitive type.");
@@ -43,7 +43,7 @@ public class ExpandableFieldDeserializer implements JsonDeserializer<ExpandableF
       // We need to get the type inside the generic ExpandableField to make sure fromJson correctly
       // serializes the JsonObject:
       Type clazz = ((ParameterizedType) typeOfT).getActualTypeArguments()[0];
-      expandableField = new ExpandableField(id, (HasId) context.deserialize(json, clazz));
+      expandableField = new ExpandableField<HasId>(id, (HasId) context.deserialize(json, clazz));
       return expandableField;
     }
 

--- a/src/main/java/com/stripe/model/ExpandableFieldSerializer.java
+++ b/src/main/java/com/stripe/model/ExpandableFieldSerializer.java
@@ -7,11 +7,11 @@ import com.google.gson.JsonSerializer;
 
 import java.lang.reflect.Type;
 
-public class ExpandableFieldSerializer implements JsonSerializer<ExpandableField> {
+public class ExpandableFieldSerializer implements JsonSerializer<ExpandableField<?>> {
   /**
    * Serializes an expandable attribute into a JSON string.
    */
-  public JsonElement serialize(ExpandableField src, Type typeOfSrc,
+  public JsonElement serialize(ExpandableField<?> src, Type typeOfSrc,
       JsonSerializationContext context) {
     if (src.isExpanded()) {
       return context.serialize(src.getExpanded());

--- a/src/main/java/com/stripe/model/ExternalAccountTypeAdapterFactory.java
+++ b/src/main/java/com/stripe/model/ExternalAccountTypeAdapterFactory.java
@@ -16,6 +16,7 @@ public class ExternalAccountTypeAdapterFactory implements TypeAdapterFactory {
    * Creates the type adapter used to instantiate {@link ExternalAccount} subclasses from JSON
    * payloads.
    */
+  @SuppressWarnings("unchecked")
   public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
     if (!ExternalAccount.class.isAssignableFrom(type.getRawType())) {
       return null; // this class only serializes 'ExternalAccount' and its subtypes

--- a/src/main/java/com/stripe/model/OrderItem.java
+++ b/src/main/java/com/stripe/model/OrderItem.java
@@ -36,6 +36,7 @@ public class OrderItem extends APIResource {
     this.parent = new ExpandableField<HasId>(o.getId(), o);
   }
 
+  @SuppressWarnings("unchecked")
   public <O extends HasId> O getParentObjectAs() {
     return (this.parent != null) ? (O) this.parent.getExpanded() : null;
   }

--- a/src/main/java/com/stripe/model/OrderItemDeserializer.java
+++ b/src/main/java/com/stripe/model/OrderItemDeserializer.java
@@ -25,6 +25,7 @@ public class OrderItemDeserializer implements JsonDeserializer<OrderItem> {
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public OrderItem deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
       throws JsonParseException {
     if (json.isJsonNull()) {

--- a/src/main/java/com/stripe/model/SubscriptionItem.java
+++ b/src/main/java/com/stripe/model/SubscriptionItem.java
@@ -10,7 +10,6 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
-import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/stripe/model/ThreeDSecure.java
+++ b/src/main/java/com/stripe/model/ThreeDSecure.java
@@ -13,7 +13,6 @@ import com.stripe.net.RequestOptions;
 
 import java.util.Map;
 
-import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/stripe/model/TransferReversalCollection.java
+++ b/src/main/java/com/stripe/model/TransferReversalCollection.java
@@ -63,7 +63,6 @@ public class TransferReversalCollection extends StripeCollection<Reversal> {
   public Reversal retrieve(String id, RequestOptions options) throws AuthenticationException,
       InvalidRequestException, APIConnectionException, CardException,
       APIException {
-    // TODO replace with subresourceURL
     String url = String.format("%s%s/%s", Stripe.getApiBase(), this.getURL(), id);
     return APIResource.request(APIResource.RequestMethod.GET, url, null, Reversal.class, options);
   }

--- a/src/main/java/com/stripe/net/APIResource.java
+++ b/src/main/java/com/stripe/net/APIResource.java
@@ -195,7 +195,7 @@ public abstract class APIResource extends StripeObject {
    * options and params through so that we can iterate to the next page if
    * necessary.
    */
-  public static <T extends StripeCollectionInterface> T requestCollection(
+  public static <T extends StripeCollectionInterface<?>> T requestCollection(
       String url, Map<String, Object> params, Class<T> clazz,
       RequestOptions options)
       throws AuthenticationException, InvalidRequestException,

--- a/src/main/java/com/stripe/net/APIResource.java
+++ b/src/main/java/com/stripe/net/APIResource.java
@@ -72,38 +72,20 @@ public abstract class APIResource extends StripeObject {
       .create();
 
   private static String className(Class<?> clazz) {
-    String className = clazz.getSimpleName().toLowerCase().replace("$", " ");
+    // Convert CamelCase to snake_case
+    final String className = clazz.getSimpleName()
+        .replaceAll("(.)([A-Z][a-z]+)", "$1_$2")
+        .replaceAll("([a-z0-9])([A-Z])", "$1_$2")
+        .toLowerCase();
 
-    // TODO: Delurk this, with invoiceitem being a valid url, we can't get too
-    // fancy yet.
-    if (className.equals("applepaydomain")) {
-      return "apple_pay_domain";
-    } else if (className.equals("applicationfee")) {
-      return "application_fee";
-    } else if (className.equals("bitcoinreceiver")) {
-      return "bitcoin_receiver";
-    } else if (className.equals("countryspec")) {
-      return "country_spec";
-    } else if (className.equals("ephemeralkey")) {
-      return "ephemeral_key";
-    } else if (className.equals("exchangerate")) {
-      return "exchange_rate";
-    } else if (className.equals("fileupload")) {
-      return "file";
-    } else if (className.equals("issuerfraudrecord")) {
-      return "issuer_fraud_record";
-    } else if (className.equals("orderreturn")) {
-      return "order_return";
-    } else if (className.equals("sourcetransaction")) {
-      return "source_transaction";
-    } else if (className.equals("subscriptionitem")) {
-      return "subscription_item";
-    } else if (className.equals("threedsecure")) {
-      return "three_d_secure";
-    } else if (className.equals("usagerecord")) {
-      return "usage_record";
-    } else {
-      return className;
+    // Handle special cases
+    switch (className) {
+      case "invoice_item":
+        return "invoiceitem";
+      case "file_upload":
+        return "file";
+      default:
+        return className;
     }
   }
 

--- a/src/main/java/com/stripe/net/MultipartProcessor.java
+++ b/src/main/java/com/stripe/net/MultipartProcessor.java
@@ -14,8 +14,6 @@ public class MultipartProcessor {
   private static final String LINE_BREAK = "\r\n";
   private OutputStream outputStream;
   private PrintWriter writer;
-  private String charset;
-  private java.net.HttpURLConnection conn;
 
   /**
    * Generates a random MIME multipart boundary.
@@ -34,8 +32,6 @@ public class MultipartProcessor {
   public MultipartProcessor(java.net.HttpURLConnection conn, String boundary, String charset)
       throws IOException {
     this.boundary = boundary;
-    this.charset = charset;
-    this.conn = conn;
 
     this.outputStream = conn.getOutputStream();
     this.writer = new PrintWriter(new OutputStreamWriter(outputStream, charset), true);

--- a/src/main/java/com/stripe/net/RequestOptions.java
+++ b/src/main/java/com/stripe/net/RequestOptions.java
@@ -295,6 +295,8 @@ public class RequestOptions {
   }
 
   public static class InvalidRequestOptionsException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
     public InvalidRequestOptionsException(String message) {
       super(message);
     }

--- a/src/test/java/com/stripe/DocumentationTest.java
+++ b/src/test/java/com/stripe/DocumentationTest.java
@@ -1,5 +1,9 @@
 package com.stripe;
 
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import com.google.common.base.Joiner;
 
 import java.io.BufferedReader;
@@ -12,7 +16,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 public class DocumentationTest {
@@ -27,78 +30,97 @@ public class DocumentationTest {
 
   @Test
   public void testChangeLogContainsStaticVersion() throws IOException {
-    File changelogFile = new File("CHANGELOG.md").getAbsoluteFile();
-    Assert.assertTrue(String.format(
-        "Expected CHANGELOG file to exist, but it doesn't. (path is %s).",
-        changelogFile.getAbsolutePath()), changelogFile.exists());
-    Assert.assertTrue(String.format(
-        "Expected CHANGELOG to be a file, but it doesn't. (path is %s).",
-        changelogFile.getAbsolutePath()), changelogFile.isFile());
-    BufferedReader reader = new BufferedReader(new FileReader(changelogFile));
-    String expectedLine = formatDateTime();
-    String line;
-    List<String> closeMatches = new LinkedList<String>();
-    while ((line = reader.readLine()) != null) {
-      if (line.contains(Stripe.VERSION)) {
-        if (Pattern.matches(String.format(
-            "^## %s - 20[12][0-9]-(0[1-9]|1[0-2])-(0[1-9]|1[0-9]|2[0-9]|3[0-1])$", Stripe.VERSION),
-            line)) {
-          return;
+    final File changelogFile = new File("CHANGELOG.md").getAbsoluteFile();
+
+    assertTrue(
+        String.format("Expected CHANGELOG file to exist, but it doesn't. (path is %s).",
+            changelogFile.getAbsolutePath()),
+        changelogFile.exists());
+    assertTrue(
+        String.format("Expected CHANGELOG to be a file, but it isn't. (path is %s).",
+            changelogFile.getAbsolutePath()),
+        changelogFile.isFile());
+
+    try (final BufferedReader reader = new BufferedReader(new FileReader(changelogFile))) {
+      final String expectedLine = formatDateTime();
+      final String pattern = String.format(
+          "^## %s - 20[12][0-9]-(0[1-9]|1[0-2])-(0[1-9]|1[0-9]|2[0-9]|3[0-1])$", Stripe.VERSION);
+      final List<String> closeMatches = new LinkedList<String>();
+      String line;
+
+      while ((line = reader.readLine()) != null) {
+        if (line.contains(Stripe.VERSION)) {
+          if (Pattern.matches(pattern, line)) {
+            return;
+          }
+          closeMatches.add(line);
         }
-        closeMatches.add(line);
       }
+
+      fail(String.format(
+          "Expected a line of the format '%s' in the CHANGELOG, but didn't find one.%n"
+          + "The following lines were close, but didn't match exactly:%n'%s'",
+          expectedLine, Joiner.on(", ").join(closeMatches)));
     }
-    Assert.fail(String.format(
-        "Expected a line of the format '%s' in the CHANGELOG, but didn't find one.%nThe following "
-        + "lines were close, but didn't match exactly:%n'%s'",
-        expectedLine, Joiner.on(", ").join(closeMatches)));
   }
 
   @Test
   public void testReadMeContainsStripeVersionThatMatches() throws IOException {
     // this will be very flaky, but we want to ensure that the readme is correct.
-    File readmeFile = new File("README.md").getAbsoluteFile();
-    Assert.assertTrue(String.format(
-        "Expected README.md file to exist, but it doesn't. (path is %s).",
-        readmeFile.getAbsolutePath()), readmeFile.exists());
-    Assert.assertTrue(String.format(
-        "Expected README.md to be a file, but it doesn't. (path is %s).",
-        readmeFile.getAbsolutePath()), readmeFile.isFile());
-    BufferedReader reader = new BufferedReader(new FileReader(readmeFile));
-    int expectedMentionsOfVersion = 2;
-    // Currently two places mention the Stripe version: the sample pom and gradle files.
-    String line;
-    List<String> mentioningLines = new LinkedList<String>();
-    while ((line = reader.readLine()) != null) {
-      if (line.contains(Stripe.VERSION)) {
-        mentioningLines.add(line);
+    final File readmeFile = new File("README.md").getAbsoluteFile();
+
+    assertTrue(
+        String.format("Expected README.md file to exist, but it doesn't. (path is %s).",
+            readmeFile.getAbsolutePath()),
+        readmeFile.exists());
+    assertTrue(
+        String.format("Expected README.md to be a file, but it doesn't. (path is %s).",
+            readmeFile.getAbsolutePath()),
+        readmeFile.isFile());
+
+    try (final BufferedReader reader = new BufferedReader(new FileReader(readmeFile))) {
+      final int expectedMentionsOfVersion = 2;
+      // Currently two places mention the Stripe version: the sample pom and gradle files.
+      final List<String> mentioningLines = new LinkedList<String>();
+      String line;
+
+      while ((line = reader.readLine()) != null) {
+        if (line.contains(Stripe.VERSION)) {
+          mentioningLines.add(line);
+        }
       }
+
+      final String message = String.format(
+          "Expected %d mentions of the stripe-java version in the Readme, but found %d:%n%s",
+          expectedMentionsOfVersion, mentioningLines.size(), Joiner.on(", ").join(mentioningLines));
+      assertSame(message, expectedMentionsOfVersion, mentioningLines.size());
     }
-    String message = String.format(
-        "Expected %d mentions of the stripe-java version in the Readme, but found %d:%n%s",
-        expectedMentionsOfVersion, mentioningLines.size(), Joiner.on(", ").join(mentioningLines));
-    Assert.assertSame(message, expectedMentionsOfVersion, mentioningLines.size());
   }
 
   @Test
   public void testGradlePropertiesContainsVersionThatMatches() throws IOException {
     // we want to ensure that the pom's version matches the static version.
-    File readmeFile = new File("gradle.properties").getAbsoluteFile();
-    Assert.assertTrue(String.format(
-        "Expected gradle.properties file to exist, but it doesn't. (path is %s).",
-        readmeFile.getAbsolutePath()), readmeFile.exists());
-    Assert.assertTrue(String.format(
-        "Expected gradle.properties to be a file, but it doesn't. (path is %s).",
-        readmeFile.getAbsolutePath()), readmeFile.isFile());
-    BufferedReader reader = new BufferedReader(new FileReader(readmeFile));
-    String line;
-    while ((line = reader.readLine()) != null) {
-      if (line.contains(Stripe.VERSION)) {
-        return;
+    final File gradleFile = new File("gradle.properties").getAbsoluteFile();
+
+    assertTrue(
+        String.format("Expected gradle.properties file to exist, but it doesn't. (path is %s).",
+            gradleFile.getAbsolutePath()),
+        gradleFile.exists());
+    assertTrue(
+        String.format("Expected gradle.properties to be a file, but it doesn't. (path is %s).",
+            gradleFile.getAbsolutePath()),
+            gradleFile.isFile());
+
+    try (final BufferedReader reader = new BufferedReader(new FileReader(gradleFile))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        if (line.contains(Stripe.VERSION)) {
+          return;
+        }
       }
+
+      fail(String.format("Expected the Stripe.VERSION (%s) to match up with the one listed in the "
+          + "gradle.properties file. It wasn't found.", Stripe.VERSION));
     }
-    Assert.fail(String.format(
-        "Expected the Stripe.VERSION (%s) to match up with the one listed in the gradle.properties "
-        + "file. It wasn't found.", Stripe.VERSION));
   }
 }

--- a/src/test/java/com/stripe/model/PagingIteratorTest.java
+++ b/src/test/java/com/stripe/model/PagingIteratorTest.java
@@ -117,17 +117,17 @@ public class PagingIteratorTest extends BaseStripeTest {
 
     verifyRequest(
         APIResource.RequestMethod.GET,
-        "/v1/pageablemodels",
+        "/v1/pageable_models",
         page0Params
     );
     verifyRequest(
         APIResource.RequestMethod.GET,
-        "/v1/pageablemodels",
+        "/v1/pageable_models",
         page1Params
     );
     verifyRequest(
         APIResource.RequestMethod.GET,
-        "/v1/pageablemodels",
+        "/v1/pageable_models",
         page2Params
     );
     verifyNoMoreInteractions(networkSpy);
@@ -169,21 +169,21 @@ public class PagingIteratorTest extends BaseStripeTest {
 
     verifyRequest(
         APIResource.RequestMethod.GET,
-        "/v1/pageablemodels",
+        "/v1/pageable_models",
         page0Params,
         null,
         options
     );
     verifyRequest(
         APIResource.RequestMethod.GET,
-        "/v1/pageablemodels",
+        "/v1/pageable_models",
         page1Params,
         null,
         options
     );
     verifyRequest(
         APIResource.RequestMethod.GET,
-        "/v1/pageablemodels",
+        "/v1/pageable_models",
         page2Params,
         null,
         options

--- a/src/test/java/com/stripe/model/StandardizationTest.java
+++ b/src/test/java/com/stripe/model/StandardizationTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 public class StandardizationTest {
   @Test
   public void allNonDeprecatedMethodsTakeOptions() throws IOException, NoSuchMethodException {
-    for (Class model : getAllModels()) {
+    for (Class<?> model : getAllModels()) {
       for (Method method : model.getMethods()) {
         // Skip methods not declared on the base class.
         if (method.getDeclaringClass() != model) {
@@ -107,14 +107,14 @@ public class StandardizationTest {
     }
   }
 
-  private Collection<Class> getAllModels() throws IOException {
+  private Collection<Class<?>> getAllModels() throws IOException {
     Class<Charge> chargeClass = Charge.class;
     ClassPath classPath = ClassPath.from(chargeClass.getClassLoader());
     ImmutableSet<ClassPath.ClassInfo> topLevelClasses
         = classPath.getTopLevelClasses(chargeClass.getPackage().getName());
-    List<Class> classList = Lists.newArrayListWithExpectedSize(topLevelClasses.size());
+    List<Class<?>> classList = Lists.newArrayListWithExpectedSize(topLevelClasses.size());
     for (ClassPath.ClassInfo classInfo : topLevelClasses) {
-      Class c = classInfo.load();
+      Class<?> c = classInfo.load();
       // Skip things that aren't APIResources
       if (!APIResource.class.isAssignableFrom(c)) {
         continue;

--- a/src/test/resources/model_fixtures/pageable_model_page_0.json
+++ b/src/test/resources/model_fixtures/pageable_model_page_0.json
@@ -11,5 +11,5 @@
   ],
   "has_more": true,
   "object": "list",
-  "url": "/v1/pageablemodels"
+  "url": "/v1/pageable_models"
 }

--- a/src/test/resources/model_fixtures/pageable_model_page_1.json
+++ b/src/test/resources/model_fixtures/pageable_model_page_1.json
@@ -11,5 +11,5 @@
   ],
   "has_more": true,
   "object": "list",
-  "url": "/v1/pageablemodels"
+  "url": "/v1/pageable_models"
 }

--- a/src/test/resources/model_fixtures/pageable_model_page_2.json
+++ b/src/test/resources/model_fixtures/pageable_model_page_2.json
@@ -7,5 +7,5 @@
   ],
   "has_more": false,
   "object": "list",
-  "url": "/v1/pageablemodels"
+  "url": "/v1/pageable_models"
 }


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

This PR fixes all warnings, and enables the `-Werror` compiler flag to treat warnings as errors to ensure we don't introduce new warnings going forward.

Some of the changes are a bit more sensitive than others, so I split the PR in smaller commits to make it easier to review.
