### PR TITLE
Fix account.application.* events data deserialization issue 

### DIFF
--- a/src/main/java/com/stripe/model/EventDataDeserializer.java
+++ b/src/main/java/com/stripe/model/EventDataDeserializer.java
@@ -23,6 +23,7 @@ public class EventDataDeserializer implements JsonDeserializer<EventData> {
     objectMap.put("account", Account.class);
     objectMap.put("alipay_account", AlipayAccount.class);
     objectMap.put("apple_pay_domain", ApplePayDomain.class);
+    objectMap.put("application", Application.class);
     objectMap.put("application_fee", ApplicationFee.class);
     objectMap.put("balance", Balance.class);
     objectMap.put("balance_transaction", BalanceTransaction.class);

--- a/src/test/java/com/stripe/model/EventDataDeserializerTest.java
+++ b/src/test/java/com/stripe/model/EventDataDeserializerTest.java
@@ -1,0 +1,26 @@
+package com.stripe.model;
+
+import static org.junit.Assert.assertNotNull;
+
+import com.stripe.BaseStripeTest;
+import com.stripe.net.APIResource;
+
+import org.junit.Test;
+
+public class EventDataDeserializerTest extends BaseStripeTest {
+
+  @Test
+  public void testEventAccountApplicationDeauthorized() throws Exception {
+    final String data = getResourceAsString("/api_fixtures/account_application_deauthorized.json");
+    final Event event = APIResource.GSON.fromJson(data, Event.class);
+    assertNotNull(event);
+    assertNotNull(event.getId());
+    assertNotNull(event.getData());
+    assertNotNull(event.getData().getObject());
+
+    final Application application = (Application) event.getData().getObject();
+    assertNotNull(application);
+    assertNotNull(application.getId());
+  }
+
+}

--- a/src/test/resources/api_fixtures/account_application_deauthorized.json
+++ b/src/test/resources/api_fixtures/account_application_deauthorized.json
@@ -1,0 +1,17 @@
+{
+  "created": 1326853478,
+  "livemode": false,
+  "id": "evt_00000000000000",
+  "type": "account.application.deauthorized",
+  "object": "event",
+  "request": null,
+  "pending_webhooks": 1,
+  "api_version": "2017-08-15",
+  "data": {
+    "object": {
+      "id": "ca_00000000000000",
+      "object": "application",
+      "name": "Test Platform"
+    }
+  }
+}


### PR DESCRIPTION
r? @ob-stripe 
cc @stripe/api-libraries 

When trying to get the data of an `account.application.*` event like so:
```java
Event event = APIResource.GSON.fromJson(data, Event.class);
Application application = (Application) event.getData().getObject();
```

casting the result of `getObject()` to `Application` throws a `java.lang.ClassCastException`:
```
java.lang.ClassCastException: com.stripe.model.StripeRawJsonObject cannot be cast to com.stripe.model.Application
``` 

This seems to be happening because an entry for `Application` model is missing from the `EventDataDeserializer` [`objectMap`](https://github.com/stripe/stripe-java/blob/58df26a289b2719898a33a86068d78233a043ab5/src/main/java/com/stripe/model/EventDataDeserializer.java#L22 ).

As a result, the deserializer seems to [fallback to the `StripeRawJsonObject​` type](https://github.com/stripe/stripe-java/blob/58df26a289b2719898a33a86068d78233a043ab5/src/main/java/com/stripe/model/EventDataDeserializer.java#L140) when trying to deserialize the object data of an `account.application.*` event.

This attempts to fix this issue and also add specific tests for the EventDataDeserializer.
