### PR TITLE
Add setClientId() method to RequestOptionsBuilder

### DIFF
--- a/src/main/java/com/stripe/net/RequestOptions.java
+++ b/src/main/java/com/stripe/net/RequestOptions.java
@@ -131,10 +131,6 @@ public class RequestOptions {
       return apiKey;
     }
 
-    public String getClientId() {
-      return clientId;
-    }
-
     public RequestOptionsBuilder setApiKey(String apiKey) {
       this.apiKey = normalizeApiKey(apiKey);
       return this;
@@ -142,6 +138,20 @@ public class RequestOptions {
 
     public RequestOptionsBuilder clearApiKey() {
       this.apiKey = null;
+      return this;
+    }
+
+    public String getClientId() {
+      return clientId;
+    }
+
+    public RequestOptionsBuilder setClientId(String clientId) {
+      this.clientId = normalizeClientId(clientId);
+      return this;
+    }
+
+    public RequestOptionsBuilder clearClientId() {
+      this.clientId = null;
       return this;
     }
 

--- a/src/test/java/com/stripe/net/OAuthTest.java
+++ b/src/test/java/com/stripe/net/OAuthTest.java
@@ -44,7 +44,9 @@ public class OAuthTest extends BaseStripeTest {
     stripeUserParams.put("country", "US");
     urlParams.put("stripe_user", stripeUserParams);
 
-    final String urlStr = OAuth.authorizeURL(urlParams, null);
+    RequestOptions requestOptions = RequestOptions.builder().setClientId("ca_456").build();
+
+    final String urlStr = OAuth.authorizeURL(urlParams, requestOptions);
 
     final URL url = new URL(urlStr);
     final Map<String, String> queryPairs = splitQuery(url.getQuery());
@@ -53,7 +55,7 @@ public class OAuthTest extends BaseStripeTest {
     assertEquals("connect.stripe.com", url.getHost());
     assertEquals("/oauth/authorize", url.getPath());
 
-    assertEquals("ca_123", queryPairs.get("client_id"));
+    assertEquals("ca_456", queryPairs.get("client_id"));
     assertEquals("read_write", queryPairs.get("scope"));
     assertEquals("test@example.com", queryPairs.get("stripe_user[email]"));
     assertEquals("https://example.com/profile/test", queryPairs.get("stripe_user[url]"));


### PR DESCRIPTION
Fixes #545.

Not sure why the setter was missing in the first place...

r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 
