### PR TITLE
Use `BigDecimal` for floating point values

### DIFF
--- a/src/main/java/com/stripe/model/ExchangeRate.java
+++ b/src/main/java/com/stripe/model/ExchangeRate.java
@@ -4,6 +4,7 @@ import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
+import java.math.BigDecimal;
 import java.util.Map;
 
 import lombok.EqualsAndHashCode;
@@ -16,7 +17,7 @@ import lombok.Setter;
 public class ExchangeRate extends ApiResource implements HasId {
   @Getter(onMethod = @__({@Override})) String id;
   String object;
-  Map<String, Double> rates;
+  Map<String, BigDecimal> rates;
 
   // <editor-fold desc="list">
   /**

--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -4,6 +4,7 @@ import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
+import java.math.BigDecimal;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -54,7 +55,7 @@ public class Invoice extends ApiResource implements MetadataStore<Invoice>, HasI
   Long subscriptionProrationDate;
   Long subtotal;
   Long tax;
-  Double taxPercent;
+  BigDecimal taxPercent;
   Long total;
   Long webhooksDeliveredAt;
 

--- a/src/main/java/com/stripe/model/PackageDimensions.java
+++ b/src/main/java/com/stripe/model/PackageDimensions.java
@@ -1,5 +1,7 @@
 package com.stripe.model;
 
+import java.math.BigDecimal;
+
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -8,8 +10,8 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class PackageDimensions extends StripeObject {
-  Double height;
-  Double length;
-  Double weight;
-  Double width;
+  BigDecimal height;
+  BigDecimal length;
+  BigDecimal weight;
+  BigDecimal width;
 }

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -4,6 +4,7 @@ import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
+import java.math.BigDecimal;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -17,7 +18,7 @@ import lombok.Setter;
 public class Subscription extends ApiResource implements MetadataStore<Subscription>, HasId {
   @Getter(onMethod = @__({@Override})) String id;
   String object;
-  Double applicationFeePercent;
+  BigDecimal applicationFeePercent;
   String billing;
   Long billingCycleAnchor;
   Boolean cancelAtPeriodEnd;
@@ -35,7 +36,7 @@ public class Subscription extends ApiResource implements MetadataStore<Subscript
   Long quantity;
   Long start;
   String status;
-  Double taxPercent;
+  BigDecimal taxPercent;
   Long trialEnd;
   Long trialStart;
 

--- a/src/test/java/com/stripe/model/SubscriptionTest.java
+++ b/src/test/java/com/stripe/model/SubscriptionTest.java
@@ -2,9 +2,12 @@ package com.stripe.model;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
+
+import java.math.BigDecimal;
 
 import org.junit.Test;
 
@@ -16,5 +19,14 @@ public class SubscriptionTest extends BaseStripeTest {
     assertNotNull(subscription);
     assertNotNull(subscription.getId());
     assertEquals("subscription", subscription.getObject());
+  }
+
+  @Test
+  public void testDeserializeBigDecimal() {
+    final String data = "{\"object\": \"subscription\", \"tax_percent\": 0.3}";
+    final Subscription subscription = ApiResource.GSON.fromJson(data, Subscription.class);
+    assertNotNull(subscription);
+    assertNotNull(subscription.getTaxPercent());
+    assertTrue(subscription.getTaxPercent().equals(new BigDecimal("0.3")));
   }
 }


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries @codylerum 

Use `BigDecimal` for floating-point values instead of `Double`.

See discussion here for context: https://github.com/stripe/stripe-java/pull/533#issuecomment-408380799.
