### PR TITLE
Properly support object on list resources

### DIFF
--- a/src/main/java/com/stripe/model/StripeCollection.java
+++ b/src/main/java/com/stripe/model/StripeCollection.java
@@ -33,6 +33,7 @@ import java.util.Map;
  */
 public abstract class StripeCollection<T extends HasId> extends StripeObject
     implements StripeCollectionInterface<T> {
+  String object;
   List<T> data;
   Long totalCount;
   Boolean hasMore;
@@ -70,6 +71,14 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject
 
   public void setHasMore(Boolean hasMore) {
     this.hasMore = hasMore;
+  }
+
+  public String getObject() {
+    return object;
+  }
+
+  public void setObject(String object) {
+    this.object = object;
   }
 
   @Override

--- a/src/test/java/com/stripe/model/StripeCollectionTest.java
+++ b/src/test/java/com/stripe/model/StripeCollectionTest.java
@@ -1,0 +1,20 @@
+package com.stripe.model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.stripe.BaseStripeTest;
+import com.stripe.model.CouponCollection;
+import com.stripe.net.ApiResource;
+
+import org.junit.Test;
+
+public class StripeCollectionTest extends BaseStripeTest {
+  @Test
+  public void testSerialize() throws Exception {
+    final String data = getFixture("/v1/coupons");
+    final CouponCollection collection = ApiResource.GSON.fromJson(data, CouponCollection.class);
+    assertNotNull(collection);
+    assertEquals("list", collection.getObject());
+  }
+}


### PR DESCRIPTION
This ensures that the `object` property is kept when serializing a list. This is important when you serialize a Customer object for example so that it gets deserialized in the mobile SDKs where they expect the list resource to have a valid object key.

Not sure if it's a breaking change on that one so flagging just in case.

r? @ob-stripe 
cc @stripe/api-libraries 