### PR TITLE
Start testing Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ addons:
   hostname: short-hostname
 
 before_install:
-  # Install script for missing JDKs
-  - wget https://github.com/sormuras/bach/raw/master/install-jdk.sh
   # Work around missing crypto in openjdk7
   - |
     if [ "$TRAVIS_JDK_VERSION" == "openjdk7" ]; then
@@ -34,24 +32,20 @@ env:
 
 matrix:
   include:
-# 7
-    - env: JDK='OpenJDK 7'
-      jdk: openjdk7
-# 8
-    - env: JDK='Oracle JDK 8'
-      jdk: oraclejdk8
-    - env: JDK='OpenJDK 8'
-      jdk: openjdk8
-# 9
-    - env: JDK='Oracle JDK 9'
-      jdk: oraclejdk9
-    - env: JDK='OpenJDK 9'
-      install: . ./install-jdk.sh -F 9 -L GPL
-# 10
-    - env: JDK='Oracle JDK 10'
-      install: . ./install-jdk.sh -F 10 -L BCL
-    - env: JDK='OpenJDK 10'
-      install: . ./install-jdk.sh -F 10 -L GPL
+    - jdk: openjdk7
+    - jdk: oraclejdk8
+    - jdk: openjdk8
+    - jdk: oraclejdk9
+    - jdk: openjdk9
+    - jdk: oraclejdk10
+    - jdk: openjdk10
+    - jdk: oraclejdk11
+    - jdk: openjdk11
+    - jdk: oraclejdk-ea
+    - jdk: openjdk-ea
+  allow_failures:
+    - jdk: oraclejdk-ea
+    - jdk: openjdk-ea
 
 notifications:
   email:
@@ -61,7 +55,7 @@ script:
   - ./gradlew --version
   - ./gradlew clean
   - if [ "$TRAVIS_JDK_VERSION" == "oraclejdk9" ]; then ./gradlew check; fi
-  - ./gradlew cobertura coveralls
+  - ./gradlew -Djdk.tls.client.protocols="TLSv1.2" cobertura coveralls
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Java 11 was released today. It's a LTS version too, so people are likely to adopt it. Let's start testing it right now :)

Travis now supports all JDKs, so I was able to remove the custom script we used to install missing JDKs.

I also added EA (Early Access) JDKs to the build matrix, with failures allowed, to help add support for future versions.
