### PR TITLE
Use `isX()` instead of `getX()` for Boolean accessors

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,2 +1,1 @@
-lombok.getter.noIsPrefix = true
 lombok.addLombokGeneratedAnnotation = true


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

Change Lombok's configuration to generate `isX()` instead of `getX()` methods for `Boolean` getters. This is (I think) more idiomatic Java.