### PR TITLE
Fix issues detected by ErrorProne

### DIFF
--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -30,9 +30,9 @@ import java.net.MalformedURLException;
 import java.net.PasswordAuthentication;
 import java.net.URL;
 import java.net.URLStreamHandler;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Scanner;
@@ -275,7 +275,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 
   private static List<Parameter> flattenParamsList(List<Object> params, String keyPrefix)
       throws InvalidRequestException {
-    List<Parameter> flatParams = new LinkedList<Parameter>();
+    List<Parameter> flatParams = new ArrayList<Parameter>();
     Iterator<?> it = ((List<?>) params).iterator();
     String newPrefix = String.format("%s[]", keyPrefix);
 
@@ -296,7 +296,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 
   private static List<Parameter> flattenParamsArray(Object[] params, String keyPrefix)
       throws InvalidRequestException {
-    List<Parameter> flatParams = new LinkedList<Parameter>();
+    List<Parameter> flatParams = new ArrayList<Parameter>();
     String newPrefix = String.format("%s[]", keyPrefix);
 
     // Because application/x-www-form-urlencoded cannot represent an empty
@@ -316,7 +316,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 
   private static List<Parameter> flattenParamsMap(Map<String, Object> params, String keyPrefix)
       throws InvalidRequestException {
-    List<Parameter> flatParams = new LinkedList<Parameter>();
+    List<Parameter> flatParams = new ArrayList<Parameter>();
     if (params == null) {
       return flatParams;
     }
@@ -339,7 +339,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
   @SuppressWarnings("unchecked")
   private static List<Parameter> flattenParamsValue(Object value, String keyPrefix)
       throws InvalidRequestException {
-    List<Parameter> flatParams = new LinkedList<Parameter>();
+    List<Parameter> flatParams = new ArrayList<Parameter>();
 
     if (value instanceof Map<?, ?>) {
       flatParams = flattenParamsMap((Map<String, Object>) value, keyPrefix);
@@ -353,10 +353,10 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
           + "You may set '" + keyPrefix + "' to null to delete the property.",
           keyPrefix, null, null, 0, null);
     } else if (value == null) {
-      flatParams = new LinkedList<Parameter>();
+      flatParams = new ArrayList<Parameter>();
       flatParams.add(new Parameter(keyPrefix, ""));
     } else {
-      flatParams = new LinkedList<Parameter>();
+      flatParams = new ArrayList<Parameter>();
       flatParams.add(new Parameter(keyPrefix, value.toString()));
     }
 

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -30,6 +30,7 @@ import java.net.MalformedURLException;
 import java.net.PasswordAuthentication;
 import java.net.URL;
 import java.net.URLStreamHandler;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -790,7 +791,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 
       if (method == APIResource.RequestMethod.POST) {
         requestClass.getDeclaredMethod("setPayload", byte[].class)
-            .invoke(request, query.getBytes());
+            .invoke(request, query.getBytes(StandardCharsets.UTF_8));
       }
 
       for (Map.Entry<String, String> header : getHeaders(options)

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -365,11 +365,11 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 
   // represents regular API errors returned as JSON
   // handleAPIError uses this class to raise the appropriate StripeException
-  private static class ErrorContainer {
-    private LiveStripeResponseGetter.Error error;
+  private static class StripeErrorContainer {
+    private StripeError error;
   }
 
-  private static class Error {
+  private static class StripeError {
     @SuppressWarnings("unused")
     String type;
 
@@ -386,7 +386,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 
   // represents OAuth API errors returned as JSON
   // handleOAuthError uses this class to raise the appropriate OAuthException
-  private static class OAuthError {
+  private static class StripeOAuthError {
     String error;
 
     String errorDescription;
@@ -685,8 +685,8 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
   private static void handleAPIError(String responseBody, int responseCode, String requestId)
       throws InvalidRequestException, AuthenticationException,
       CardException, APIException {
-    LiveStripeResponseGetter.Error error = APIResource.GSON.fromJson(responseBody,
-        LiveStripeResponseGetter.ErrorContainer.class).error;
+    LiveStripeResponseGetter.StripeError error = APIResource.GSON.fromJson(responseBody,
+        LiveStripeResponseGetter.StripeErrorContainer.class).error;
     switch (responseCode) {
       case 400:
         throw new InvalidRequestException(error.message, error.param, requestId, error.code,
@@ -713,8 +713,8 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
       throws InvalidClientException, InvalidGrantException,
       com.stripe.exception.oauth.InvalidRequestException, InvalidScopeException,
       UnsupportedGrantTypeException, UnsupportedResponseTypeException, APIException {
-    LiveStripeResponseGetter.OAuthError error = APIResource.GSON.fromJson(responseBody,
-        LiveStripeResponseGetter.OAuthError.class);
+    LiveStripeResponseGetter.StripeOAuthError error = APIResource.GSON.fromJson(responseBody,
+        LiveStripeResponseGetter.StripeOAuthError.class);
     String code = error.error;
     String description = (error.errorDescription != null) ? error.errorDescription : code;
 

--- a/src/main/java/com/stripe/net/Webhook.java
+++ b/src/main/java/com/stripe/net/Webhook.java
@@ -3,7 +3,7 @@ package com.stripe.net;
 import com.stripe.exception.SignatureVerificationException;
 import com.stripe.model.Event;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -162,7 +162,7 @@ public final class Webhook {
      * @return the signature as a string.
      */
     private static String computeSignature(String payload, String secret)
-        throws UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException {
+        throws NoSuchAlgorithmException, InvalidKeyException {
       return Util.computeHmacSHA256(secret, payload);
     }
   }
@@ -176,10 +176,10 @@ public final class Webhook {
      * @return the code as a string.
      */
     public static String computeHmacSHA256(String key, String message)
-        throws UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException {
+        throws NoSuchAlgorithmException, InvalidKeyException {
       Mac hasher = Mac.getInstance("HmacSHA256");
-      hasher.init(new SecretKeySpec(key.getBytes("UTF8"), "HmacSHA256"));
-      byte[] hash = hasher.doFinal(message.getBytes("UTF8"));
+      hasher.init(new SecretKeySpec(key.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+      byte[] hash = hasher.doFinal(message.getBytes(StandardCharsets.UTF_8));
       String result = "";
       for (byte b : hash) {
         result += Integer.toString((b & 0xff) + 0x100, 16).substring(1);
@@ -196,8 +196,8 @@ public final class Webhook {
      * @return true if the strings are equal, false otherwise.
      */
     public static boolean secureCompare(String a, String b) {
-      byte[] digesta = a.getBytes();
-      byte[] digestb = b.getBytes();
+      byte[] digesta = a.getBytes(StandardCharsets.UTF_8);
+      byte[] digestb = b.getBytes(StandardCharsets.UTF_8);
 
       return MessageDigest.isEqual(digesta, digestb);
     }

--- a/src/main/java/com/stripe/net/Webhook.java
+++ b/src/main/java/com/stripe/net/Webhook.java
@@ -119,7 +119,7 @@ public final class Webhook {
      * @return the timestamp contained in the header.
      */
     private static long getTimestamp(String sigHeader) {
-      String[] items = sigHeader.split(",");
+      String[] items = sigHeader.split(",", -1);
 
       for (String item : items) {
         String[] itemParts = item.split("=", 2);
@@ -140,7 +140,7 @@ public final class Webhook {
      */
     private static List<String> getSignatures(String sigHeader, String scheme) {
       List<String> signatures = new ArrayList<String>();
-      String[] items = sigHeader.split(",");
+      String[] items = sigHeader.split(",", -1);
 
       for (String item : items) {
         String[] itemParts = item.split("=", 2);
@@ -154,7 +154,7 @@ public final class Webhook {
 
     /**
      * Computes the signature for a given payload and secret.
-     * 
+     *
      * <p>The current scheme used by Stripe ("v1") is HMAC/SHA-256.
      *
      * @param payload the payload to sign.

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -71,7 +71,7 @@ public class BaseStripeTest {
     }
 
     String version = conn.getHeaderField("Stripe-Mock-Version");
-    if ((version != "master") && (compareVersions(version, MOCK_MINIMUM_VERSION) > 0)) {
+    if (!(version.equals("master")) && (compareVersions(version, MOCK_MINIMUM_VERSION) > 0)) {
       throw new RuntimeException(String.format(
         "Your version of stripe-mock (%s) is too old. The minimum "
         + "version to run this test suite is %s. Please see its "

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -362,18 +362,18 @@ public class BaseStripeTest {
       IOException, MalformedURLException, ProtocolException {
     int status;
 
-    StringBuffer urlStringBuffer = new StringBuffer();
-    urlStringBuffer.append("http://localhost:" + port + path);
+    StringBuilder urlStringBuilder = new StringBuilder();
+    urlStringBuilder.append("http://localhost:" + port + path);
 
     if (expansions != null) {
-      urlStringBuffer.append("?");
+      urlStringBuilder.append("?");
       for (String expansion : expansions) {
-        urlStringBuffer.append("expand[]=");
-        urlStringBuffer.append(expansion);
-        urlStringBuffer.append("&");
+        urlStringBuilder.append("expand[]=");
+        urlStringBuilder.append(expansion);
+        urlStringBuilder.append("&");
       }
     }
-    URL url = new URL(urlStringBuffer.toString());
+    URL url = new URL(urlStringBuilder.toString());
 
     HttpURLConnection conn = (HttpURLConnection)url.openConnection();
     conn.setRequestMethod("GET");
@@ -422,13 +422,13 @@ public class BaseStripeTest {
   private static String readUntilEnd(InputStream inputStream) throws IOException {
     BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
     try {
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder builder = new StringBuilder();
       String line;
       while ((line = reader.readLine()) != null) {
-        buffer.append(line);
-        buffer.append("\r");
+        builder.append(line);
+        builder.append("\r");
       }
-      return buffer.toString();
+      return builder.toString();
     } finally {
       reader.close();
     }

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -22,6 +22,7 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.ProtocolException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
@@ -420,7 +421,8 @@ public class BaseStripeTest {
   }
 
   private static String readUntilEnd(InputStream inputStream) throws IOException {
-    BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+    BufferedReader reader =
+        new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
     try {
       StringBuilder builder = new StringBuilder();
       String line;

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -444,8 +444,8 @@ public class BaseStripeTest {
   private static int compareVersions(String a, String b) {
     int ret = 0;
 
-    String[] as = a.split("\\.");
-    String[] bs = b.split("\\.");
+    String[] as = a.split("\\.", -1);
+    String[] bs = b.split("\\.", -1);
 
     int loopMax = bs.length;
     if (as.length > bs.length) {

--- a/src/test/java/com/stripe/DocumentationTest.java
+++ b/src/test/java/com/stripe/DocumentationTest.java
@@ -11,8 +11,8 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Calendar;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -45,7 +45,7 @@ public class DocumentationTest {
       final String expectedLine = formatDateTime();
       final String pattern = String.format(
           "^## %s - 20[12][0-9]-(0[1-9]|1[0-2])-(0[1-9]|1[0-9]|2[0-9]|3[0-1])$", Stripe.VERSION);
-      final List<String> closeMatches = new LinkedList<String>();
+      final List<String> closeMatches = new ArrayList<String>();
       String line;
 
       while ((line = reader.readLine()) != null) {
@@ -81,7 +81,7 @@ public class DocumentationTest {
     try (final BufferedReader reader = new BufferedReader(new FileReader(readmeFile))) {
       final int expectedMentionsOfVersion = 2;
       // Currently two places mention the Stripe version: the sample pom and gradle files.
-      final List<String> mentioningLines = new LinkedList<String>();
+      final List<String> mentioningLines = new ArrayList<String>();
       String line;
 
       while ((line = reader.readLine()) != null) {

--- a/src/test/java/com/stripe/DocumentationTest.java
+++ b/src/test/java/com/stripe/DocumentationTest.java
@@ -8,8 +8,11 @@ import com.google.common.base.Joiner;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -41,7 +44,8 @@ public class DocumentationTest {
             changelogFile.getAbsolutePath()),
         changelogFile.isFile());
 
-    try (final BufferedReader reader = new BufferedReader(new FileReader(changelogFile))) {
+    try (final BufferedReader reader = new BufferedReader(new InputStreamReader(
+        new FileInputStream(changelogFile), StandardCharsets.UTF_8))) {
       final String expectedLine = formatDateTime();
       final String pattern = String.format(
           "^## %s - 20[12][0-9]-(0[1-9]|1[0-2])-(0[1-9]|1[0-9]|2[0-9]|3[0-1])$", Stripe.VERSION);
@@ -78,7 +82,8 @@ public class DocumentationTest {
             readmeFile.getAbsolutePath()),
         readmeFile.isFile());
 
-    try (final BufferedReader reader = new BufferedReader(new FileReader(readmeFile))) {
+    try (final BufferedReader reader = new BufferedReader(new InputStreamReader(
+        new FileInputStream(readmeFile), StandardCharsets.UTF_8))) {
       final int expectedMentionsOfVersion = 2;
       // Currently two places mention the Stripe version: the sample pom and gradle files.
       final List<String> mentioningLines = new ArrayList<String>();
@@ -111,7 +116,8 @@ public class DocumentationTest {
             gradleFile.getAbsolutePath()),
             gradleFile.isFile());
 
-    try (final BufferedReader reader = new BufferedReader(new FileReader(gradleFile))) {
+    try (final BufferedReader reader = new BufferedReader(new InputStreamReader(
+        new FileInputStream(gradleFile), StandardCharsets.UTF_8))) {
       String line;
       while ((line = reader.readLine()) != null) {
         if (line.contains(Stripe.VERSION)) {

--- a/src/test/java/com/stripe/functional/BankAccountTest.java
+++ b/src/test/java/com/stripe/functional/BankAccountTest.java
@@ -13,8 +13,8 @@ import com.stripe.model.ExternalAccountCollection;
 import com.stripe.net.APIResource;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -106,7 +106,7 @@ public class BankAccountTest extends BaseStripeTest {
     final BankAccount stubbedBankAccount = APIResource.GSON.fromJson(
         getResourceAsString("/api_fixtures/bank_account.json"), BankAccount.class);
     final ExternalAccountCollection stubbedCollection = new ExternalAccountCollection();
-    final List<ExternalAccount> stubbedData = new LinkedList<ExternalAccount>();
+    final List<ExternalAccount> stubbedData = new ArrayList<ExternalAccount>();
     stubbedData.add(stubbedBankAccount);
     stubbedCollection.setData(stubbedData);
     stubRequest(
@@ -149,7 +149,7 @@ public class BankAccountTest extends BaseStripeTest {
     final Customer customer = Customer.retrieve(CUSTOMER_ID);
     final BankAccount bankAccount = getBankAccountFixture(customer);
 
-    final List<Integer> values = new LinkedList<Integer>();
+    final List<Integer> values = new ArrayList<Integer>();
     values.add(32);
     values.add(45);
     final Map<String, Object> params = new HashMap<String, Object>();

--- a/src/test/java/com/stripe/functional/CardTest.java
+++ b/src/test/java/com/stripe/functional/CardTest.java
@@ -13,8 +13,8 @@ import com.stripe.model.ExternalAccountCollection;
 import com.stripe.net.APIResource;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -112,7 +112,7 @@ public class CardTest extends BaseStripeTest {
     // stripe-mock doesn't handle this, so we stub the request
     final Card stubbedCard = getCardFixture(customer);
     final ExternalAccountCollection stubbedCollection = new ExternalAccountCollection();
-    final List<ExternalAccount> stubbedData = new LinkedList<ExternalAccount>();
+    final List<ExternalAccount> stubbedData = new ArrayList<ExternalAccount>();
     stubbedData.add(stubbedCard);
     stubbedCollection.setData(stubbedData);
     stubRequest(

--- a/src/test/java/com/stripe/functional/CustomerTest.java
+++ b/src/test/java/com/stripe/functional/CustomerTest.java
@@ -13,8 +13,8 @@ import com.stripe.model.Subscription;
 import com.stripe.net.APIResource;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -152,7 +152,7 @@ public class CustomerTest extends BaseStripeTest {
 
     final Map<String, Object> item = new HashMap<String, Object>();
     item.put("plan", "silver-plan_123-898");
-    final List<Object> items = new LinkedList<Object>();
+    final List<Object> items = new ArrayList<Object>();
     items.add(item);
     final Map<String, Object> params = new HashMap<String, Object>();
     params.put("items", items);

--- a/src/test/java/com/stripe/functional/ProductTest.java
+++ b/src/test/java/com/stripe/functional/ProductTest.java
@@ -9,8 +9,8 @@ import com.stripe.model.Product;
 import com.stripe.model.ProductCollection;
 import com.stripe.net.APIResource;
 
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -27,7 +27,7 @@ public class ProductTest extends BaseStripeTest {
 
   @Test
   public void testCreate() throws StripeException {
-    final List<String> attributes = new LinkedList<String>();
+    final List<String> attributes = new ArrayList<String>();
     attributes.add("attr1");
     attributes.add("attr2");
     final Map<String, Object> packageDimensions = new HashMap<String, Object>();

--- a/src/test/java/com/stripe/functional/SourceTest.java
+++ b/src/test/java/com/stripe/functional/SourceTest.java
@@ -11,8 +11,8 @@ import com.stripe.model.SourceTransactionCollection;
 import com.stripe.net.APIResource;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -80,7 +80,7 @@ public class SourceTest extends BaseStripeTest {
   public void testVerify() throws StripeException {
     final Source source = getSourceFixture();
 
-    final List<Integer> values = new LinkedList<Integer>();
+    final List<Integer> values = new ArrayList<Integer>();
     values.add(32);
     values.add(45);
     final Map<String, Object> params = new HashMap<String, Object>();

--- a/src/test/java/com/stripe/functional/SubscriptionTest.java
+++ b/src/test/java/com/stripe/functional/SubscriptionTest.java
@@ -8,8 +8,8 @@ import com.stripe.model.Subscription;
 import com.stripe.model.SubscriptionCollection;
 import com.stripe.net.APIResource;
 
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -28,7 +28,7 @@ public class SubscriptionTest extends BaseStripeTest {
   public void testCreate() throws StripeException {
     final Map<String, Object> item = new HashMap<String, Object>();
     item.put("plan", "silver-plan_123-898");
-    final List<Object> items = new LinkedList<Object>();
+    final List<Object> items = new ArrayList<Object>();
     items.add(item);
     final Map<String, Object> params = new HashMap<String, Object>();
     params.put("customer", "cus_123");

--- a/src/test/java/com/stripe/model/EphemeralKeyTest.java
+++ b/src/test/java/com/stripe/model/EphemeralKeyTest.java
@@ -23,6 +23,6 @@ public class EphemeralKeyTest extends BaseStripeTest {
   public void testRawJson() {
     final String jsonString = "{\"foo\":5,\"bar\":[\"baz\",null]}";
     final EphemeralKey key = APIResource.GSON.fromJson(jsonString, EphemeralKey.class);
-    assertEquals(key.getRawJson(), jsonString);
+    assertEquals(jsonString, key.getRawJson());
   }
 }

--- a/src/test/java/com/stripe/model/ExpandableFieldDeserializerTest.java
+++ b/src/test/java/com/stripe/model/ExpandableFieldDeserializerTest.java
@@ -20,7 +20,7 @@ public class ExpandableFieldDeserializerTest extends BaseStripeTest {
 
   private static Gson gson = APIResource.GSON;
 
-  private class TestObject implements HasId {
+  private static class TestObject implements HasId {
     String id;
     int bar;
 

--- a/src/test/java/com/stripe/model/ExpandableFieldDeserializerTest.java
+++ b/src/test/java/com/stripe/model/ExpandableFieldDeserializerTest.java
@@ -46,7 +46,7 @@ public class ExpandableFieldDeserializerTest extends BaseStripeTest {
     // that here:
     final ExpandableField<TestObject> out = gson.fromJson(json,
         new TypeToken<ExpandableField<TestObject>>() {}.getType());
-    assertEquals(out.getId(), "just_an_id");
+    assertEquals("just_an_id", out.getId());
     assertFalse(out.isExpanded());
   }
 
@@ -61,8 +61,8 @@ public class ExpandableFieldDeserializerTest extends BaseStripeTest {
     // that here:
     final ExpandableField<TestObject> out = gson.fromJson(json,
         new TypeToken<ExpandableField<TestObject>>() {}.getType());
-    assertEquals(out.getId(), "an_id_here");
-    assertEquals(out.getExpanded().id, "an_id_here");
-    assertEquals(out.getExpanded().bar, 12);
+    assertEquals("an_id_here", out.getId());
+    assertEquals("an_id_here", out.getExpanded().id);
+    assertEquals(12, out.getExpanded().bar);
   }
 }

--- a/src/test/java/com/stripe/model/ExpandableFieldSerializerTest.java
+++ b/src/test/java/com/stripe/model/ExpandableFieldSerializerTest.java
@@ -11,7 +11,7 @@ import org.junit.Test;
 
 public class ExpandableFieldSerializerTest extends BaseStripeTest {
 
-  private class TestNestedObject implements HasId {
+  private static class TestNestedObject implements HasId {
     String id;
     @SuppressWarnings("unused")
     int bar;
@@ -21,7 +21,7 @@ public class ExpandableFieldSerializerTest extends BaseStripeTest {
     }
   }
 
-  private class TestTopLevelObject extends StripeObject {
+  private static class TestTopLevelObject extends StripeObject {
     @SuppressWarnings("unused")
     ExpandableField<TestNestedObject> nested;
   }

--- a/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
+++ b/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
@@ -13,9 +13,9 @@ import com.stripe.net.RequestOptions;
 import com.stripe.net.RequestOptions.RequestOptionsBuilder;
 
 import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -53,7 +53,7 @@ public class LiveStripeResponseGetterTest {
 
   @Test
   public void testCreateQueryWithListParams() throws StripeException, UnsupportedEncodingException {
-    final List<String> nested = new LinkedList<String>();
+    final List<String> nested = new ArrayList<String>();
     nested.add("A");
     nested.add("B");
     nested.add("C");
@@ -95,7 +95,7 @@ public class LiveStripeResponseGetterTest {
     deepNestedMap2.put("A", "A-2");
     deepNestedMap2.put("B", "B-2");
 
-    final List<Object> nested = new LinkedList<Object>();
+    final List<Object> nested = new ArrayList<Object>();
     nested.add(deepNestedMap1);
     nested.add(deepNestedMap2);
 
@@ -110,7 +110,7 @@ public class LiveStripeResponseGetterTest {
   @Test
   public void testCreateQueryWithEmptyList() throws StripeException, UnsupportedEncodingException {
     final Map<String, Object> params = new HashMap<String, Object>();
-    params.put("a", new LinkedList<String>());
+    params.put("a", new ArrayList<String>());
     assertEquals("a=", LiveStripeResponseGetter.createQuery(params));
   }
 
@@ -135,7 +135,7 @@ public class LiveStripeResponseGetterTest {
     final Map<String, String> ownerParams = new HashMap<String, String>();
     ownerParams.put("first_name", "Stripe");
 
-    final List<Object> additionalOwners = new LinkedList<Object>();
+    final List<Object> additionalOwners = new ArrayList<Object>();
     additionalOwners.add(ownerParams);
 
     final Map<String, Object> legalEntityParams = new HashMap<String, Object>();

--- a/src/test/java/com/stripe/net/OAuthTest.java
+++ b/src/test/java/com/stripe/net/OAuthTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 public class OAuthTest extends BaseStripeTest {
   private static Map<String, String> splitQuery(String query) throws UnsupportedEncodingException {
     final Map<String, String> queryPairs = new HashMap<String, String>();
-    final String[] pairs = query.split("&");
+    final String[] pairs = query.split("&", -1);
     for (final String pair : pairs) {
       final int idx = pair.indexOf("=");
       queryPairs.put(URLDecoder.decode(pair.substring(0, idx), "UTF8"),

--- a/src/test/java/com/stripe/net/StripeResponseTest.java
+++ b/src/test/java/com/stripe/net/StripeResponseTest.java
@@ -74,6 +74,6 @@ public class StripeResponseTest extends BaseStripeTest {
   public void testRequestId() {
     final Map<String, List<String>> headerMap = generateHeaderMap();
     final StripeResponse stripeResponse = new StripeResponse(200, chargeBody, headerMap);
-    assertEquals(stripeResponse.requestId(), "req_12345");
+    assertEquals("req_12345", stripeResponse.requestId());
   }
 }


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @codylerum 

A few weeks back, @codylerum opened a PR to enable the use of the [ErrorProne](http://errorprone.info/) compiler and fix a number of issues it detected.

Unfortunately, I don't think we can enable ErrorProne by default because it only works with Java 8 and 9, and we still need to support 7 for the foreseeable future. (There's probably a way to only enable it for the supported versions but it's beyond my meagre Gradle skills.)

I did run the compiler locally though, and fixed a number of issues it detected.

For the [TypeParameterUnusedInFormals](http://errorprone.info/bugpattern/TypeParameterUnusedInFormals) (see last commit), I wasn't able to simply fix the issue because it would be a breaking change, but I added new signatures that don't have the issue and flagged the existing signatures as deprecated so we can remove those in the next major version.

I've also ignored the [MissingOverride](http://errorprone.info/bugpattern/MissingOverride) warnings for now -- I'll tackle that one in a separate PR since it's going to be pretty chunderous :/