### PR TITLE
Add exchangeRate to BalanceTransaction

### DIFF
--- a/src/main/java/com/stripe/model/BalanceTransaction.java
+++ b/src/main/java/com/stripe/model/BalanceTransaction.java
@@ -5,6 +5,7 @@ import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 
@@ -24,6 +25,7 @@ public class BalanceTransaction extends ApiResource implements HasId {
   Long created;
   String currency;
   String description;
+  BigDecimal exchangeRate;
   Long fee;
   List<Fee> feeDetails;
   Long net;


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries

Adds support for the `exchange_rate` attribute on `balance_transaction` objects.
