### PR TITLE
Fix changelog to remove bad release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## 4.11.0 - 2018-11-07
-* [#610](https://github.com/stripe/stripe-java/pull/610) Add support for `flat_amount` on `Plan` tiers.
-* [#611](https://github.com/stripe/stripe-java/pull/611) Add support for `supported_transfer_countries` on `CountrySpec` and `support_address` on `Account`.
-
 ## 7.2.0 - 2018-10-31
 * [#603](https://github.com/stripe/stripe-java/pull/603) Add support for the `Person` resource
 * [#606](https://github.com/stripe/stripe-java/pull/606) Add support for the `WebhookEndpoint` resource


### PR DESCRIPTION
Remove 4.11.0 from the release in the changelog since this was the wrong number.