### PR TITLE
Add LGTM code quality badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Stripe Java Bindings [![Build Status](https://travis-ci.org/stripe/stripe-java.svg?branch=master)](https://travis-ci.org/stripe/stripe-java)
+[![Code Quality: Java](https://img.shields.io/lgtm/grade/java/g/stripe/stripe-java.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/stripe/stripe-java/context:java)
+[![Total Alerts](https://img.shields.io/lgtm/alerts/g/stripe/stripe-java.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/stripe/stripe-java/alerts)
 
 You can sign up for a Stripe account at https://stripe.com.
 


### PR DESCRIPTION
Hi there!

I thought you might be interested in adding these LGTM [code quality badges](https://lgtm.com/projects/g/stripe/stripe-java/ci/#badges) to your project. They indicate how you care about code quality and encourage your future contributors to do the same.
To get an idea of the analyses reflected by these grades, check the [alerts discovered by LGTM](https://lgtm.com/projects/g/stripe/stripe-java).

N.B.: I am on the team behind LGTM.com, I'd appreciate your feedback on this initiative, whether you're interested or not, if you find time to drop me a line. Thanks.
