### PR TITLE
Add support for `last_payment_error` for PaymentIntent

### DIFF
--- a/src/main/java/com/stripe/model/PaymentIntent.java
+++ b/src/main/java/com/stripe/model/PaymentIntent.java
@@ -33,6 +33,7 @@ public class PaymentIntent extends ApiResource implements MetadataStore<PaymentI
   Long created;
   String currency;
   @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Customer> customer;
+  PaymentIntentLastPaymentError lastPaymentError;
   Boolean livemode;
   @Getter(onMethod = @__({@Override})) Map<String, String> metadata;
   PaymentIntentSourceAction nextSourceAction;

--- a/src/main/java/com/stripe/model/PaymentIntentLastPaymentError.java
+++ b/src/main/java/com/stripe/model/PaymentIntentLastPaymentError.java
@@ -1,0 +1,19 @@
+package com.stripe.model;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
+public final class PaymentIntentLastPaymentError extends StripeObject {
+  String charge;
+  String code;
+  String declineCode;
+  String docUrl;
+  String message;
+  String param;
+  ExternalAccount source;
+  String type;
+}

--- a/src/test/java/com/stripe/model/PaymentIntentTest.java
+++ b/src/test/java/com/stripe/model/PaymentIntentTest.java
@@ -27,6 +27,25 @@ public class PaymentIntentTest extends BaseStripeTest {
     assertEquals("https://stripe.com/return", actionAuthorize.getReturnUrl());
   }
 
+  @Test
+  public void testDeserializeLastPaymentError() throws Exception {
+    final PaymentIntent resource = ApiResource.GSON.fromJson(
+        getResourceAsString("/api_fixtures/payment_intent_last_payment_error.json"),
+        PaymentIntent.class);
+    assertNotNull(resource);
+    assertNotNull(resource.getId());
+
+    PaymentIntentLastPaymentError error =  resource.getLastPaymentError();
+    assertNotNull(error);
+
+    assertEquals("ch_123", error.getCharge());
+    assertEquals("generic_decline", error.getDeclineCode());
+
+    final ExternalAccount source = error.getSource();
+    assertNotNull(source);
+    assertNotNull(source.getId());
+  }
+
   // Ensure legacy version of `next_source_action` with `value` still works
   @Test
   public void testDeserializeSourceActionValue() throws Exception {

--- a/src/test/resources/api_fixtures/payment_intent_last_payment_error.json
+++ b/src/test/resources/api_fixtures/payment_intent_last_payment_error.json
@@ -1,0 +1,64 @@
+{
+    "id": "pi_123",
+    "object": "payment_intent",
+    "allowed_source_types": [
+        "card"
+    ],
+    "amount": 100,
+    "amount_capturable": 0,
+    "amount_received": 0,
+    "application": null,
+    "application_fee_amount": null,
+    "canceled_at": null,
+    "cancellation_reason": null,
+    "capture_method": "automatic",
+    "charges": {
+        "object": "list",
+        "data": [
+            {
+                "id": "ch_123",
+                "object": "charge"
+            }
+        ],
+        "has_more": false,
+        "total_count": 1,
+        "url": "\/v1\/charges?payment_intent=pi_123"
+    },
+    "client_secret": null,
+    "confirmation_method": "publishable",
+    "created": 1541614878,
+    "currency": "eur",
+    "customer": "cus_DvnENrEbZJeIQE",
+    "description": "PaymentIntent Description",
+    "last_payment_error": {
+        "charge": "ch_123",
+        "code": "card_declined",
+        "decline_code": "generic_decline",
+        "doc_url": "https:\/\/stripe.com\/docs\/error-codes\/card-declined",
+        "message": "Your card was declined.",
+        "source": {
+            "id": "card_123",
+            "object": "card",
+            "brand": "Visa",
+            "country": "US",
+            "customer": "cus_123",
+            "exp_month": 9,
+            "exp_year": 2019,
+            "fingerprint": "fingerprint",
+            "last4": "0341"
+        },
+        "type": "card_error"
+    },
+    "livemode": false,
+    "next_source_action": null,
+    "on_behalf_of": null,
+    "receipt_email": null,
+    "return_url": null,
+    "review": null,
+    "shipping": null,
+    "source": null,
+    "statement_descriptor": null,
+    "status": "requires_source",
+    "transfer_data": null,
+    "transfer_group": null
+}


### PR DESCRIPTION
r? @ob-stripe 
cc @stripe/api-libraries @kelvin-stripe 