### PR TITLE
Add missing properties to the Invoice resource

### DIFF
--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -24,10 +24,13 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
   String id;
   String object;
   Long amountDue;
+  Long amountPaid;
+  Long amountRemaining;
   Long applicationFee;
   Integer attemptCount;
   Boolean attempted;
   String billing;
+  String billingReason;
   @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Charge> charge;
   Boolean closed;
   Long created;


### PR DESCRIPTION
Add support for `billing_reason`, `amount_paid` and `amount_remaining` on the Invoice object.

r? @ob-stripe 
cc @stripe/api-libraries 