### PR TITLE
Fix flattening of array params

### DIFF
--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -280,7 +280,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
     ListIterator<?> it = ((List<?>) params).listIterator();
     // Because application/x-www-form-urlencoded cannot represent an empty
     // list, convention is to take the list parameter and just set it to an
-    // empty string. (e.g. A regular list might look like `a[]=1&b[]=2`.
+    // empty string. (e.g. A regular list might look like `a[0]=1&b[1]=2`.
     // Emptying it would look like `a=`.)
     if (params.isEmpty()) {
       flatParams.add(new Parameter(keyPrefix, ""));
@@ -300,7 +300,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 
     // Because application/x-www-form-urlencoded cannot represent an empty
     // list, convention is to take the list parameter and just set it to an
-    // empty string. (e.g. A regular list might look like `a[]=1&b[]=2`.
+    // empty string. (e.g. A regular list might look like `a[0]=1&b[1]=2`.
     // Emptying it would look like `a=`.)
     if (params.length == 0) {
       flatParams.add(new Parameter(keyPrefix, ""));

--- a/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
+++ b/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
@@ -64,7 +64,7 @@ public class LiveStripeResponseGetterTest {
     params.put("a", "b");
     params.put("c", "d");
 
-    assertEquals("nested[]=A&nested[]=B&nested[]=C&a=b&c=d",
+    assertEquals("nested[0]=A&nested[1]=B&nested[2]=C&a=b&c=d",
         LiveStripeResponseGetter.createQuery(params));
   }
 
@@ -80,7 +80,7 @@ public class LiveStripeResponseGetterTest {
     params.put("a", "b");
     params.put("c", "d");
 
-    assertEquals("nested[]=A&nested[]=B&nested[]=C&a=b&c=d",
+    assertEquals("nested[0]=A&nested[1]=B&nested[2]=C&a=b&c=d",
         LiveStripeResponseGetter.createQuery(params));
   }
 
@@ -103,7 +103,7 @@ public class LiveStripeResponseGetterTest {
     final Map<String, Object> params = new LinkedHashMap<String, Object>();
     params.put("nested", nested);
 
-    assertEquals("nested[][A]=A-1&nested[][B]=B-1&nested[][A]=A-2&nested[][B]=B-2",
+    assertEquals("nested[0][A]=A-1&nested[0][B]=B-1&nested[1][A]=A-2&nested[1][B]=B-2",
         LiveStripeResponseGetter.createQuery(params));
   }
 
@@ -144,7 +144,7 @@ public class LiveStripeResponseGetterTest {
     final Map<String, Object> params = new HashMap<String, Object>();
     params.put("legal_entity", legalEntityParams);
 
-    assertEquals("legal_entity[additional_owners][][first_name]=Stripe",
+    assertEquals("legal_entity[additional_owners][0][first_name]=Stripe",
         LiveStripeResponseGetter.createQuery(params));
   }
 


### PR DESCRIPTION
Consider the following Java snippet using the Stripe java SDK:
```java
final Map<String, Object> params=newLinkedHashMap<String, Object>();
finalMap<String, Object> legal_entity=newLinkedHashMap<String, Object>();
finalList<Map> additional_owners=newArrayList<Map>();
finalMap<String, Object> owner_0=newLinkedHashMap<String, Object>();

owner_0.put("first_name", "FirstOwner"); finalMap<String, Object> owner_0_address=newLinkedHashMap<String, Object>();
owner_0_address.put("line1", "First Owner Address"); 

finalMap<String, Object> owner_1=newLinkedHashMap<String, Object>();
owner_1.put("first_name", "SecondOwner");
finalMap<String, Object> owner_1_address=newLinkedHashMap<String, Object>(); owner_1_address.put("line1", "Second Owner Address");

params.put("legal_entity", legal_entity);
legal_entity.put("additional_owners", additional_owners);
owner_0.put("address", owner_0_address);
owner_1.put("address", owner_1_address);
additional_owners.add(owner_0);
additional_owners.add(owner_1);

System.out.println(LiveStripeResponseGetter.createQuery(params))
```

This code outputs the url query parameters:

```
legal_entity[additional_owners][][first_name]=FirstOwner&legal_entity[additional_owners][][address][line1]=First+Owner+Address&legal_entity[additional_owners][][first_name]=SecondOwner&legal_entity[additional_owners][][address][line1]=Second+Owner+Address
```

When in actuality Stripe's API cannot interpret the hashes within the array elements correctly without index numbers assigned to each empty `[]`. Instead with this PR the output looks like:

```
legal_entity[additional_owners][0][first_name]=FirstOwner&legal_entity[additional_owners][0][address][line1]=First+Owner+Address&legal_entity[additional_owners][1][first_name]=SecondOwner&legal_entity[additional_owners][1][address][line1]=Second+Owner+Address
```

I've modified the existing tests to accommodate for this change however new tests do not seem to be required.