### PR TITLE
Add missing `@Override` annotations

### DIFF
--- a/deploy.gradle
+++ b/deploy.gradle
@@ -97,8 +97,8 @@ afterEvaluate { project ->
         sign configurations.archives
     }
 
-    task makeJavadocs(type: Javadoc) {
-        source = sourceSets.main.allJava
+    task makeJavadocs(type: Javadoc, dependsOn: delombok) {
+        source = delombok.outputDir
         classpath = configurations.compile
         failOnError = true
     }

--- a/src/main/java/com/stripe/exception/StripeException.java
+++ b/src/main/java/com/stripe/exception/StripeException.java
@@ -62,6 +62,7 @@ public abstract class StripeException extends Exception {
    *
    * @return a string representation of the exception.
    */
+  @Override
   public String toString() {
     String additionalInfo = "";
     if (code != null) {

--- a/src/main/java/com/stripe/model/Account.java
+++ b/src/main/java/com/stripe/model/Account.java
@@ -21,7 +21,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class Account extends APIResource implements HasId, MetadataStore<Account> {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   String businessLogo;
   String businessName;
@@ -40,7 +40,7 @@ public class Account extends APIResource implements HasId, MetadataStore<Account
   ExternalAccountCollection externalAccounts;
   Keys keys;
   LegalEntity legalEntity;
-  Map<String, String> metadata;
+  @Getter(onMethod = @__({@Override})) Map<String, String> metadata;
   Boolean payoutsEnabled;
   AccountPayoutSchedule payoutSchedule;
   String productDescription;
@@ -155,12 +155,14 @@ public class Account extends APIResource implements HasId, MetadataStore<Account
         options);
   }
 
+  @Override
   public Account update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
     return update(params, null);
   }
 
+  @Override
   public Account update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/AlipayAccount.java
+++ b/src/main/java/com/stripe/model/AlipayAccount.java
@@ -27,24 +27,28 @@ public class AlipayAccount extends ExternalAccount {
   String username;
   String status;
 
+  @Override
   public AlipayAccount update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
     return update(params, null);
   }
 
+  @Override
   public AlipayAccount update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
     return request(RequestMethod.POST, this.getInstanceURL(), params, AlipayAccount.class, options);
   }
 
+  @Override
   public DeletedAlipayAccount delete() throws AuthenticationException,
       InvalidRequestException, APIConnectionException, CardException,
       APIException {
     return delete(null);
   }
 
+  @Override
   public DeletedAlipayAccount delete(RequestOptions options) throws AuthenticationException,
       InvalidRequestException, APIConnectionException, CardException,
       APIException {

--- a/src/main/java/com/stripe/model/ApplePayDomain.java
+++ b/src/main/java/com/stripe/model/ApplePayDomain.java
@@ -19,7 +19,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class ApplePayDomain extends APIResource implements HasId {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   Long created;
   String domainName;

--- a/src/main/java/com/stripe/model/Application.java
+++ b/src/main/java/com/stripe/model/Application.java
@@ -8,6 +8,6 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class Application extends StripeObject implements HasId {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String name;
 }

--- a/src/main/java/com/stripe/model/ApplicationFee.java
+++ b/src/main/java/com/stripe/model/ApplicationFee.java
@@ -19,7 +19,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class ApplicationFee extends APIResource implements HasId {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Account> account;
   Long amount;

--- a/src/main/java/com/stripe/model/BalanceTransaction.java
+++ b/src/main/java/com/stripe/model/BalanceTransaction.java
@@ -21,7 +21,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class BalanceTransaction extends APIResource implements HasId {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   Long amount;
   Long availableOn;

--- a/src/main/java/com/stripe/model/BankAccount.java
+++ b/src/main/java/com/stripe/model/BankAccount.java
@@ -29,24 +29,28 @@ public class BankAccount extends ExternalAccount {
   String status;
   Boolean validated;
 
+  @Override
   public BankAccount update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException, APIConnectionException,
       CardException, APIException {
     return update(params, null);
   }
 
+  @Override
   public BankAccount update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException, APIConnectionException,
       CardException, APIException {
     return request(RequestMethod.POST, this.getInstanceURL(), params, BankAccount.class, options);
   }
 
+  @Override
   public DeletedBankAccount delete()
       throws AuthenticationException, InvalidRequestException, APIConnectionException,
       CardException, APIException {
     return delete(null);
   }
 
+  @Override
   public DeletedBankAccount delete(RequestOptions options)
       throws AuthenticationException, InvalidRequestException, APIConnectionException,
       CardException, APIException {

--- a/src/main/java/com/stripe/model/BitcoinTransaction.java
+++ b/src/main/java/com/stripe/model/BitcoinTransaction.java
@@ -10,7 +10,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class BitcoinTransaction extends APIResource implements HasId {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   Long amount;
   Long bitcoinAmount;
   Long created;

--- a/src/main/java/com/stripe/model/Card.java
+++ b/src/main/java/com/stripe/model/Card.java
@@ -59,6 +59,7 @@ public class Card extends ExternalAccount {
   @Deprecated
   String type;
 
+  @Override
   public Card update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
@@ -72,12 +73,14 @@ public class Card extends ExternalAccount {
     return update(params, RequestOptions.builder().setApiKey(apiKey).build());
   }
 
+  @Override
   public Card update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
     return request(RequestMethod.POST, this.getInstanceURL(), params, Card.class, options);
   }
 
+  @Override
   public DeletedCard delete()
       throws AuthenticationException, InvalidRequestException, APIConnectionException,
       CardException, APIException {
@@ -91,6 +94,7 @@ public class Card extends ExternalAccount {
     return delete(RequestOptions.builder().setApiKey(apiKey).build());
   }
 
+  @Override
   public DeletedCard delete(RequestOptions options)
       throws AuthenticationException, InvalidRequestException, APIConnectionException,
       CardException, APIException {

--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -22,6 +22,7 @@ import lombok.Setter;
 public class Charge extends APIResource implements MetadataStore<Charge>, HasId {
   public static final String FRAUD_DETAILS = "fraud_details";
 
+  @Getter(onMethod = @__({@Override}))
   String id;
   String object;
   Long amount;
@@ -44,7 +45,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
   FraudDetails fraudDetails;
   @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Invoice> invoice;
   Boolean livemode;
-  Map<String, String> metadata;
+  @Getter(onMethod = @__({@Override})) Map<String, String> metadata;
   @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Account> onBehalfOf;
   @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Order> order;
   ChargeOutcome outcome;
@@ -367,6 +368,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
     return request(RequestMethod.GET, instanceURL(Charge.class, id), params, Charge.class, options);
   }
 
+  @Override
   public Charge update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
@@ -380,6 +382,7 @@ public class Charge extends APIResource implements MetadataStore<Charge>, HasId 
     return update(params, RequestOptions.builder().setApiKey(apiKey).build());
   }
 
+  @Override
   public Charge update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/ChargeOutcomeRule.java
+++ b/src/main/java/com/stripe/model/ChargeOutcomeRule.java
@@ -8,7 +8,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class ChargeOutcomeRule extends StripeObject implements HasId {
+  @Getter(onMethod = @__({@Override})) protected String id;
   protected String action;
-  protected String id;
   protected String predicate;
 }

--- a/src/main/java/com/stripe/model/ChargeRefundCollectionDeserializer.java
+++ b/src/main/java/com/stripe/model/ChargeRefundCollectionDeserializer.java
@@ -20,6 +20,7 @@ public class ChargeRefundCollectionDeserializer
   /**
    * Deserializes a refund list JSON payload into a {@link ChargeRefundCollection} object.
    */
+  @Override
   public ChargeRefundCollection deserialize(JsonElement json, Type typeOfT,
       JsonDeserializationContext context)
       throws JsonParseException {

--- a/src/main/java/com/stripe/model/CountrySpec.java
+++ b/src/main/java/com/stripe/model/CountrySpec.java
@@ -19,7 +19,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class CountrySpec extends APIResource implements HasId {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   String defaultCurrency;
   Map<String, List<String>> supportedBankAccountCurrencies;

--- a/src/main/java/com/stripe/model/Coupon.java
+++ b/src/main/java/com/stripe/model/Coupon.java
@@ -18,7 +18,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class Coupon extends APIResource implements MetadataStore<Coupon>, HasId {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   Long amountOff;
   Long created;
@@ -27,7 +27,7 @@ public class Coupon extends APIResource implements MetadataStore<Coupon>, HasId 
   Integer durationInMonths;
   Boolean livemode;
   Long maxRedemptions;
-  Map<String, String> metadata;
+  @Getter(onMethod = @__({@Override})) Map<String, String> metadata;
   Integer percentOff;
   Long redeemBy;
   Integer timesRedeemed;
@@ -71,6 +71,7 @@ public class Coupon extends APIResource implements MetadataStore<Coupon>, HasId 
     return request(RequestMethod.GET, instanceURL(Coupon.class, id), null, Coupon.class, options);
   }
 
+  @Override
   public Coupon update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException, APIConnectionException,
       CardException, APIException {
@@ -84,6 +85,7 @@ public class Coupon extends APIResource implements MetadataStore<Coupon>, HasId 
     return update(params, RequestOptions.builder().setApiKey(apiKey).build());
   }
 
+  @Override
   public Coupon update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException, APIConnectionException,
       CardException, APIException {

--- a/src/main/java/com/stripe/model/Customer.java
+++ b/src/main/java/com/stripe/model/Customer.java
@@ -20,7 +20,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class Customer extends APIResource implements MetadataStore<Customer>, HasId {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   Long accountBalance;
   String businessVatId;
@@ -34,7 +34,7 @@ public class Customer extends APIResource implements MetadataStore<Customer>, Ha
   Discount discount;
   String email;
   Boolean livemode;
-  Map<String, String> metadata;
+  @Getter(onMethod = @__({@Override})) Map<String, String> metadata;
   ShippingDetails shipping;
   ExternalAccountCollection sources;
   CustomerSubscriptionCollection subscriptions;
@@ -153,6 +153,7 @@ public class Customer extends APIResource implements MetadataStore<Customer>, Ha
         options);
   }
 
+  @Override
   public Customer update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
@@ -166,6 +167,7 @@ public class Customer extends APIResource implements MetadataStore<Customer>, Ha
     return update(params, RequestOptions.builder().setApiKey(apiKey).build());
   }
 
+  @Override
   public Customer update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/DeletedAccount.java
+++ b/src/main/java/com/stripe/model/DeletedAccount.java
@@ -4,8 +4,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
-@Getter
-@Setter
+@Getter(onMethod = @__({@Override}))
+@Setter(onMethod = @__({@Override}))
 @EqualsAndHashCode(callSuper = false)
 public class DeletedAccount extends StripeObject implements DeletedStripeObject {
   String id;

--- a/src/main/java/com/stripe/model/DeletedApplePayDomain.java
+++ b/src/main/java/com/stripe/model/DeletedApplePayDomain.java
@@ -4,8 +4,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
-@Getter
-@Setter
+@Getter(onMethod = @__({@Override}))
+@Setter(onMethod = @__({@Override}))
 @EqualsAndHashCode(callSuper = false)
 public class DeletedApplePayDomain extends StripeObject implements DeletedStripeObject {
   String id;

--- a/src/main/java/com/stripe/model/DeletedCoupon.java
+++ b/src/main/java/com/stripe/model/DeletedCoupon.java
@@ -4,8 +4,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
-@Getter
-@Setter
+@Getter(onMethod = @__({@Override}))
+@Setter(onMethod = @__({@Override}))
 @EqualsAndHashCode(callSuper = false)
 public class DeletedCoupon extends StripeObject implements DeletedStripeObject {
   String id;

--- a/src/main/java/com/stripe/model/DeletedCustomer.java
+++ b/src/main/java/com/stripe/model/DeletedCustomer.java
@@ -4,8 +4,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
-@Getter
-@Setter
+@Getter(onMethod = @__({@Override}))
+@Setter(onMethod = @__({@Override}))
 @EqualsAndHashCode(callSuper = false)
 public class DeletedCustomer extends StripeObject implements DeletedStripeObject {
   String id;

--- a/src/main/java/com/stripe/model/DeletedExternalAccount.java
+++ b/src/main/java/com/stripe/model/DeletedExternalAccount.java
@@ -4,8 +4,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
-@Getter
-@Setter
+@Getter(onMethod = @__({@Override}))
+@Setter(onMethod = @__({@Override}))
 @EqualsAndHashCode(callSuper = false)
 public class DeletedExternalAccount extends StripeObject implements DeletedStripeObject {
   String id;

--- a/src/main/java/com/stripe/model/DeletedInvoiceItem.java
+++ b/src/main/java/com/stripe/model/DeletedInvoiceItem.java
@@ -4,8 +4,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
-@Getter
-@Setter
+@Getter(onMethod = @__({@Override}))
+@Setter(onMethod = @__({@Override}))
 @EqualsAndHashCode(callSuper = false)
 public class DeletedInvoiceItem extends StripeObject implements DeletedStripeObject {
   String id;

--- a/src/main/java/com/stripe/model/DeletedPlan.java
+++ b/src/main/java/com/stripe/model/DeletedPlan.java
@@ -4,8 +4,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
-@Getter
-@Setter
+@Getter(onMethod = @__({@Override}))
+@Setter(onMethod = @__({@Override}))
 @EqualsAndHashCode(callSuper = false)
 public class DeletedPlan extends StripeObject implements DeletedStripeObject {
   String id;

--- a/src/main/java/com/stripe/model/DeletedProduct.java
+++ b/src/main/java/com/stripe/model/DeletedProduct.java
@@ -4,8 +4,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
-@Getter
-@Setter
+@Getter(onMethod = @__({@Override}))
+@Setter(onMethod = @__({@Override}))
 @EqualsAndHashCode(callSuper = false)
 public class DeletedProduct extends StripeObject implements DeletedStripeObject {
   String id;

--- a/src/main/java/com/stripe/model/DeletedRecipient.java
+++ b/src/main/java/com/stripe/model/DeletedRecipient.java
@@ -4,8 +4,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
-@Getter
-@Setter
+@Getter(onMethod = @__({@Override}))
+@Setter(onMethod = @__({@Override}))
 @EqualsAndHashCode(callSuper = false)
 public class DeletedRecipient extends StripeObject implements DeletedStripeObject {
   String id;

--- a/src/main/java/com/stripe/model/DeletedSKU.java
+++ b/src/main/java/com/stripe/model/DeletedSKU.java
@@ -4,8 +4,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
-@Getter
-@Setter
+@Getter(onMethod = @__({@Override}))
+@Setter(onMethod = @__({@Override}))
 @EqualsAndHashCode(callSuper = false)
 public class DeletedSKU extends StripeObject implements DeletedStripeObject {
   String id;

--- a/src/main/java/com/stripe/model/DeletedSubscriptionItem.java
+++ b/src/main/java/com/stripe/model/DeletedSubscriptionItem.java
@@ -4,8 +4,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
-@Getter
-@Setter
+@Getter(onMethod = @__({@Override}))
+@Setter(onMethod = @__({@Override}))
 @EqualsAndHashCode(callSuper = false)
 public class DeletedSubscriptionItem extends StripeObject implements DeletedStripeObject {
   String id;

--- a/src/main/java/com/stripe/model/Dispute.java
+++ b/src/main/java/com/stripe/model/Dispute.java
@@ -20,7 +20,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class Dispute extends APIResource implements HasId {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   Long amount;
   List<BalanceTransaction> balanceTransactions;

--- a/src/main/java/com/stripe/model/DisputeDataDeserializer.java
+++ b/src/main/java/com/stripe/model/DisputeDataDeserializer.java
@@ -16,6 +16,7 @@ public class DisputeDataDeserializer implements JsonDeserializer<Dispute> {
   /**
    * Deserializes a dispute JSON payload into a {@link Dispute} object.
    */
+  @Override
   public Dispute deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
       throws JsonParseException {
     Gson gson = new GsonBuilder()

--- a/src/main/java/com/stripe/model/EphemeralKey.java
+++ b/src/main/java/com/stripe/model/EphemeralKey.java
@@ -19,7 +19,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class EphemeralKey extends APIResource implements HasId {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   Long created;
   Long expires;

--- a/src/main/java/com/stripe/model/EphemeralKeyAssociatedObject.java
+++ b/src/main/java/com/stripe/model/EphemeralKeyAssociatedObject.java
@@ -1,22 +1,13 @@
 package com.stripe.model;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public class EphemeralKeyAssociatedObject extends StripeObject implements HasId {
+  @Getter(onMethod = @__({@Override})) String id;
   String type;
-  String id;
-
-  public String getType() {
-    return type;
-  }
-
-  public void setType(String type) {
-    this.type = type;
-  }
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
 }

--- a/src/main/java/com/stripe/model/EphemeralKeyDeserializer.java
+++ b/src/main/java/com/stripe/model/EphemeralKeyDeserializer.java
@@ -14,6 +14,7 @@ public class EphemeralKeyDeserializer implements JsonDeserializer<EphemeralKey> 
   /**
    * Deserializes an ephemeral_key JSON payload into an {@link EphemeralKey} object.
    */
+  @Override
   public EphemeralKey deserialize(JsonElement json, Type typeOfT,
       JsonDeserializationContext context)
       throws JsonParseException {

--- a/src/main/java/com/stripe/model/Event.java
+++ b/src/main/java/com/stripe/model/Event.java
@@ -18,7 +18,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class Event extends APIResource implements HasId {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   String account;
   String apiVersion;

--- a/src/main/java/com/stripe/model/EventDataDeserializer.java
+++ b/src/main/java/com/stripe/model/EventDataDeserializer.java
@@ -117,6 +117,7 @@ public class EventDataDeserializer implements JsonDeserializer<EventData> {
    * Deserializes the JSON payload contained in an event's {@code data} attribute into an
    * {@link EventData} instance.
    */
+  @Override
   public EventData deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
       throws JsonParseException {
     EventData eventData = new EventData();

--- a/src/main/java/com/stripe/model/EventRequestDeserializer.java
+++ b/src/main/java/com/stripe/model/EventRequestDeserializer.java
@@ -16,6 +16,7 @@ public class EventRequestDeserializer implements JsonDeserializer<EventRequest> 
    * Deserializes the JSON payload contained in an event's {@code request} attribute into an
    * {@link EventRequest} instance.
    */
+  @Override
   public EventRequest deserialize(JsonElement json, Type typeOfT,
       JsonDeserializationContext context)
       throws JsonParseException {

--- a/src/main/java/com/stripe/model/ExchangeRate.java
+++ b/src/main/java/com/stripe/model/ExchangeRate.java
@@ -18,7 +18,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class ExchangeRate extends APIResource implements HasId {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   Map<String, Float> rates;
 

--- a/src/main/java/com/stripe/model/ExpandableFieldDeserializer.java
+++ b/src/main/java/com/stripe/model/ExpandableFieldDeserializer.java
@@ -15,6 +15,7 @@ public class ExpandableFieldDeserializer implements JsonDeserializer<ExpandableF
    * Deserializes an expandable field JSON payload (i.e. either a string with just the ID, or a full
    * JSON object) into an {@link ExpandableField} object.
    */
+  @Override
   public ExpandableField<?> deserialize(JsonElement json, Type typeOfT,
       JsonDeserializationContext context) throws JsonParseException {
     if (json.isJsonNull()) {

--- a/src/main/java/com/stripe/model/ExpandableFieldSerializer.java
+++ b/src/main/java/com/stripe/model/ExpandableFieldSerializer.java
@@ -11,6 +11,7 @@ public class ExpandableFieldSerializer implements JsonSerializer<ExpandableField
   /**
    * Serializes an expandable attribute into a JSON string.
    */
+  @Override
   public JsonElement serialize(ExpandableField<?> src, Type typeOfSrc,
       JsonSerializationContext context) {
     if (src.isExpanded()) {

--- a/src/main/java/com/stripe/model/ExternalAccount.java
+++ b/src/main/java/com/stripe/model/ExternalAccount.java
@@ -18,11 +18,11 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class ExternalAccount extends APIResource implements HasId, MetadataStore<ExternalAccount> {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   String account;
   String customer;
-  Map<String, String> metadata;
+  @Getter(onMethod = @__({@Override})) Map<String, String> metadata;
 
   public ExternalAccount verify(Map<String, Object> params) throws
       AuthenticationException, InvalidRequestException,
@@ -50,12 +50,14 @@ public class ExternalAccount extends APIResource implements HasId, MetadataStore
     }
   }
 
+  @Override
   public ExternalAccount update(Map<String, Object> params) throws
       AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
     return update(params, null);
   }
 
+  @Override
   public ExternalAccount update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/ExternalAccountTypeAdapterFactory.java
+++ b/src/main/java/com/stripe/model/ExternalAccountTypeAdapterFactory.java
@@ -17,6 +17,7 @@ public class ExternalAccountTypeAdapterFactory implements TypeAdapterFactory {
    * payloads.
    */
   @SuppressWarnings("unchecked")
+  @Override
   public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
     if (!ExternalAccount.class.isAssignableFrom(type.getRawType())) {
       return null; // this class only serializes 'ExternalAccount' and its subtypes
@@ -39,11 +40,13 @@ public class ExternalAccountTypeAdapterFactory implements TypeAdapterFactory {
         = gson.getDelegateAdapter(this, TypeToken.get(Source.class));
 
     TypeAdapter<ExternalAccount> result = new TypeAdapter<ExternalAccount>() {
+      @Override
       public void write(JsonWriter out, ExternalAccount value) throws IOException {
         // TODO: check instance of for correct writer
         externalAccountAdapter.write(out, value);
       }
 
+      @Override
       public ExternalAccount read(JsonReader in) throws IOException {
         JsonObject object = elementAdapter.read(in).getAsJsonObject();
         String sourceObject = object.getAsJsonPrimitive(sourceObjectProp).getAsString();

--- a/src/main/java/com/stripe/model/FeeRefund.java
+++ b/src/main/java/com/stripe/model/FeeRefund.java
@@ -19,7 +19,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class FeeRefund extends APIResource implements MetadataStore<ApplicationFee>, HasId {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   Long amount;
   @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
@@ -27,7 +27,7 @@ public class FeeRefund extends APIResource implements MetadataStore<ApplicationF
   String currency;
   Long created;
   @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<ApplicationFee> fee;
-  Map<String, String> metadata;
+  @Getter(onMethod = @__({@Override})) Map<String, String> metadata;
 
   // <editor-fold desc="balanceTransaction">
   public String getBalanceTransaction() {
@@ -65,6 +65,7 @@ public class FeeRefund extends APIResource implements MetadataStore<ApplicationF
   }
   // </editor-fold>
 
+  @Override
   public FeeRefund update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
@@ -78,6 +79,7 @@ public class FeeRefund extends APIResource implements MetadataStore<ApplicationF
     return update(params, RequestOptions.builder().setApiKey(apiKey).build());
   }
 
+  @Override
   public FeeRefund update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/FeeRefundCollectionDeserializer.java
+++ b/src/main/java/com/stripe/model/FeeRefundCollectionDeserializer.java
@@ -22,6 +22,7 @@ public class FeeRefundCollectionDeserializer implements JsonDeserializer<FeeRefu
   /**
    * Deserializes a fee_refund list JSON payload into a {@link FeeRefundCollection} object.
    */
+  @Override
   public FeeRefundCollection deserialize(JsonElement json, Type typeOfT,
       JsonDeserializationContext context)
       throws JsonParseException {

--- a/src/main/java/com/stripe/model/FileUpload.java
+++ b/src/main/java/com/stripe/model/FileUpload.java
@@ -20,7 +20,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class FileUpload extends APIResource implements HasId {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   Long created;
   String purpose;

--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -21,7 +21,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class Invoice extends APIResource implements MetadataStore<Invoice>, HasId {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   Long amountDue;
   Long amountPaid;
@@ -46,7 +46,7 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
   @SerializedName("invoice_pdf") String invoicePDF;
   InvoiceLineItemCollection lines;
   Boolean livemode;
-  Map<String, String> metadata;
+  @Getter(onMethod = @__({@Override})) Map<String, String> metadata;
   Long nextPaymentAttempt;
   String number;
   Boolean paid;
@@ -197,6 +197,7 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
         instanceURL(Invoice.class, this.getId())), params, Invoice.class, options);
   }
 
+  @Override
   public Invoice update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
@@ -210,6 +211,7 @@ public class Invoice extends APIResource implements MetadataStore<Invoice>, HasI
     return update(params, RequestOptions.builder().setApiKey(apiKey).build());
   }
 
+  @Override
   public Invoice update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/InvoiceItem.java
+++ b/src/main/java/com/stripe/model/InvoiceItem.java
@@ -19,7 +19,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class InvoiceItem extends APIResource implements MetadataStore<InvoiceItem>, HasId {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   Long amount;
   String currency;
@@ -29,7 +29,7 @@ public class InvoiceItem extends APIResource implements MetadataStore<InvoiceIte
   Boolean discountable;
   @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Invoice> invoice;
   Boolean livemode;
-  Map<String, String> metadata;
+  @Getter(onMethod = @__({@Override})) Map<String, String> metadata;
   InvoiceLineItemPeriod period;
   Plan plan;
   Boolean proration;
@@ -137,6 +137,7 @@ public class InvoiceItem extends APIResource implements MetadataStore<InvoiceIte
         options);
   }
 
+  @Override
   public InvoiceItem update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
@@ -150,6 +151,7 @@ public class InvoiceItem extends APIResource implements MetadataStore<InvoiceIte
     return update(params, RequestOptions.builder().setApiKey(apiKey).build());
   }
 
+  @Override
   public InvoiceItem update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/InvoiceLineItem.java
+++ b/src/main/java/com/stripe/model/InvoiceLineItem.java
@@ -10,7 +10,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class InvoiceLineItem extends StripeObject implements HasId {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   Long amount;
   String currency;

--- a/src/main/java/com/stripe/model/IssuerFraudRecord.java
+++ b/src/main/java/com/stripe/model/IssuerFraudRecord.java
@@ -19,7 +19,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class IssuerFraudRecord extends APIResource implements HasId {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Charge> charge;
   Long created;

--- a/src/main/java/com/stripe/model/LoginLink.java
+++ b/src/main/java/com/stripe/model/LoginLink.java
@@ -14,6 +14,7 @@ public class LoginLink extends APIResource implements HasId {
   Long created;
   String url;
 
+  @Override
   public String getId() {
     throw new UnsupportedOperationException(
         "Login links are ephemeral and do not have an identifier");

--- a/src/main/java/com/stripe/model/Order.java
+++ b/src/main/java/com/stripe/model/Order.java
@@ -20,7 +20,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class Order extends APIResource implements HasId, MetadataStore<Order> {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   Long amount;
   Long amountReturned;
@@ -34,7 +34,7 @@ public class Order extends APIResource implements HasId, MetadataStore<Order> {
   String externalCouponCode;
   List<OrderItem> items;
   Boolean livemode;
-  Map<String, String> metadata;
+  @Getter(onMethod = @__({@Override})) Map<String, String> metadata;
   OrderReturnCollection returns;
   String selectedShippingMethod;
   ShippingDetails shipping;
@@ -110,13 +110,14 @@ public class Order extends APIResource implements HasId, MetadataStore<Order> {
     return request(RequestMethod.GET, instanceURL(Order.class, id), params, Order.class, options);
   }
 
+  @Override
   public Order update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
     return update(params, null);
   }
 
-  @Deprecated
+  @Override
   public Order update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/OrderReturn.java
+++ b/src/main/java/com/stripe/model/OrderReturn.java
@@ -20,7 +20,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class OrderReturn extends APIResource implements HasId {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   Long amount;
   Long created;

--- a/src/main/java/com/stripe/model/PagingIterable.java
+++ b/src/main/java/com/stripe/model/PagingIterable.java
@@ -14,6 +14,7 @@ public class PagingIterable<T extends HasId> implements Iterable<T> {
     this.page = page;
   }
 
+  @Override
   public Iterator<T> iterator() {
     return new PagingIterator<T>(page);
   }

--- a/src/main/java/com/stripe/model/Payout.java
+++ b/src/main/java/com/stripe/model/Payout.java
@@ -19,7 +19,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class Payout extends APIResource implements MetadataStore<Payout>, HasId {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   Long amount;
   Long arrivalDate;
@@ -34,7 +34,7 @@ public class Payout extends APIResource implements MetadataStore<Payout>, HasId 
   String failureCode;
   String failureMessage;
   Boolean livemode;
-  Map<String, String> metadata;
+  @Getter(onMethod = @__({@Override})) Map<String, String> metadata;
   String method;
   String sourceType;
   String statementDescriptor;
@@ -153,12 +153,14 @@ public class Payout extends APIResource implements MetadataStore<Payout>, HasId 
     return request(RequestMethod.GET, instanceURL(Payout.class, id), params, Payout.class, options);
   }
 
+  @Override
   public Payout update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
     return update(params, null);
   }
 
+  @Override
   public Payout update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/Plan.java
+++ b/src/main/java/com/stripe/model/Plan.java
@@ -20,7 +20,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   Boolean active;
   Long amount;
@@ -30,7 +30,7 @@ public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
   String interval;
   Integer intervalCount;
   Boolean livemode;
-  Map<String, String> metadata;
+  @Getter(onMethod = @__({@Override})) Map<String, String> metadata;
   String nickname;
   @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Product> product;
   List<PlanTier> tiers;
@@ -168,6 +168,7 @@ public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
     return request(RequestMethod.GET, instanceURL(Plan.class, id), null, Plan.class, options);
   }
 
+  @Override
   public Plan update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
@@ -181,6 +182,7 @@ public class Plan extends APIResource implements MetadataStore<Plan>, HasId {
     return update(params, RequestOptions.builder().setApiKey(apiKey).build());
   }
 
+  @Override
   public Plan update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/Product.java
+++ b/src/main/java/com/stripe/model/Product.java
@@ -20,7 +20,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class Product extends APIResource implements HasId, MetadataStore<Product> {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   Boolean active;
   List<String> attributes;
@@ -30,7 +30,7 @@ public class Product extends APIResource implements HasId, MetadataStore<Product
   String description;
   List<String> images;
   Boolean livemode;
-  Map<String, String> metadata;
+  @Getter(onMethod = @__({@Override})) Map<String, String> metadata;
   String name;
   PackageDimensions packageDimensions;
   Boolean shippable;
@@ -74,12 +74,14 @@ public class Product extends APIResource implements HasId, MetadataStore<Product
     return request(RequestMethod.GET, instanceURL(Product.class, id), null, Product.class, options);
   }
 
+  @Override
   public Product update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
     return update(params, null);
   }
 
+  @Override
   public Product update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/Recipient.java
+++ b/src/main/java/com/stripe/model/Recipient.java
@@ -20,7 +20,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class Recipient extends APIResource implements MetadataStore<Recipient>, HasId {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   BankAccount activeAccount;
   RecipientCardCollection cards;
@@ -30,7 +30,7 @@ public class Recipient extends APIResource implements MetadataStore<Recipient>, 
   String description;
   String email;
   Boolean livemode;
-  Map<String, String> metadata;
+  @Getter(onMethod = @__({@Override})) Map<String, String> metadata;
   @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Account> migratedTo;
   String name;
   String type;
@@ -118,6 +118,7 @@ public class Recipient extends APIResource implements MetadataStore<Recipient>, 
         options);
   }
 
+  @Override
   public Recipient update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
@@ -131,6 +132,7 @@ public class Recipient extends APIResource implements MetadataStore<Recipient>, 
     return update(params, RequestOptions.builder().setApiKey(apiKey).build());
   }
 
+  @Override
   public Recipient update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/Refund.java
+++ b/src/main/java/com/stripe/model/Refund.java
@@ -19,7 +19,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class Refund extends APIResource implements MetadataStore<Charge>, HasId {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   Long amount;
   @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
@@ -28,7 +28,7 @@ public class Refund extends APIResource implements MetadataStore<Charge>, HasId 
   Long created;
   String currency;
   String description;
-  Map<String, String> metadata;
+  @Getter(onMethod = @__({@Override})) Map<String, String> metadata;
   String reason;
   String receiptNumber;
   String status;
@@ -69,6 +69,7 @@ public class Refund extends APIResource implements MetadataStore<Charge>, HasId 
   }
   // </editor-fold>
 
+  @Override
   public Refund update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
@@ -82,6 +83,7 @@ public class Refund extends APIResource implements MetadataStore<Charge>, HasId 
     return update(params, RequestOptions.builder().setApiKey(apiKey).build());
   }
 
+  @Override
   public Refund update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/Reversal.java
+++ b/src/main/java/com/stripe/model/Reversal.java
@@ -19,14 +19,14 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class Reversal extends APIResource implements MetadataStore<Transfer>, HasId {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   Long amount;
   @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
       ExpandableField<BalanceTransaction> balanceTransaction;
   Long created;
   String currency;
-  Map<String, String> metadata;
+  @Getter(onMethod = @__({@Override})) Map<String, String> metadata;
   @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Transfer> transfer;
 
   // <editor-fold desc="balanceTransaction">
@@ -65,6 +65,7 @@ public class Reversal extends APIResource implements MetadataStore<Transfer>, Ha
   }
   // </editor-fold>
 
+  @Override
   public Reversal update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
@@ -78,6 +79,7 @@ public class Reversal extends APIResource implements MetadataStore<Transfer>, Ha
     return update(params, RequestOptions.builder().setApiKey(apiKey).build());
   }
 
+  @Override
   public Reversal update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/Review.java
+++ b/src/main/java/com/stripe/model/Review.java
@@ -8,7 +8,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class Review extends StripeObject implements HasId {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   String charge;
   Long created;

--- a/src/main/java/com/stripe/model/SKU.java
+++ b/src/main/java/com/stripe/model/SKU.java
@@ -19,7 +19,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class SKU extends APIResource implements HasId, MetadataStore<SKU> {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   Boolean active;
   Map<String, String> attributes;
@@ -28,7 +28,7 @@ public class SKU extends APIResource implements HasId, MetadataStore<SKU> {
   String image;
   Inventory inventory;
   Boolean livemode;
-  Map<String, String> metadata;
+  @Getter(onMethod = @__({@Override})) Map<String, String> metadata;
   PackageDimensions packageDimensions;
   Integer price;
   @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Product> product;
@@ -83,12 +83,14 @@ public class SKU extends APIResource implements HasId, MetadataStore<SKU> {
     return request(RequestMethod.GET, instanceURL(SKU.class, id), params, SKU.class, options);
   }
 
+  @Override
   public SKU update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
     return update(params, null);
   }
 
+  @Override
   public SKU update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/Source.java
+++ b/src/main/java/com/stripe/model/Source.java
@@ -33,7 +33,8 @@ public class Source extends ExternalAccount implements HasSourceTypeData {
   String usage;
 
   // Type-specific properties
-  Map<String, String> typeData;
+  @Getter(onMethod = @__({@Override})) @Setter(onMethod = @__({@Override}))
+      Map<String, String> typeData;
 
   // APIResource methods
 
@@ -100,6 +101,7 @@ public class Source extends ExternalAccount implements HasSourceTypeData {
    * {@link InvalidRequestException}. Call {@link #detach} to detach the source from a
    * customer object.
    */
+  @Override
   public DeletedExternalAccount delete(RequestOptions options) throws
       AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/SourceMandateNotification.java
+++ b/src/main/java/com/stripe/model/SourceMandateNotification.java
@@ -12,7 +12,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class SourceMandateNotification extends APIResource implements HasId, HasSourceTypeData {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   Long amount;
   Long created;
@@ -23,5 +23,6 @@ public class SourceMandateNotification extends APIResource implements HasId, Has
   String type;
 
   // Type-specific properties
-  Map<String, String> typeData;
+  @Getter(onMethod = @__({@Override})) @Setter(onMethod = @__({@Override}))
+      Map<String, String> typeData;
 }

--- a/src/main/java/com/stripe/model/SourceTransaction.java
+++ b/src/main/java/com/stripe/model/SourceTransaction.java
@@ -12,7 +12,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class SourceTransaction extends APIResource implements HasId, HasSourceTypeData {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   Long amount;
   Long created;
@@ -23,5 +23,6 @@ public class SourceTransaction extends APIResource implements HasId, HasSourceTy
   String type;
 
   // Type-specific properties
-  Map<String, String> typeData;
+  @Getter(onMethod = @__({@Override})) @Setter(onMethod = @__({@Override}))
+      Map<String, String> typeData;
 }

--- a/src/main/java/com/stripe/model/SourceTypeDataDeserializer.java
+++ b/src/main/java/com/stripe/model/SourceTypeDataDeserializer.java
@@ -36,6 +36,7 @@ public class SourceTypeDataDeserializer<T extends HasSourceTypeData>
   /**
    * Deserializes the type-specific data of a {@link Source} or {@link SourceTransaction} object.
    */
+  @Override
   public T deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
           throws JsonParseException {
     if (json.isJsonNull()) {

--- a/src/main/java/com/stripe/model/StripeCollection.java
+++ b/src/main/java/com/stripe/model/StripeCollection.java
@@ -45,6 +45,7 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject
    */
   Integer count;
 
+  @Override
   public List<T> getData() {
     return data;
   }
@@ -53,6 +54,7 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject
     this.data = data;
   }
 
+  @Override
   public Integer getTotalCount() {
     return totalCount;
   }
@@ -61,6 +63,7 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject
     this.totalCount = totalCount;
   }
 
+  @Override
   public Boolean getHasMore() {
     return hasMore;
   }
@@ -69,6 +72,7 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject
     this.hasMore = hasMore;
   }
 
+  @Override
   public String getURL() {
     return url;
   }
@@ -114,18 +118,22 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject
     return new PagingIterable<T>(this);
   }
 
+  @Override
   public RequestOptions getRequestOptions() {
     return this.requestOptions;
   }
 
+  @Override
   public Map<String, Object> getRequestParams() {
     return this.requestParams;
   }
 
+  @Override
   public void setRequestOptions(RequestOptions requestOptions) {
     this.requestOptions = requestOptions;
   }
 
+  @Override
   public void setRequestParams(Map<String, Object> requestParams) {
     this.requestParams = requestParams;
   }

--- a/src/main/java/com/stripe/model/StripeRawJsonObjectDeserializer.java
+++ b/src/main/java/com/stripe/model/StripeRawJsonObjectDeserializer.java
@@ -11,6 +11,7 @@ public class StripeRawJsonObjectDeserializer implements JsonDeserializer<StripeR
   /**
    * Deserializes a JSON payload into a {@link StripeRawJsonObject} object.
    */
+  @Override
   public StripeRawJsonObject deserialize(JsonElement json, Type typeOfT,
       JsonDeserializationContext context)
       throws JsonParseException {

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -19,7 +19,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class Subscription extends APIResource implements MetadataStore<Subscription>, HasId {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   Double applicationFeePercent;
   String billing;
@@ -34,7 +34,7 @@ public class Subscription extends APIResource implements MetadataStore<Subscript
   Discount discount;
   Long endedAt;
   @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) SubscriptionItemCollection items;
-  Map<String, String> metadata;
+  @Getter(onMethod = @__({@Override})) Map<String, String> metadata;
   Plan plan;
   Integer quantity;
   Long start;
@@ -134,6 +134,7 @@ public class Subscription extends APIResource implements MetadataStore<Subscript
         Subscription.class, options);
   }
 
+  @Override
   public Subscription update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
@@ -147,6 +148,7 @@ public class Subscription extends APIResource implements MetadataStore<Subscript
     return update(params, RequestOptions.builder().setApiKey(apiKey).build());
   }
 
+  @Override
   public Subscription update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/SubscriptionItem.java
+++ b/src/main/java/com/stripe/model/SubscriptionItem.java
@@ -18,7 +18,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class SubscriptionItem extends APIResource implements HasId {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   Long created;
   Plan plan;

--- a/src/main/java/com/stripe/model/ThreeDSecure.java
+++ b/src/main/java/com/stripe/model/ThreeDSecure.java
@@ -21,7 +21,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class ThreeDSecure extends APIResource implements HasId {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   Long amount;
   Boolean authenticated;

--- a/src/main/java/com/stripe/model/Token.java
+++ b/src/main/java/com/stripe/model/Token.java
@@ -18,7 +18,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class Token extends APIResource implements HasId {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   Long amount;
   BankAccount bankAccount;

--- a/src/main/java/com/stripe/model/Topup.java
+++ b/src/main/java/com/stripe/model/Topup.java
@@ -19,7 +19,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class Topup extends APIResource implements MetadataStore<Topup>, HasId {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   Integer amount;
   @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
@@ -31,7 +31,7 @@ public class Topup extends APIResource implements MetadataStore<Topup>, HasId {
   String failureCode;
   String failureMessage;
   Boolean livemode;
-  Map<String, String> metadata;
+  @Getter(onMethod = @__({@Override})) Map<String, String> metadata;
   Source source;
   String statementDescriptor;
   String status;

--- a/src/main/java/com/stripe/model/Transfer.java
+++ b/src/main/java/com/stripe/model/Transfer.java
@@ -20,7 +20,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class Transfer extends APIResource implements MetadataStore<Transfer>, HasId {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   Long amount;
   Long amountReversed;
@@ -37,7 +37,7 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
   String failureCode;
   String failureMessage;
   Boolean livemode;
-  Map<String, String> metadata;
+  @Getter(onMethod = @__({@Override})) Map<String, String> metadata;
   @Getter(AccessLevel.NONE) TransferReversalCollection reversals;
   Boolean reversed;
   @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Charge> sourceTransaction;
@@ -244,6 +244,7 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
         Transfer.class, options);
   }
 
+  @Override
   public Transfer update(Map<String, Object> params)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {
@@ -257,6 +258,7 @@ public class Transfer extends APIResource implements MetadataStore<Transfer>, Ha
     return update(params, RequestOptions.builder().setApiKey(apiKey).build());
   }
 
+  @Override
   public Transfer update(Map<String, Object> params, RequestOptions options)
       throws AuthenticationException, InvalidRequestException,
       APIConnectionException, CardException, APIException {

--- a/src/main/java/com/stripe/model/TransferTransaction.java
+++ b/src/main/java/com/stripe/model/TransferTransaction.java
@@ -8,7 +8,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class TransferTransaction extends StripeObject implements HasId {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   Long amount;
   Long net;

--- a/src/main/java/com/stripe/model/UsageRecord.java
+++ b/src/main/java/com/stripe/model/UsageRecord.java
@@ -19,7 +19,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class UsageRecord extends APIResource implements HasId {
-  String id;
+  @Getter(onMethod = @__({@Override})) String id;
   String object;
   Boolean livemode;
   Long quantity;

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -63,6 +63,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 
   private static final SSLSocketFactory socketFactory = new StripeSSLSocketFactory();
 
+  @Override
   public <T> T request(
       APIResource.RequestMethod method,
       String url,
@@ -75,6 +76,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
     return staticRequest(method, url, params, clazz, type, options);
   }
 
+  @Override
   public <T> T oauthRequest(
       APIResource.RequestMethod method,
       String url,

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -490,6 +490,7 @@ public class BaseStripeTest {
     /**
      * Informs if this matcher accepts the given argument.
      */
+    @Override
     public boolean matches(Map<String,Object> paramMap) {
       if (this.other == null) {
         // If the matcher was constructed with null, accept any params
@@ -514,6 +515,7 @@ public class BaseStripeTest {
     /**
      * Informs if this matcher accepts the given argument.
      */
+    @Override
     public boolean matches(RequestOptions requestOptions) {
       if (this.other == null) {
         // If the matcher was constructed with null, accept any options

--- a/src/test/java/com/stripe/model/ExpandableFieldDeserializerTest.java
+++ b/src/test/java/com/stripe/model/ExpandableFieldDeserializerTest.java
@@ -24,6 +24,7 @@ public class ExpandableFieldDeserializerTest extends BaseStripeTest {
     String id;
     int bar;
 
+    @Override
     public String getId() {
       return id;
     }

--- a/src/test/java/com/stripe/model/ExpandableFieldSerializerTest.java
+++ b/src/test/java/com/stripe/model/ExpandableFieldSerializerTest.java
@@ -16,6 +16,7 @@ public class ExpandableFieldSerializerTest extends BaseStripeTest {
     @SuppressWarnings("unused")
     int bar;
 
+    @Override
     public String getId() {
       return id;
     }

--- a/src/test/java/com/stripe/model/PagingIteratorTest.java
+++ b/src/test/java/com/stripe/model/PagingIteratorTest.java
@@ -43,6 +43,7 @@ public class PagingIteratorTest extends BaseStripeTest {
           PageableModelCollection.class, options);
     }
 
+    @Override
     public String getId() {
       return id;
     }
@@ -68,6 +69,7 @@ public class PagingIteratorTest extends BaseStripeTest {
           // essentially all we're doing here is returning the first page of
           // results on the first request and the second page of results on
           // the second
+          @Override
           public PageableModelCollection answer(InvocationOnMock invocation) {
             if (count >= pages.size()) {
               throw new RuntimeException("Page out of bounds");


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @codylerum 

Adds missing `@Override` annotations detected by Error Prone.

There are still a few missing annotations: `@EqualsAndHashCode` automatically annotates the `equals` and `hashCode` methods it generates with `@Override`, but it also generates a `canEqual` method that is not annotated (cf. https://github.com/rzwitserloot/lombok/issues/1343#issuecomment-374416985). So all `ExternalAccount` subclasses are missing the `@Override` annotation on their `canEqual` method that overrides `ExternalAccount`'s own method.

There doesn't seem to be a good solution for this issue, but it's not that big a deal so ignoring for now.

I also fixed `deploy.gradle` -- our custom `makeJavadocs` task did not use the delombok'd sources.
