### PR TITLE
Cleanup

### DIFF
--- a/src/main/java/com/stripe/model/RecipientCardCollection.java
+++ b/src/main/java/com/stripe/model/RecipientCardCollection.java
@@ -56,7 +56,6 @@ public class RecipientCardCollection extends StripeCollection<Card> {
    * Retrieve a recipient card.
    */
   public Card retrieve(String id, RequestOptions options) throws StripeException {
-    String url = String.format("%s%s/%s", Stripe.getApiBase(), this.getUrl(), id);
     return retrieve(id, null, options);
   }
 

--- a/src/main/java/com/stripe/model/TransferReversalCollection.java
+++ b/src/main/java/com/stripe/model/TransferReversalCollection.java
@@ -56,7 +56,6 @@ public class TransferReversalCollection extends StripeCollection<Reversal> {
    * Retrieve a reversal.
    */
   public Reversal retrieve(String id, RequestOptions options) throws StripeException {
-    String url = String.format("%s%s/%s", Stripe.getApiBase(), this.getUrl(), id);
     return retrieve(id, null, options);
   }
 

--- a/src/main/java/com/stripe/model/UsageRecordSummary.java
+++ b/src/main/java/com/stripe/model/UsageRecordSummary.java
@@ -2,8 +2,6 @@ package com.stripe.model;
 
 import com.stripe.net.ApiResource;
 
-import java.util.Map;
-
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/stripe/model/reporting/ReportRun.java
+++ b/src/main/java/com/stripe/model/reporting/ReportRun.java
@@ -1,18 +1,14 @@
 package com.stripe.model.reporting;
 
 import com.stripe.exception.StripeException;
-import com.stripe.model.ExpandableField;
 import com.stripe.model.FileUpload;
 import com.stripe.model.HasId;
-import com.stripe.model.MetadataStore;
 import com.stripe.model.StripeObject;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
-import java.util.List;
 import java.util.Map;
 
-import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/stripe/model/reporting/ReportType.java
+++ b/src/main/java/com/stripe/model/reporting/ReportType.java
@@ -1,18 +1,12 @@
 package com.stripe.model.reporting;
 
 import com.stripe.exception.StripeException;
-import com.stripe.model.ExpandableField;
-import com.stripe.model.FileUpload;
 import com.stripe.model.HasId;
-import com.stripe.model.MetadataStore;
-import com.stripe.model.StripeObject;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
-import java.util.List;
 import java.util.Map;
 
-import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -640,7 +640,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
             multipartProcessor.addFileField(key, currentFile.getName(),
                 new FileInputStream(currentFile));
           } else if (value instanceof InputStream) {
-            InputStream inputStream = (InputStream) value;
+            @Cleanup InputStream inputStream = (InputStream) value;
             if (inputStream.available() == 0) {
               throw new InvalidRequestException(
                 "Must have available bytes to read on InputStream for key "

--- a/src/main/java/com/stripe/net/MultipartProcessor.java
+++ b/src/main/java/com/stripe/net/MultipartProcessor.java
@@ -8,8 +8,6 @@ import java.io.PrintWriter;
 import java.net.URLConnection;
 import java.util.Random;
 
-import lombok.Cleanup;
-
 public class MultipartProcessor {
   private final String boundary;
   private static final String LINE_BREAK = "\r\n";

--- a/src/test/java/com/stripe/functional/sigma/ScheduledQueryRunTest.java
+++ b/src/test/java/com/stripe/functional/sigma/ScheduledQueryRunTest.java
@@ -9,9 +9,7 @@ import com.stripe.model.sigma.ScheduledQueryRunCollection;
 import com.stripe.net.ApiResource;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;

--- a/src/test/java/com/stripe/model/UsageRecordSummaryTest.java
+++ b/src/test/java/com/stripe/model/UsageRecordSummaryTest.java
@@ -4,10 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import com.stripe.BaseStripeTest;
-import com.stripe.model.UsageRecordSummaryCollection;
 import com.stripe.net.ApiResource;
-
-import java.util.Map;
 
 import org.junit.Test;
 


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Minor cleanup:
- removed unused imports and variables
- fixed a case where a stream could potentially not be closed with Lombok's `@Cleanup` annotation
