### PR TITLE
Drop connection timeout test

### DIFF
--- a/src/test/java/com/stripe/functional/TimeoutTest.java
+++ b/src/test/java/com/stripe/functional/TimeoutTest.java
@@ -20,19 +20,6 @@ public class TimeoutTest extends BaseStripeTest {
   public ExpectedException thrown = ExpectedException.none();
 
   @Test
-  public void testConnectTimeout() throws IOException, StripeException {
-    // Kind of a hack, but we use the non-routable address 10.255.255.0 to trigger a connection
-    // timeout
-    Stripe.overrideApiBase(String.format("http://10.255.255.0"));
-
-    thrown.expect(APIConnectionException.class);
-    thrown.expectMessage("connect timed out");
-
-    final RequestOptions options = RequestOptions.builder().setConnectTimeout(1).build();
-    Balance.retrieve(options);
-  }
-
-  @Test
   public void testReadTimeout() throws IOException, StripeException {
     // Create a local server that does nothing to trigger a read timeout
     try (final ServerSocket serverSocket =


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

We're _still_ seeing transient failures with this test (e.g. https://travis-ci.org/stripe/stripe-java/jobs/393784427#L866-L869). Let's just drop it :(
