### PR TITLE
Support document_back param

### DIFF
--- a/src/main/java/com/stripe/model/LegalEntity.java
+++ b/src/main/java/com/stripe/model/LegalEntity.java
@@ -41,6 +41,7 @@ public class LegalEntity extends StripeObject {
     String details;
     String detailsCode;
     String document;
+    String documentBack;
     String status;
   }
 

--- a/src/test/java/com/stripe/functional/AccountTest.java
+++ b/src/test/java/com/stripe/functional/AccountTest.java
@@ -96,29 +96,6 @@ public class AccountTest extends BaseStripeTest {
   }
 
   @Test
-  public void testUpdateDocument() throws StripeException {
-    final Account account = getAccountFixture();
-
-    final Map<String, Object> legalEntity = new HashMap<String, Object>();
-    legalEntity.put("type", "individual");
-
-    final Map<String, Object> verification = new HashMap<String, Object>();
-    verification.put("document", "file_123");
-    verification.put("document_back", "file_456");
-    legalEntity.put("verification", verification);
-    final Map<String, Object> params = new HashMap<String, Object>();
-    params.put("legal_entity", legalEntity);
-    final Account updatedAccount = account.update(params);
-
-    assertNotNull(updatedAccount);
-    verifyRequest(
-        APIResource.RequestMethod.POST,
-        String.format("/v1/accounts/%s", account.getId()),
-        params
-    );
-  }
-
-  @Test
   public void testDelete() throws StripeException {
     final Account account = getAccountFixture();
 

--- a/src/test/java/com/stripe/functional/AccountTest.java
+++ b/src/test/java/com/stripe/functional/AccountTest.java
@@ -96,6 +96,29 @@ public class AccountTest extends BaseStripeTest {
   }
 
   @Test
+  public void testUpdateDocument() throws StripeException {
+    final Account account = getAccountFixture();
+
+    final Map<String, Object> legalEntity = new HashMap<String, Object>();
+    legalEntity.put("type", "individual");
+
+    final Map<String, Object> verification = new HashMap<String, Object>();
+    verification.put("document", "file_123");
+    verification.put("document_back", "file_456");
+    legalEntity.put("verification", verification);
+    final Map<String, Object> params = new HashMap<String, Object>();
+    params.put("legal_entity", legalEntity);
+    final Account updatedAccount = account.update(params);
+
+    assertNotNull(updatedAccount);
+    verifyRequest(
+        APIResource.RequestMethod.POST,
+        String.format("/v1/accounts/%s", account.getId()),
+        params
+    );
+  }
+
+  @Test
   public void testDelete() throws StripeException {
     final Account account = getAccountFixture();
 

--- a/src/test/java/com/stripe/model/LegalEntityTest.java
+++ b/src/test/java/com/stripe/model/LegalEntityTest.java
@@ -13,7 +13,17 @@ public class LegalEntityTest extends BaseStripeTest {
     final String json = getResourceAsString("/api_fixtures/legal_entity.json");
     final LegalEntity le = APIResource.GSON.fromJson(json, LegalEntity.class);
     assertNotNull(le);
+    assertNotNull(le.verification.document);
+    assertNotNull(le.verification.documentBack);
     // TODO: Figure out how to test various versions of legal_entity
     // such as with additional_owners, with expanded verification doc, etc.
+  }
+  @Test
+  public void testDeserializeCompany() throws Exception {
+    final String json = getResourceAsString("/api_fixtures/legal_entity.json");
+    final LegalEntity le = APIResource.GSON.fromJson(json, LegalEntity.class);
+    assertNotNull(le);
+    assertNotNull(le.additionalOwners.get(0).verification.document);
+    assertNotNull(le.additionalOwners.get(0).verification.documentBack);
   }
 }

--- a/src/test/java/com/stripe/model/LegalEntityTest.java
+++ b/src/test/java/com/stripe/model/LegalEntityTest.java
@@ -18,6 +18,7 @@ public class LegalEntityTest extends BaseStripeTest {
     // TODO: Figure out how to test various versions of legal_entity
     // such as with additional_owners, with expanded verification doc, etc.
   }
+
   @Test
   public void testDeserializeCompany() throws Exception {
     final String json = getResourceAsString("/api_fixtures/legal_entity.json");

--- a/src/test/resources/api_fixtures/legal_entity.json
+++ b/src/test/resources/api_fixtures/legal_entity.json
@@ -1,5 +1,5 @@
 {
-  "type": "sole_prop",
+  "type": "company",
   "business_name": "business name",
   "address": {
     "line1": "12 Grove Street",
@@ -18,10 +18,37 @@
     "month": 4,
     "year": 1969
   },
-  "additional_owners": [],
+  "additional_owners": [
+      {
+        "dob": {
+          "day": "29",
+          "month": "8",
+          "year": "1980"
+        },
+        "first_name": "Bumble",
+        "last_name": "B",
+        "verification": {
+          "document": "file_1CbtgHBhukJnEcMNhwLBPmA4",
+          "document_back": "file_1CbtgKBhukJnEcMNW2MoQ8Qu"
+        }
+      },
+      {
+        "address": {
+          "city": "RockAndWheat",
+          "country": "US",
+          "line1": "B",
+          "line2": "C",
+          "postal_code": "27635",
+          "state": "CA"
+        },
+        "first_name": "Trouble",
+        "last_name": "China"
+      }
+  ],
   "verification": {
     "status": "verified",
-    "document": null,
+    "document": "file_123",
+    "document_back": "file_456",
     "details": null
   }
 }


### PR DESCRIPTION
With the introduction of the document_back parameter for both [additional owners](https://stripe.com/docs/api#account_object-legal_entity-additional_owners-verification-document_back) and the [representative](https://stripe.com/docs/api#account_object-legal_entity-verification-document_back) we can now update the back of photo IDs 🎉 

This PR includes wrappers and tests for the associated wrappers.