### PR TITLE
Allow uploading files from InputStreams and Files

### DIFF
--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -17,6 +17,7 @@ import com.stripe.exception.oauth.UnsupportedResponseTypeException;
 import com.stripe.model.StripeObject;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -642,7 +643,17 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
                   "Must have read permissions on file for key "
                       + key + ".", null, null, null, 0, null);
             }
-            multipartProcessor.addFileField(key, currentFile);
+            multipartProcessor.addFileField(key, currentFile.getName(), 
+                new FileInputStream(currentFile));
+          } else if (value instanceof InputStream) {
+            InputStream inputStream = (InputStream) value;
+            if (inputStream.available() == 0) {
+              throw new InvalidRequestException(
+                "Must have available bytes to read on InputStream for key "
+                  + key + ".", null, null, null, 0, null
+              );
+            }
+            multipartProcessor.addFileField(key, "blob", inputStream);
           } else {
             // We only allow a single level of nesting for params
             // for multipart

--- a/src/main/java/com/stripe/net/MultipartProcessor.java
+++ b/src/main/java/com/stripe/net/MultipartProcessor.java
@@ -3,6 +3,7 @@ package com.stripe.net;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -53,26 +54,38 @@ public class MultipartProcessor {
   }
 
   /**
-   * Adds a file field to the multipart message.
+   * Adds a file field to the multipart message, but takes in an InputStream instead of
+   * just a file to read bytes from.
    *
-   * @param name field name
-   * @param file File instance
+   * @param name          Field name
+   * @param fileName      Name of the "file" being uploaded.
+   * @param inputStream   Stream of bytes to use in place of a file.
+   * @throws IOException  Thrown when writing / reading from streams fails.
    */
-  public void addFileField(String name, File file) throws IOException {
-    String fileName = file.getName();
-    writer.append("--" + boundary).append(LINE_BREAK);
-    writer.append(
-        "Content-Disposition: form-data; name=\"" + name
-            + "\"; filename=\"" + fileName + "\"").append(
-        LINE_BREAK);
+  public void addFileField(String name, String fileName, InputStream inputStream) 
+      throws IOException {
+    writer.append("--").append(boundary).append(LINE_BREAK);
+    writer.append("Content-Disposition: form-data; name=\"").append(name)
+            .append("\"; filename=\"").append(fileName).append("\"").append(LINE_BREAK);
 
     String probableContentType = URLConnection.guessContentTypeFromName(fileName);
-    writer.append("Content-Type: " + probableContentType).append(LINE_BREAK);
+    writer.append("Content-Type: ").append(probableContentType).append(LINE_BREAK);
     writer.append("Content-Transfer-Encoding: binary").append(LINE_BREAK);
     writer.append(LINE_BREAK);
     writer.flush();
 
-    FileInputStream inputStream = new FileInputStream(file);
+    streamToOutput(inputStream);
+
+    writer.append(LINE_BREAK);
+    writer.flush();
+  }
+
+  /**
+   * Utility method to read all the bytes from an InputStream into the outputStream.
+   * @param inputStream   Stream of bytes to read from.
+   * @throws IOException  Thrown on errors reading / writing.
+   */
+  private void streamToOutput(InputStream inputStream) throws IOException {
     try {
       byte[] buffer = new byte[4096];
       int bytesRead = -1;
@@ -83,9 +96,6 @@ public class MultipartProcessor {
     } finally {
       inputStream.close();
     }
-
-    writer.append(LINE_BREAK);
-    writer.flush();
   }
 
   /**

--- a/src/test/java/com/stripe/functional/FileUploadTest.java
+++ b/src/test/java/com/stripe/functional/FileUploadTest.java
@@ -9,6 +9,7 @@ import com.stripe.model.FileUploadCollection;
 import com.stripe.net.APIResource;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -33,6 +34,24 @@ public class FileUploadTest extends BaseStripeTest {
         params,
         APIResource.RequestType.MULTIPART,
         null
+    );
+  }
+
+  @Test
+  public void testStreamCreate() throws IOException, StripeException {
+    final Map<String, Object> params = new HashMap<>();
+    params.put("purpose", "dispute_evidence");
+    params.put("file", new FileInputStream(getClass().getResource("/test.png").getFile()));
+
+    final FileUpload fileUpload = FileUpload.create(params);
+
+    assertNotNull(fileUpload);
+    verifyRequest(
+            APIResource.RequestMethod.POST,
+            "/v1/files",
+            params,
+            APIResource.RequestType.MULTIPART,
+            null
     );
   }
 


### PR DESCRIPTION
This allows users to create a FileUpload with either a `File` or a `InputStream` under the `file` parameter. It defaults to calling the uploaded file "blob".

stripe/stripe-java#299