### PR TITLE
Stop testing oraclejdk10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ matrix:
     - jdk: openjdk8
     - jdk: oraclejdk9
     - jdk: openjdk9
-    - jdk: oraclejdk10
     - jdk: openjdk10
     - jdk: oraclejdk11
     - jdk: openjdk11


### PR DESCRIPTION
cc @stripe/api-libraries 

Stop testing OracleJDK 10. The download no longer works as the version is deprecated.