### PR TITLE
Better timeout tests

### DIFF
--- a/src/test/java/com/stripe/functional/RequestOptionsTest.java
+++ b/src/test/java/com/stripe/functional/RequestOptionsTest.java
@@ -4,19 +4,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import com.stripe.BaseStripeTest;
-import com.stripe.Stripe;
-import com.stripe.exception.APIConnectionException;
 import com.stripe.exception.StripeException;
 import com.stripe.model.Balance;
 import com.stripe.net.RequestOptions;
 import com.stripe.net.StripeResponse;
 
-import java.io.IOException;
-
 import org.junit.Ignore;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class RequestOptionsTest extends BaseStripeTest {
   @Ignore // stripe-mock doesn't send a Stripe-Version header
@@ -45,34 +39,5 @@ public class RequestOptionsTest extends BaseStripeTest {
 
     assertNotNull(response);
     assertEquals(idempotencyKey, response.headers().get("Idempotency-Key"));
-  }
-
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
-
-  @Test
-  public void testConnectTimeout() throws IOException, StripeException {
-    // Kind of terrible, but let's test connection timeouts with an external server and a super
-    // short timeout.
-    Stripe.overrideApiBase("https://api.stripe.com");
-
-    thrown.expect(APIConnectionException.class);
-    thrown.expectMessage("connect timed out");
-
-    final RequestOptions options = RequestOptions.builder().setConnectTimeout(1).build();
-    Balance.retrieve(options);
-  }
-
-  @Test
-  public void testReadTimeout() throws IOException, StripeException {
-    // Also kind of terrible, but let's test read connection timeouts with a valid external server
-    // but a super short timeout.
-    Stripe.overrideApiBase("https://api.stripe.com");
-
-    thrown.expect(APIConnectionException.class);
-    thrown.expectMessage("Read timed out");
-
-    final RequestOptions options = RequestOptions.builder().setReadTimeout(1).build();
-    Balance.retrieve(options);
   }
 }

--- a/src/test/java/com/stripe/functional/TimeoutTest.java
+++ b/src/test/java/com/stripe/functional/TimeoutTest.java
@@ -1,0 +1,49 @@
+package com.stripe.functional;
+
+import com.stripe.BaseStripeTest;
+import com.stripe.Stripe;
+import com.stripe.exception.APIConnectionException;
+import com.stripe.exception.StripeException;
+import com.stripe.model.Balance;
+import com.stripe.net.RequestOptions;
+
+import java.io.IOException;
+import java.net.Inet4Address;
+import java.net.ServerSocket;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class TimeoutTest extends BaseStripeTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testConnectTimeout() throws IOException, StripeException {
+    // Kind of a hack, but we use the non-routable address 10.255.255.0 to trigger a connection
+    // timeout
+    Stripe.overrideApiBase(String.format("http://10.255.255.0"));
+
+    thrown.expect(APIConnectionException.class);
+    thrown.expectMessage("connect timed out");
+
+    final RequestOptions options = RequestOptions.builder().setConnectTimeout(1).build();
+    Balance.retrieve(options);
+  }
+
+  @Test
+  public void testReadTimeout() throws IOException, StripeException {
+    // Create a local server that does nothing to trigger a read timeout
+    try (final ServerSocket serverSocket =
+        new ServerSocket(0, 1, Inet4Address.getByName("localhost"))) {
+      Stripe.overrideApiBase(String.format("http://localhost:%d", serverSocket.getLocalPort()));
+
+      thrown.expect(APIConnectionException.class);
+      thrown.expectMessage("Read timed out");
+
+      final RequestOptions options = RequestOptions.builder().setReadTimeout(1).build();
+      Balance.retrieve(options);
+    }
+  }
+}


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Instead of trying to connect to `api.stripe.com`, the timeout tests now create and use their own server socket. This should hopefully make them more reliable.
