### PR TITLE
Update attributes for Account and LegalEntity

### DIFF
--- a/src/main/java/com/stripe/model/Account.java
+++ b/src/main/java/com/stripe/model/Account.java
@@ -27,16 +27,18 @@ public class Account extends ApiResource implements HasId, MetadataStore<Account
   Boolean debitNegativeBalances;
   DeclineChargeOn declineChargeOn;
   String defaultCurrency;
+  Boolean deleted;
   Boolean detailsSubmitted;
   String displayName;
-  LoginLinkCollection loginLinks;
   String email;
   ExternalAccountCollection externalAccounts;
   Keys keys;
   LegalEntity legalEntity;
+  LoginLinkCollection loginLinks;
   @Getter(onMethod = @__({@Override})) Map<String, String> metadata;
-  Boolean payoutsEnabled;
   PayoutSchedule payoutSchedule;
+  String payoutStatementDescriptor;
+  Boolean payoutsEnabled;
   String productDescription;
   String statementDescriptor;
   String supportEmail;
@@ -44,11 +46,19 @@ public class Account extends ApiResource implements HasId, MetadataStore<Account
   String supportUrl;
   String timezone;
   TosAcceptance tosAcceptance;
-  TransferSchedule transferSchedule;
   Boolean transfersEnabled;
   String type;
   Verification verification;
-  Boolean deleted;
+
+  /**
+   * The {@code currencies_supported} attribute.
+   *
+   * @deprecated Prefer using the {@link CountrySpec#getSupportedPaymentCurrencies()} method
+   *     instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2016-03-07">API version 2016-03-07</a>
+   */
+  @Deprecated
+  List<String> currenciesSupported;
 
   /**
    * The {@code managed} attribute.
@@ -60,14 +70,13 @@ public class Account extends ApiResource implements HasId, MetadataStore<Account
   Boolean managed;
 
   /**
-   * The {@code currencies_supported} attribute.
+   * The {@code transfer_schedule} attribute.
    *
-   * @deprecated Prefer using the {@link CountrySpec#getSupportedPaymentCurrencies()} method
-   *     instead.
-   * @see <a href="https://stripe.com/docs/upgrades#2016-03-07">API version 2016-03-07</a>
+   * @deprecated Prefer using the {@link #payoutSchedule} attribute instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2017-04-06">API version 2017-04-06</a>
    */
   @Deprecated
-  List<String> currenciesSupported;
+  TransferSchedule transferSchedule;
 
   // <editor-fold desc="create">
   /**

--- a/src/main/java/com/stripe/model/LegalEntity.java
+++ b/src/main/java/com/stripe/model/LegalEntity.java
@@ -14,14 +14,29 @@ import lombok.Setter;
 public class LegalEntity extends StripeObject {
   List<Owner> additionalOwners;
   Address address;
+  JapanAddress addressKana;
+  JapanAddress addressKanji;
   String businessName;
+  String businessNameKana;
+  String businessNameKanji;
   Boolean businessTaxIdProvided;
+  Boolean businessVatIdProvided;
   DateOfBirth dob;
   String firstName;
+  String firstNameKana;
+  String firstNameKanji;
+  String gender;
   String lastName;
+  String lastNameKana;
+  String lastNameKanji;
+  String maidenName;
   Address personalAddress;
+  JapanAddress personalAddressKana;
+  JapanAddress personalAddressKanji;
   Boolean personalIdNumberProvided;
+  String phoneNumber;
   @SerializedName("ssn_last_4_provided") Boolean ssnLast4Provided;
+  String taxIdRegistrar;
   String type;
   Verification verification;
 
@@ -37,12 +52,14 @@ public class LegalEntity extends StripeObject {
   @Getter
   @Setter
   @EqualsAndHashCode(callSuper = false)
-  public static class Verification extends StripeObject {
-    String details;
-    String detailsCode;
-    String document;
-    String documentBack;
-    String status;
+  public static class JapanAddress extends StripeObject {
+    String city;
+    String country;
+    String line1;
+    String line2;
+    String postalCode;
+    String state;
+    String town;
   }
 
   @Getter
@@ -53,6 +70,19 @@ public class LegalEntity extends StripeObject {
     DateOfBirth dob;
     String firstName;
     String lastName;
+    String maidenName;
+    Boolean personalIdNumberProvided;
     Verification verification;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class Verification extends StripeObject {
+    String details;
+    String detailsCode;
+    String document;
+    String documentBack;
+    String status;
   }
 }


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries @scherr-stripe 

Updates attributes for the `Account` and `LegalEntity` classes. A lot of attributes were missing, particularly the Japan-specific ones.
