### PR TITLE
Use delomboked sources when creating sources JAR

### DIFF
--- a/deploy.gradle
+++ b/deploy.gradle
@@ -108,9 +108,9 @@ afterEvaluate { project ->
         from makeJavadocs.destinationDir
     }
 
-    task sourcesJar(type: Jar) {
+    task sourcesJar(type: Jar, dependsOn: delombok) {
         classifier = 'sources'
-        from sourceSets.main.java
+        from delombok.outputDir
     }
 
     artifacts {


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries @lure

Use delomboked sources instead of original files when creating sources JAR.

I've tested that this works by manually creating the JAR (with `gradle clean sourcesJar`) then uncompressing it (JARs are actually just ZIP files) and checking the sources.

Fixes #555.
