### PR TITLE
Add missing properties to Refund class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
 
 env:
   global:
-  - STRIPE_MOCK_VERSION=0.37.0
+  - STRIPE_MOCK_VERSION=0.38.0
 
 matrix:
   include:

--- a/src/main/java/com/stripe/model/Refund.java
+++ b/src/main/java/com/stripe/model/Refund.java
@@ -24,10 +24,16 @@ public class Refund extends ApiResource implements MetadataStore<Charge>, HasId 
   Long created;
   String currency;
   String description;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+      ExpandableField<BalanceTransaction> failureBalanceTransaction;
+  String failureReason;
   @Getter(onMethod = @__({@Override})) Map<String, String> metadata;
   String reason;
   String receiptNumber;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+      ExpandableField<Reversal> sourceTransferReversal;
   String status;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Reversal> transferReversal;
 
   // <editor-fold desc="balanceTransaction">
   public String getBalanceTransaction() {
@@ -62,6 +68,63 @@ public class Refund extends ApiResource implements MetadataStore<Charge>, HasId 
 
   public void setChargeObject(Charge c) {
     this.charge = new ExpandableField<Charge>(c.getId(), c);
+  }
+  // </editor-fold>
+
+  // <editor-fold desc="failureBalanceTransaction">
+  public String getFailureBalanceTransaction() {
+    return (this.failureBalanceTransaction != null) ? this.failureBalanceTransaction.getId() : null;
+  }
+
+  public void setFailureBalanceTransaction(String failureBalanceTransactionId) {
+    this.failureBalanceTransaction = setExpandableFieldId(failureBalanceTransactionId,
+        this.failureBalanceTransaction);
+  }
+
+  public BalanceTransaction getFailureBalanceTransactionObject() {
+    return (this.failureBalanceTransaction != null)
+        ? this.failureBalanceTransaction.getExpanded() : null;
+  }
+
+  public void setFailureBalanceTransactionObject(BalanceTransaction c) {
+    this.failureBalanceTransaction = new ExpandableField<BalanceTransaction>(c.getId(), c);
+  }
+  // </editor-fold>
+
+  // <editor-fold desc="sourceTransferReversal">
+  public String getSourceTransferReversal() {
+    return (this.sourceTransferReversal != null) ? this.sourceTransferReversal.getId() : null;
+  }
+
+  public void setSourceTransferReversal(String sourceTransferReversalId) {
+    this.sourceTransferReversal = setExpandableFieldId(sourceTransferReversalId,
+        this.sourceTransferReversal);
+  }
+
+  public Reversal getSourceTransferReversalObject() {
+    return (this.sourceTransferReversal != null) ? this.sourceTransferReversal.getExpanded() : null;
+  }
+
+  public void setSourceTransferReversalObject(Reversal c) {
+    this.sourceTransferReversal = new ExpandableField<Reversal>(c.getId(), c);
+  }
+  // </editor-fold>
+
+  // <editor-fold desc="transferReversal">
+  public String getTransferReversal() {
+    return (this.transferReversal != null) ? this.transferReversal.getId() : null;
+  }
+
+  public void setTransferReversal(String transferReversalId) {
+    this.transferReversal = setExpandableFieldId(transferReversalId, this.transferReversal);
+  }
+
+  public Reversal getTransferReversalObject() {
+    return (this.transferReversal != null) ? this.transferReversal.getExpanded() : null;
+  }
+
+  public void setTransferReversalObject(Reversal c) {
+    this.transferReversal = new ExpandableField<Reversal>(c.getId(), c);
   }
   // </editor-fold>
 

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -37,7 +37,7 @@ import org.mockito.Mockito;
 
 public class BaseStripeTest {
   // If changing this number, please also change it in `.travis.yml`.
-  private static final String MOCK_MINIMUM_VERSION = "0.37.0";
+  private static final String MOCK_MINIMUM_VERSION = "0.38.0";
 
   private static String port;
 

--- a/src/test/java/com/stripe/model/RefundTest.java
+++ b/src/test/java/com/stripe/model/RefundTest.java
@@ -18,4 +18,39 @@ public class RefundTest extends BaseStripeTest {
     assertNotNull(refund.getId());
     assertEquals("refund", refund.getObject());
   }
+
+  @Test
+  public void testDeserializeWithExpansions() throws Exception {
+    final String[] expansions = {
+      "balance_transaction",
+      "charge",
+      "failure_balance_transaction",
+      "source_transfer_reversal",
+      "transfer_reversal",
+    };
+    final String data = getFixture("/v1/refunds/re_123", expansions);
+    final Refund refund = ApiResource.GSON.fromJson(data, Refund.class);
+    assertNotNull(refund);
+    final BalanceTransaction balanceTransaction = refund.getBalanceTransactionObject();
+    assertNotNull(balanceTransaction);
+    assertNotNull(balanceTransaction.getId());
+    assertEquals(refund.getBalanceTransaction(), balanceTransaction.getId());
+    final Charge charge = refund.getChargeObject();
+    assertNotNull(charge);
+    assertNotNull(charge.getId());
+    assertEquals(refund.getCharge(), charge.getId());
+    final BalanceTransaction failureBalanceTransaction
+        = refund.getFailureBalanceTransactionObject();
+    assertNotNull(failureBalanceTransaction);
+    assertNotNull(failureBalanceTransaction.getId());
+    assertEquals(refund.getFailureBalanceTransaction(), failureBalanceTransaction.getId());
+    final Reversal sourceTransferReversal = refund.getSourceTransferReversalObject();
+    assertNotNull(sourceTransferReversal);
+    assertNotNull(sourceTransferReversal.getId());
+    assertEquals(refund.getSourceTransferReversal(), sourceTransferReversal.getId());
+    final Reversal transferReversal = refund.getTransferReversalObject();
+    assertNotNull(transferReversal);
+    assertNotNull(transferReversal.getId());
+    assertEquals(refund.getTransferReversal(), transferReversal.getId());
+  }
 }


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Add `failureBalanceTransaction`, `failureReason` and `sourceTransferReversal` to `Refund` class.

Fixes #620.
