### PR TITLE
Add a retrieve() signature with params to all resources

### DIFF
--- a/src/main/java/com/stripe/model/Account.java
+++ b/src/main/java/com/stripe/model/Account.java
@@ -189,7 +189,7 @@ public class Account extends ApiResource implements HasId, MetadataStore<Account
    * Retrieve account details.
    */
   public static Account retrieve(String id, RequestOptions options) throws StripeException {
-    return request(RequestMethod.GET, instanceUrl(Account.class, id), null, Account.class, options);
+    return retrieve(id, null, options);
   }
 
   /**

--- a/src/main/java/com/stripe/model/ApplePayDomain.java
+++ b/src/main/java/com/stripe/model/ApplePayDomain.java
@@ -85,7 +85,15 @@ public class ApplePayDomain extends ApiResource implements HasId {
    * Retrieve an Apple Pay domain.
    */
   public static ApplePayDomain retrieve(String id, RequestOptions options) throws StripeException {
-    return request(RequestMethod.GET, getInstanceUrl(id), null, ApplePayDomain.class, options);
+    return retrieve(id, null, options);
+  }
+
+  /**
+   * Retrieve an Apple Pay domain.
+   */
+  public static ApplePayDomain retrieve(String id, Map<String, Object> params,
+      RequestOptions options) throws StripeException {
+    return request(RequestMethod.GET, getInstanceUrl(id), params, ApplePayDomain.class, options);
   }
   // </editor-fold>
 

--- a/src/main/java/com/stripe/model/ApplicationFee.java
+++ b/src/main/java/com/stripe/model/ApplicationFee.java
@@ -178,7 +178,15 @@ public class ApplicationFee extends ApiResource implements HasId {
    * Retrieve an application fee.
    */
   public static ApplicationFee retrieve(String id, RequestOptions options) throws StripeException {
-    return request(RequestMethod.GET, instanceUrl(ApplicationFee.class, id), null,
+    return retrieve(id, null, options);
+  }
+
+  /**
+   * Retrieve an application fee.
+   */
+  public static ApplicationFee retrieve(String id, Map<String, Object> params,
+      RequestOptions options) throws StripeException {
+    return request(RequestMethod.GET, instanceUrl(ApplicationFee.class, id), params,
         ApplicationFee.class, options);
   }
   // </editor-fold>

--- a/src/main/java/com/stripe/model/Balance.java
+++ b/src/main/java/com/stripe/model/Balance.java
@@ -5,6 +5,7 @@ import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
 import java.util.List;
+import java.util.Map;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -31,7 +32,16 @@ public class Balance extends ApiResource {
    * Retrieve balance.
    */
   public static Balance retrieve(RequestOptions options) throws StripeException {
-    return request(RequestMethod.GET, singleClassUrl(Balance.class), null, Balance.class, options);
+    return retrieve(null, options);
+  }
+
+  /**
+   * Retrieve balance.
+   */
+  public static Balance retrieve(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    return request(RequestMethod.GET, singleClassUrl(Balance.class), params, Balance.class,
+        options);
   }
   // </editor-fold>
 

--- a/src/main/java/com/stripe/model/BalanceTransaction.java
+++ b/src/main/java/com/stripe/model/BalanceTransaction.java
@@ -96,8 +96,16 @@ public class BalanceTransaction extends ApiResource implements HasId {
    */
   public static BalanceTransaction retrieve(String id, RequestOptions options)
       throws StripeException {
+    return retrieve(id, null, options);
+  }
+
+  /**
+   * Retrieve a balance transaction.
+   */
+  public static BalanceTransaction retrieve(String id, Map<String, Object> params,
+      RequestOptions options) throws StripeException {
     String url = String.format("%s/%s/%s", Stripe.getApiBase(), "v1/balance/history", id);
-    return request(RequestMethod.GET, url, null, BalanceTransaction.class, options);
+    return request(RequestMethod.GET, url, params, BalanceTransaction.class, options);
   }
   // </editor-fold>
 

--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -463,7 +463,7 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, HasId 
    * Retrieve a charge.
    */
   public static Charge retrieve(String id, RequestOptions options) throws StripeException {
-    return request(RequestMethod.GET, instanceUrl(Charge.class, id), null, Charge.class, options);
+    return retrieve(id, null, options);
   }
 
   /**

--- a/src/main/java/com/stripe/model/CountrySpec.java
+++ b/src/main/java/com/stripe/model/CountrySpec.java
@@ -54,7 +54,15 @@ public class CountrySpec extends ApiResource implements HasId {
    */
   public static CountrySpec retrieve(String country, RequestOptions options)
       throws StripeException {
-    return request(RequestMethod.GET, instanceUrl(CountrySpec.class, country), null,
+    return retrieve(country, null, options);
+  }
+
+  /**
+   * Retrieve a country spec.
+   */
+  public static CountrySpec retrieve(String country, Map<String, Object> params,
+      RequestOptions options) throws StripeException {
+    return request(RequestMethod.GET, instanceUrl(CountrySpec.class, country), params,
         CountrySpec.class, options);
   }
   // </editor-fold>

--- a/src/main/java/com/stripe/model/Coupon.java
+++ b/src/main/java/com/stripe/model/Coupon.java
@@ -94,7 +94,15 @@ public class Coupon extends ApiResource implements MetadataStore<Coupon>, HasId 
    * Retrieve a coupon.
    */
   public static Coupon retrieve(String id, RequestOptions options) throws StripeException {
-    return request(RequestMethod.GET, instanceUrl(Coupon.class, id), null, Coupon.class, options);
+    return retrieve(id, null, options);
+  }
+
+  /**
+   * Retrieve a coupon.
+   */
+  public static Coupon retrieve(String id, Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    return request(RequestMethod.GET, instanceUrl(Coupon.class, id), params, Coupon.class, options);
   }
   // </editor-fold>
 

--- a/src/main/java/com/stripe/model/Customer.java
+++ b/src/main/java/com/stripe/model/Customer.java
@@ -182,8 +182,7 @@ public class Customer extends ApiResource implements MetadataStore<Customer>, Ha
    * Retrieve a customer.
    */
   public static Customer retrieve(String id, RequestOptions options) throws StripeException {
-    return request(RequestMethod.GET, instanceUrl(Customer.class, id), null, Customer.class,
-        options);
+    return retrieve(id, null, options);
   }
 
   /**

--- a/src/main/java/com/stripe/model/CustomerCardCollection.java
+++ b/src/main/java/com/stripe/model/CustomerCardCollection.java
@@ -55,8 +55,16 @@ public class CustomerCardCollection extends StripeCollection<Card> {
    * Retrieve a card.
    */
   public Card retrieve(String id, RequestOptions options) throws StripeException {
+    return retrieve(id, null, options);
+  }
+
+  /**
+   * Retrieve a card.
+   */
+  public Card retrieve(String id, Map<String, Object> params, RequestOptions options)
+      throws StripeException {
     String url = String.format("%s%s/%s", Stripe.getApiBase(), this.getUrl(), id);
-    return ApiResource.request(ApiResource.RequestMethod.GET, url, null, Card.class, options);
+    return ApiResource.request(ApiResource.RequestMethod.GET, url, params, Card.class, options);
   }
   // </editor-fold>
 }

--- a/src/main/java/com/stripe/model/Event.java
+++ b/src/main/java/com/stripe/model/Event.java
@@ -59,9 +59,16 @@ public class Event extends ApiResource implements HasId {
   /**
    * Retrieve an event.
    */
-  public static Event retrieve(String id, RequestOptions options)
+  public static Event retrieve(String id, RequestOptions options) throws StripeException {
+    return retrieve(id, null, options);
+  }
+
+  /**
+   * Retrieve an event.
+   */
+  public static Event retrieve(String id, Map<String, Object> params, RequestOptions options)
       throws StripeException {
-    return request(RequestMethod.GET, instanceUrl(Event.class, id), null, Event.class, options);
+    return request(RequestMethod.GET, instanceUrl(Event.class, id), params, Event.class, options);
   }
   // </editor-fold>
 }

--- a/src/main/java/com/stripe/model/ExchangeRate.java
+++ b/src/main/java/com/stripe/model/ExchangeRate.java
@@ -50,7 +50,15 @@ public class ExchangeRate extends ApiResource implements HasId {
    */
   public static ExchangeRate retrieve(String currency, RequestOptions options)
       throws StripeException {
-    return request(RequestMethod.GET, instanceUrl(ExchangeRate.class, currency), null,
+    return retrieve(currency, null, options);
+  }
+
+  /**
+   * Retrieve an exchange rate.
+   */
+  public static ExchangeRate retrieve(String currency, Map<String, Object> params,
+      RequestOptions options) throws StripeException {
+    return request(RequestMethod.GET, instanceUrl(ExchangeRate.class, currency), params,
         ExchangeRate.class, options);
   }
   // </editor-fold>

--- a/src/main/java/com/stripe/model/ExternalAccountCollection.java
+++ b/src/main/java/com/stripe/model/ExternalAccountCollection.java
@@ -51,8 +51,13 @@ public class ExternalAccountCollection extends StripeCollection<ExternalAccount>
   }
 
   public ExternalAccount retrieve(String id, RequestOptions options) throws StripeException {
+    return retrieve(id, null, options);
+  }
+
+  public ExternalAccount retrieve(String id, Map<String, Object> params, RequestOptions options)
+      throws StripeException {
     return ApiResource.request(ApiResource.RequestMethod.GET, String.format("%s%s/%s",
-        Stripe.getApiBase(), this.getUrl(), id), null, ExternalAccount.class, options);
+        Stripe.getApiBase(), this.getUrl(), id), params, ExternalAccount.class, options);
   }
   // </editor-fold>
 }

--- a/src/main/java/com/stripe/model/FeeRefundCollection.java
+++ b/src/main/java/com/stripe/model/FeeRefundCollection.java
@@ -56,8 +56,17 @@ public class FeeRefundCollection extends StripeCollection<FeeRefund> {
    * Retrieve an application fee refund.
    */
   public FeeRefund retrieve(String id, RequestOptions options) throws StripeException {
+    return retrieve(id, null, options);
+  }
+
+  /**
+   * Retrieve an application fee refund.
+   */
+  public FeeRefund retrieve(String id, Map<String, Object> params, RequestOptions options)
+      throws StripeException {
     String url = String.format("%s%s/%s", Stripe.getApiBase(), this.getUrl(), id);
-    return ApiResource.request(ApiResource.RequestMethod.GET, url, null, FeeRefund.class, options);
+    return ApiResource.request(ApiResource.RequestMethod.GET, url, params, FeeRefund.class,
+        options);
   }
   // </editor-fold>
 }

--- a/src/main/java/com/stripe/model/FileUpload.java
+++ b/src/main/java/com/stripe/model/FileUpload.java
@@ -71,8 +71,16 @@ public class FileUpload extends ApiResource implements HasId {
    * Retrieve a file upload.
    */
   public static FileUpload retrieve(String id, RequestOptions options) throws StripeException {
+    return retrieve(id, null, options);
+  }
+
+  /**
+   * Retrieve a file upload.
+   */
+  public static FileUpload retrieve(String id, Map<String, Object> params, RequestOptions options)
+      throws StripeException {
     return request(RequestMethod.GET, instanceUrl(FileUpload.class, id, Stripe.getUploadBase()),
-        null, FileUpload.class, options);
+        params, FileUpload.class, options);
   }
   // </editor-fold>
 }

--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -172,7 +172,7 @@ public class Invoice extends ApiResource implements MetadataStore<Invoice>, HasI
    * Retrieve an invoice.
    */
   public static Invoice retrieve(String id, RequestOptions options) throws StripeException {
-    return request(RequestMethod.GET, instanceUrl(Invoice.class, id), null, Invoice.class, options);
+    return retrieve(id, null, options);
   }
 
   /**

--- a/src/main/java/com/stripe/model/InvoiceItem.java
+++ b/src/main/java/com/stripe/model/InvoiceItem.java
@@ -154,8 +154,7 @@ public class InvoiceItem extends ApiResource implements MetadataStore<InvoiceIte
    * Retrieve an invoice item.
    */
   public static InvoiceItem retrieve(String id, RequestOptions options) throws StripeException {
-    return request(RequestMethod.GET, instanceUrl(InvoiceItem.class, id), null, InvoiceItem.class,
-        options);
+    return retrieve(id, null, options);
   }
 
   /**

--- a/src/main/java/com/stripe/model/IssuerFraudRecord.java
+++ b/src/main/java/com/stripe/model/IssuerFraudRecord.java
@@ -69,6 +69,11 @@ public class IssuerFraudRecord extends ApiResource implements HasId {
 
   public static IssuerFraudRecord retrieve(String id, RequestOptions options)
       throws StripeException {
+    return retrieve(id, null, options);
+  }
+
+  public static IssuerFraudRecord retrieve(String id, Map<String, Object> params,
+      RequestOptions options) throws StripeException {
     String url = instanceUrl(IssuerFraudRecord.class, id);
     return request(RequestMethod.GET, url, null, IssuerFraudRecord.class, null);
   }

--- a/src/main/java/com/stripe/model/Order.java
+++ b/src/main/java/com/stripe/model/Order.java
@@ -139,7 +139,7 @@ public class Order extends ApiResource implements HasId, MetadataStore<Order> {
    * Retrieve an order.
    */
   public static Order retrieve(String id, RequestOptions options) throws StripeException {
-    return request(RequestMethod.GET, instanceUrl(Order.class, id), null, Order.class, options);
+    return retrieve(id, null, options);
   }
 
   /**

--- a/src/main/java/com/stripe/model/OrderReturn.java
+++ b/src/main/java/com/stripe/model/OrderReturn.java
@@ -92,7 +92,15 @@ public class OrderReturn extends ApiResource implements HasId {
    * Retrieve an order return.
    */
   public static OrderReturn retrieve(String id, RequestOptions options) throws StripeException {
-    return request(RequestMethod.GET, instanceUrl(OrderReturn.class, id), null, OrderReturn.class,
+    return retrieve(id, null, options);
+  }
+
+  /**
+   * Retrieve an order return.
+   */
+  public static OrderReturn retrieve(String id, Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    return request(RequestMethod.GET, instanceUrl(OrderReturn.class, id), params, OrderReturn.class,
         options);
   }
   // </editor-fold>

--- a/src/main/java/com/stripe/model/PaymentIntent.java
+++ b/src/main/java/com/stripe/model/PaymentIntent.java
@@ -240,8 +240,7 @@ public class PaymentIntent extends ApiResource implements MetadataStore<PaymentI
    * Retrieve a payment intent.
    */
   public static PaymentIntent retrieve(String id, RequestOptions options) throws StripeException {
-    return request(RequestMethod.GET, instanceUrl(PaymentIntent.class, id), null,
-      PaymentIntent.class, options);
+    return retrieve(id, null, options);
   }
 
   /**

--- a/src/main/java/com/stripe/model/Payout.java
+++ b/src/main/java/com/stripe/model/Payout.java
@@ -157,7 +157,7 @@ public class Payout extends ApiResource implements MetadataStore<Payout>, HasId 
    * Retrieve a payout.
    */
   public static Payout retrieve(String id, RequestOptions options) throws StripeException {
-    return request(RequestMethod.GET, instanceUrl(Payout.class, id), null, Payout.class, options);
+    return retrieve(id, null, options);
   }
 
   /**

--- a/src/main/java/com/stripe/model/Plan.java
+++ b/src/main/java/com/stripe/model/Plan.java
@@ -158,7 +158,15 @@ public class Plan extends ApiResource implements MetadataStore<Plan>, HasId {
    * Retrieve a plan.
    */
   public static Plan retrieve(String id, RequestOptions options) throws StripeException {
-    return request(RequestMethod.GET, instanceUrl(Plan.class, id), null, Plan.class, options);
+    return retrieve(id, null, options);
+  }
+
+  /**
+   * Retrieve a plan.
+   */
+  public static Plan retrieve(String id, Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    return request(RequestMethod.GET, instanceUrl(Plan.class, id), params, Plan.class, options);
   }
   // </editor-fold>
 

--- a/src/main/java/com/stripe/model/Product.java
+++ b/src/main/java/com/stripe/model/Product.java
@@ -99,7 +99,16 @@ public class Product extends ApiResource implements HasId, MetadataStore<Product
    * Retrieve a product.
    */
   public static Product retrieve(String id, RequestOptions options) throws StripeException {
-    return request(RequestMethod.GET, instanceUrl(Product.class, id), null, Product.class, options);
+    return retrieve(id, null, options);
+  }
+
+  /**
+   * Retrieve a product.
+   */
+  public static Product retrieve(String id, Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    return request(RequestMethod.GET, instanceUrl(Product.class, id), params, Product.class,
+        options);
   }
   // </editor-fold>
 

--- a/src/main/java/com/stripe/model/Recipient.java
+++ b/src/main/java/com/stripe/model/Recipient.java
@@ -130,8 +130,7 @@ public class Recipient extends ApiResource implements MetadataStore<Recipient>, 
    * Retrieve a recipient.
    */
   public static Recipient retrieve(String id, RequestOptions options) throws StripeException {
-    return request(RequestMethod.GET, instanceUrl(Recipient.class, id), null, Recipient.class,
-        options);
+    return retrieve(id, null, options);
   }
 
   /**

--- a/src/main/java/com/stripe/model/RecipientCardCollection.java
+++ b/src/main/java/com/stripe/model/RecipientCardCollection.java
@@ -57,7 +57,16 @@ public class RecipientCardCollection extends StripeCollection<Card> {
    */
   public Card retrieve(String id, RequestOptions options) throws StripeException {
     String url = String.format("%s%s/%s", Stripe.getApiBase(), this.getUrl(), id);
-    return ApiResource.request(ApiResource.RequestMethod.GET, url, null, Card.class, options);
+    return retrieve(id, null, options);
+  }
+
+  /**
+   * Retrieve a recipient card.
+   */
+  public Card retrieve(String id, Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s/%s", Stripe.getApiBase(), this.getUrl(), id);
+    return ApiResource.request(ApiResource.RequestMethod.GET, url, params, Card.class, options);
   }
   // </editor-fold>
 }

--- a/src/main/java/com/stripe/model/Refund.java
+++ b/src/main/java/com/stripe/model/Refund.java
@@ -111,7 +111,7 @@ public class Refund extends ApiResource implements MetadataStore<Charge>, HasId 
    * Retrieve a refund.
    */
   public static Refund retrieve(String id, RequestOptions options) throws StripeException {
-    return request(RequestMethod.GET, instanceUrl(Refund.class, id), null, Refund.class, options);
+    return retrieve(id, null, options);
   }
 
   /**

--- a/src/main/java/com/stripe/model/Sku.java
+++ b/src/main/java/com/stripe/model/Sku.java
@@ -113,7 +113,7 @@ public class Sku extends ApiResource implements HasId, MetadataStore<Sku> {
    * Retrieve a SKU.
    */
   public static Sku retrieve(String id, RequestOptions options) throws StripeException {
-    return request(RequestMethod.GET, instanceUrl(Sku.class, id), null, Sku.class, options);
+    return retrieve(id, null, options);
   }
 
   /**

--- a/src/main/java/com/stripe/model/Source.java
+++ b/src/main/java/com/stripe/model/Source.java
@@ -114,7 +114,15 @@ public class Source extends ExternalAccount implements HasSourceTypeData {
    * Retrieve a source.
    */
   public static Source retrieve(String id, RequestOptions options) throws StripeException {
-    return request(RequestMethod.GET, instanceUrl(Source.class, id), null, Source.class, options);
+    return retrieve(id, null, options);
+  }
+
+  /**
+   * Retrieve a source.
+   */
+  public static Source retrieve(String id, Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    return request(RequestMethod.GET, instanceUrl(Source.class, id), params, Source.class, options);
   }
   // </editor-fold>
 

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -151,8 +151,7 @@ public class Subscription extends ApiResource implements MetadataStore<Subscript
    * Retrieve a subscription.
    */
   public static Subscription retrieve(String id, RequestOptions options) throws StripeException {
-    return request(RequestMethod.GET, instanceUrl(Subscription.class, id), null, Subscription.class,
-        options);
+    return retrieve(id, null, options);
   }
 
   /**

--- a/src/main/java/com/stripe/model/SubscriptionItem.java
+++ b/src/main/java/com/stripe/model/SubscriptionItem.java
@@ -102,7 +102,15 @@ public class SubscriptionItem extends ApiResource implements HasId {
    */
   public static SubscriptionItem retrieve(String id, RequestOptions options)
       throws StripeException {
-    return request(RequestMethod.GET, instanceUrl(SubscriptionItem.class, id), null,
+    return retrieve(id, null, options);
+  }
+
+  /**
+   * Retrieve a subscription item.
+   */
+  public static SubscriptionItem retrieve(String id, Map<String, Object> params,
+      RequestOptions options) throws StripeException {
+    return request(RequestMethod.GET, instanceUrl(SubscriptionItem.class, id), params,
         SubscriptionItem.class, options);
   }
   // </editor-fold>

--- a/src/main/java/com/stripe/model/ThreeDSecure.java
+++ b/src/main/java/com/stripe/model/ThreeDSecure.java
@@ -43,7 +43,12 @@ public class ThreeDSecure extends ApiResource implements HasId {
   }
 
   public static ThreeDSecure retrieve(String id, RequestOptions options) throws StripeException {
-    return request(RequestMethod.GET, getInstanceUrl(id), null, ThreeDSecure.class, options);
+    return retrieve(id, null, options);
+  }
+
+  public static ThreeDSecure retrieve(String id, Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    return request(RequestMethod.GET, getInstanceUrl(id), params, ThreeDSecure.class, options);
   }
   // </editor-fold>
 

--- a/src/main/java/com/stripe/model/Token.java
+++ b/src/main/java/com/stripe/model/Token.java
@@ -56,7 +56,15 @@ public class Token extends ApiResource implements HasId {
    * Retrieve a token.
    */
   public static Token retrieve(String id, RequestOptions options) throws StripeException {
-    return request(RequestMethod.GET, instanceUrl(Token.class, id), null, Token.class, options);
+    return retrieve(id, null, options);
+  }
+
+  /**
+   * Retrieve a token.
+   */
+  public static Token retrieve(String id, Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    return request(RequestMethod.GET, instanceUrl(Token.class, id), params, Token.class, options);
   }
   // </editor-fold>
 }

--- a/src/main/java/com/stripe/model/Transfer.java
+++ b/src/main/java/com/stripe/model/Transfer.java
@@ -242,8 +242,7 @@ public class Transfer extends ApiResource implements MetadataStore<Transfer>, Ha
    * Retrive a transfer.
    */
   public static Transfer retrieve(String id, RequestOptions options) throws StripeException {
-    return request(RequestMethod.GET, instanceUrl(Transfer.class, id), null, Transfer.class,
-        options);
+    return retrieve(id, null, options);
   }
 
   /**

--- a/src/main/java/com/stripe/model/TransferReversalCollection.java
+++ b/src/main/java/com/stripe/model/TransferReversalCollection.java
@@ -57,7 +57,16 @@ public class TransferReversalCollection extends StripeCollection<Reversal> {
    */
   public Reversal retrieve(String id, RequestOptions options) throws StripeException {
     String url = String.format("%s%s/%s", Stripe.getApiBase(), this.getUrl(), id);
-    return ApiResource.request(ApiResource.RequestMethod.GET, url, null, Reversal.class, options);
+    return retrieve(id, null, options);
+  }
+
+  /**
+   * Retrieve a reversal.
+   */
+  public Reversal retrieve(String id, Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s/%s", Stripe.getApiBase(), this.getUrl(), id);
+    return ApiResource.request(ApiResource.RequestMethod.GET, url, params, Reversal.class, options);
   }
   // </editor-fold>
 }

--- a/src/main/java/com/stripe/model/issuing/Authorization.java
+++ b/src/main/java/com/stripe/model/issuing/Authorization.java
@@ -148,8 +148,7 @@ public class Authorization extends ApiResource implements MetadataStore<Authoriz
    * Retrieve an issuing authorization.
    */
   public static Authorization retrieve(String id, RequestOptions options) throws StripeException {
-    return request(RequestMethod.GET, instanceUrl(Authorization.class, id), null,
-      Authorization.class, options);
+    return retrieve(id, null, options);
   }
 
   /**

--- a/src/main/java/com/stripe/model/issuing/Card.java
+++ b/src/main/java/com/stripe/model/issuing/Card.java
@@ -103,8 +103,7 @@ public class Card extends ApiResource implements MetadataStore<Card>, HasId {
    * Retrieve an issuing card.
    */
   public static Card retrieve(String id, RequestOptions options) throws StripeException {
-    return request(RequestMethod.GET, instanceUrl(Card.class, id), null,
-      Card.class, options);
+    return retrieve(id, null, options);
   }
 
   /**

--- a/src/main/java/com/stripe/model/issuing/Cardholder.java
+++ b/src/main/java/com/stripe/model/issuing/Cardholder.java
@@ -78,8 +78,7 @@ public class Cardholder extends ApiResource implements MetadataStore<Cardholder>
    * Retrieve an issuing cardholder.
    */
   public static Cardholder retrieve(String id, RequestOptions options) throws StripeException {
-    return request(RequestMethod.GET, instanceUrl(Cardholder.class, id), null,
-      Cardholder.class, options);
+    return retrieve(id, null, options);
   }
 
   /**

--- a/src/main/java/com/stripe/model/issuing/Dispute.java
+++ b/src/main/java/com/stripe/model/issuing/Dispute.java
@@ -97,8 +97,7 @@ public class Dispute extends ApiResource implements MetadataStore<Dispute>, HasI
    * Retrieve an issuing dispute.
    */
   public static Dispute retrieve(String id, RequestOptions options) throws StripeException {
-    return request(RequestMethod.GET, instanceUrl(Dispute.class, id), null,
-      Dispute.class, options);
+    return retrieve(id, null, options);
   }
 
   /**

--- a/src/main/java/com/stripe/model/issuing/Transaction.java
+++ b/src/main/java/com/stripe/model/issuing/Transaction.java
@@ -159,8 +159,7 @@ public class Transaction extends ApiResource implements MetadataStore<Transactio
    * Retrieve an issuing transaction.
    */
   public static Transaction retrieve(String id, RequestOptions options) throws StripeException {
-    return request(RequestMethod.GET, instanceUrl(Transaction.class, id), null,
-      Transaction.class, options);
+    return retrieve(id, null, options);
   }
 
   /**

--- a/src/main/java/com/stripe/model/sigma/ScheduledQueryRun.java
+++ b/src/main/java/com/stripe/model/sigma/ScheduledQueryRun.java
@@ -30,7 +30,7 @@ public class ScheduledQueryRun extends ApiResource implements HasId {
 
   // <editor-fold desc="list">
   /**
-   * List all issuing authorizations.
+   * List all scheduled query runs.
    */
   public static ScheduledQueryRunCollection list(Map<String, Object> params)
       throws StripeException {
@@ -38,7 +38,7 @@ public class ScheduledQueryRun extends ApiResource implements HasId {
   }
 
   /**
-   * List all issuing authorizations.
+   * List all scheduled query runs.
    */
   public static ScheduledQueryRunCollection list(Map<String, Object> params, RequestOptions options)
       throws StripeException {
@@ -49,18 +49,26 @@ public class ScheduledQueryRun extends ApiResource implements HasId {
 
   // <editor-fold desc="retrieve">
   /**
-   * Retrieve an issuing authorization.
+   * Retrieve a scheduled query run.
    */
   public static ScheduledQueryRun retrieve(String id) throws StripeException {
     return retrieve(id, null);
   }
 
   /**
-   * Retrieve an issuing authorization.
+   * Retrieve a scheduled query run.
    */
   public static ScheduledQueryRun retrieve(String id, RequestOptions options)
       throws StripeException {
-    return request(RequestMethod.GET, instanceUrl(ScheduledQueryRun.class, id), null,
+    return retrieve(id, null, options);
+  }
+
+  /**
+   * Retrieve a scheduled query run.
+   */
+  public static ScheduledQueryRun retrieve(String id, Map<String, Object> params,
+      RequestOptions options) throws StripeException {
+    return request(RequestMethod.GET, instanceUrl(ScheduledQueryRun.class, id), params,
       ScheduledQueryRun.class, options);
   }
   // </editor-fold>


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

Adds a `retrieve()` signature with params to all resources.

Fixes #559.
