### PR TITLE
logging friendly client-user-agent header

### DIFF
--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -125,29 +125,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 
     headers.put("Authorization", String.format("Bearer %s", options.getApiKey()));
 
-    // debug headers
-    String[] propertyNames = {"os.name", "os.version", "os.arch",
-        "java.version", "java.vendor", "java.vm.version",
-        "java.vm.vendor"};
-    Map<String, String> propertyMap = new HashMap<String, String>();
-    for (String propertyName : propertyNames) {
-      propertyMap.put(propertyName, System.getProperty(propertyName));
-    }
-    propertyMap.put("bindings.version", Stripe.VERSION);
-    propertyMap.put("lang", "Java");
-    propertyMap.put("publisher", "Stripe");
-
-    Set<String> propertyKeySet = new HashSet<>(propertyMap.keySet());
-    for (String propertyKey: propertyKeySet) {
-      String property = propertyMap.get(propertyKey);
-      propertyMap.put(propertyKey.replace('.', '_'), property);
-      propertyMap.remove(propertyKey);
-    }
-
-    if (Stripe.getAppInfo() != null) {
-      propertyMap.put("application", ApiResource.GSON.toJson(Stripe.getAppInfo()));
-    }
-    headers.put("X-Stripe-Client-User-Agent", ApiResource.GSON.toJson(propertyMap));
+    headers.put("X-Stripe-Client-User-Agent", ApiResource.GSON.toJson(buildClientUserAgentMap()));
     if (options.getStripeVersion() != null) {
       headers.put("Stripe-Version", options.getStripeVersion());
     }
@@ -158,6 +136,34 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
       headers.put("Stripe-Account", options.getStripeAccount());
     }
     return headers;
+  }
+
+  private static Map<String, String> buildClientUserAgentMap() {
+    String[] propertyNames = {"os.name", "os.version", "os.arch",
+            "java.version", "java.vendor", "java.vm.version",
+            "java.vm.vendor"};
+    Map<String, String> clientUserAgentMap = new HashMap<>();
+    for (String propertyName : propertyNames) {
+      clientUserAgentMap.put(propertyName, System.getProperty(propertyName));
+    }
+
+    clientUserAgentMap.put("bindings.version", Stripe.VERSION);
+    clientUserAgentMap.put("lang", "Java");
+    clientUserAgentMap.put("publisher", "Stripe");
+    if (Stripe.getAppInfo() != null) {
+      clientUserAgentMap.put("application", ApiResource.GSON.toJson(Stripe.getAppInfo()));
+    }
+
+    // Format keys to be friendly for log analysis and consistent with other client libraries
+    // key containing '.' is considered nested, but that's not the case here, so we are replacing it with '_'
+    Set<String> keySet = new HashSet<>(clientUserAgentMap.keySet());
+    for (String key: keySet) {
+      String value = clientUserAgentMap.get(key);
+      clientUserAgentMap.remove(key);
+      String formattedKey = key.replace('.', '_');
+      clientUserAgentMap.put(formattedKey, value);
+    }
+    return clientUserAgentMap;
   }
 
   @SuppressWarnings("unchecked")

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -139,9 +139,8 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
   }
 
   private static Map<String, String> buildClientUserAgentMap() {
-    String[] propertyNames = {"os.name", "os.version", "os.arch",
-            "java.version", "java.vendor", "java.vm.version",
-            "java.vm.vendor"};
+    String[] propertyNames = {"os.name", "os.version", "os.arch", "java.version", "java.vendor",
+      "java.vm.version", "java.vm.vendor"};
     Map<String, String> clientUserAgentMap = new HashMap<>();
     for (String propertyName : propertyNames) {
       clientUserAgentMap.put(propertyName, System.getProperty(propertyName));
@@ -155,7 +154,8 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
     }
 
     // Format keys to be friendly for log analysis and consistent with other client libraries
-    // Key containing '.' is considered nested in Splunk, but that's not the case here, so we are replacing it with '_'
+    // Key containing '.' is considered nested in Splunk, but that's not the case here,
+    // so we are replacing it with '_'
     Set<String> keySet = new HashSet<>(clientUserAgentMap.keySet());
     for (String key: keySet) {
       String value = clientUserAgentMap.get(key);

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -155,7 +155,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
     }
 
     // Format keys to be friendly for log analysis and consistent with other client libraries
-    // key containing '.' is considered nested, but that's not the case here, so we are replacing it with '_'
+    // Key containing '.' is considered nested in Splunk, but that's not the case here, so we are replacing it with '_'
     Set<String> keySet = new HashSet<>(clientUserAgentMap.keySet());
     for (String key: keySet) {
       String value = clientUserAgentMap.get(key);

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -36,11 +36,13 @@ import java.net.URLStreamHandler;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.Scanner;
+import java.util.Set;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
 
@@ -134,6 +136,14 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
     propertyMap.put("bindings.version", Stripe.VERSION);
     propertyMap.put("lang", "Java");
     propertyMap.put("publisher", "Stripe");
+
+    Set<String> propertyKeySet = new HashSet<>(propertyMap.keySet());
+    for (String propertyKey: propertyKeySet) {
+      String property = propertyMap.get(propertyKey);
+      propertyMap.put(propertyKey.replace('.', '_'), property);
+      propertyMap.remove(propertyKey);
+    }
+
     if (Stripe.getAppInfo() != null) {
       propertyMap.put("application", ApiResource.GSON.toJson(Stripe.getAppInfo()));
     }

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -159,8 +159,8 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
     Set<String> keySet = new HashSet<>(clientUserAgentMap.keySet());
     for (String key: keySet) {
       String value = clientUserAgentMap.get(key);
-      clientUserAgentMap.remove(key);
       String formattedKey = key.replace('.', '_');
+      clientUserAgentMap.remove(key);
       clientUserAgentMap.put(formattedKey, value);
     }
     return clientUserAgentMap;

--- a/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
+++ b/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
@@ -1,5 +1,6 @@
 package com.stripe.net;
 
+import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -8,8 +9,6 @@ import com.google.gson.reflect.TypeToken;
 
 import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
-import com.stripe.net.LiveStripeResponseGetter;
-import com.stripe.net.RequestOptions;
 import com.stripe.net.RequestOptions.RequestOptionsBuilder;
 
 import java.io.UnsupportedEncodingException;
@@ -190,5 +189,18 @@ public class LiveStripeResponseGetterTest {
     assertEquals("MyAwesomePlugin", appMap.get("name"));
     assertEquals("1.2.34", appMap.get("version"));
     assertEquals("https://myawesomeplugin.info", appMap.get("url"));
+  }
+
+  @Test
+  public void testXStripeClientUserAgent() {
+    final RequestOptions options = (new RequestOptionsBuilder()).setApiKey("sk_foobar").build();
+
+    final Map<String, String> headers = LiveStripeResponseGetter.getHeaders(options);
+    final Map<String, String> uaMap = new Gson().fromJson(headers.get("X-Stripe-Client-User-Agent"),
+            new TypeToken<Map<String, String>>() {}.getType());
+
+    for (Map.Entry<String, String> entry : uaMap.entrySet()) {
+      assertTrue("Header key contains unexpected '.'", !entry.getKey().contains("."));
+    }
   }
 }

--- a/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
+++ b/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
@@ -201,6 +201,21 @@ public class LiveStripeResponseGetterTest {
 
     for (Map.Entry<String, String> entry : uaMap.entrySet()) {
       assertTrue("Header key contains unexpected '.'", !entry.getKey().contains("."));
+      assertTrue("Header value should not be empty", entry.getValue() != null);
     }
+
+    // properties common to other stripe client libraries
+    assertTrue(uaMap.containsKey("bindings_version"));
+    assertTrue(uaMap.containsKey("lang"));
+    assertTrue(uaMap.containsKey("publisher"));
+
+    // properties specific to java-client
+    assertTrue(uaMap.containsKey("java_version"));
+    assertTrue(uaMap.containsKey("java_vendor"));
+    assertTrue(uaMap.containsKey("java_vm_version"));
+    assertTrue(uaMap.containsKey("java_vm_vendor"));
+    assertTrue(uaMap.containsKey("os_name"));
+    assertTrue(uaMap.containsKey("os_version"));
+    assertTrue(uaMap.containsKey("os_arch"));
   }
 }


### PR DESCRIPTION
- Format client-user-agent key to be friendly for logging analysis
- This is consistent with other language bindings
  - dotnet https://github.com/stripe/stripe-dotnet/blob/5b6a010515e94cd72f6bef4659350922f023d2cf/src/Stripe.net/Infrastructure/Client.cs#L38
  - ruby https://github.com/stripe/stripe-ruby/blob/156145b96b3f3196c9c14a5c0401fea3458413df/lib/stripe/stripe_client.rb#L586

r? @remi-stripe @stripe/api-libraries 