### PR TITLE
Add extra properties to the Level III data on a Charge

### DIFF
--- a/src/main/java/com/stripe/model/ChargeLevel3.java
+++ b/src/main/java/com/stripe/model/ChargeLevel3.java
@@ -10,8 +10,10 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public final class ChargeLevel3 extends StripeObject {
+  protected String customerReference;
   protected List<ChargeLevel3LineItem> lineItems;
   protected String merchantReference;
   protected String shippingAddressZip;
+  protected String shippingFromZip;
   protected Long shippingAmount;
 }


### PR DESCRIPTION
Added support for 2 new properties as reported by @brandur-stripe after confirming internally that they are supported.

r? @ob-stripe 
cc @stripe/api-libraries 