### PR TITLE
Change signatures to throw StripeException

### DIFF
--- a/src/main/java/com/stripe/model/Account.java
+++ b/src/main/java/com/stripe/model/Account.java
@@ -1,10 +1,6 @@
 package com.stripe.model;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -75,9 +71,7 @@ public class Account extends ApiResource implements HasId, MetadataStore<Account
   /**
    * Create an account.
    */
-  public static Account create(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Account create(Map<String, Object> params) throws StripeException {
     return create(params, null);
   }
 
@@ -85,8 +79,7 @@ public class Account extends ApiResource implements HasId, MetadataStore<Account
    * Create an account.
    */
   public static Account create(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.POST, classUrl(Account.class), params, Account.class, options);
   }
   // </editor-fold>
@@ -95,27 +88,21 @@ public class Account extends ApiResource implements HasId, MetadataStore<Account
   /**
    * Delete an account.
    */
-  public DeletedAccount delete()
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public DeletedAccount delete() throws StripeException {
     return delete(null, (RequestOptions) null);
   }
 
   /**
    * Delete an account.
    */
-  public DeletedAccount delete(RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public DeletedAccount delete(RequestOptions options) throws StripeException {
     return delete(null, options);
   }
 
   /**
    * Delete an account.
    */
-  public DeletedAccount delete(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public DeletedAccount delete(Map<String, Object> params) throws StripeException {
     return delete(params, null);
   }
 
@@ -123,8 +110,7 @@ public class Account extends ApiResource implements HasId, MetadataStore<Account
    * Delete an account.
    */
   public DeletedAccount delete(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.DELETE, instanceUrl(Account.class, this.id), params,
         DeletedAccount.class, options);
   }
@@ -134,9 +120,7 @@ public class Account extends ApiResource implements HasId, MetadataStore<Account
   /**
    * List all connected accounts.
    */
-  public static AccountCollection list(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static AccountCollection list(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
@@ -144,8 +128,7 @@ public class Account extends ApiResource implements HasId, MetadataStore<Account
    * List all connected accounts.
    */
   public static AccountCollection list(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return requestCollection(classUrl(Account.class), params, AccountCollection.class, options);
   }
   // </editor-fold>
@@ -154,18 +137,14 @@ public class Account extends ApiResource implements HasId, MetadataStore<Account
   /**
    * Reject an account.
    */
-  public Account reject(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Account reject(Map<String, Object> params) throws StripeException {
     return reject(params, null);
   }
 
   /**
    * Reject an account.
    */
-  public Account reject(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Account reject(Map<String, Object> params, RequestOptions options) throws StripeException {
     return request(RequestMethod.POST, String.format("%s/reject",
         instanceUrl(Account.class, this.getId())), params, Account.class, options);
   }
@@ -175,18 +154,14 @@ public class Account extends ApiResource implements HasId, MetadataStore<Account
   /**
    * Retrieve account details.
    */
-  public static Account retrieve()
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Account retrieve() throws StripeException {
     return retrieve((RequestOptions) null);
   }
 
   /**
    * Retrieve account details.
    */
-  public static Account retrieve(RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Account retrieve(RequestOptions options) throws StripeException {
     return request(RequestMethod.GET, singleClassUrl(Account.class), null, Account.class, options);
   }
 
@@ -200,9 +175,7 @@ public class Account extends ApiResource implements HasId, MetadataStore<Account
    *     this method with API keys, use the {@link #retrieve(RequestOptions)} method instead.
    */
   @Deprecated
-  public static Account retrieve(String apiKeyOrAccountId)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Account retrieve(String apiKeyOrAccountId) throws StripeException {
     if (null == apiKeyOrAccountId || apiKeyOrAccountId.startsWith("sk_")) {
       return retrieve(RequestOptions.builder().setApiKey(apiKeyOrAccountId).build());
     } else {
@@ -213,9 +186,7 @@ public class Account extends ApiResource implements HasId, MetadataStore<Account
   /**
    * Retrieve account details.
    */
-  public static Account retrieve(String id, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Account retrieve(String id, RequestOptions options) throws StripeException {
     return request(RequestMethod.GET, instanceUrl(Account.class, id), null, Account.class, options);
   }
 
@@ -223,8 +194,7 @@ public class Account extends ApiResource implements HasId, MetadataStore<Account
    * Retrieve account details.
    */
   public static Account retrieve(String id, Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.GET, instanceUrl(Account.class, id), params, Account.class,
         options);
   }
@@ -235,9 +205,7 @@ public class Account extends ApiResource implements HasId, MetadataStore<Account
    * Update an account.
    */
   @Override
-  public Account update(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Account update(Map<String, Object> params) throws StripeException {
     return update(params, null);
   }
 
@@ -245,9 +213,7 @@ public class Account extends ApiResource implements HasId, MetadataStore<Account
    * Update an account.
    */
   @Override
-  public Account update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Account update(Map<String, Object> params, RequestOptions options) throws StripeException {
     return request(RequestMethod.POST, instanceUrl(Account.class, this.id), params, Account.class,
         options);
   }

--- a/src/main/java/com/stripe/model/AlipayAccount.java
+++ b/src/main/java/com/stripe/model/AlipayAccount.java
@@ -1,10 +1,6 @@
 package com.stripe.model;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.RequestOptions;
 
 import java.util.Map;
@@ -28,31 +24,24 @@ public class AlipayAccount extends ExternalAccount {
   String status;
 
   @Override
-  public DeletedAlipayAccount delete() throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public DeletedAlipayAccount delete() throws StripeException {
     return delete(null);
   }
 
   @Override
-  public DeletedAlipayAccount delete(RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public DeletedAlipayAccount delete(RequestOptions options) throws StripeException {
     return request(RequestMethod.DELETE, this.getInstanceUrl(), null, DeletedAlipayAccount.class,
         options);
   }
 
   @Override
-  public AlipayAccount update(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public AlipayAccount update(Map<String, Object> params) throws StripeException {
     return update(params, null);
   }
 
   @Override
   public AlipayAccount update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.POST, this.getInstanceUrl(), params, AlipayAccount.class, options);
   }
 }

--- a/src/main/java/com/stripe/model/ApplePayDomain.java
+++ b/src/main/java/com/stripe/model/ApplePayDomain.java
@@ -1,11 +1,7 @@
 package com.stripe.model;
 
 import com.stripe.Stripe;
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -29,9 +25,7 @@ public class ApplePayDomain extends ApiResource implements HasId {
   /**
    * Create an Apple Pay domain.
    */
-  public static ApplePayDomain create(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static ApplePayDomain create(Map<String, Object> params) throws StripeException {
     return create(params, null);
   }
 
@@ -39,8 +33,7 @@ public class ApplePayDomain extends ApiResource implements HasId {
    * Create an Apple Pay domain.
    */
   public static ApplePayDomain create(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.POST, getClassUrl(), params, ApplePayDomain.class, options);
   }
   // </editor-fold>
@@ -49,18 +42,14 @@ public class ApplePayDomain extends ApiResource implements HasId {
   /**
    * Delete an Apple Pay domain.
    */
-  public DeletedApplePayDomain delete() throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public DeletedApplePayDomain delete() throws StripeException {
     return delete(null);
   }
 
   /**
    * Delete an Apple Pay domain.
    */
-  public DeletedApplePayDomain delete(RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public DeletedApplePayDomain delete(RequestOptions options) throws StripeException {
     return request(RequestMethod.DELETE, getInstanceUrl(id), null, DeletedApplePayDomain.class,
         options);
   }
@@ -70,9 +59,7 @@ public class ApplePayDomain extends ApiResource implements HasId {
   /**
    * List all Apple Pay domains.
    */
-  public static ApplePayDomainCollection list(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static ApplePayDomainCollection list(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
@@ -80,8 +67,7 @@ public class ApplePayDomain extends ApiResource implements HasId {
    * List all Apple Pay domains.
    */
   public static ApplePayDomainCollection list(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return requestCollection(getClassUrl(), params, ApplePayDomainCollection.class, options);
   }
   // </editor-fold>
@@ -90,18 +76,14 @@ public class ApplePayDomain extends ApiResource implements HasId {
   /**
    * Retrieve an Apple Pay domain.
    */
-  public static ApplePayDomain retrieve(String id) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static ApplePayDomain retrieve(String id) throws StripeException {
     return retrieve(id, null);
   }
 
   /**
    * Retrieve an Apple Pay domain.
    */
-  public static ApplePayDomain retrieve(String id, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static ApplePayDomain retrieve(String id, RequestOptions options) throws StripeException {
     return request(RequestMethod.GET, getInstanceUrl(id), null, ApplePayDomain.class, options);
   }
   // </editor-fold>

--- a/src/main/java/com/stripe/model/ApplicationFee.java
+++ b/src/main/java/com/stripe/model/ApplicationFee.java
@@ -1,10 +1,6 @@
 package com.stripe.model;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -157,9 +153,7 @@ public class ApplicationFee extends ApiResource implements HasId {
   /**
    * List all application fees.
    */
-  public static ApplicationFeeCollection list(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static ApplicationFeeCollection list(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
@@ -167,8 +161,7 @@ public class ApplicationFee extends ApiResource implements HasId {
    * List all application fees.
    */
   public static ApplicationFeeCollection list(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return requestCollection(classUrl(ApplicationFee.class), params, ApplicationFeeCollection.class,
         options);
   }
@@ -178,18 +171,14 @@ public class ApplicationFee extends ApiResource implements HasId {
   /**
    * Retrieve an application fee.
    */
-  public static ApplicationFee retrieve(String id) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static ApplicationFee retrieve(String id) throws StripeException {
     return retrieve(id, (RequestOptions) null);
   }
 
   /**
    * Retrieve an application fee.
    */
-  public static ApplicationFee retrieve(String id, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static ApplicationFee retrieve(String id, RequestOptions options) throws StripeException {
     return request(RequestMethod.GET, instanceUrl(ApplicationFee.class, id), null,
         ApplicationFee.class, options);
   }

--- a/src/main/java/com/stripe/model/Balance.java
+++ b/src/main/java/com/stripe/model/Balance.java
@@ -1,10 +1,6 @@
 package com.stripe.model;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -27,18 +23,14 @@ public class Balance extends ApiResource {
   /**
    * Retrieve balance.
    */
-  public static Balance retrieve() throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static Balance retrieve() throws StripeException {
     return retrieve((RequestOptions) null);
   }
 
   /**
    * Retrieve balance.
    */
-  public static Balance retrieve(RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Balance retrieve(RequestOptions options) throws StripeException {
     return request(RequestMethod.GET, singleClassUrl(Balance.class), null, Balance.class, options);
   }
   // </editor-fold>

--- a/src/main/java/com/stripe/model/BalanceTransaction.java
+++ b/src/main/java/com/stripe/model/BalanceTransaction.java
@@ -1,11 +1,7 @@
 package com.stripe.model;
 
 import com.stripe.Stripe;
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -73,8 +69,7 @@ public class BalanceTransaction extends ApiResource implements HasId {
    * List all balance history.
    */
   public static BalanceTransactionCollection list(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return list(params, null);
   }
 
@@ -82,9 +77,7 @@ public class BalanceTransaction extends ApiResource implements HasId {
    * List all balance history.
    */
   public static BalanceTransactionCollection list(Map<String, Object> params,
-      RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      RequestOptions options) throws StripeException {
     String url = String.format("%s/%s", Stripe.getApiBase(), "v1/balance/history");
     return requestCollection(url, params, BalanceTransactionCollection.class, options);
   }
@@ -94,9 +87,7 @@ public class BalanceTransaction extends ApiResource implements HasId {
   /**
    * Retrieve a balance transaction.
    */
-  public static BalanceTransaction retrieve(String id) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static BalanceTransaction retrieve(String id) throws StripeException {
     return retrieve(id, (RequestOptions) null);
   }
 
@@ -104,8 +95,7 @@ public class BalanceTransaction extends ApiResource implements HasId {
    * Retrieve a balance transaction.
    */
   public static BalanceTransaction retrieve(String id, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     String url = String.format("%s/%s/%s", Stripe.getApiBase(), "v1/balance/history", id);
     return request(RequestMethod.GET, url, null, BalanceTransaction.class, options);
   }

--- a/src/main/java/com/stripe/model/BankAccount.java
+++ b/src/main/java/com/stripe/model/BankAccount.java
@@ -1,10 +1,6 @@
 package com.stripe.model;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.RequestOptions;
 
 import java.util.Map;
@@ -34,9 +30,7 @@ public class BankAccount extends ExternalAccount {
    * Delete a bank account.
    */
   @Override
-  public DeletedBankAccount delete()
-      throws AuthenticationException, InvalidRequestException, ApiConnectionException,
-      CardException, ApiException {
+  public DeletedBankAccount delete() throws StripeException {
     return delete(null);
   }
 
@@ -44,9 +38,7 @@ public class BankAccount extends ExternalAccount {
    * Delete a bank account.
    */
   @Override
-  public DeletedBankAccount delete(RequestOptions options)
-      throws AuthenticationException, InvalidRequestException, ApiConnectionException,
-      CardException, ApiException {
+  public DeletedBankAccount delete(RequestOptions options) throws StripeException {
     return request(RequestMethod.DELETE, this.getInstanceUrl(), null, DeletedBankAccount.class,
         options);
   }
@@ -57,9 +49,7 @@ public class BankAccount extends ExternalAccount {
    * Update a bank account.
    */
   @Override
-  public BankAccount update(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException, ApiConnectionException,
-      CardException, ApiException {
+  public BankAccount update(Map<String, Object> params) throws StripeException {
     return update(params, null);
   }
 
@@ -68,8 +58,7 @@ public class BankAccount extends ExternalAccount {
    */
   @Override
   public BankAccount update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException, ApiConnectionException,
-      CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.POST, this.getInstanceUrl(), params, BankAccount.class, options);
   }
   // </editor-fold>

--- a/src/main/java/com/stripe/model/BitcoinReceiver.java
+++ b/src/main/java/com/stripe/model/BitcoinReceiver.java
@@ -1,11 +1,7 @@
 package com.stripe.model;
 
 import com.stripe.Stripe;
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.RequestOptions;
 
 import java.util.Map;
@@ -40,85 +36,64 @@ public class BitcoinReceiver extends ExternalAccount {
   Boolean usedForPayment;
 
   @Deprecated
-  public static BitcoinReceiverCollection all(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static BitcoinReceiverCollection all(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
   @Deprecated
   public static BitcoinReceiverCollection all(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return list(params, options);
   }
 
-  public static BitcoinReceiver create(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static BitcoinReceiver create(Map<String, Object> params) throws StripeException {
     return create(params, null);
   }
 
   public static BitcoinReceiver create(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.POST, String.format("%s/%s", Stripe.getApiBase(),
         "v1/bitcoin/receivers"), params, BitcoinReceiver.class, options);
   }
 
   @Override
-  public DeletedBitcoinReceiver delete() throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public DeletedBitcoinReceiver delete() throws StripeException {
     return delete(null);
   }
 
   @Override
-  public DeletedBitcoinReceiver delete(RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public DeletedBitcoinReceiver delete(RequestOptions options) throws StripeException {
     return request(RequestMethod.DELETE, this.getInstanceUrl(), null, DeletedBitcoinReceiver.class,
         options);
   }
 
-  public static BitcoinReceiverCollection list(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static BitcoinReceiverCollection list(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
   public static BitcoinReceiverCollection list(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     String url = String.format("%s/%s", Stripe.getApiBase(), "v1/bitcoin/receivers");
     return requestCollection(url, params, BitcoinReceiverCollection.class, options);
   }
 
-  public static BitcoinReceiver retrieve(String id) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static BitcoinReceiver retrieve(String id) throws StripeException {
     return retrieve(id, null);
   }
 
-
-  public static BitcoinReceiver retrieve(String id, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static BitcoinReceiver retrieve(String id, RequestOptions options) throws StripeException {
     return request(RequestMethod.GET, String.format("%s/%s/%s", Stripe.getApiBase(),
         "v1/bitcoin/receivers", id), null, BitcoinReceiver.class, options);
   }
 
   @Override
-  public BitcoinReceiver update(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public BitcoinReceiver update(Map<String, Object> params) throws StripeException {
     return update(params, null);
   }
 
   @Override
   public BitcoinReceiver update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.POST, this.getInstanceUrl(), params, BitcoinReceiver.class,
         options);
   }

--- a/src/main/java/com/stripe/model/BitcoinTransactionCollection.java
+++ b/src/main/java/com/stripe/model/BitcoinTransactionCollection.java
@@ -1,11 +1,7 @@
 package com.stripe.model;
 
 import com.stripe.Stripe;
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -13,30 +9,24 @@ import java.util.Map;
 
 
 public class BitcoinTransactionCollection extends StripeCollection<BitcoinTransaction> {
-  public BitcoinTransactionCollection list(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public BitcoinTransactionCollection list(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
   public BitcoinTransactionCollection list(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     String url = String.format("%s%s", Stripe.getApiBase(), this.getUrl());
     return ApiResource.requestCollection(url, params, BitcoinTransactionCollection.class, options);
   }
 
   @Deprecated
-  public BitcoinTransactionCollection all(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public BitcoinTransactionCollection all(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
   @Deprecated
   public BitcoinTransactionCollection all(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return list(params, options);
   }
 }

--- a/src/main/java/com/stripe/model/Card.java
+++ b/src/main/java/com/stripe/model/Card.java
@@ -1,10 +1,6 @@
 package com.stripe.model;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.RequestOptions;
 
 import java.util.List;
@@ -64,9 +60,7 @@ public class Card extends ExternalAccount {
    * Delete a card.
    */
   @Override
-  public DeletedCard delete()
-      throws AuthenticationException, InvalidRequestException, ApiConnectionException,
-      CardException, ApiException {
+  public DeletedCard delete() throws StripeException {
     return delete((RequestOptions) null);
   }
 
@@ -74,9 +68,7 @@ public class Card extends ExternalAccount {
    * Delete a card.
    */
   @Override
-  public DeletedCard delete(RequestOptions options)
-      throws AuthenticationException, InvalidRequestException, ApiConnectionException,
-      CardException, ApiException {
+  public DeletedCard delete(RequestOptions options) throws StripeException {
     return request(RequestMethod.DELETE, this.getInstanceUrl(), null, DeletedCard.class, options);
   }
   // </editor-fold>
@@ -86,9 +78,7 @@ public class Card extends ExternalAccount {
    * Update a card.
    */
   @Override
-  public Card update(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Card update(Map<String, Object> params) throws StripeException {
     return update(params, (RequestOptions) null);
   }
 
@@ -96,9 +86,7 @@ public class Card extends ExternalAccount {
    * Update a card.
    */
   @Override
-  public Card update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Card update(Map<String, Object> params, RequestOptions options) throws StripeException {
     return request(RequestMethod.POST, this.getInstanceUrl(), params, Card.class, options);
   }
   // </editor-fold>

--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -1,10 +1,6 @@
 package com.stripe.model;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -328,36 +324,28 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, HasId 
   /**
    * Capture a charge.
    */
-  public Charge capture() throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public Charge capture() throws StripeException {
     return this.capture(null, (RequestOptions) null);
   }
 
   /**
    * Capture a charge.
    */
-  public Charge capture(RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public Charge capture(RequestOptions options) throws StripeException {
     return this.capture(null, options);
   }
 
   /**
    * Capture a charge.
    */
-  public Charge capture(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Charge capture(Map<String, Object> params) throws StripeException {
     return this.capture(params, (RequestOptions) null);
   }
 
   /**
    * Capture a charge.
    */
-  public Charge capture(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Charge capture(Map<String, Object> params, RequestOptions options) throws StripeException {
     return request(RequestMethod.POST, String.format("%s/capture",
         instanceUrl(Charge.class, this.getId())), params, Charge.class, options);
   }
@@ -367,9 +355,7 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, HasId 
   /**
    * Create a charge.
    */
-  public static Charge create(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Charge create(Map<String, Object> params) throws StripeException {
     return create(params, (RequestOptions) null);
   }
 
@@ -377,8 +363,7 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, HasId 
    * Create a charge.
    */
   public static Charge create(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.POST, classUrl(Charge.class), params, Charge.class, options);
   }
   // </editor-fold>
@@ -387,9 +372,7 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, HasId 
   /**
    * List all charges.
    */
-  public static ChargeCollection list(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static ChargeCollection list(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
@@ -397,8 +380,7 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, HasId 
    * List all charges.
    */
   public static ChargeCollection list(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return requestCollection(classUrl(Charge.class), params, ChargeCollection.class, options);
   }
   // </editor-fold>
@@ -407,9 +389,7 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, HasId 
   /**
    * Mark the charge as fraudulent.
    */
-  public Charge markFraudulent(RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Charge markFraudulent(RequestOptions options) throws StripeException {
     Map<String, Object> params = Collections.<String, Object>singletonMap(
         FRAUD_DETAILS, Collections.singletonMap(FraudDetails.USER_REPORT, "fraudulent"));
     return this.update(params, options);
@@ -420,9 +400,7 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, HasId 
   /**
    * Mark the charge as safe.
    */
-  public Charge markSafe(RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Charge markSafe(RequestOptions options) throws StripeException {
     Map<String, Object> params = Collections.<String, Object>singletonMap(
         FRAUD_DETAILS, Collections.singletonMap(FraudDetails.USER_REPORT, "safe"));
     return this.update(params, options);
@@ -436,9 +414,7 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, HasId 
    * @deprecated Prefer using the {@link Refund#create(Map)} method instead.
    */
   @Deprecated
-  public Charge refund() throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public Charge refund() throws StripeException {
     return this.refund(null, (RequestOptions) null);
   }
 
@@ -448,9 +424,7 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, HasId 
    * @deprecated Prefer using the {@link Refund#create(Map, RequestOptions)} method instead.
    */
   @Deprecated
-  public Charge refund(RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public Charge refund(RequestOptions options) throws StripeException {
     return this.refund(null, options);
   }
 
@@ -460,9 +434,7 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, HasId 
    * @deprecated Prefer using the {@link Refund#create(Map)} method instead.
    */
   @Deprecated
-  public Charge refund(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Charge refund(Map<String, Object> params) throws StripeException {
     return this.refund(params, (RequestOptions) null);
   }
 
@@ -472,9 +444,7 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, HasId 
    * @deprecated Prefer using the {@link Refund#create(Map, RequestOptions)} method instead.
    */
   @Deprecated
-  public Charge refund(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Charge refund(Map<String, Object> params, RequestOptions options) throws StripeException {
     return request(RequestMethod.POST, String.format("%s/refund",
         instanceUrl(Charge.class, this.getId())), params, Charge.class, options);
   }
@@ -484,18 +454,14 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, HasId 
   /**
    * Retrieve a charge.
    */
-  public static Charge retrieve(String id) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static Charge retrieve(String id) throws StripeException {
     return retrieve(id, (RequestOptions) null);
   }
 
   /**
    * Retrieve a charge.
    */
-  public static Charge retrieve(String id, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Charge retrieve(String id, RequestOptions options) throws StripeException {
     return request(RequestMethod.GET, instanceUrl(Charge.class, id), null, Charge.class, options);
   }
 
@@ -503,8 +469,7 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, HasId 
    * Retrieve a charge.
    */
   public static Charge retrieve(String id, Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.GET, instanceUrl(Charge.class, id), params, Charge.class, options);
   }
   // </editor-fold>
@@ -514,9 +479,7 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, HasId 
    * Update a charge.
    */
   @Override
-  public Charge update(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Charge update(Map<String, Object> params) throws StripeException {
     return update(params, (RequestOptions) null);
   }
 
@@ -524,9 +487,7 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, HasId 
    * Update a charge.
    */
   @Override
-  public Charge update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Charge update(Map<String, Object> params, RequestOptions options) throws StripeException {
     return request(RequestMethod.POST, instanceUrl(Charge.class, id), params, Charge.class,
         options);
   }

--- a/src/main/java/com/stripe/model/ChargeRefundCollection.java
+++ b/src/main/java/com/stripe/model/ChargeRefundCollection.java
@@ -1,11 +1,7 @@
 package com.stripe.model;
 
 import com.stripe.Stripe;
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -19,9 +15,7 @@ public class ChargeRefundCollection extends StripeCollection<Refund> {
    * @deprecated Prefer using the {@link Refund#create(Map)} instead.
    */
   @Deprecated
-  public Refund create(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Refund create(Map<String, Object> params) throws StripeException {
     return create(params, (RequestOptions) null);
   }
 
@@ -31,10 +25,7 @@ public class ChargeRefundCollection extends StripeCollection<Refund> {
    * @deprecated Prefer using the {@link Refund#create(Map)} instead.
    */
   @Deprecated
-  public Refund create(Map<String, Object> params,
-             RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public Refund create(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url = String.format("%s%s", Stripe.getApiBase(), this.getUrl());
     return ApiResource.request(ApiResource.RequestMethod.POST, url, params, Refund.class, options);
   }
@@ -47,9 +38,7 @@ public class ChargeRefundCollection extends StripeCollection<Refund> {
    * @deprecated Prefer using the {@link Refund#list(Map)} method instead.
    */
   @Deprecated
-  public ChargeRefundCollection list(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public ChargeRefundCollection list(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
@@ -59,10 +48,8 @@ public class ChargeRefundCollection extends StripeCollection<Refund> {
    * @deprecated Prefer using the {@link Refund#list(Map, RequestOptions)} method instead.
    */
   @Deprecated
-  public ChargeRefundCollection list(Map<String, Object> params,
-                     RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public ChargeRefundCollection list(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
     String url = String.format("%s%s", Stripe.getApiBase(), this.getUrl());
     return ApiResource.requestCollection(url, params, ChargeRefundCollection.class, options);
   }
@@ -75,9 +62,7 @@ public class ChargeRefundCollection extends StripeCollection<Refund> {
    * @deprecated Prefer using the {@link Refund#retrieve(String)} method instead.
    */
   @Deprecated
-  public Refund retrieve(String id)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Refund retrieve(String id) throws StripeException {
     return retrieve(id, (RequestOptions) null);
   }
 
@@ -87,9 +72,7 @@ public class ChargeRefundCollection extends StripeCollection<Refund> {
    * @deprecated Prefer using the {@link Refund#retrieve(String, RequestOptions)} method instead.
    */
   @Deprecated
-  public Refund retrieve(String id, RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public Refund retrieve(String id, RequestOptions options) throws StripeException {
     String url = String.format("%s%s/%s", Stripe.getApiBase(), this.getUrl(), id);
     return ApiResource.request(ApiResource.RequestMethod.GET, url, null, Refund.class, options);
   }

--- a/src/main/java/com/stripe/model/CountrySpec.java
+++ b/src/main/java/com/stripe/model/CountrySpec.java
@@ -1,10 +1,6 @@
 package com.stripe.model;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -31,9 +27,7 @@ public class CountrySpec extends ApiResource implements HasId {
   /**
    * List country specs.
    */
-  public static CountrySpecCollection list(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static CountrySpecCollection list(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
@@ -41,8 +35,7 @@ public class CountrySpec extends ApiResource implements HasId {
    * List country specs.
    */
   public static CountrySpecCollection list(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return requestCollection(classUrl(CountrySpec.class), params, CountrySpecCollection.class,
         options);
   }
@@ -52,9 +45,7 @@ public class CountrySpec extends ApiResource implements HasId {
   /**
    * Retrieve a country spec.
    */
-  public static CountrySpec retrieve(String country) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static CountrySpec retrieve(String country) throws StripeException {
     return retrieve(country, null);
   }
 
@@ -62,8 +53,7 @@ public class CountrySpec extends ApiResource implements HasId {
    * Retrieve a country spec.
    */
   public static CountrySpec retrieve(String country, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.GET, instanceUrl(CountrySpec.class, country), null,
         CountrySpec.class, options);
   }

--- a/src/main/java/com/stripe/model/Coupon.java
+++ b/src/main/java/com/stripe/model/Coupon.java
@@ -1,10 +1,6 @@
 package com.stripe.model;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -38,9 +34,7 @@ public class Coupon extends ApiResource implements MetadataStore<Coupon>, HasId 
   /**
    * Create a coupon.
    */
-  public static Coupon create(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Coupon create(Map<String, Object> params) throws StripeException {
     return create(params, (RequestOptions) null);
   }
 
@@ -48,8 +42,7 @@ public class Coupon extends ApiResource implements MetadataStore<Coupon>, HasId 
    * Create a coupon.
    */
   public static Coupon create(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.POST, classUrl(Coupon.class), params, Coupon.class, options);
   }
   // </editor-fold>
@@ -58,18 +51,14 @@ public class Coupon extends ApiResource implements MetadataStore<Coupon>, HasId 
   /**
    * Delete a coupon.
    */
-  public DeletedCoupon delete() throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public DeletedCoupon delete() throws StripeException {
     return delete((RequestOptions) null);
   }
 
   /**
    * Delete a coupon.
    */
-  public DeletedCoupon delete(RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public DeletedCoupon delete(RequestOptions options) throws StripeException {
     return request(RequestMethod.DELETE, instanceUrl(Coupon.class, this.id), null,
         DeletedCoupon.class, options);
   }
@@ -79,9 +68,7 @@ public class Coupon extends ApiResource implements MetadataStore<Coupon>, HasId 
   /**
    * List all coupons.
    */
-  public static CouponCollection list(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static CouponCollection list(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
@@ -89,8 +76,7 @@ public class Coupon extends ApiResource implements MetadataStore<Coupon>, HasId 
    * List all coupons.
    */
   public static CouponCollection list(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return requestCollection(classUrl(Coupon.class), params, CouponCollection.class, options);
   }
   // </editor-fold>
@@ -99,18 +85,14 @@ public class Coupon extends ApiResource implements MetadataStore<Coupon>, HasId 
   /**
    * Retrieve a coupon.
    */
-  public static Coupon retrieve(String id) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static Coupon retrieve(String id) throws StripeException {
     return retrieve(id, (RequestOptions) null);
   }
 
   /**
    * Retrieve a coupon.
    */
-  public static Coupon retrieve(String id, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Coupon retrieve(String id, RequestOptions options) throws StripeException {
     return request(RequestMethod.GET, instanceUrl(Coupon.class, id), null, Coupon.class, options);
   }
   // </editor-fold>
@@ -120,9 +102,7 @@ public class Coupon extends ApiResource implements MetadataStore<Coupon>, HasId 
    * Update a coupon.
    */
   @Override
-  public Coupon update(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException, ApiConnectionException,
-      CardException, ApiException {
+  public Coupon update(Map<String, Object> params) throws StripeException {
     return update(params, (RequestOptions) null);
   }
 
@@ -130,9 +110,7 @@ public class Coupon extends ApiResource implements MetadataStore<Coupon>, HasId 
    * Update a coupon.
    */
   @Override
-  public Coupon update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException, ApiConnectionException,
-      CardException, ApiException {
+  public Coupon update(Map<String, Object> params, RequestOptions options) throws StripeException {
     return request(RequestMethod.POST, instanceUrl(Coupon.class, this.id), params, Coupon.class,
         options);
   }

--- a/src/main/java/com/stripe/model/Customer.java
+++ b/src/main/java/com/stripe/model/Customer.java
@@ -1,10 +1,6 @@
 package com.stripe.model;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -111,9 +107,7 @@ public class Customer extends ApiResource implements MetadataStore<Customer>, Ha
   /**
    * Create a customer.
    */
-  public static Customer create(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Customer create(Map<String, Object> params) throws StripeException {
     return create(params, (RequestOptions) null);
   }
 
@@ -121,8 +115,7 @@ public class Customer extends ApiResource implements MetadataStore<Customer>, Ha
    * Create a customer.
    */
   public static Customer create(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.POST, classUrl(Customer.class), params, Customer.class, options);
   }
   // </editor-fold>
@@ -131,18 +124,14 @@ public class Customer extends ApiResource implements MetadataStore<Customer>, Ha
   /**
    * Delete a customer.
    */
-  public DeletedCustomer delete() throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public DeletedCustomer delete() throws StripeException {
     return delete((RequestOptions) null);
   }
 
   /**
    * Delete a customer.
    */
-  public DeletedCustomer delete(RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public DeletedCustomer delete(RequestOptions options) throws StripeException {
     return request(RequestMethod.DELETE, instanceUrl(Customer.class, this.id), null,
         DeletedCustomer.class, options);
   }
@@ -152,18 +141,14 @@ public class Customer extends ApiResource implements MetadataStore<Customer>, Ha
   /**
    * Delete a customer discount.
    */
-  public void deleteDiscount() throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public void deleteDiscount() throws StripeException {
     deleteDiscount((RequestOptions) null);
   }
 
   /**
    * Delete a customer discount.
    */
-  public void deleteDiscount(RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public void deleteDiscount(RequestOptions options) throws StripeException {
     request(RequestMethod.DELETE, String.format("%s/discount",
         instanceUrl(Customer.class, this.id)), null, Discount.class, options);
   }
@@ -173,20 +158,15 @@ public class Customer extends ApiResource implements MetadataStore<Customer>, Ha
   /**
    * List all customers.
    */
-  public static CustomerCollection list(Map<String, Object> params)
-      throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static CustomerCollection list(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
   /**
    * List all customers.
    */
-  public static CustomerCollection list(Map<String, Object> params,
-                      RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static CustomerCollection list(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
     return requestCollection(classUrl(Customer.class), params, CustomerCollection.class, options);
   }
   // </editor-fold>
@@ -195,18 +175,14 @@ public class Customer extends ApiResource implements MetadataStore<Customer>, Ha
   /**
    * Retrieve a customer.
    */
-  public static Customer retrieve(String id) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static Customer retrieve(String id) throws StripeException {
     return retrieve(id, (RequestOptions) null);
   }
 
   /**
    * Retrieve a customer.
    */
-  public static Customer retrieve(String id, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Customer retrieve(String id, RequestOptions options) throws StripeException {
     return request(RequestMethod.GET, instanceUrl(Customer.class, id), null, Customer.class,
         options);
   }
@@ -215,8 +191,7 @@ public class Customer extends ApiResource implements MetadataStore<Customer>, Ha
    * Retrieve a customer.
    */
   public static Customer retrieve(String id, Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.GET, instanceUrl(Customer.class, id), params, Customer.class,
         options);
   }
@@ -227,9 +202,7 @@ public class Customer extends ApiResource implements MetadataStore<Customer>, Ha
    * Update a customer.
    */
   @Override
-  public Customer update(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Customer update(Map<String, Object> params) throws StripeException {
     return update(params, (RequestOptions) null);
   }
 
@@ -238,8 +211,7 @@ public class Customer extends ApiResource implements MetadataStore<Customer>, Ha
    */
   @Override
   public Customer update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.POST, instanceUrl(Customer.class, this.id), params,
         Customer.class, options);
   }

--- a/src/main/java/com/stripe/model/CustomerCardCollection.java
+++ b/src/main/java/com/stripe/model/CustomerCardCollection.java
@@ -1,11 +1,7 @@
 package com.stripe.model;
 
 import com.stripe.Stripe;
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -16,19 +12,14 @@ public class CustomerCardCollection extends StripeCollection<Card> {
   /**
    * Create a card.
    */
-  public Card create(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Card create(Map<String, Object> params) throws StripeException {
     return create(params, (RequestOptions) null);
   }
 
   /**
    * Create a card.
    */
-  public Card create(Map<String, Object> params,
-             RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public Card create(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url = String.format("%s%s", Stripe.getApiBase(), this.getUrl());
     return ApiResource.request(ApiResource.RequestMethod.POST, url, params, Card.class, options);
   }
@@ -38,19 +29,15 @@ public class CustomerCardCollection extends StripeCollection<Card> {
   /**
    * List all cards.
    */
-  public CustomerCardCollection list(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public CustomerCardCollection list(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
   /**
    * List all cards.
    */
-  public CustomerCardCollection list(Map<String, Object> params,
-                     RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public CustomerCardCollection list(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
     String url = String.format("%s%s", Stripe.getApiBase(), this.getUrl());
     return ApiResource.requestCollection(url, params, CustomerCardCollection.class, options);
   }
@@ -60,18 +47,14 @@ public class CustomerCardCollection extends StripeCollection<Card> {
   /**
    * Retrieve a card.
    */
-  public Card retrieve(String id)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Card retrieve(String id) throws StripeException {
     return retrieve(id, (RequestOptions) null);
   }
 
   /**
    * Retrieve a card.
    */
-  public Card retrieve(String id, RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public Card retrieve(String id, RequestOptions options) throws StripeException {
     String url = String.format("%s%s/%s", Stripe.getApiBase(), this.getUrl(), id);
     return ApiResource.request(ApiResource.RequestMethod.GET, url, null, Card.class, options);
   }

--- a/src/main/java/com/stripe/model/CustomerSubscriptionCollection.java
+++ b/src/main/java/com/stripe/model/CustomerSubscriptionCollection.java
@@ -1,11 +1,7 @@
 package com.stripe.model;
 
 import com.stripe.Stripe;
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -19,9 +15,7 @@ public class CustomerSubscriptionCollection extends StripeCollection<Subscriptio
    * @deprecated Prefer using the {@link Subscription#create(Map)} method instead.
    */
   @Deprecated
-  public Subscription create(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Subscription create(Map<String, Object> params) throws StripeException {
     return create(params, (RequestOptions) null);
   }
 
@@ -31,10 +25,8 @@ public class CustomerSubscriptionCollection extends StripeCollection<Subscriptio
    * @deprecated Prefer using the {@link Subscription#create(Map, RequestOptions)} method instead.
    */
   @Deprecated
-  public Subscription create(Map<String, Object> params,
-                 RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public Subscription create(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
     return ApiResource.request(ApiResource.RequestMethod.POST, String.format("%s%s",
         Stripe.getApiBase(), this.getUrl()), params, Subscription.class, options);
   }
@@ -47,9 +39,7 @@ public class CustomerSubscriptionCollection extends StripeCollection<Subscriptio
    * @deprecated Prefer using the {@link Subscription#list(Map)} method instead.
    */
   @Deprecated
-  public CustomerSubscriptionCollection list(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public CustomerSubscriptionCollection list(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
@@ -59,10 +49,8 @@ public class CustomerSubscriptionCollection extends StripeCollection<Subscriptio
    * @deprecated Prefer using the {@link Subscription#list(Map)} method instead.
    */
   @Deprecated
-  public CustomerSubscriptionCollection list(Map<String, Object> params,
-                         RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public CustomerSubscriptionCollection list(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
     return ApiResource.requestCollection(String.format("%s%s", Stripe.getApiBase(), this.getUrl()),
         params, CustomerSubscriptionCollection.class, options);
   }
@@ -75,9 +63,7 @@ public class CustomerSubscriptionCollection extends StripeCollection<Subscriptio
    * @deprecated Prefer using the {@link Subscription#retrieve(String)} method instead.
    */
   @Deprecated
-  public Subscription retrieve(String id)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Subscription retrieve(String id) throws StripeException {
     return retrieve(id, (RequestOptions) null);
   }
 
@@ -87,9 +73,7 @@ public class CustomerSubscriptionCollection extends StripeCollection<Subscriptio
    * @deprecated Prefer using the {@link Subscription#retrieve(String)} method instead.
    */
   @Deprecated
-  public Subscription retrieve(String id, RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public Subscription retrieve(String id, RequestOptions options) throws StripeException {
     return ApiResource.request(ApiResource.RequestMethod.GET, String.format("%s%s/%s",
         Stripe.getApiBase(), this.getUrl(), id), null, Subscription.class, options);
   }

--- a/src/main/java/com/stripe/model/Dispute.java
+++ b/src/main/java/com/stripe/model/Dispute.java
@@ -1,10 +1,6 @@
 package com.stripe.model;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -93,18 +89,14 @@ public class Dispute extends ApiResource implements HasId {
   /**
    * Close a dispute.
    */
-  public Dispute close()
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Dispute close() throws StripeException {
     return close(null);
   }
 
   /**
    * Close a dispute.
    */
-  public Dispute close(RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Dispute close(RequestOptions options) throws StripeException {
     return request(RequestMethod.POST, String.format("%s/close",
         instanceUrl(Dispute.class, this.getId())), null, Dispute.class, options);
   }
@@ -114,9 +106,7 @@ public class Dispute extends ApiResource implements HasId {
   /**
    * List all disputes.
    */
-  public static DisputeCollection list(Map<String, Object> params) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static DisputeCollection list(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
@@ -124,8 +114,7 @@ public class Dispute extends ApiResource implements HasId {
    * List all disputes.
    */
   public static DisputeCollection list(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException, ApiConnectionException,
-      CardException, ApiException {
+      throws StripeException {
     return requestCollection(classUrl(Dispute.class), params, DisputeCollection.class, options);
   }
   // </editor-fold>
@@ -134,18 +123,14 @@ public class Dispute extends ApiResource implements HasId {
   /**
    * Retrieve a dispute.
    */
-  public static Dispute retrieve(String id) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static Dispute retrieve(String id) throws StripeException {
     return retrieve(id, null, null);
   }
 
   /**
    * Retrieve a dispute.
    */
-  public static Dispute retrieve(String id, RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static Dispute retrieve(String id, RequestOptions options) throws StripeException {
     return retrieve(id, null, options);
   }
 
@@ -153,8 +138,7 @@ public class Dispute extends ApiResource implements HasId {
    * Retrieve a dispute.
    */
   public static Dispute retrieve(String id, Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException, ApiConnectionException,
-      CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.GET, instanceUrl(Dispute.class, id), params, Dispute.class,
         options);
   }
@@ -164,18 +148,14 @@ public class Dispute extends ApiResource implements HasId {
   /**
    * Update a dispute.
    */
-  public Dispute update(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Dispute update(Map<String, Object> params) throws StripeException {
     return update(params, null);
   }
 
   /**
    * Update a dispute.
    */
-  public Dispute update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Dispute update(Map<String, Object> params, RequestOptions options) throws StripeException {
     return request(RequestMethod.POST, instanceUrl(Dispute.class, this.getId()),
         params, Dispute.class, options);
   }

--- a/src/main/java/com/stripe/model/EphemeralKey.java
+++ b/src/main/java/com/stripe/model/EphemeralKey.java
@@ -1,10 +1,6 @@
 package com.stripe.model;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -38,8 +34,7 @@ public class EphemeralKey extends ApiResource implements HasId {
    * @return the new ephemeral key
    */
   public static EphemeralKey create(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     if (options.getStripeVersion() == null) {
       throw new IllegalArgumentException("stripeVersion must be specified in RequestOptions");
     }
@@ -53,18 +48,14 @@ public class EphemeralKey extends ApiResource implements HasId {
   /**
    * Delete an ephemeral key.
    */
-  public EphemeralKey delete()
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public EphemeralKey delete() throws StripeException {
     return delete(null);
   }
 
   /**
    * Delete an ephemeral key.
    */
-  public EphemeralKey delete(RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public EphemeralKey delete(RequestOptions options) throws StripeException {
     return request(RequestMethod.DELETE, instanceUrl(EphemeralKey.class, this.id), null,
         EphemeralKey.class, options);
   }

--- a/src/main/java/com/stripe/model/Event.java
+++ b/src/main/java/com/stripe/model/Event.java
@@ -1,10 +1,6 @@
 package com.stripe.model;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -39,9 +35,7 @@ public class Event extends ApiResource implements HasId {
   /**
    * List all events.
    */
-  public static EventCollection list(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static EventCollection list(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
@@ -49,8 +43,7 @@ public class Event extends ApiResource implements HasId {
    * List all events.
    */
   public static EventCollection list(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return requestCollection(classUrl(Event.class), params, EventCollection.class, options);
   }
   // </editor-fold>
@@ -59,9 +52,7 @@ public class Event extends ApiResource implements HasId {
   /**
    * Retrieve an event.
    */
-  public static Event retrieve(String id) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static Event retrieve(String id) throws StripeException {
     return retrieve(id, (RequestOptions) null);
   }
 
@@ -69,8 +60,7 @@ public class Event extends ApiResource implements HasId {
    * Retrieve an event.
    */
   public static Event retrieve(String id, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.GET, instanceUrl(Event.class, id), null, Event.class, options);
   }
   // </editor-fold>

--- a/src/main/java/com/stripe/model/ExchangeRate.java
+++ b/src/main/java/com/stripe/model/ExchangeRate.java
@@ -1,10 +1,6 @@
 package com.stripe.model;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -26,9 +22,7 @@ public class ExchangeRate extends ApiResource implements HasId {
   /**
    * List all exchange rates.
    */
-  public static ExchangeRateCollection list(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static ExchangeRateCollection list(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
@@ -36,8 +30,7 @@ public class ExchangeRate extends ApiResource implements HasId {
    * List all exchange rates.
    */
   public static ExchangeRateCollection list(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return requestCollection(classUrl(ExchangeRate.class), params, ExchangeRateCollection.class,
         options);
   }
@@ -47,9 +40,7 @@ public class ExchangeRate extends ApiResource implements HasId {
   /**
    * Retrieve an exchange rate.
    */
-  public static ExchangeRate retrieve(String currency) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static ExchangeRate retrieve(String currency) throws StripeException {
     return retrieve(currency, null);
   }
 
@@ -57,8 +48,7 @@ public class ExchangeRate extends ApiResource implements HasId {
    * Retrieve an exchange rate.
    */
   public static ExchangeRate retrieve(String currency, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.GET, instanceUrl(ExchangeRate.class, currency), null,
         ExchangeRate.class, options);
   }

--- a/src/main/java/com/stripe/model/ExternalAccount.java
+++ b/src/main/java/com/stripe/model/ExternalAccount.java
@@ -1,10 +1,7 @@
 package com.stripe.model;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -25,15 +22,11 @@ public class ExternalAccount extends ApiResource implements HasId, MetadataStore
   @Getter(onMethod = @__({@Override})) Map<String, String> metadata;
 
   // <editor-fold desc="delete">
-  public DeletedExternalAccount delete() throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException,
-      CardException, ApiException {
+  public DeletedExternalAccount delete() throws StripeException {
     return delete(null);
   }
 
-  public DeletedExternalAccount delete(RequestOptions options) throws
-      AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public DeletedExternalAccount delete(RequestOptions options) throws StripeException {
     return request(RequestMethod.DELETE, this.getInstanceUrl(), null, DeletedExternalAccount.class,
         options);
   }
@@ -41,25 +34,20 @@ public class ExternalAccount extends ApiResource implements HasId, MetadataStore
 
   // <editor-fold desc="update">
   @Override
-  public ExternalAccount update(Map<String, Object> params) throws
-      AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public ExternalAccount update(Map<String, Object> params) throws StripeException {
     return update(params, null);
   }
 
   @Override
   public ExternalAccount update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.POST, this.getInstanceUrl(), params, ExternalAccount.class,
         options);
   }
   // </editor-fold>
 
   // <editor-fold desc="verify">
-  public ExternalAccount verify(Map<String, Object> params) throws
-      AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public ExternalAccount verify(Map<String, Object> params) throws StripeException {
     return verify(params, null);
   }
 
@@ -70,9 +58,8 @@ public class ExternalAccount extends ApiResource implements HasId, MetadataStore
    * @param options request options
    * @return the verified bank account
    */
-  public ExternalAccount verify(Map<String, Object> params, RequestOptions options) throws
-      AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public ExternalAccount verify(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
     if (this.getCustomer() != null) {
       return request(RequestMethod.POST, String.format("%s/verify", this.getInstanceUrl()), params,
           ExternalAccount.class, options);

--- a/src/main/java/com/stripe/model/ExternalAccountCollection.java
+++ b/src/main/java/com/stripe/model/ExternalAccountCollection.java
@@ -1,11 +1,7 @@
 package com.stripe.model;
 
 import com.stripe.Stripe;
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -14,63 +10,47 @@ import java.util.Map;
 public class ExternalAccountCollection extends StripeCollection<ExternalAccount> {
   // <editor-fold desc="all">
   @Deprecated
-  public ExternalAccountCollection all(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public ExternalAccountCollection all(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
   @Deprecated
-  public ExternalAccountCollection all(Map<String, Object> params,
-                     RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public ExternalAccountCollection all(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
     return list(params, options);
   }
   // </editor-fold>
 
   // <editor-fold desc="create">
-  public ExternalAccount create(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public ExternalAccount create(Map<String, Object> params) throws StripeException {
     return create(params, null);
   }
 
-  public ExternalAccount create(Map<String, Object> params,
-                  RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public ExternalAccount create(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
     return ApiResource.request(ApiResource.RequestMethod.POST, String.format("%s%s",
         Stripe.getApiBase(), this.getUrl()), params, ExternalAccount.class, options);
   }
   // </editor-fold>
 
   // <editor-fold desc="list">
-  public ExternalAccountCollection list(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public ExternalAccountCollection list(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
-  public ExternalAccountCollection list(Map<String, Object> params,
-                      RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public ExternalAccountCollection list(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
     String url = String.format("%s%s", Stripe.getApiBase(), this.getUrl());
     return ApiResource.requestCollection(url, params, ExternalAccountCollection.class, options);
   }
   // </editor-fold>
 
   // <editor-fold desc="retrieve">
-  public ExternalAccount retrieve(String id) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public ExternalAccount retrieve(String id) throws StripeException {
     return retrieve(id, null);
   }
 
-  public ExternalAccount retrieve(String id, RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public ExternalAccount retrieve(String id, RequestOptions options) throws StripeException {
     return ApiResource.request(ApiResource.RequestMethod.GET, String.format("%s%s/%s",
         Stripe.getApiBase(), this.getUrl(), id), null, ExternalAccount.class, options);
   }

--- a/src/main/java/com/stripe/model/FeeRefund.java
+++ b/src/main/java/com/stripe/model/FeeRefund.java
@@ -1,10 +1,6 @@
 package com.stripe.model;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -70,9 +66,7 @@ public class FeeRefund extends ApiResource implements MetadataStore<ApplicationF
    * Update an application fee refund.
    */
   @Override
-  public FeeRefund update(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public FeeRefund update(Map<String, Object> params) throws StripeException {
     return update(params, (RequestOptions) null);
   }
 
@@ -81,8 +75,7 @@ public class FeeRefund extends ApiResource implements MetadataStore<ApplicationF
    */
   @Override
   public FeeRefund update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.POST, this.getInstanceUrl(), params, FeeRefund.class, options);
   }
   // </editor-fold>

--- a/src/main/java/com/stripe/model/FeeRefundCollection.java
+++ b/src/main/java/com/stripe/model/FeeRefundCollection.java
@@ -1,11 +1,7 @@
 package com.stripe.model;
 
 import com.stripe.Stripe;
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -16,19 +12,15 @@ public class FeeRefundCollection extends StripeCollection<FeeRefund> {
   /**
    * Create an application fee refund.
    */
-  public FeeRefund create(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public FeeRefund create(Map<String, Object> params) throws StripeException {
     return create(params, (RequestOptions) null);
   }
 
   /**
    * Create an application fee refund.
    */
-  public FeeRefund create(Map<String, Object> params,
-              RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public FeeRefund create(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
     return ApiResource.request(ApiResource.RequestMethod.POST, String.format("%s%s",
         Stripe.getApiBase(), this.getUrl()), params, FeeRefund.class, options);
   }
@@ -38,19 +30,15 @@ public class FeeRefundCollection extends StripeCollection<FeeRefund> {
   /**
    * List all application fee refunds.
    */
-  public FeeRefundCollection list(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public FeeRefundCollection list(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
   /**
    * List all application fee refunds.
    */
-  public FeeRefundCollection list(Map<String, Object> params,
-                  RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public FeeRefundCollection list(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
     String url = String.format("%s%s", Stripe.getApiBase(), this.getUrl());
     return ApiResource.requestCollection(url, params, FeeRefundCollection.class, options);
   }
@@ -60,18 +48,14 @@ public class FeeRefundCollection extends StripeCollection<FeeRefund> {
   /**
    * Retrieve an application fee refund.
    */
-  public FeeRefund retrieve(String id)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public FeeRefund retrieve(String id) throws StripeException {
     return retrieve(id, (RequestOptions) null);
   }
 
   /**
    * Retrieve an application fee refund.
    */
-  public FeeRefund retrieve(String id, RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public FeeRefund retrieve(String id, RequestOptions options) throws StripeException {
     String url = String.format("%s%s/%s", Stripe.getApiBase(), this.getUrl(), id);
     return ApiResource.request(ApiResource.RequestMethod.GET, url, null, FeeRefund.class, options);
   }

--- a/src/main/java/com/stripe/model/FileUpload.java
+++ b/src/main/java/com/stripe/model/FileUpload.java
@@ -1,11 +1,7 @@
 package com.stripe.model;
 
 import com.stripe.Stripe;
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -31,19 +27,15 @@ public class FileUpload extends ApiResource implements HasId {
   /**
    * Create a file upload.
    */
-  public static FileUpload create(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static FileUpload create(Map<String, Object> params) throws StripeException {
     return create(params, (RequestOptions) null);
   }
 
   /**
    * Create a file upload.
    */
-  public static FileUpload create(Map<String, Object> params,
-                  RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static FileUpload create(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
     return multipartRequest(RequestMethod.POST, classUrl(FileUpload.class, Stripe.getUploadBase()),
         params, FileUpload.class, options);
   }
@@ -53,9 +45,7 @@ public class FileUpload extends ApiResource implements HasId {
   /**
    * List all file uploads.
    */
-  public static FileUploadCollection list(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static FileUploadCollection list(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
@@ -63,8 +53,7 @@ public class FileUpload extends ApiResource implements HasId {
    * List all file uploads.
    */
   public static FileUploadCollection list(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return requestCollection(classUrl(FileUpload.class, Stripe.getUploadBase()),
         params, FileUploadCollection.class, options);
   }
@@ -74,18 +63,14 @@ public class FileUpload extends ApiResource implements HasId {
   /**
    * Retrieve a file upload.
    */
-  public static FileUpload retrieve(String id)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static FileUpload retrieve(String id) throws StripeException {
     return retrieve(id, (RequestOptions) null);
   }
 
   /**
    * Retrieve a file upload.
    */
-  public static FileUpload retrieve(String id, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static FileUpload retrieve(String id, RequestOptions options) throws StripeException {
     return request(RequestMethod.GET, instanceUrl(FileUpload.class, id, Stripe.getUploadBase()),
         null, FileUpload.class, options);
   }

--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -1,12 +1,6 @@
 package com.stripe.model;
 
-import com.google.gson.annotations.SerializedName;
-
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -103,9 +97,7 @@ public class Invoice extends ApiResource implements MetadataStore<Invoice>, HasI
   /**
    * Create an invoice.
    */
-  public static Invoice create(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Invoice create(Map<String, Object> params) throws StripeException {
     return create(params, (RequestOptions) null);
   }
 
@@ -113,8 +105,7 @@ public class Invoice extends ApiResource implements MetadataStore<Invoice>, HasI
    * Create an invoice.
    */
   public static Invoice create(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.POST, classUrl(Invoice.class), params, Invoice.class, options);
   }
   // </editor-fold>
@@ -123,19 +114,15 @@ public class Invoice extends ApiResource implements MetadataStore<Invoice>, HasI
   /**
    * List all invoices.
    */
-  public static InvoiceCollection list(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static InvoiceCollection list(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
   /**
    * List all invoices.
    */
-  public static InvoiceCollection list(Map<String, Object> params,
-                     RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static InvoiceCollection list(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
     return requestCollection(classUrl(Invoice.class), params, InvoiceCollection.class, options);
   }
   // </editor-fold>
@@ -144,36 +131,28 @@ public class Invoice extends ApiResource implements MetadataStore<Invoice>, HasI
   /**
    * Pay an invoice.
    */
-  public Invoice pay() throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public Invoice pay() throws StripeException {
     return this.pay((RequestOptions) null);
   }
 
   /**
    * Pay an invoice.
    */
-  public Invoice pay(RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public Invoice pay(RequestOptions options) throws StripeException {
     return pay(null, options);
   }
 
   /**
    * Pay an invoice.
    */
-  public Invoice pay(Map<String, Object> params) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public Invoice pay(Map<String, Object> params) throws StripeException {
     return this.pay(params, null);
   }
 
   /**
    * Pay an invoice.
    */
-  public Invoice pay(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException, ApiConnectionException,
-      CardException, ApiException {
+  public Invoice pay(Map<String, Object> params, RequestOptions options) throws StripeException {
     return request(RequestMethod.POST, String.format("%s/pay",
         instanceUrl(Invoice.class, this.getId())), params, Invoice.class, options);
   }
@@ -183,18 +162,14 @@ public class Invoice extends ApiResource implements MetadataStore<Invoice>, HasI
   /**
    * Retrieve an invoice.
    */
-  public static Invoice retrieve(String id) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static Invoice retrieve(String id) throws StripeException {
     return retrieve(id, (RequestOptions) null);
   }
 
   /**
    * Retrieve an invoice.
    */
-  public static Invoice retrieve(String id, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Invoice retrieve(String id, RequestOptions options) throws StripeException {
     return request(RequestMethod.GET, instanceUrl(Invoice.class, id), null, Invoice.class, options);
   }
 
@@ -202,8 +177,7 @@ public class Invoice extends ApiResource implements MetadataStore<Invoice>, HasI
    * Retrieve an invoice.
    */
   public static Invoice retrieve(String id, Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.GET, instanceUrl(Invoice.class, id), params, Invoice.class,
         options);
   }
@@ -213,9 +187,7 @@ public class Invoice extends ApiResource implements MetadataStore<Invoice>, HasI
   /**
    * Retrieve an upcoming invoice.
    */
-  public static Invoice upcoming(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Invoice upcoming(Map<String, Object> params) throws StripeException {
     return upcoming(params, (RequestOptions) null);
   }
 
@@ -223,8 +195,7 @@ public class Invoice extends ApiResource implements MetadataStore<Invoice>, HasI
    * Retrieve an upcoming invoice.
    */
   public static Invoice upcoming(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.GET, String.format("%s/upcoming", classUrl(Invoice.class)), params,
         Invoice.class, options);
   }
@@ -235,9 +206,7 @@ public class Invoice extends ApiResource implements MetadataStore<Invoice>, HasI
    * Update an invoice.
    */
   @Override
-  public Invoice update(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Invoice update(Map<String, Object> params) throws StripeException {
     return update(params, (RequestOptions) null);
   }
 
@@ -245,9 +214,7 @@ public class Invoice extends ApiResource implements MetadataStore<Invoice>, HasI
    * Update an invoice.
    */
   @Override
-  public Invoice update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Invoice update(Map<String, Object> params, RequestOptions options) throws StripeException {
     return request(RequestMethod.POST, instanceUrl(Invoice.class, this.id), params, Invoice.class,
         options);
   }

--- a/src/main/java/com/stripe/model/InvoiceItem.java
+++ b/src/main/java/com/stripe/model/InvoiceItem.java
@@ -1,10 +1,6 @@
 package com.stripe.model;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -94,9 +90,7 @@ public class InvoiceItem extends ApiResource implements MetadataStore<InvoiceIte
   /**
    * Create an invoice item.
    */
-  public static InvoiceItem create(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static InvoiceItem create(Map<String, Object> params) throws StripeException {
     return create(params, (RequestOptions) null);
   }
 
@@ -104,8 +98,7 @@ public class InvoiceItem extends ApiResource implements MetadataStore<InvoiceIte
    * Create an invoice item.
    */
   public static InvoiceItem create(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.POST, classUrl(InvoiceItem.class), params, InvoiceItem.class,
         options);
   }
@@ -115,18 +108,14 @@ public class InvoiceItem extends ApiResource implements MetadataStore<InvoiceIte
   /**
    * Delete an invoice item.
    */
-  public DeletedInvoiceItem delete() throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public DeletedInvoiceItem delete() throws StripeException {
     return delete((RequestOptions) null);
   }
 
   /**
    * Delete an invoice item.
    */
-  public DeletedInvoiceItem delete(RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public DeletedInvoiceItem delete(RequestOptions options) throws StripeException {
     return request(RequestMethod.DELETE, instanceUrl(InvoiceItem.class, this.id), null,
         DeletedInvoiceItem.class, options);
   }
@@ -136,19 +125,15 @@ public class InvoiceItem extends ApiResource implements MetadataStore<InvoiceIte
   /**
    * List all invoice items.
    */
-  public static InvoiceItemCollection list(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static InvoiceItemCollection list(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
   /**
    * List all invoice items.
    */
-  public static InvoiceItemCollection list(Map<String, Object> params,
-                       RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static InvoiceItemCollection list(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
     return requestCollection(classUrl(InvoiceItem.class), params, InvoiceItemCollection.class,
         options);
   }
@@ -158,18 +143,14 @@ public class InvoiceItem extends ApiResource implements MetadataStore<InvoiceIte
   /**
    * Retrieve an invoice item.
    */
-  public static InvoiceItem retrieve(String id)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static InvoiceItem retrieve(String id) throws StripeException {
     return retrieve(id, (RequestOptions) null);
   }
 
   /**
    * Retrieve an invoice item.
    */
-  public static InvoiceItem retrieve(String id, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static InvoiceItem retrieve(String id, RequestOptions options) throws StripeException {
     return request(RequestMethod.GET, instanceUrl(InvoiceItem.class, id), null, InvoiceItem.class,
         options);
   }
@@ -178,8 +159,7 @@ public class InvoiceItem extends ApiResource implements MetadataStore<InvoiceIte
    * Retrieve an invoice item.
    */
   public static InvoiceItem retrieve(String id, Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.GET, instanceUrl(InvoiceItem.class, id), params, InvoiceItem.class,
         options);
   }
@@ -190,9 +170,7 @@ public class InvoiceItem extends ApiResource implements MetadataStore<InvoiceIte
    * Update an invoice item.
    */
   @Override
-  public InvoiceItem update(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public InvoiceItem update(Map<String, Object> params) throws StripeException {
     return update(params, (RequestOptions) null);
   }
 
@@ -201,8 +179,7 @@ public class InvoiceItem extends ApiResource implements MetadataStore<InvoiceIte
    */
   @Override
   public InvoiceItem update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.POST, instanceUrl(InvoiceItem.class, this.id), params,
         InvoiceItem.class, options);
   }

--- a/src/main/java/com/stripe/model/InvoiceLineItemCollection.java
+++ b/src/main/java/com/stripe/model/InvoiceLineItemCollection.java
@@ -1,11 +1,7 @@
 package com.stripe.model;
 
 import com.stripe.Stripe;
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -16,19 +12,15 @@ public class InvoiceLineItemCollection extends StripeCollection<InvoiceLineItem>
   /**
    * Retrieve an invoice's line items.
    */
-  public InvoiceLineItemCollection list(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public InvoiceLineItemCollection list(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
   /**
    * Retrieve an invoice's line items.
    */
-  public InvoiceLineItemCollection list(Map<String, Object> params,
-                      RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public InvoiceLineItemCollection list(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
     String url = String.format("%s%s", Stripe.getApiBase(), this.getUrl());
     return ApiResource.requestCollection(url, params, InvoiceLineItemCollection.class, options);
   }

--- a/src/main/java/com/stripe/model/IssuerFraudRecord.java
+++ b/src/main/java/com/stripe/model/IssuerFraudRecord.java
@@ -1,10 +1,6 @@
 package com.stripe.model;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -45,8 +41,7 @@ public class IssuerFraudRecord extends ApiResource implements HasId {
 
   // <editor-fold desc="list">
   public static IssuerFraudRecordCollection list(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-                      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return list(params, null);
   }
 
@@ -58,8 +53,7 @@ public class IssuerFraudRecord extends ApiResource implements HasId {
    * @return the listing of params at /v1/issuer_fraud_records.
    */
   public static IssuerFraudRecordCollection list(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-                      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return requestCollection(
         classUrl(IssuerFraudRecord.class), params, IssuerFraudRecordCollection.class, options
     );
@@ -67,15 +61,12 @@ public class IssuerFraudRecord extends ApiResource implements HasId {
   // </editor-fold>
 
   // <editor-fold desc="retrieve">
-  public static IssuerFraudRecord retrieve(String id)
-      throws AuthenticationException, InvalidRequestException,
-                      ApiConnectionException, CardException, ApiException {
+  public static IssuerFraudRecord retrieve(String id) throws StripeException {
     return retrieve(id, null);
   }
 
   public static IssuerFraudRecord retrieve(String id, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-                      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     String url = instanceUrl(IssuerFraudRecord.class, id);
     return request(RequestMethod.GET, url, null, IssuerFraudRecord.class, null);
   }

--- a/src/main/java/com/stripe/model/LoginLinkCollection.java
+++ b/src/main/java/com/stripe/model/LoginLinkCollection.java
@@ -1,11 +1,7 @@
 package com.stripe.model;
 
 import com.stripe.Stripe;
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -14,18 +10,14 @@ public class LoginLinkCollection extends StripeCollection<LoginLink> {
   /**
    * Create a login link.
    */
-  public LoginLink create()
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public LoginLink create() throws StripeException {
     return create(null);
   }
 
   /**
    * Create a login link.
    */
-  public LoginLink create(RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public LoginLink create(RequestOptions options) throws StripeException {
     String url = String.format("%s%s", Stripe.getApiBase(), this.getUrl());
     return ApiResource.request(ApiResource.RequestMethod.POST, url, null, LoginLink.class, options);
   }

--- a/src/main/java/com/stripe/model/MetadataStore.java
+++ b/src/main/java/com/stripe/model/MetadataStore.java
@@ -1,10 +1,6 @@
 package com.stripe.model;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.RequestOptions;
 
 import java.util.Map;
@@ -15,10 +11,8 @@ import java.util.Map;
 public interface MetadataStore<T> {
   Map<String, String> getMetadata();
 
-  MetadataStore<T> update(Map<String, Object> params) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException, ApiException;
+  MetadataStore<T> update(Map<String, Object> params) throws StripeException;
 
   MetadataStore<T> update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException, ApiConnectionException,
-      CardException, ApiException;
+      throws StripeException;
 }

--- a/src/main/java/com/stripe/model/Order.java
+++ b/src/main/java/com/stripe/model/Order.java
@@ -1,10 +1,6 @@
 package com.stripe.model;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -84,9 +80,7 @@ public class Order extends ApiResource implements HasId, MetadataStore<Order> {
   /**
    * Create an order.
    */
-  public static Order create(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Order create(Map<String, Object> params) throws StripeException {
     return create(params, null);
   }
 
@@ -94,8 +88,7 @@ public class Order extends ApiResource implements HasId, MetadataStore<Order> {
    * Create an order.
    */
   public static Order create(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.POST, classUrl(Order.class), params, Order.class, options);
   }
   // </editor-fold>
@@ -104,19 +97,15 @@ public class Order extends ApiResource implements HasId, MetadataStore<Order> {
   /**
    * List all orders.
    */
-  public static OrderCollection list(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static OrderCollection list(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
   /**
    * List all orders.
    */
-  public static OrderCollection list(Map<String, Object> params,
-                     RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static OrderCollection list(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
     return requestCollection(classUrl(Order.class), params, OrderCollection.class, options);
   }
   // </editor-fold>
@@ -125,18 +114,14 @@ public class Order extends ApiResource implements HasId, MetadataStore<Order> {
   /**
    * Pay an order.
    */
-  public Order pay(Map<String, Object> params) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public Order pay(Map<String, Object> params) throws StripeException {
     return this.pay(params, null);
   }
 
   /**
    * Pay an order.
    */
-  public Order pay(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException, ApiConnectionException,
-      CardException, ApiException {
+  public Order pay(Map<String, Object> params, RequestOptions options) throws StripeException {
     return request(RequestMethod.POST, String.format("%s/pay",
         instanceUrl(Order.class, this.getId())), params, Order.class, options);
   }
@@ -146,18 +131,14 @@ public class Order extends ApiResource implements HasId, MetadataStore<Order> {
   /**
    * Retrieve an order.
    */
-  public static Order retrieve(String id)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Order retrieve(String id) throws StripeException {
     return retrieve(id, null);
   }
 
   /**
    * Retrieve an order.
    */
-  public static Order retrieve(String id, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Order retrieve(String id, RequestOptions options) throws StripeException {
     return request(RequestMethod.GET, instanceUrl(Order.class, id), null, Order.class, options);
   }
 
@@ -165,8 +146,7 @@ public class Order extends ApiResource implements HasId, MetadataStore<Order> {
    * Retrieve an order.
    */
   public static Order retrieve(String id, Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.GET, instanceUrl(Order.class, id), params, Order.class, options);
   }
   // </editor-fold>
@@ -175,9 +155,7 @@ public class Order extends ApiResource implements HasId, MetadataStore<Order> {
   /**
    * Return an order.
    */
-  public OrderReturn returnOrder(Map<String, Object> params) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public OrderReturn returnOrder(Map<String, Object> params) throws StripeException {
     return this.returnOrder(params, null);
   }
 
@@ -185,8 +163,7 @@ public class Order extends ApiResource implements HasId, MetadataStore<Order> {
    * Return an order.
    */
   public OrderReturn returnOrder(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException, ApiConnectionException,
-      CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.POST, String.format("%s/returns",
         instanceUrl(Order.class, this.getId())), params, OrderReturn.class, options);
   }
@@ -197,9 +174,7 @@ public class Order extends ApiResource implements HasId, MetadataStore<Order> {
    * Update an order.
    */
   @Override
-  public Order update(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Order update(Map<String, Object> params) throws StripeException {
     return update(params, null);
   }
 
@@ -207,9 +182,7 @@ public class Order extends ApiResource implements HasId, MetadataStore<Order> {
    * Update an order.
    */
   @Override
-  public Order update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Order update(Map<String, Object> params, RequestOptions options) throws StripeException {
     return request(RequestMethod.POST, instanceUrl(Order.class, this.id), params, Order.class,
         options);
   }

--- a/src/main/java/com/stripe/model/OrderReturn.java
+++ b/src/main/java/com/stripe/model/OrderReturn.java
@@ -1,10 +1,6 @@
 package com.stripe.model;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -70,19 +66,15 @@ public class OrderReturn extends ApiResource implements HasId {
   /**
    * List all order returns.
    */
-  public static OrderReturnCollection list(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static OrderReturnCollection list(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
   /**
    * List all order returns.
    */
-  public static OrderReturnCollection list(Map<String, Object> params,
-                       RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static OrderReturnCollection list(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
     return requestCollection(classUrl(OrderReturn.class), params, OrderReturnCollection.class,
         options);
   }
@@ -92,18 +84,14 @@ public class OrderReturn extends ApiResource implements HasId {
   /**
    * Retrieve an order return.
    */
-  public static OrderReturn retrieve(String id)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static OrderReturn retrieve(String id) throws StripeException {
     return retrieve(id, null);
   }
 
   /**
    * Retrieve an order return.
    */
-  public static OrderReturn retrieve(String id, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static OrderReturn retrieve(String id, RequestOptions options) throws StripeException {
     return request(RequestMethod.GET, instanceUrl(OrderReturn.class, id), null, OrderReturn.class,
         options);
   }

--- a/src/main/java/com/stripe/model/Payout.java
+++ b/src/main/java/com/stripe/model/Payout.java
@@ -1,10 +1,6 @@
 package com.stripe.model;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -102,18 +98,14 @@ public class Payout extends ApiResource implements MetadataStore<Payout>, HasId 
   /**
    * Cancel a payout.
    */
-  public Payout cancel()
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Payout cancel() throws StripeException {
     return cancel(null);
   }
 
   /**
    * Cancel a payout.
    */
-  public Payout cancel(RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Payout cancel(RequestOptions options) throws StripeException {
     return request(RequestMethod.POST, instanceUrl(Payout.class, this.id) + "/cancel", null,
         Payout.class, options);
   }
@@ -123,9 +115,7 @@ public class Payout extends ApiResource implements MetadataStore<Payout>, HasId 
   /**
    * Create a payout.
    */
-  public static Payout create(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Payout create(Map<String, Object> params) throws StripeException {
     return create(params, null);
   }
 
@@ -133,8 +123,7 @@ public class Payout extends ApiResource implements MetadataStore<Payout>, HasId 
    * Create a payout.
    */
   public static Payout create(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.POST, classUrl(Payout.class), params, Payout.class, options);
   }
   // </editor-fold>
@@ -143,9 +132,7 @@ public class Payout extends ApiResource implements MetadataStore<Payout>, HasId 
   /**
    * List all payouts.
    */
-  public static PayoutCollection list(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static PayoutCollection list(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
@@ -153,8 +140,7 @@ public class Payout extends ApiResource implements MetadataStore<Payout>, HasId 
    * List all payouts.
    */
   public static PayoutCollection list(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException, ApiConnectionException,
-      CardException, ApiException {
+      throws StripeException {
     return requestCollection(classUrl(Payout.class), params, PayoutCollection.class, options);
   }
   // </editor-fold>
@@ -163,18 +149,14 @@ public class Payout extends ApiResource implements MetadataStore<Payout>, HasId 
   /**
    * Retrieve a payout.
    */
-  public static Payout retrieve(String id) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static Payout retrieve(String id) throws StripeException {
     return retrieve(id, null);
   }
 
   /**
    * Retrieve a payout.
    */
-  public static Payout retrieve(String id, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Payout retrieve(String id, RequestOptions options) throws StripeException {
     return request(RequestMethod.GET, instanceUrl(Payout.class, id), null, Payout.class, options);
   }
 
@@ -182,8 +164,7 @@ public class Payout extends ApiResource implements MetadataStore<Payout>, HasId 
    * Retrieve a payout.
    */
   public static Payout retrieve(String id, Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.GET, instanceUrl(Payout.class, id), params, Payout.class, options);
   }
   // </editor-fold>
@@ -193,9 +174,7 @@ public class Payout extends ApiResource implements MetadataStore<Payout>, HasId 
    * Update a payout.
    */
   @Override
-  public Payout update(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Payout update(Map<String, Object> params) throws StripeException {
     return update(params, null);
   }
 
@@ -203,9 +182,7 @@ public class Payout extends ApiResource implements MetadataStore<Payout>, HasId 
    * Update a payout.
    */
   @Override
-  public Payout update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Payout update(Map<String, Object> params, RequestOptions options) throws StripeException {
     return request(RequestMethod.POST, instanceUrl(Payout.class, this.id), params, Payout.class,
         options);
   }

--- a/src/main/java/com/stripe/model/Plan.java
+++ b/src/main/java/com/stripe/model/Plan.java
@@ -1,10 +1,6 @@
 package com.stripe.model;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -102,9 +98,7 @@ public class Plan extends ApiResource implements MetadataStore<Plan>, HasId {
   /**
    * Create a plan.
    */
-  public static Plan create(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Plan create(Map<String, Object> params) throws StripeException {
     return create(params, (RequestOptions) null);
   }
 
@@ -112,8 +106,7 @@ public class Plan extends ApiResource implements MetadataStore<Plan>, HasId {
    * Create a plan.
    */
   public static Plan create(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.POST, classUrl(Plan.class), params, Plan.class, options);
   }
   // </editor-fold>
@@ -122,18 +115,14 @@ public class Plan extends ApiResource implements MetadataStore<Plan>, HasId {
   /**
    * Delete a plan.
    */
-  public DeletedPlan delete() throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public DeletedPlan delete() throws StripeException {
     return delete((RequestOptions) null);
   }
 
   /**
    * Delete a plan.
    */
-  public DeletedPlan delete(RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public DeletedPlan delete(RequestOptions options) throws StripeException {
     return request(RequestMethod.DELETE, instanceUrl(Plan.class, this.id), null, DeletedPlan.class,
         options);
   }
@@ -143,9 +132,7 @@ public class Plan extends ApiResource implements MetadataStore<Plan>, HasId {
   /**
    * List all plans.
    */
-  public static PlanCollection list(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static PlanCollection list(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
@@ -153,8 +140,7 @@ public class Plan extends ApiResource implements MetadataStore<Plan>, HasId {
    * List all plans.
    */
   public static PlanCollection list(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return requestCollection(classUrl(Plan.class), params, PlanCollection.class, options);
   }
   // </editor-fold>
@@ -163,18 +149,14 @@ public class Plan extends ApiResource implements MetadataStore<Plan>, HasId {
   /**
    * Retrieve a plan.
    */
-  public static Plan retrieve(String id) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static Plan retrieve(String id) throws StripeException {
     return retrieve(id, (RequestOptions) null);
   }
 
   /**
    * Retrieve a plan.
    */
-  public static Plan retrieve(String id, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Plan retrieve(String id, RequestOptions options) throws StripeException {
     return request(RequestMethod.GET, instanceUrl(Plan.class, id), null, Plan.class, options);
   }
   // </editor-fold>
@@ -184,9 +166,7 @@ public class Plan extends ApiResource implements MetadataStore<Plan>, HasId {
    * Update a plan.
    */
   @Override
-  public Plan update(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Plan update(Map<String, Object> params) throws StripeException {
     return update(params, (RequestOptions) null);
   }
 
@@ -194,9 +174,7 @@ public class Plan extends ApiResource implements MetadataStore<Plan>, HasId {
    * Update a plan.
    */
   @Override
-  public Plan update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Plan update(Map<String, Object> params, RequestOptions options) throws StripeException {
     return request(RequestMethod.POST, instanceUrl(Plan.class, this.id), params, Plan.class,
         options);
   }

--- a/src/main/java/com/stripe/model/Product.java
+++ b/src/main/java/com/stripe/model/Product.java
@@ -1,10 +1,6 @@
 package com.stripe.model;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -43,9 +39,7 @@ public class Product extends ApiResource implements HasId, MetadataStore<Product
   /**
    * Create a product.
    */
-  public static Product create(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Product create(Map<String, Object> params) throws StripeException {
     return create(params, null);
   }
 
@@ -53,8 +47,7 @@ public class Product extends ApiResource implements HasId, MetadataStore<Product
    * Create a product.
    */
   public static Product create(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.POST, classUrl(Product.class), params, Product.class, options);
   }
   // </editor-fold>
@@ -63,18 +56,14 @@ public class Product extends ApiResource implements HasId, MetadataStore<Product
   /**
    * Delete a product.
    */
-  public DeletedProduct delete()
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public DeletedProduct delete() throws StripeException {
     return delete(null);
   }
 
   /**
    * Delete a product.
    */
-  public DeletedProduct delete(RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public DeletedProduct delete(RequestOptions options) throws StripeException {
     return request(RequestMethod.DELETE, instanceUrl(Product.class, this.id), null,
         DeletedProduct.class, options);
   }
@@ -84,19 +73,15 @@ public class Product extends ApiResource implements HasId, MetadataStore<Product
   /**
    * List all products.
    */
-  public static ProductCollection list(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static ProductCollection list(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
   /**
    * List all products.
    */
-  public static ProductCollection list(Map<String, Object> params,
-                     RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static ProductCollection list(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
     return requestCollection(classUrl(Product.class), params, ProductCollection.class, options);
   }
   // </editor-fold>
@@ -105,18 +90,14 @@ public class Product extends ApiResource implements HasId, MetadataStore<Product
   /**
    * Retrieve a product.
    */
-  public static Product retrieve(String id)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Product retrieve(String id) throws StripeException {
     return retrieve(id, null);
   }
 
   /**
    * Retrieve a product.
    */
-  public static Product retrieve(String id, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Product retrieve(String id, RequestOptions options) throws StripeException {
     return request(RequestMethod.GET, instanceUrl(Product.class, id), null, Product.class, options);
   }
   // </editor-fold>
@@ -126,9 +107,7 @@ public class Product extends ApiResource implements HasId, MetadataStore<Product
    * Update a product.
    */
   @Override
-  public Product update(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Product update(Map<String, Object> params) throws StripeException {
     return update(params, null);
   }
 
@@ -136,9 +115,7 @@ public class Product extends ApiResource implements HasId, MetadataStore<Product
    * Update a product.
    */
   @Override
-  public Product update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Product update(Map<String, Object> params, RequestOptions options) throws StripeException {
     return request(RequestMethod.POST, instanceUrl(Product.class, this.id), params,
         Product.class, options);
   }

--- a/src/main/java/com/stripe/model/Recipient.java
+++ b/src/main/java/com/stripe/model/Recipient.java
@@ -1,14 +1,9 @@
 package com.stripe.model;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -76,9 +71,7 @@ public class Recipient extends ApiResource implements MetadataStore<Recipient>, 
   /**
    * Create a recipient.
    */
-  public static Recipient create(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Recipient create(Map<String, Object> params) throws StripeException {
     return create(params, (RequestOptions) null);
   }
 
@@ -86,8 +79,7 @@ public class Recipient extends ApiResource implements MetadataStore<Recipient>, 
    * Create a recipient.
    */
   public static Recipient create(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.POST, classUrl(Recipient.class), params, Recipient.class, options);
   }
   // </editor-fold>
@@ -96,18 +88,14 @@ public class Recipient extends ApiResource implements MetadataStore<Recipient>, 
   /**
    * Delete a recipient.
    */
-  public DeletedRecipient delete() throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public DeletedRecipient delete() throws StripeException {
     return delete((RequestOptions) null);
   }
 
   /**
    * Delete a recipient.
    */
-  public DeletedRecipient delete(RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public DeletedRecipient delete(RequestOptions options) throws StripeException {
     return request(RequestMethod.DELETE, instanceUrl(Recipient.class, this.id), null,
         DeletedRecipient.class, options);
   }
@@ -117,19 +105,15 @@ public class Recipient extends ApiResource implements MetadataStore<Recipient>, 
   /**
    * List all recipients.
    */
-  public static RecipientCollection list(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static RecipientCollection list(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
   /**
    * List all recipients.
    */
-  public static RecipientCollection list(Map<String, Object> params,
-                       RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static RecipientCollection list(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
     return requestCollection(classUrl(Recipient.class), params, RecipientCollection.class, options);
   }
   // </editor-fold>
@@ -138,18 +122,14 @@ public class Recipient extends ApiResource implements MetadataStore<Recipient>, 
   /**
    * Retrieve a recipient.
    */
-  public static Recipient retrieve(String id) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static Recipient retrieve(String id) throws StripeException {
     return retrieve(id, (RequestOptions) null);
   }
 
   /**
    * Retrieve a recipient.
    */
-  public static Recipient retrieve(String id, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Recipient retrieve(String id, RequestOptions options) throws StripeException {
     return request(RequestMethod.GET, instanceUrl(Recipient.class, id), null, Recipient.class,
         options);
   }
@@ -158,8 +138,7 @@ public class Recipient extends ApiResource implements MetadataStore<Recipient>, 
    * Retrieve a recipient.
    */
   public static Recipient retrieve(String id, Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.GET, instanceUrl(Recipient.class, id), params, Recipient.class,
         options);
   }
@@ -170,9 +149,7 @@ public class Recipient extends ApiResource implements MetadataStore<Recipient>, 
    * Update a recipient.
    */
   @Override
-  public Recipient update(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Recipient update(Map<String, Object> params) throws StripeException {
     return update(params, (RequestOptions) null);
   }
 
@@ -181,8 +158,7 @@ public class Recipient extends ApiResource implements MetadataStore<Recipient>, 
    */
   @Override
   public Recipient update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.POST, instanceUrl(Recipient.class, this.id), params,
         Recipient.class, options);
   }

--- a/src/main/java/com/stripe/model/RecipientCardCollection.java
+++ b/src/main/java/com/stripe/model/RecipientCardCollection.java
@@ -1,11 +1,7 @@
 package com.stripe.model;
 
 import com.stripe.Stripe;
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -16,19 +12,15 @@ public class RecipientCardCollection extends StripeCollection<Card> {
   /**
    * Create a recipient card.
    */
-  public RecipientCardCollection create(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public RecipientCardCollection create(Map<String, Object> params) throws StripeException {
     return create(params, (RequestOptions) null);
   }
 
   /**
    * Create a recipient card.
    */
-  public RecipientCardCollection create(Map<String, Object> params,
-                      RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public RecipientCardCollection create(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
     return ApiResource.request(ApiResource.RequestMethod.POST, String.format("%s%s",
         Stripe.getApiBase(), this.getUrl()), params, RecipientCardCollection.class, options);
   }
@@ -38,19 +30,15 @@ public class RecipientCardCollection extends StripeCollection<Card> {
   /**
    * List all recipient cards.
    */
-  public RecipientCardCollection list(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public RecipientCardCollection list(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
   /**
    * List all recipient cards.
    */
-  public RecipientCardCollection list(Map<String, Object> params,
-                    RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public RecipientCardCollection list(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
     String url = String.format("%s%s", Stripe.getApiBase(), this.getUrl());
     return ApiResource.requestCollection(url, params, RecipientCardCollection.class, options);
   }
@@ -60,18 +48,14 @@ public class RecipientCardCollection extends StripeCollection<Card> {
   /**
    * Retrieve a recipient card.
    */
-  public Card retrieve(String id)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Card retrieve(String id) throws StripeException {
     return retrieve(id, (RequestOptions) null);
   }
 
   /**
    * Retrieve a recipient card.
    */
-  public Card retrieve(String id, RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public Card retrieve(String id, RequestOptions options) throws StripeException {
     String url = String.format("%s%s/%s", Stripe.getApiBase(), this.getUrl(), id);
     return ApiResource.request(ApiResource.RequestMethod.GET, url, null, Card.class, options);
   }

--- a/src/main/java/com/stripe/model/Refund.java
+++ b/src/main/java/com/stripe/model/Refund.java
@@ -1,10 +1,6 @@
 package com.stripe.model;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -73,9 +69,7 @@ public class Refund extends ApiResource implements MetadataStore<Charge>, HasId 
   /**
    * Create a refund.
    */
-  public static Refund create(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Refund create(Map<String, Object> params) throws StripeException {
     return create(params, null);
   }
 
@@ -83,8 +77,7 @@ public class Refund extends ApiResource implements MetadataStore<Charge>, HasId 
    * Create a refund.
    */
   public static Refund create(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.POST, classUrl(Refund.class), params, Refund.class, options);
   }
   // </editor-fold>
@@ -93,9 +86,7 @@ public class Refund extends ApiResource implements MetadataStore<Charge>, HasId 
   /**
    * List all refunds.
    */
-  public static RefundCollection list(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static RefundCollection list(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
@@ -103,8 +94,7 @@ public class Refund extends ApiResource implements MetadataStore<Charge>, HasId 
    * List all refunds.
    */
   public static RefundCollection list(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return requestCollection(classUrl(Refund.class), params, RefundCollection.class, options);
   }
   // </editor-fold>
@@ -113,18 +103,14 @@ public class Refund extends ApiResource implements MetadataStore<Charge>, HasId 
   /**
    * Retrieve a refund.
    */
-  public static Refund retrieve(String id)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Refund retrieve(String id) throws StripeException {
     return retrieve(id, null);
   }
 
   /**
    * Retrieve a refund.
    */
-  public static Refund retrieve(String id, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Refund retrieve(String id, RequestOptions options) throws StripeException {
     return request(RequestMethod.GET, instanceUrl(Refund.class, id), null, Refund.class, options);
   }
 
@@ -132,8 +118,7 @@ public class Refund extends ApiResource implements MetadataStore<Charge>, HasId 
    * Retrieve a refund.
    */
   public static Refund retrieve(String id, Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.GET, instanceUrl(Refund.class, id), params, Refund.class, options);
   }
   // </editor-fold>
@@ -143,9 +128,7 @@ public class Refund extends ApiResource implements MetadataStore<Charge>, HasId 
    * Update a refund.
    */
   @Override
-  public Refund update(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Refund update(Map<String, Object> params) throws StripeException {
     return update(params, (RequestOptions) null);
   }
 
@@ -153,9 +136,7 @@ public class Refund extends ApiResource implements MetadataStore<Charge>, HasId 
    * Update a refund.
    */
   @Override
-  public Refund update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Refund update(Map<String, Object> params, RequestOptions options) throws StripeException {
     return request(RequestMethod.POST, instanceUrl(Refund.class, id), params, Refund.class,
         options);
   }

--- a/src/main/java/com/stripe/model/Reversal.java
+++ b/src/main/java/com/stripe/model/Reversal.java
@@ -1,10 +1,6 @@
 package com.stripe.model;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -70,9 +66,7 @@ public class Reversal extends ApiResource implements MetadataStore<Transfer>, Ha
    * Update a reversal.
    */
   @Override
-  public Reversal update(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Reversal update(Map<String, Object> params) throws StripeException {
     return update(params, (RequestOptions) null);
   }
 
@@ -81,8 +75,7 @@ public class Reversal extends ApiResource implements MetadataStore<Transfer>, Ha
    */
   @Override
   public Reversal update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.POST, this.getInstanceUrl(), params, Reversal.class, options);
   }
   // </editor-fold>

--- a/src/main/java/com/stripe/model/Sku.java
+++ b/src/main/java/com/stripe/model/Sku.java
@@ -1,10 +1,6 @@
 package com.stripe.model;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -57,9 +53,7 @@ public class Sku extends ApiResource implements HasId, MetadataStore<Sku> {
   /**
    * Create a SKU.
    */
-  public static Sku create(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Sku create(Map<String, Object> params) throws StripeException {
     return create(params, null);
   }
 
@@ -67,8 +61,7 @@ public class Sku extends ApiResource implements HasId, MetadataStore<Sku> {
    * Create a SKU.
    */
   public static Sku create(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.POST, classUrl(Sku.class), params, Sku.class, options);
   }
   // </editor-fold>
@@ -77,18 +70,14 @@ public class Sku extends ApiResource implements HasId, MetadataStore<Sku> {
   /**
    * Delete a SKU.
    */
-  public DeletedSku delete()
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public DeletedSku delete() throws StripeException {
     return delete(null);
   }
 
   /**
    * Delete a SKU.
    */
-  public DeletedSku delete(RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public DeletedSku delete(RequestOptions options) throws StripeException {
     return request(RequestMethod.DELETE, instanceUrl(Sku.class, this.id), null, DeletedSku.class,
         options);
   }
@@ -98,19 +87,15 @@ public class Sku extends ApiResource implements HasId, MetadataStore<Sku> {
   /**
    * List all SKUs.
    */
-  public static SkuCollection list(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static SkuCollection list(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
   /**
    * List all SKUs.
    */
-  public static SkuCollection list(Map<String, Object> params,
-                   RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static SkuCollection list(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
     return requestCollection(classUrl(Sku.class), params, SkuCollection.class, options);
   }
   // </editor-fold>
@@ -119,18 +104,14 @@ public class Sku extends ApiResource implements HasId, MetadataStore<Sku> {
   /**
    * Retrieve a SKU.
    */
-  public static Sku retrieve(String id)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Sku retrieve(String id) throws StripeException {
     return retrieve(id, null);
   }
 
   /**
    * Retrieve a SKU.
    */
-  public static Sku retrieve(String id, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Sku retrieve(String id, RequestOptions options) throws StripeException {
     return request(RequestMethod.GET, instanceUrl(Sku.class, id), null, Sku.class, options);
   }
 
@@ -138,8 +119,7 @@ public class Sku extends ApiResource implements HasId, MetadataStore<Sku> {
    * Retrieve a SKU.
    */
   public static Sku retrieve(String id, Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.GET, instanceUrl(Sku.class, id), params, Sku.class, options);
   }
   // </editor-fold>
@@ -149,9 +129,7 @@ public class Sku extends ApiResource implements HasId, MetadataStore<Sku> {
    * Update a SKU.
    */
   @Override
-  public Sku update(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Sku update(Map<String, Object> params) throws StripeException {
     return update(params, null);
   }
 
@@ -159,9 +137,7 @@ public class Sku extends ApiResource implements HasId, MetadataStore<Sku> {
    * Update a SKU.
    */
   @Override
-  public Sku update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Sku update(Map<String, Object> params, RequestOptions options) throws StripeException {
     return request(RequestMethod.POST, instanceUrl(Sku.class, this.id), params, Sku.class, options);
   }
   // </editor-fold>

--- a/src/main/java/com/stripe/model/Source.java
+++ b/src/main/java/com/stripe/model/Source.java
@@ -1,10 +1,7 @@
 package com.stripe.model;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.RequestOptions;
 
 import java.util.Map;
@@ -38,8 +35,7 @@ public class Source extends ExternalAccount implements HasSourceTypeData {
 
   // APIResource methods
 
-  public String getSourceInstanceUrl()
-      throws InvalidRequestException {
+  public String getSourceInstanceUrl() throws InvalidRequestException {
     return instanceUrl(Source.class, this.getId());
   }
 
@@ -47,9 +43,7 @@ public class Source extends ExternalAccount implements HasSourceTypeData {
   /**
    * Create a source.
    */
-  public static Source create(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Source create(Map<String, Object> params) throws StripeException {
     return create(params, null);
   }
 
@@ -57,8 +51,7 @@ public class Source extends ExternalAccount implements HasSourceTypeData {
    * Create a source.
    */
   public static Source create(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.POST, classUrl(Source.class), params, Source.class, options);
   }
   // </editor-fold>
@@ -70,9 +63,7 @@ public class Source extends ExternalAccount implements HasSourceTypeData {
    * customer object.
    */
   @Override
-  public DeletedExternalAccount delete(RequestOptions options) throws
-      AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public DeletedExternalAccount delete(RequestOptions options) throws StripeException {
     throw new InvalidRequestException(
         "Source objects cannot be deleted. If you want to detach the source from a customer "
         + "object, use detach().",
@@ -84,27 +75,21 @@ public class Source extends ExternalAccount implements HasSourceTypeData {
   /**
    * Detach a source.
    */
-  public Source detach()
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Source detach() throws StripeException {
     return detach(null, null);
   }
 
   /**
    * Detach a source.
    */
-  public Source detach(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Source detach(Map<String, Object> params) throws StripeException {
     return detach(params, null);
   }
 
   /**
    * Detach a source.
    */
-  public Source detach(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Source detach(Map<String, Object> params, RequestOptions options) throws StripeException {
     if (this.getCustomer() != null) {
       String url = String.format("%s/%s/sources/%s", classUrl(Customer.class), this.getCustomer(),
           this.getId());
@@ -121,18 +106,14 @@ public class Source extends ExternalAccount implements HasSourceTypeData {
   /**
    * Retrieve a source.
    */
-  public static Source retrieve(String id)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Source retrieve(String id) throws StripeException {
     return retrieve(id, null);
   }
 
   /**
    * Retrieve a source.
    */
-  public static Source retrieve(String id, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Source retrieve(String id, RequestOptions options) throws StripeException {
     return request(RequestMethod.GET, instanceUrl(Source.class, id), null, Source.class, options);
   }
   // </editor-fold>
@@ -142,8 +123,7 @@ public class Source extends ExternalAccount implements HasSourceTypeData {
    * Retrieve a source's transactions.
    */
   public SourceTransactionCollection sourceTransactions(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return sourceTransactions(params, null);
   }
 
@@ -151,9 +131,7 @@ public class Source extends ExternalAccount implements HasSourceTypeData {
    * Retrieve a source's transactions.
    */
   public SourceTransactionCollection sourceTransactions(Map<String, Object> params,
-      RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      RequestOptions options) throws StripeException {
     String url = instanceUrl(Source.class, this.getId()) + "/source_transactions";
     return requestCollection(url, params, SourceTransactionCollection.class, options);
   }
@@ -164,9 +142,7 @@ public class Source extends ExternalAccount implements HasSourceTypeData {
    * Update a source.
    */
   @Override
-  public Source update(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Source update(Map<String, Object> params) throws StripeException {
     return update(params, null);
   }
 
@@ -174,9 +150,7 @@ public class Source extends ExternalAccount implements HasSourceTypeData {
    * Update a source.
    */
   @Override
-  public Source update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Source update(Map<String, Object> params, RequestOptions options) throws StripeException {
     return request(RequestMethod.POST, this.getSourceInstanceUrl(), params, Source.class, options);
   }
   // </editor-fold>
@@ -186,9 +160,7 @@ public class Source extends ExternalAccount implements HasSourceTypeData {
    * Verify a source.
    */
   @Override
-  public Source verify(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Source verify(Map<String, Object> params) throws StripeException {
     return verify(params, null);
   }
 
@@ -196,9 +168,7 @@ public class Source extends ExternalAccount implements HasSourceTypeData {
    * Verify a source.
    */
   @Override
-  public Source verify(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Source verify(Map<String, Object> params, RequestOptions options) throws StripeException {
     return request(RequestMethod.POST, String.format("%s/verify", this.getSourceInstanceUrl()),
         params, Source.class, options);
   }

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -1,10 +1,6 @@
 package com.stripe.model;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -75,9 +71,7 @@ public class Subscription extends ApiResource implements MetadataStore<Subscript
   /**
    * Cancel a subscription.
    */
-  public Subscription cancel(Map<String, Object> params) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public Subscription cancel(Map<String, Object> params) throws StripeException {
     return cancel(params, (RequestOptions) null);
   }
 
@@ -85,8 +79,7 @@ public class Subscription extends ApiResource implements MetadataStore<Subscript
    * Cancel a subscription.
    */
   public Subscription cancel(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException, ApiConnectionException,
-      CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.DELETE, instanceUrl(Subscription.class, id), params,
         Subscription.class, options);
   }
@@ -96,9 +89,7 @@ public class Subscription extends ApiResource implements MetadataStore<Subscript
   /**
    * Create a subscription.
    */
-  public static Subscription create(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Subscription create(Map<String, Object> params) throws StripeException {
     return create(params, null);
   }
 
@@ -106,8 +97,7 @@ public class Subscription extends ApiResource implements MetadataStore<Subscript
    * Create a subscription.
    */
   public static Subscription create(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.POST, classUrl(Subscription.class), params, Subscription.class,
         options);
   }
@@ -117,18 +107,14 @@ public class Subscription extends ApiResource implements MetadataStore<Subscript
   /**
    * Delete a subscription discount.
    */
-  public void deleteDiscount() throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public void deleteDiscount() throws StripeException {
     deleteDiscount((RequestOptions) null);
   }
 
   /**
    * Delete a subscription discount.
    */
-  public void deleteDiscount(RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public void deleteDiscount(RequestOptions options) throws StripeException {
     request(RequestMethod.DELETE, String.format("%s/discount", instanceUrl(Subscription.class, id)),
         null, Discount.class, options);
   }
@@ -138,20 +124,15 @@ public class Subscription extends ApiResource implements MetadataStore<Subscript
   /**
    * List subscriptions.
    */
-  public static SubscriptionCollection list(Map<String, Object> params)
-      throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static SubscriptionCollection list(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
   /**
    * List subscriptions.
    */
-  public static SubscriptionCollection list(Map<String, Object> params,
-                        RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static SubscriptionCollection list(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
     return requestCollection(classUrl(Subscription.class), params, SubscriptionCollection.class,
         options);
   }
@@ -161,18 +142,14 @@ public class Subscription extends ApiResource implements MetadataStore<Subscript
   /**
    * Retrieve a subscription.
    */
-  public static Subscription retrieve(String id) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static Subscription retrieve(String id) throws StripeException {
     return retrieve(id, null);
   }
 
   /**
    * Retrieve a subscription.
    */
-  public static Subscription retrieve(String id, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Subscription retrieve(String id, RequestOptions options) throws StripeException {
     return request(RequestMethod.GET, instanceUrl(Subscription.class, id), null, Subscription.class,
         options);
   }
@@ -181,8 +158,7 @@ public class Subscription extends ApiResource implements MetadataStore<Subscript
    * Retrieve a subscription.
    */
   public static Subscription retrieve(String id, Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.GET, instanceUrl(Subscription.class, id), params,
         Subscription.class, options);
   }
@@ -193,9 +169,7 @@ public class Subscription extends ApiResource implements MetadataStore<Subscript
    * Update a subscription.
    */
   @Override
-  public Subscription update(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Subscription update(Map<String, Object> params) throws StripeException {
     return update(params, (RequestOptions) null);
   }
 
@@ -204,8 +178,7 @@ public class Subscription extends ApiResource implements MetadataStore<Subscript
    */
   @Override
   public Subscription update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.POST, instanceUrl(Subscription.class, id), params,
         Subscription.class, options);
   }

--- a/src/main/java/com/stripe/model/SubscriptionItem.java
+++ b/src/main/java/com/stripe/model/SubscriptionItem.java
@@ -1,10 +1,6 @@
 package com.stripe.model;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -28,9 +24,7 @@ public class SubscriptionItem extends ApiResource implements HasId {
   /**
    * Create a subscription item.
    */
-  public static SubscriptionItem create(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static SubscriptionItem create(Map<String, Object> params) throws StripeException {
     return create(params, null);
   }
 
@@ -38,8 +32,7 @@ public class SubscriptionItem extends ApiResource implements HasId {
    * Create a subscription item.
    */
   public static SubscriptionItem create(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.POST, classUrl(SubscriptionItem.class), params,
         SubscriptionItem.class, options);
   }
@@ -49,27 +42,21 @@ public class SubscriptionItem extends ApiResource implements HasId {
   /**
    * Delete a subscription item.
    */
-  public DeletedSubscriptionItem delete() throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public DeletedSubscriptionItem delete() throws StripeException {
     return delete(null, null);
   }
 
   /**
    * Delete a subscription item.
    */
-  public DeletedSubscriptionItem delete(RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public DeletedSubscriptionItem delete(RequestOptions options) throws StripeException {
     return delete(null, options);
   }
 
   /**
    * Delete a subscription item.
    */
-  public DeletedSubscriptionItem delete(Map<String, Object> params) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public DeletedSubscriptionItem delete(Map<String, Object> params) throws StripeException {
     return delete(params, null);
   }
 
@@ -77,8 +64,7 @@ public class SubscriptionItem extends ApiResource implements HasId {
    * Delete a subscription item.
    */
   public DeletedSubscriptionItem delete(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException, ApiConnectionException,
-      CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.DELETE, instanceUrl(SubscriptionItem.class, id), params,
         DeletedSubscriptionItem.class, options);
   }
@@ -88,20 +74,15 @@ public class SubscriptionItem extends ApiResource implements HasId {
   /**
    * List all subscription items.
    */
-  public static SubscriptionItemCollection list(Map<String, Object> params)
-      throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static SubscriptionItemCollection list(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
   /**
    * List all subscription items.
    */
-  public static SubscriptionItemCollection list(Map<String, Object> params,
-                          RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static SubscriptionItemCollection list(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
     return requestCollection(classUrl(SubscriptionItem.class), params,
         SubscriptionItemCollection.class, options);
   }
@@ -111,9 +92,7 @@ public class SubscriptionItem extends ApiResource implements HasId {
   /**
    * Retrieve a subscription item.
    */
-  public static SubscriptionItem retrieve(String id) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static SubscriptionItem retrieve(String id) throws StripeException {
     return retrieve(id, null);
   }
 
@@ -121,8 +100,7 @@ public class SubscriptionItem extends ApiResource implements HasId {
    * Retrieve a subscription item.
    */
   public static SubscriptionItem retrieve(String id, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.GET, instanceUrl(SubscriptionItem.class, id), null,
         SubscriptionItem.class, options);
   }
@@ -132,9 +110,7 @@ public class SubscriptionItem extends ApiResource implements HasId {
   /**
    * Update a subscription item.
    */
-  public SubscriptionItem update(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public SubscriptionItem update(Map<String, Object> params) throws StripeException {
     return update(params, null);
   }
 
@@ -142,8 +118,7 @@ public class SubscriptionItem extends ApiResource implements HasId {
    * Update a subscription item.
    */
   public SubscriptionItem update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.POST, instanceUrl(SubscriptionItem.class, id), params,
         SubscriptionItem.class, options);
   }

--- a/src/main/java/com/stripe/model/ThreeDSecure.java
+++ b/src/main/java/com/stripe/model/ThreeDSecure.java
@@ -3,11 +3,7 @@ package com.stripe.model;
 import com.google.gson.annotations.SerializedName;
 
 import com.stripe.Stripe;
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -33,29 +29,22 @@ public class ThreeDSecure extends ApiResource implements HasId {
   String status;
 
   // <editor-fold desc="create">
-  public static ThreeDSecure create(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static ThreeDSecure create(Map<String, Object> params)  throws StripeException {
     return create(params, null);
   }
 
   public static ThreeDSecure create(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.POST, getClassUrl(), params, ThreeDSecure.class, options);
   }
   // </editor-fold>
 
   // <editor-fold desc="retrieve">
-  public static ThreeDSecure retrieve(String id) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static ThreeDSecure retrieve(String id) throws StripeException {
     return retrieve(id, null);
   }
 
-  public static ThreeDSecure retrieve(String id, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static ThreeDSecure retrieve(String id, RequestOptions options) throws StripeException {
     return request(RequestMethod.GET, getInstanceUrl(id), null, ThreeDSecure.class, options);
   }
   // </editor-fold>

--- a/src/main/java/com/stripe/model/Token.java
+++ b/src/main/java/com/stripe/model/Token.java
@@ -1,10 +1,6 @@
 package com.stripe.model;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -35,9 +31,7 @@ public class Token extends ApiResource implements HasId {
   /**
    * Create a token.
    */
-  public static Token create(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Token create(Map<String, Object> params) throws StripeException {
     return create(params, (RequestOptions) null);
   }
 
@@ -45,8 +39,7 @@ public class Token extends ApiResource implements HasId {
    * Create a token.
    */
   public static Token create(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.POST, classUrl(Token.class), params, Token.class, options);
   }
   // </editor-fold>
@@ -55,18 +48,14 @@ public class Token extends ApiResource implements HasId {
   /**
    * Retrieve a token.
    */
-  public static Token retrieve(String id) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static Token retrieve(String id) throws StripeException {
     return retrieve(id, (RequestOptions) null);
   }
 
   /**
    * Retrieve a token.
    */
-  public static Token retrieve(String id, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Token retrieve(String id, RequestOptions options) throws StripeException {
     return request(RequestMethod.GET, instanceUrl(Token.class, id), null, Token.class, options);
   }
   // </editor-fold>

--- a/src/main/java/com/stripe/model/Topup.java
+++ b/src/main/java/com/stripe/model/Topup.java
@@ -1,10 +1,6 @@
 package com.stripe.model;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -58,9 +54,7 @@ public class Topup extends ApiResource implements MetadataStore<Topup>, HasId {
   /**
    * Create a topup.
    */
-  public static Topup create(Map<String, Object> params)
-          throws AuthenticationException, InvalidRequestException,
-          ApiConnectionException, CardException, ApiException {
+  public static Topup create(Map<String, Object> params) throws StripeException {
     return create(params, null);
   }
 
@@ -68,8 +62,7 @@ public class Topup extends ApiResource implements MetadataStore<Topup>, HasId {
    * Create a topup.
    */
   public static Topup create(Map<String, Object> params, RequestOptions options)
-          throws AuthenticationException, InvalidRequestException,
-          ApiConnectionException, CardException, ApiException {
+          throws StripeException {
     return request(RequestMethod.POST, classUrl(Topup.class), params, Topup.class, options);
   }
   // </editor-fold>
@@ -78,9 +71,7 @@ public class Topup extends ApiResource implements MetadataStore<Topup>, HasId {
   /**
    * List all topups.
    */
-  public static TopupCollection list(Map<String, Object> params)
-          throws AuthenticationException, InvalidRequestException,
-          ApiConnectionException, CardException, ApiException {
+  public static TopupCollection list(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
@@ -88,8 +79,7 @@ public class Topup extends ApiResource implements MetadataStore<Topup>, HasId {
    * List all topups.
    */
   public static TopupCollection list(Map<String, Object> params, RequestOptions options)
-          throws AuthenticationException, InvalidRequestException,
-          ApiConnectionException, CardException, ApiException {
+          throws StripeException {
     return requestCollection(classUrl(Topup.class), params, TopupCollection.class, options);
   }
   // </editor-fold>
@@ -98,18 +88,14 @@ public class Topup extends ApiResource implements MetadataStore<Topup>, HasId {
   /**
    * Retrieve a topup.
    */
-  public static Topup retrieve(String id) throws AuthenticationException,
-          InvalidRequestException, ApiConnectionException, CardException,
-          ApiException {
+  public static Topup retrieve(String id) throws StripeException {
     return retrieve(id, null);
   }
 
   /**
    * Retrieve a topup.
    */
-  public static Topup retrieve(String id, RequestOptions options)
-          throws AuthenticationException, InvalidRequestException,
-          ApiConnectionException, CardException, ApiException {
+  public static Topup retrieve(String id, RequestOptions options) throws StripeException {
     return retrieve(id, null, options);
   }
 
@@ -117,8 +103,7 @@ public class Topup extends ApiResource implements MetadataStore<Topup>, HasId {
    * Retrieve a topup.
    */
   public static Topup retrieve(String id, Map<String, Object> params, RequestOptions options)
-          throws AuthenticationException, InvalidRequestException,
-          ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.GET, instanceUrl(Topup.class, id), params, Topup.class, options);
   }
   // </editor-fold>
@@ -128,8 +113,7 @@ public class Topup extends ApiResource implements MetadataStore<Topup>, HasId {
    * Update a topup.
    */
   @Override
-  public Topup update(Map<String, Object> params) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException, ApiException {
+  public Topup update(Map<String, Object> params) throws StripeException {
     return update(params, null);
   }
 
@@ -137,9 +121,7 @@ public class Topup extends ApiResource implements MetadataStore<Topup>, HasId {
    * Update a topup.
    */
   @Override
-  public Topup update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException, ApiConnectionException,
-      CardException, ApiException {
+  public Topup update(Map<String, Object> params, RequestOptions options) throws StripeException {
     return request(RequestMethod.POST, instanceUrl(Topup.class, id), params, Topup.class, options);
   }
   // </editor-fold>

--- a/src/main/java/com/stripe/model/Transfer.java
+++ b/src/main/java/com/stripe/model/Transfer.java
@@ -1,10 +1,6 @@
 package com.stripe.model;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -184,9 +180,7 @@ public class Transfer extends ApiResource implements MetadataStore<Transfer>, Ha
    * @deprecated Use the {#link Payout#cancel()} method instead.
    */
   @Deprecated
-  public Transfer cancel()
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Transfer cancel() throws StripeException {
     return cancel((RequestOptions) null);
   }
 
@@ -196,9 +190,7 @@ public class Transfer extends ApiResource implements MetadataStore<Transfer>, Ha
    * @deprecated Use the {#link Payout#cancel(RequestOptions)} method instead.
    */
   @Deprecated
-  public Transfer cancel(RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Transfer cancel(RequestOptions options) throws StripeException {
     return request(RequestMethod.POST, instanceUrl(Transfer.class, this.id) + "/cancel", null,
         Transfer.class, options);
   }
@@ -208,9 +200,7 @@ public class Transfer extends ApiResource implements MetadataStore<Transfer>, Ha
   /**
    * Create a transfer.
    */
-  public static Transfer create(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Transfer create(Map<String, Object> params) throws StripeException {
     return create(params, (RequestOptions) null);
   }
 
@@ -218,8 +208,7 @@ public class Transfer extends ApiResource implements MetadataStore<Transfer>, Ha
    * Create a transfer.
    */
   public static Transfer create(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.POST, classUrl(Transfer.class), params, Transfer.class, options);
   }
   // </editor-fold>
@@ -228,19 +217,15 @@ public class Transfer extends ApiResource implements MetadataStore<Transfer>, Ha
   /**
    * List all transfers.
    */
-  public static TransferCollection list(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static TransferCollection list(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
   /**
    * List all transfers.
    */
-  public static TransferCollection list(Map<String, Object> params,
-                      RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static TransferCollection list(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
     return requestCollection(classUrl(Transfer.class), params, TransferCollection.class, options);
   }
   // </editor-fold>
@@ -249,18 +234,14 @@ public class Transfer extends ApiResource implements MetadataStore<Transfer>, Ha
   /**
    * Retrive a transfer.
    */
-  public static Transfer retrieve(String id) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public static Transfer retrieve(String id) throws StripeException {
     return retrieve(id, (RequestOptions) null);
   }
 
   /**
    * Retrive a transfer.
    */
-  public static Transfer retrieve(String id, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public static Transfer retrieve(String id, RequestOptions options) throws StripeException {
     return request(RequestMethod.GET, instanceUrl(Transfer.class, id), null, Transfer.class,
         options);
   }
@@ -269,8 +250,7 @@ public class Transfer extends ApiResource implements MetadataStore<Transfer>, Ha
    * Retrieve a transfer.
    */
   public static Transfer retrieve(String id, Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.GET, instanceUrl(Transfer.class, id), params, Transfer.class,
         options);
   }
@@ -285,8 +265,7 @@ public class Transfer extends ApiResource implements MetadataStore<Transfer>, Ha
    */
   @Deprecated
   public TransferTransactionCollection transactions(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return transactions(params, (RequestOptions) null);
   }
 
@@ -299,8 +278,7 @@ public class Transfer extends ApiResource implements MetadataStore<Transfer>, Ha
   @Deprecated
   public TransferTransactionCollection transactions(
       Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     String url = String.format("%s%s", instanceUrl(Transfer.class, this.getId()), "/transactions");
     return requestCollection(url, params, TransferTransactionCollection.class, options);
   }
@@ -311,9 +289,7 @@ public class Transfer extends ApiResource implements MetadataStore<Transfer>, Ha
    * Update a transfer.
    */
   @Override
-  public Transfer update(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Transfer update(Map<String, Object> params) throws StripeException {
     return update(params, (RequestOptions) null);
   }
 
@@ -322,8 +298,7 @@ public class Transfer extends ApiResource implements MetadataStore<Transfer>, Ha
    */
   @Override
   public Transfer update(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     return request(RequestMethod.POST, instanceUrl(Transfer.class, this.id), params,
         Transfer.class, options);
   }

--- a/src/main/java/com/stripe/model/TransferReversalCollection.java
+++ b/src/main/java/com/stripe/model/TransferReversalCollection.java
@@ -1,11 +1,7 @@
 package com.stripe.model;
 
 import com.stripe.Stripe;
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -16,19 +12,15 @@ public class TransferReversalCollection extends StripeCollection<Reversal> {
   /**
    * Create a reversal.
    */
-  public Reversal create(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Reversal create(Map<String, Object> params) throws StripeException {
     return create(params, null);
   }
 
   /**
    * Create a reversal.
    */
-  public Reversal create(Map<String, Object> params,
-               RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public Reversal create(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
     return ApiResource.request(ApiResource.RequestMethod.POST, String.format("%s%s",
         Stripe.getApiBase(), this.getUrl()), params, Reversal.class, options);
   }
@@ -38,19 +30,15 @@ public class TransferReversalCollection extends StripeCollection<Reversal> {
   /**
    * List all reversals.
    */
-  public TransferReversalCollection list(Map<String, Object> params)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public TransferReversalCollection list(Map<String, Object> params) throws StripeException {
     return list(params, null);
   }
 
   /**
    * List all reversals.
    */
-  public TransferReversalCollection list(Map<String, Object> params,
-                       RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public TransferReversalCollection list(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
     String url = String.format("%s%s", Stripe.getApiBase(), this.getUrl());
     return ApiResource.requestCollection(url, params, TransferReversalCollection.class, options);
   }
@@ -60,9 +48,7 @@ public class TransferReversalCollection extends StripeCollection<Reversal> {
   /**
    * Retrieve a reversal.
    */
-  public Reversal retrieve(String id)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+  public Reversal retrieve(String id) throws StripeException {
     return retrieve(id, (RequestOptions) null);
   }
 
@@ -70,18 +56,14 @@ public class TransferReversalCollection extends StripeCollection<Reversal> {
    * Retrieve a reversal.
    */
   @Deprecated
-  public Reversal retrieve(String id, String apiKey) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public Reversal retrieve(String id, String apiKey) throws StripeException {
     return retrieve(id, RequestOptions.builder().setApiKey(apiKey).build());
   }
 
   /**
    * Retrieve a reversal.
    */
-  public Reversal retrieve(String id, RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+  public Reversal retrieve(String id, RequestOptions options) throws StripeException {
     String url = String.format("%s%s/%s", Stripe.getApiBase(), this.getUrl(), id);
     return ApiResource.request(ApiResource.RequestMethod.GET, url, null, Reversal.class, options);
   }

--- a/src/main/java/com/stripe/model/UsageRecord.java
+++ b/src/main/java/com/stripe/model/UsageRecord.java
@@ -1,10 +1,7 @@
 package com.stripe.model;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
@@ -34,8 +31,7 @@ public class UsageRecord extends ApiResource implements HasId {
    * @return The created usage record
    */
   public static UsageRecord create(Map<String, Object> params, RequestOptions options)
-          throws AuthenticationException, InvalidRequestException,
-          ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     String subscriptionItem = (String)params.get("subscription_item");
     if (subscriptionItem == null) {
       throw new InvalidRequestException(

--- a/src/main/java/com/stripe/net/ApiResource.java
+++ b/src/main/java/com/stripe/net/ApiResource.java
@@ -5,11 +5,8 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 import com.stripe.Stripe;
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
 import com.stripe.model.BalanceTransaction;
 import com.stripe.model.BalanceTransactionDeserializer;
 import com.stripe.model.ChargeRefundCollection;
@@ -171,18 +168,14 @@ public abstract class ApiResource extends StripeObject {
 
   public static <T> T multipartRequest(ApiResource.RequestMethod method,
                      String url, Map<String, Object> params, Class<T> clazz,
-                     RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+                     RequestOptions options) throws StripeException {
     return ApiResource.stripeResponseGetter.request(method, url, params, clazz,
         ApiResource.RequestType.MULTIPART, options);
   }
 
   public static <T> T request(ApiResource.RequestMethod method,
                 String url, Map<String, Object> params, Class<T> clazz,
-                RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, CardException,
-      ApiException {
+                RequestOptions options) throws StripeException {
     return ApiResource.stripeResponseGetter.request(method, url, params, clazz,
         ApiResource.RequestType.NORMAL, options);
   }
@@ -198,8 +191,7 @@ public abstract class ApiResource extends StripeObject {
   public static <T extends StripeCollectionInterface<?>> T requestCollection(
       String url, Map<String, Object> params, Class<T> clazz,
       RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     T collection = request(RequestMethod.GET, url, params, clazz, options);
 
     if (collection != null) {

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -8,6 +8,7 @@ import com.stripe.exception.CardException;
 import com.stripe.exception.InvalidRequestException;
 import com.stripe.exception.PermissionException;
 import com.stripe.exception.RateLimitException;
+import com.stripe.exception.StripeException;
 import com.stripe.exception.oauth.InvalidClientException;
 import com.stripe.exception.oauth.InvalidGrantException;
 import com.stripe.exception.oauth.InvalidScopeException;
@@ -71,8 +72,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
       Class<T> clazz,
       ApiResource.RequestType type,
       RequestOptions options)
-      throws AuthenticationException, InvalidRequestException, ApiConnectionException,
-      CardException, ApiException {
+      throws StripeException {
     return staticRequest(method, url, params, clazz, type, options);
   }
 
@@ -83,9 +83,8 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
       Map<String, Object> params,
       Class<T> clazz,
       ApiResource.RequestType type,
-      RequestOptions options) throws AuthenticationException,
-      InvalidRequestException, ApiConnectionException, ApiException,
-      OAuthException {
+      RequestOptions options)
+      throws StripeException {
     return staticOAuthRequest(method, url, params, clazz, type, options);
   }
 
@@ -524,8 +523,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
   private static <T> T staticRequest(
       ApiResource.RequestMethod method, String url, Map<String, Object> params,
       Class<T> clazz, ApiResource.RequestType type, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, CardException, ApiException {
+      throws StripeException {
     StripeResponse response = rawRequest(method, url, params, type, options);
 
     int responseCode = response.code();

--- a/src/main/java/com/stripe/net/OAuth.java
+++ b/src/main/java/com/stripe/net/OAuth.java
@@ -1,11 +1,9 @@
 package com.stripe.net;
 
 import com.stripe.Stripe;
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
 import com.stripe.exception.AuthenticationException;
 import com.stripe.exception.InvalidRequestException;
-import com.stripe.exception.oauth.OAuthException;
+import com.stripe.exception.StripeException;
 import com.stripe.model.oauth.DeauthorizedAccount;
 import com.stripe.model.oauth.TokenResponse;
 import com.stripe.net.ApiResource;
@@ -63,8 +61,7 @@ public final class OAuth {
    *         API.
    */
   public static TokenResponse token(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException, ApiConnectionException, ApiException,
-      OAuthException {
+      throws StripeException {
     String url = Stripe.getConnectBase() + "/oauth/token";
     return OAuth.stripeResponseGetter.oauthRequest(ApiResource.RequestMethod.POST, url, params,
         TokenResponse.class, ApiResource.RequestType.NORMAL, options);
@@ -80,8 +77,7 @@ public final class OAuth {
    *         OAuth API.
    */
   public static DeauthorizedAccount deauthorize(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException, InvalidRequestException, ApiConnectionException, ApiException,
-      OAuthException {
+      throws StripeException {
     String url = Stripe.getConnectBase() + "/oauth/deauthorize";
     params.put("client_id", getClientId(params, options));
     return OAuth.stripeResponseGetter.oauthRequest(ApiResource.RequestMethod.POST, url, params,

--- a/src/main/java/com/stripe/net/StripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/StripeResponseGetter.java
@@ -1,11 +1,6 @@
 package com.stripe.net;
 
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
-import com.stripe.exception.oauth.OAuthException;
+import com.stripe.exception.StripeException;
 
 import java.util.Map;
 
@@ -17,8 +12,7 @@ public interface StripeResponseGetter {
       Class<T> clazz,
       ApiResource.RequestType type,
       RequestOptions options)
-      throws AuthenticationException, InvalidRequestException, ApiConnectionException,
-      CardException, ApiException;
+      throws StripeException;
 
   <T> T oauthRequest(
       ApiResource.RequestMethod method,
@@ -27,6 +21,5 @@ public interface StripeResponseGetter {
       Class<T> clazz,
       ApiResource.RequestType type,
       RequestOptions options)
-      throws AuthenticationException, InvalidRequestException,
-      ApiConnectionException, ApiException, OAuthException;
+      throws StripeException;
 }

--- a/src/test/java/com/stripe/model/PagingIteratorTest.java
+++ b/src/test/java/com/stripe/model/PagingIteratorTest.java
@@ -37,8 +37,7 @@ public class PagingIteratorTest extends BaseStripeTest {
 
     public static PageableModelCollection list(Map<String, Object> params,
         RequestOptions options)
-        throws AuthenticationException, InvalidRequestException,
-        ApiConnectionException, CardException, ApiException {
+        throws StripeException {
       return requestCollection(classUrl(PageableModel.class), params,
           PageableModelCollection.class, options);
     }


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

Change method signatures to throw `StripeException` instead of listing every possible exception class.

This makes it way easier to introduce new exceptions (e.g. `IdempotentException`).
