### PR TITLE
Use Lombok for StripeCollection

### DIFF
--- a/src/main/java/com/stripe/model/StripeCollection.java
+++ b/src/main/java/com/stripe/model/StripeCollection.java
@@ -5,6 +5,10 @@ import com.stripe.net.RequestOptions;
 import java.util.List;
 import java.util.Map;
 
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * Provides a representation of a single page worth of data from the Stripe
  * API.
@@ -31,69 +35,30 @@ import java.util.Map;
  * }
  * </pre>
  */
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
 public abstract class StripeCollection<T extends HasId> extends StripeObject
     implements StripeCollectionInterface<T> {
-  List<T> data;
-  Long totalCount;
-  Boolean hasMore;
-  private RequestOptions requestOptions;
-  private Map<String, Object> requestParams;
-  String url;
+  String object;
+  @Getter(onMethod = @__({@Override})) List<T> data;
+  @Getter(onMethod = @__({@Override})) Boolean hasMore;
+  @Getter(onMethod = @__({@Override})) Long totalCount;
+  @Getter(onMethod = @__({@Override})) String url;
 
   /**
-   * 3/2014: Legacy (from before newstyle pagination API).
+   * The {@code count} attribute.
+   *
+   * @deprecated Use pagination parameters instead.
+   * @see <a href="https://stripe.com/docs/api/java#pagination">Pagination</a>
    */
+  @Deprecated
   Long count;
 
-  @Override
-  public List<T> getData() {
-    return data;
-  }
-
-  public void setData(List<T> data) {
-    this.data = data;
-  }
-
-  @Override
-  public Long getTotalCount() {
-    return totalCount;
-  }
-
-  public void setTotalCount(Long totalCount) {
-    this.totalCount = totalCount;
-  }
-
-  @Override
-  public Boolean getHasMore() {
-    return hasMore;
-  }
-
-  public void setHasMore(Boolean hasMore) {
-    this.hasMore = hasMore;
-  }
-
-  @Override
-  public String getUrl() {
-    return url;
-  }
-
-  public void setUrl(String url) {
-    this.url = url;
-  }
-
-  /**
-   * 3/2014: Legacy (from before newstyle pagination API).
-   */
-  public Long getCount() {
-    return count;
-  }
-
-  /**
-   * 3/2014: Legacy (from before newstyle pagination API).
-   */
-  public void setCount(Long count) {
-    this.count = count;
-  }
+  @Getter(onMethod = @__({@Override})) @Setter(onMethod = @__({@Override}))
+      private RequestOptions requestOptions;
+  @Getter(onMethod = @__({@Override})) @Setter(onMethod = @__({@Override}))
+      private Map<String, Object> requestParams;
 
   public Iterable<T> autoPagingIterable() {
     return new PagingIterable<T>(this);
@@ -116,25 +81,5 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject
     this.setRequestOptions(options);
     this.setRequestParams(params);
     return new PagingIterable<T>(this);
-  }
-
-  @Override
-  public RequestOptions getRequestOptions() {
-    return this.requestOptions;
-  }
-
-  @Override
-  public Map<String, Object> getRequestParams() {
-    return this.requestParams;
-  }
-
-  @Override
-  public void setRequestOptions(RequestOptions requestOptions) {
-    this.requestOptions = requestOptions;
-  }
-
-  @Override
-  public void setRequestParams(Map<String, Object> requestParams) {
-    this.requestParams = requestParams;
   }
 }


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

Use Project Lombok for generating `StripeCollection` accessors.

Also adds the `object` property to `StripeCollection` (replaces #564).

I've checked with the [Java API Compliance Checker](https://lvc.github.io/japi-compliance-checker/) that the new API is 100% compatible with the old one.
