### PR TITLE
Add support for idempotency errors

### DIFF
--- a/src/main/java/com/stripe/exception/IdempotencyException.java
+++ b/src/main/java/com/stripe/exception/IdempotencyException.java
@@ -1,0 +1,9 @@
+package com.stripe.exception;
+
+public class IdempotencyException extends StripeException {
+  private static final long serialVersionUID = 2L;
+
+  public IdempotencyException(String message, String requestId, String code, Integer statusCode) {
+    super(message, requestId, code, statusCode);
+  }
+}

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -5,6 +5,7 @@ import com.stripe.exception.ApiConnectionException;
 import com.stripe.exception.ApiException;
 import com.stripe.exception.AuthenticationException;
 import com.stripe.exception.CardException;
+import com.stripe.exception.IdempotencyException;
 import com.stripe.exception.InvalidRequestException;
 import com.stripe.exception.PermissionException;
 import com.stripe.exception.RateLimitException;
@@ -372,7 +373,6 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
   }
 
   private static class StripeError {
-    @SuppressWarnings("unused")
     String type;
 
     String message;
@@ -684,17 +684,19 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
   }
 
   private static void handleApiError(String responseBody, int responseCode, String requestId)
-      throws InvalidRequestException, AuthenticationException,
-      CardException, ApiException {
+      throws ApiException, AuthenticationException, CardException, IdempotencyException,
+      InvalidRequestException {
     LiveStripeResponseGetter.StripeError error = ApiResource.GSON.fromJson(responseBody,
         LiveStripeResponseGetter.StripeErrorContainer.class).error;
     switch (responseCode) {
       case 400:
-        throw new InvalidRequestException(error.message, error.param, requestId, error.code,
-            responseCode, null);
       case 404:
-        throw new InvalidRequestException(error.message, error.param, requestId, error.code,
-            responseCode, null);
+        if (error.type.equals("idempotency_error")) {
+          throw new IdempotencyException(error.message, requestId, error.code, responseCode);
+        } else {
+          throw new InvalidRequestException(error.message, error.param, requestId, error.code,
+          responseCode, null);
+        }
       case 401:
         throw new AuthenticationException(error.message, requestId, error.code, responseCode);
       case 402:

--- a/src/test/java/com/stripe/model/PagingIteratorTest.java
+++ b/src/test/java/com/stripe/model/PagingIteratorTest.java
@@ -4,11 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.stripe.BaseStripeTest;
-import com.stripe.exception.ApiConnectionException;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.AuthenticationException;
-import com.stripe.exception.CardException;
-import com.stripe.exception.InvalidRequestException;
 import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

Add a new `IdempotencyException` exception class that is raised when the API returns an `idempotency_error`.

No tests because stripe-mock doesn't support this scenario and it's ~impossible to stub this right now, but the logic is fairly trivial and is exactly the same as https://github.com/stripe/stripe-ruby/blob/ec66c3f0f44274f885de8d13de5dce2657932121/lib/stripe/stripe_client.rb#L320-L329