### PR TITLE
Compatibility with latest API version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
 
 env:
   global:
-  - STRIPE_MOCK_VERSION=0.30.0
+  - STRIPE_MOCK_VERSION=0.32.0
 
 matrix:
   include:

--- a/src/main/java/com/stripe/model/Coupon.java
+++ b/src/main/java/com/stripe/model/Coupon.java
@@ -4,6 +4,7 @@ import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
+import java.math.BigDecimal;
 import java.util.Map;
 
 import lombok.EqualsAndHashCode;
@@ -19,17 +20,27 @@ public class Coupon extends ApiResource implements MetadataStore<Coupon>, HasId 
   Long amountOff;
   Long created;
   String currency;
+  Boolean deleted;
   String duration;
   Long durationInMonths;
   Boolean livemode;
   Long maxRedemptions;
   @Getter(onMethod = @__({@Override})) Map<String, String> metadata;
   String name;
-  Long percentOff;
+  BigDecimal percentOff;
   Long redeemBy;
   Long timesRedeemed;
   Boolean valid;
-  Boolean deleted;
+
+  /**
+   * The {@code percent_off_precise} attribute.
+   *
+   * @return the {@code percent_off_precise} attribute
+   * @deprecated Prefer using the {@link #percentOff} attribute instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2018-07-27">API version 2018-07-27</a>
+   */
+  @Deprecated
+  BigDecimal percentOffPrecise;
 
   // <editor-fold desc="create">
   /**

--- a/src/main/java/com/stripe/model/issuing/Dispute.java
+++ b/src/main/java/com/stripe/model/issuing/Dispute.java
@@ -23,29 +23,30 @@ public class Dispute extends ApiResource implements MetadataStore<Dispute>, HasI
   String object;
   Long amount;
   Long created;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+    ExpandableField<Transaction> disputedTransaction;
   Evidence evidence;
   Boolean livemode;
   @Getter(onMethod = @__({@Override})) Map<String, String> metadata;
   String reason;
   String status;
-  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
-    ExpandableField<Transaction> transaction;
 
   // <editor-fold desc="transaction">
-  public String getTransaction() {
-    return (this.transaction != null) ? this.transaction.getId() : null;
+  public String getDisputedTransaction() {
+    return (this.disputedTransaction != null) ? this.disputedTransaction.getId() : null;
   }
 
-  public void setTransaction(String transactionId) {
-    this.transaction = setExpandableFieldId(transactionId, this.transaction);
+  public void setDisputedTransaction(String disputedTransactionId) {
+    this.disputedTransaction = setExpandableFieldId(disputedTransactionId,
+        this.disputedTransaction);
   }
 
-  public Transaction getTransactionObject() {
-    return (this.transaction != null) ? this.transaction.getExpanded() : null;
+  public Transaction getDisputedTransactionObject() {
+    return (this.disputedTransaction != null) ? this.disputedTransaction.getExpanded() : null;
   }
 
-  public void setTransactionObject(Transaction c) {
-    this.transaction = new ExpandableField<Transaction>(c.getId(), c);
+  public void setDisputedTransactionObject(Transaction c) {
+    this.disputedTransaction = new ExpandableField<Transaction>(c.getId(), c);
   }
   // </editor-fold>
 

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -37,7 +37,7 @@ import org.mockito.Mockito;
 
 public class BaseStripeTest {
   // If changing this number, please also change it in `.travis.yml`.
-  private static final String MOCK_MINIMUM_VERSION = "0.30.0";
+  private static final String MOCK_MINIMUM_VERSION = "0.32.0";
 
   private static String port;
 

--- a/src/test/java/com/stripe/functional/issuing/DisputeTest.java
+++ b/src/test/java/com/stripe/functional/issuing/DisputeTest.java
@@ -22,7 +22,7 @@ public class DisputeTest extends BaseStripeTest {
   public void testCreate() throws IOException, StripeException {
     final Map<String, Object> params = new HashMap<String, Object>();
     params.put("reason", "fraudulent");
-    params.put("transaction", "ipi_123");
+    params.put("disputed_transaction", "ipi_123");
 
     final Dispute dispute = Dispute.create(params);
 

--- a/src/test/java/com/stripe/model/issuing/DisputeTest.java
+++ b/src/test/java/com/stripe/model/issuing/DisputeTest.java
@@ -22,7 +22,7 @@ public class DisputeTest extends BaseStripeTest {
   @Test
   public void testDeserializeWithExpansions() throws Exception {
     final String[] expansions = {
-      "transaction",
+      "disputed_transaction",
     };
     final String data = getFixture("/v1/issuing/disputes/idp_123", expansions);
     final Dispute dispute = ApiResource.GSON.fromJson(data, Dispute.class);
@@ -31,9 +31,9 @@ public class DisputeTest extends BaseStripeTest {
     assertNotNull(dispute.getId());
     assertEquals("issuing.dispute", dispute.getObject());
 
-    final Transaction transaction = dispute.getTransactionObject();
-    assertNotNull(transaction);
-    assertNotNull(transaction.getId());
-    assertEquals(dispute.getTransaction(), transaction.getId());
+    final Transaction disputedTransaction = dispute.getDisputedTransactionObject();
+    assertNotNull(disputedTransaction);
+    assertNotNull(disputedTransaction.getId());
+    assertEquals(dispute.getDisputedTransaction(), disputedTransaction.getId());
   }
 }


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

The library is incompatible with the latest API version, because `percent_off` on coupons is now a float.

Fix this by changing the type of the `percentOff` attribute from `Long` to `BigDecimal`. For users on older API versions, they will simply get an integer value in the `BigDecimal` instance. They can access the exact value via the `percentOffPrecise` attribute.

Also, it looks like the `transaction` attribute on issuing dispute objects was renamed to `disputed_transaction`, so fix that as well.

Unfortunately, changing the type of `percentOff` is a breaking change, but I was going to release #593 which also breaks BC anyway. I set the target branch for this PR to `integration-v7` so that we can release both changes at once.
