### PR TITLE
Use primitive type for `signatureFound`

### DIFF
--- a/src/main/java/com/stripe/net/Webhook.java
+++ b/src/main/java/com/stripe/net/Webhook.java
@@ -92,7 +92,7 @@ public final class Webhook {
       }
 
       // Check if expected signature is found in list of header's signatures
-      Boolean signatureFound = false;
+      boolean signatureFound = false;
       for (String signature : signatures) {
         if (Util.secureCompare(expectedSignature, signature)) {
           signatureFound = true;


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

`signatureFound` can never be `null`, so there is no reason to use the boxed type `Boolean`.
