### PR TITLE
Adds support for 'partner_id' to 'setAppInfo'

### DIFF
--- a/src/main/java/com/stripe/Stripe.java
+++ b/src/main/java/com/stripe/Stripe.java
@@ -18,6 +18,7 @@ public abstract class Stripe {
   public static volatile String apiKey;
   public static volatile String apiVersion;
   public static volatile String clientId;
+  public static volatile String partnerId;
 
   // Note that URLConnection reserves the value of 0 to mean "infinite
   // timeout", so we use -1 here to represent an unset value which should
@@ -146,11 +147,15 @@ public abstract class Stripe {
   }
 
   public static void setAppInfo(String name) {
-    setAppInfo(name, null, null);
+    setAppInfo(name, null, null, null);
   }
 
   public static void setAppInfo(String name, String version) {
-    setAppInfo(name, version, null);
+    setAppInfo(name, version, null, null);
+  }
+
+  public static void setAppInfo(String name, String version, String url) {
+    setAppInfo(name, version, url, null);
   }
 
   /**
@@ -159,8 +164,9 @@ public abstract class Stripe {
    * @param name Name of your application (e.g. "MyAwesomeApp")
    * @param version Version of your application (e.g. "1.2.34")
    * @param url Website for your application (e.g. "https://myawesomeapp.info")
+   * @param partnerId Your Stripe Partner ID (e.g. "pp_partner_1234")
    */
-  public static void setAppInfo(String name, String version, String url) {
+  public static void setAppInfo(String name, String version, String url, String partnerId) {
     if (appInfo == null) {
       appInfo = new HashMap<String, String>();
     }
@@ -168,6 +174,7 @@ public abstract class Stripe {
     appInfo.put("name", name);
     appInfo.put("version", version);
     appInfo.put("url", url);
+    appInfo.put("partner_id", partnerId);
   }
 
   public static Map<String, String> getAppInfo() {

--- a/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
+++ b/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
@@ -170,7 +170,7 @@ public class LiveStripeResponseGetterTest {
   public void testAppInfo() {
     final RequestOptions options = (new RequestOptionsBuilder()).setApiKey("sk_foobar").build();
 
-    Stripe.setAppInfo("MyAwesomePlugin", "1.2.34", "https://myawesomeplugin.info");
+    Stripe.setAppInfo("MyAwesomePlugin", "1.2.34", "https://myawesomeplugin.info", "pp_partner_1234");
 
     final Map<String, String> headers = LiveStripeResponseGetter.getHeaders(options);
 
@@ -190,5 +190,6 @@ public class LiveStripeResponseGetterTest {
     assertEquals("MyAwesomePlugin", appMap.get("name"));
     assertEquals("1.2.34", appMap.get("version"));
     assertEquals("https://myawesomeplugin.info", appMap.get("url"));
+    assertEquals("pp_partner_1234", appMap.get("partner_id"));
   }
 }


### PR DESCRIPTION
This adds support for the `partner_id` parameter in the `setAppInfo` API for use by participants in the Stripe Partner Program. Similar patches landed in the other Stripe API client libraries, but I didn't add support for Java at that time because the Stripe docs seemed to indicate that SetAppInfo wasn't supported in Java.
I will also be updating the Stripe docs at https://stripe.com/docs/building-plugins#setappinfo to show how to use this part of the Java bindings.