### PR TITLE
Minor fixes

### DIFF
--- a/src/main/java/com/stripe/exception/ApiException.java
+++ b/src/main/java/com/stripe/exception/ApiException.java
@@ -3,17 +3,6 @@ package com.stripe.exception;
 public class ApiException extends StripeException {
   private static final long serialVersionUID = 2L;
 
-  /**
-   * Constructs a new API exception with the specified details.
-   *
-   * @deprecated Use new constructor with `code` argument instead.
-   */
-  @Deprecated
-  // TODO: remove this constructor in next major version bump
-  public ApiException(String message, String requestId, Integer statusCode, Throwable e) {
-    this(message, requestId, null, statusCode, e);
-  }
-
   public ApiException(String message, String requestId, String code, Integer statusCode,
       Throwable e) {
     super(message, requestId, code, statusCode, e);

--- a/src/main/java/com/stripe/exception/AuthenticationException.java
+++ b/src/main/java/com/stripe/exception/AuthenticationException.java
@@ -3,17 +3,6 @@ package com.stripe.exception;
 public class AuthenticationException extends StripeException {
   private static final long serialVersionUID = 2L;
 
-  /**
-   * Constructs a new authentication exception with the specified details.
-   *
-   * @deprecated Use new constructor with `code` argument instead.
-   */
-  @Deprecated
-  // TODO: remove this constructor in next major version bump
-  public AuthenticationException(String message, String requestId, Integer statusCode) {
-    this(message, requestId, null, statusCode);
-  }
-
   public AuthenticationException(String message, String requestId, String code,
       Integer statusCode) {
     super(message, requestId, code, statusCode);

--- a/src/main/java/com/stripe/exception/InvalidRequestException.java
+++ b/src/main/java/com/stripe/exception/InvalidRequestException.java
@@ -5,18 +5,6 @@ public class InvalidRequestException extends StripeException {
 
   private final String param;
 
-  /**
-   * Constructs a new invalid request exception with the specified details.
-   *
-   * @deprecated Use new constructor with `code` argument instead.
-   */
-  @Deprecated
-  // TODO: remove this constructor in next major version bump
-  public InvalidRequestException(String message, String param, String requestId, Integer statusCode,
-      Throwable e) {
-    this(message, param, requestId, null, statusCode, e);
-  }
-
   public InvalidRequestException(String message, String param, String requestId, String code,
       Integer statusCode, Throwable e) {
     super(message, requestId, code, statusCode, e);

--- a/src/main/java/com/stripe/exception/PermissionException.java
+++ b/src/main/java/com/stripe/exception/PermissionException.java
@@ -3,17 +3,6 @@ package com.stripe.exception;
 public class PermissionException extends AuthenticationException {
   private static final long serialVersionUID = 2L;
 
-  /**
-   * Constructs a new permission exception with the specified details.
-   *
-   * @deprecated Use new constructor with `code` argument instead.
-   */
-  @Deprecated
-  // TODO: remove this constructor in next major version bump
-  public PermissionException(String message, String requestId, Integer statusCode) {
-    this(message, requestId, null, statusCode);
-  }
-
   public PermissionException(String message, String requestId, String code, Integer statusCode) {
     super(message, requestId, code, statusCode);
   }

--- a/src/main/java/com/stripe/exception/RateLimitException.java
+++ b/src/main/java/com/stripe/exception/RateLimitException.java
@@ -3,18 +3,6 @@ package com.stripe.exception;
 public class RateLimitException extends InvalidRequestException {
   private static final long serialVersionUID = 2L;
 
-  /**
-   * Constructs a new rate limit exception with the specified details.
-   *
-   * @deprecated Use new constructor with `code` argument instead.
-   */
-  @Deprecated
-  // TODO: remove this constructor in next major version bump
-  public RateLimitException(String message, String param, String requestId, Integer statusCode,
-      Throwable e) {
-    this(message, param, requestId, null, statusCode, e);
-  }
-
   public RateLimitException(String message, String param, String requestId, String code,
       Integer statusCode, Throwable e) {
     super(message, param, requestId, code, statusCode, e);

--- a/src/main/java/com/stripe/exception/StripeException.java
+++ b/src/main/java/com/stripe/exception/StripeException.java
@@ -7,28 +7,6 @@ public abstract class StripeException extends Exception {
   private String requestId;
   private Integer statusCode;
 
-  /**
-   * Constructs a new Stripe exception with the specified details.
-   *
-   * @deprecated Use new constructor with `code` argument instead.
-   */
-  @Deprecated
-  // TODO: remove this constructor in next major version bump
-  public StripeException(String message, String requestId, Integer statusCode) {
-    this(message, requestId, null, statusCode, null);
-  }
-
-  /**
-   * Constructs a new Stripe exception with the specified details.
-   *
-   * @deprecated Use new constructor with `code` argument instead.
-   */
-  @Deprecated
-  // TODO: remove this constructor in next major version bump
-  public StripeException(String message, String requestId, Integer statusCode, Throwable e) {
-    this(message, requestId, null, statusCode, e);
-  }
-
   public StripeException(String message, String requestId, String code, Integer statusCode) {
     this(message, requestId, code, statusCode, null);
   }

--- a/src/main/java/com/stripe/model/ApplicationFee.java
+++ b/src/main/java/com/stripe/model/ApplicationFee.java
@@ -142,7 +142,6 @@ public class ApplicationFee extends ApiResource implements HasId {
     // API versions 2014-07-26 and earlier render charge refunds as an array
     // instead of an object, meaning there is no sublist URL.
     if (refunds.getUrl() == null) {
-      // TODO replace with subresourceUrl
       refunds.setUrl(String.format("/v1/application_fees/%s/refunds", getId()));
     }
 

--- a/src/main/java/com/stripe/model/Customer.java
+++ b/src/main/java/com/stripe/model/Customer.java
@@ -4,7 +4,6 @@ import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import lombok.AccessLevel;

--- a/src/main/java/com/stripe/model/Dispute.java
+++ b/src/main/java/com/stripe/model/Dispute.java
@@ -25,7 +25,7 @@ public class Dispute extends ApiResource implements HasId {
   String currency;
   EvidenceSubObject evidenceSubObject; // `evidence`
   EvidenceDetails evidenceDetails;
-  @Getter(AccessLevel.NONE) Boolean isChargeRefundable;
+  Boolean isChargeRefundable;
   Boolean livemode;
   Map<String, String> metadata;
   String reason;
@@ -79,11 +79,6 @@ public class Dispute extends ApiResource implements HasId {
     this.charge = new ExpandableField<Charge>(charge.getId(), charge);
   }
   // </editor-fold>
-
-  // TODO: change return type to Boolean in next major version
-  public boolean getIsChargeRefundable() {
-    return isChargeRefundable;
-  }
 
   // <editor-fold desc="close">
   /**

--- a/src/main/java/com/stripe/model/ExternalAccount.java
+++ b/src/main/java/com/stripe/model/ExternalAccount.java
@@ -72,7 +72,6 @@ public class ExternalAccount extends ApiResource implements HasId, MetadataStore
   // </editor-fold>
 
   protected String getInstanceUrl() {
-    // TODO: Replace with subresourceURL
     if (this.getCustomer() != null) {
       return String.format("%s/%s/sources/%s", classUrl(Customer.class), this.getCustomer(),
           this.getId());

--- a/src/main/java/com/stripe/model/StripeObject.java
+++ b/src/main/java/com/stripe/model/StripeObject.java
@@ -15,9 +15,6 @@ public abstract class StripeObject {
       .serializeNulls()
       .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
       .registerTypeAdapter(ExpandableField.class, new ExpandableFieldSerializer())
-      // TODO: remove the deserializers in the next major release
-      .registerTypeAdapter(EventData.class, new EventDataDeserializer())
-      .registerTypeAdapter(EventRequest.class, new EventRequestDeserializer())
       .create();
 
   @Override
@@ -35,7 +32,7 @@ public abstract class StripeObject {
   }
 
   public void setLastResponse(StripeResponse response) {
-    this.lastResponse = response; 
+    this.lastResponse = response;
   }
 
   public String toJson() {

--- a/src/main/java/com/stripe/model/ThreeDSecure.java
+++ b/src/main/java/com/stripe/model/ThreeDSecure.java
@@ -1,7 +1,5 @@
 package com.stripe.model;
 
-import com.google.gson.annotations.SerializedName;
-
 import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;

--- a/src/main/java/com/stripe/model/TransferReversalCollection.java
+++ b/src/main/java/com/stripe/model/TransferReversalCollection.java
@@ -55,14 +55,6 @@ public class TransferReversalCollection extends StripeCollection<Reversal> {
   /**
    * Retrieve a reversal.
    */
-  @Deprecated
-  public Reversal retrieve(String id, String apiKey) throws StripeException {
-    return retrieve(id, RequestOptions.builder().setApiKey(apiKey).build());
-  }
-
-  /**
-   * Retrieve a reversal.
-   */
   public Reversal retrieve(String id, RequestOptions options) throws StripeException {
     String url = String.format("%s%s/%s", Stripe.getApiBase(), this.getUrl(), id);
     return ApiResource.request(ApiResource.RequestMethod.GET, url, null, Reversal.class, options);

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -42,6 +42,8 @@ import java.util.Scanner;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
 
+import lombok.Cleanup;
+
 public class LiveStripeResponseGetter implements StripeResponseGetter {
   private static final String DNS_CACHE_TTL_PROPERTY_NAME = "networkaddress.cache.ttl";
 
@@ -232,15 +234,9 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
     conn.setRequestProperty("Content-Type", String.format(
         "application/x-www-form-urlencoded;charset=%s", ApiResource.CHARSET));
 
-    OutputStream output = null;
-    try {
-      output = conn.getOutputStream();
-      output.write(query.getBytes(ApiResource.CHARSET));
-    } finally {
-      if (output != null) {
-        output.close();
-      }
-    }
+    @Cleanup OutputStream output = conn.getOutputStream();
+    output.write(query.getBytes(ApiResource.CHARSET));
+
     return conn;
   }
 

--- a/src/main/java/com/stripe/net/MultipartProcessor.java
+++ b/src/main/java/com/stripe/net/MultipartProcessor.java
@@ -9,6 +9,8 @@ import java.io.PrintWriter;
 import java.net.URLConnection;
 import java.util.Random;
 
+import lombok.Cleanup;
+
 public class MultipartProcessor {
   private final String boundary;
   private static final String LINE_BREAK = "\r\n";
@@ -72,17 +74,13 @@ public class MultipartProcessor {
     writer.append(LINE_BREAK);
     writer.flush();
 
-    FileInputStream inputStream = new FileInputStream(file);
-    try {
-      byte[] buffer = new byte[4096];
-      int bytesRead = -1;
-      while ((bytesRead = inputStream.read(buffer)) != -1) {
-        outputStream.write(buffer, 0, bytesRead);
-      }
-      outputStream.flush();
-    } finally {
-      inputStream.close();
+    @Cleanup FileInputStream inputStream = new FileInputStream(file);
+    byte[] buffer = new byte[4096];
+    int bytesRead = -1;
+    while ((bytesRead = inputStream.read(buffer)) != -1) {
+      outputStream.write(buffer, 0, bytesRead);
     }
+    outputStream.flush();
 
     writer.append(LINE_BREAK);
     writer.flush();

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -26,6 +26,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
+import lombok.Cleanup;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -421,19 +423,15 @@ public class BaseStripeTest {
   }
 
   private static String readUntilEnd(InputStream inputStream) throws IOException {
-    BufferedReader reader =
+    @Cleanup BufferedReader reader =
         new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
-    try {
-      StringBuilder builder = new StringBuilder();
-      String line;
-      while ((line = reader.readLine()) != null) {
-        builder.append(line);
-        builder.append("\r");
-      }
-      return builder.toString();
-    } finally {
-      reader.close();
+    StringBuilder builder = new StringBuilder();
+    String line;
+    while ((line = reader.readLine()) != null) {
+      builder.append(line);
+      builder.append("\r");
     }
+    return builder.toString();
   }
 
   /**

--- a/src/test/java/com/stripe/DocumentationTest.java
+++ b/src/test/java/com/stripe/DocumentationTest.java
@@ -9,7 +9,6 @@ import com.google.common.base.Joiner;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;

--- a/src/test/java/com/stripe/functional/ApplicationFeeTest.java
+++ b/src/test/java/com/stripe/functional/ApplicationFeeTest.java
@@ -16,12 +16,6 @@ import org.junit.Test;
 public class ApplicationFeeTest extends BaseStripeTest {
   public static final String FEE_ID = "fee_123";
 
-  private ApplicationFee getFeeFixture() throws StripeException {
-    final ApplicationFee fee = ApplicationFee.retrieve(FEE_ID);
-    resetNetworkSpy();
-    return fee;
-  }
-
   @Test
   public void testRetrieve() throws StripeException {
     final ApplicationFee fee = ApplicationFee.retrieve(FEE_ID);


### PR DESCRIPTION
A bunch of minor fixes:
- Remove deprecated exception constructors
- Make `Dispute.getIsChargeRefundable()` return a `Boolean`
- Remove deserializers from `StripeObject.PRETTY_PRINT_GSON`
    The correct Gson instance to use when deserializing resources is `ApiResource.GSON`, this one is used only to serialize resources via `toString()` or `toJson()`.
- Remove TODOs about `subResourceUrl`
    Unfortunately, it's not really possible to use `subResourceUrl` everywhere because the URLs for nested resources don't map 1:1 with the resource names, e.g. the URL for application fee refunds is `/v1/application_fees/:id/refunds` and not `/v1/application_fees/:id/fee_refunds`.
- Remove deprecated `TransferReversalCollection.retrieve(String id, String apiKey)` method (missed this one in #532)
- Remove some unused imports and methods
- Use lombok's [`@Cleanup`](https://projectlombok.org/features/Cleanup) annotation to close resources without having to use `try/finally`

r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 
