### PR TITLE
Add no-parameter Topup.cancel()

### DIFF
--- a/src/main/java/com/stripe/model/Topup.java
+++ b/src/main/java/com/stripe/model/Topup.java
@@ -54,6 +54,13 @@ public class Topup extends ApiResource implements MetadataStore<Topup>, HasId {
   /**
    * Cancel a topup.
    */
+  public Topup cancel() throws StripeException {
+    return cancel(null, null);
+  }
+
+  /**
+   * Cancel a topup.
+   */
   public Topup cancel(Map<String, Object> params) throws StripeException {
     return cancel(params, null);
   }

--- a/src/test/java/com/stripe/functional/TopupTest.java
+++ b/src/test/java/com/stripe/functional/TopupTest.java
@@ -39,6 +39,20 @@ public class TopupTest extends BaseStripeTest {
   }
 
   @Test
+  public void testCancelEmpty() throws StripeException {
+    final Topup topup = getTopupFixture();
+
+    final Topup canceledTopup = topup.cancel();
+
+    assertNotNull(canceledTopup);
+    verifyRequest(
+            ApiResource.RequestMethod.POST,
+            String.format("/v1/topups/%s/cancel", topup.getId()),
+            null
+    );
+  }
+
+  @Test
   public void testCreate() throws StripeException {
     final Map<String, Object> params = new HashMap<String, Object>();
     params.put("amount", 100);

--- a/src/test/java/com/stripe/functional/TopupTest.java
+++ b/src/test/java/com/stripe/functional/TopupTest.java
@@ -39,20 +39,6 @@ public class TopupTest extends BaseStripeTest {
   }
 
   @Test
-  public void testCancelEmpty() throws StripeException {
-    final Topup topup = getTopupFixture();
-
-    final Topup canceledTopup = topup.cancel();
-
-    assertNotNull(canceledTopup);
-    verifyRequest(
-            ApiResource.RequestMethod.POST,
-            String.format("/v1/topups/%s/cancel", topup.getId()),
-            null
-    );
-  }
-
-  @Test
   public void testCreate() throws StripeException {
     final Map<String, Object> params = new HashMap<String, Object>();
     params.put("amount", 100);


### PR DESCRIPTION
This adds a no-parameter version of `Topup.cancel()` — the one currently displayed in the docs: https://stripe.com/docs/api/java#cancel_topup