### PR TITLE
Refactor: add deserialization helper classes

### DIFF
--- a/src/main/java/com/stripe/model/EventDataClassLookup.java
+++ b/src/main/java/com/stripe/model/EventDataClassLookup.java
@@ -1,0 +1,87 @@
+package com.stripe.model;
+
+import com.stripe.model.issuing.Authorization;
+import com.stripe.model.issuing.CardDetails;
+import com.stripe.model.issuing.Cardholder;
+import com.stripe.model.issuing.Transaction;
+import com.stripe.model.radar.ValueList;
+import com.stripe.model.radar.ValueListItem;
+import com.stripe.model.reporting.ReportRun;
+import com.stripe.model.reporting.ReportType;
+import com.stripe.model.sigma.ScheduledQueryRun;
+import com.stripe.model.terminal.ConnectionToken;
+import com.stripe.model.terminal.Location;
+import com.stripe.model.terminal.Reader;
+import java.util.HashMap;
+import java.util.Map;
+
+public class EventDataClassLookup {
+  private static final Map<String, Class<? extends StripeObject>> classLookup = new HashMap<>();
+
+  static {
+    classLookup.put("account", Account.class);
+    classLookup.put("alipay_account", AlipayAccount.class);
+    classLookup.put("apple_pay_domain", ApplePayDomain.class);
+    classLookup.put("application", Application.class);
+    classLookup.put("application_fee", ApplicationFee.class);
+    classLookup.put("balance", Balance.class);
+    classLookup.put("balance_transaction", BalanceTransaction.class);
+    classLookup.put("bank_account", BankAccount.class);
+    classLookup.put("bitcoin_receiver", BitcoinReceiver.class);
+    classLookup.put("card", Card.class);
+    classLookup.put("charge", Charge.class);
+    classLookup.put("country_spec", CountrySpec.class);
+    classLookup.put("coupon", Coupon.class);
+    classLookup.put("customer", Customer.class);
+    classLookup.put("discount", Discount.class);
+    classLookup.put("dispute", Dispute.class);
+    classLookup.put("event", Event.class);
+    classLookup.put("exchange_rate", ExchangeRate.class);
+    classLookup.put("fee", BalanceTransaction.Fee.class);
+    classLookup.put("fee_refund", FeeRefund.class);
+    classLookup.put("file", File.class);
+    classLookup.put("file_upload", File.class);
+    classLookup.put("invoice", Invoice.class);
+    classLookup.put("invoice_line_item", InvoiceLineItem.class);
+    classLookup.put("invoiceitem", InvoiceItem.class);
+    classLookup.put("issuing.authorization", com.stripe.model.issuing.Authorization.class);
+    classLookup.put("issuing.card", com.stripe.model.issuing.Card.class);
+    classLookup.put("issuing.card_details", com.stripe.model.issuing.CardDetails.class);
+    classLookup.put("issuing.cardholder", com.stripe.model.issuing.Cardholder.class);
+    classLookup.put("issuing.dispute", com.stripe.model.issuing.Dispute.class);
+    classLookup.put("issuing.transaction", com.stripe.model.issuing.Transaction.class);
+    classLookup.put("order", Order.class);
+    classLookup.put("order_item", OrderItem.class);
+    classLookup.put("order_return", OrderReturn.class);
+    classLookup.put("payment_intent", PaymentIntent.class);
+    classLookup.put("payout", Payout.class);
+    classLookup.put("plan", Plan.class);
+    classLookup.put("product", Product.class);
+    classLookup.put("radar.value_list", com.stripe.model.radar.ValueList.class);
+    classLookup.put("radar.value_list_item", com.stripe.model.radar.ValueListItem.class);
+    classLookup.put("reporting.report_run", com.stripe.model.reporting.ReportRun.class);
+    classLookup.put("reporting.report_type", com.stripe.model.reporting.ReportType.class);
+    classLookup.put("refund", Refund.class);
+    classLookup.put("recipient", Recipient.class);
+    classLookup.put("review", Review.class);
+    classLookup.put("scheduled_query_run", com.stripe.model.sigma.ScheduledQueryRun.class);
+    classLookup.put("sku", Sku.class);
+    classLookup.put("source", Source.class);
+    classLookup.put("source_mandate_notification", SourceMandateNotification.class);
+    classLookup.put("source_transaction", SourceTransaction.class);
+    classLookup.put("subscription", Subscription.class);
+    classLookup.put("subscription_item", SubscriptionItem.class);
+    classLookup.put("summary", Transfer.Summary.class);
+    classLookup.put("terminal.connection_token", com.stripe.model.terminal.ConnectionToken.class);
+    classLookup.put("terminal.location", com.stripe.model.terminal.Location.class);
+    classLookup.put("terminal.reader", com.stripe.model.terminal.Reader.class);
+    classLookup.put("three_d_secure", ThreeDSecure.class);
+    classLookup.put("token", Token.class);
+    classLookup.put("transfer", Transfer.class);
+    classLookup.put("transfer_reversal", Reversal.class);
+  }
+
+  public static Class<? extends StripeObject> findClass(String objectType) {
+    return classLookup.get(objectType);
+  }
+}

--- a/src/main/java/com/stripe/model/EventDataClassLookup.java
+++ b/src/main/java/com/stripe/model/EventDataClassLookup.java
@@ -1,21 +1,12 @@
 package com.stripe.model;
 
-import com.stripe.model.issuing.Authorization;
-import com.stripe.model.issuing.CardDetails;
-import com.stripe.model.issuing.Cardholder;
-import com.stripe.model.issuing.Transaction;
-import com.stripe.model.radar.ValueList;
-import com.stripe.model.radar.ValueListItem;
-import com.stripe.model.reporting.ReportRun;
-import com.stripe.model.reporting.ReportType;
-import com.stripe.model.sigma.ScheduledQueryRun;
-import com.stripe.model.terminal.ConnectionToken;
-import com.stripe.model.terminal.Location;
-import com.stripe.model.terminal.Reader;
 import java.util.HashMap;
 import java.util.Map;
 
-public class EventDataClassLookup {
+/**
+ * Event data class look up used in {@link EventDataDeserializer}.
+ */
+final class EventDataClassLookup {
   private static final Map<String, Class<? extends StripeObject>> classLookup = new HashMap<>();
 
   static {

--- a/src/main/java/com/stripe/model/EventDataDeserializer.java
+++ b/src/main/java/com/stripe/model/EventDataDeserializer.java
@@ -16,72 +16,6 @@ import java.util.Map;
 
 public class EventDataDeserializer implements JsonDeserializer<EventData> {
 
-  static final Map<String, Class<? extends StripeObject>> objectMap =
-      new HashMap<String, Class<? extends StripeObject>>();
-
-  static {
-    objectMap.put("account", Account.class);
-    objectMap.put("alipay_account", AlipayAccount.class);
-    objectMap.put("apple_pay_domain", ApplePayDomain.class);
-    objectMap.put("application", Application.class);
-    objectMap.put("application_fee", ApplicationFee.class);
-    objectMap.put("balance", Balance.class);
-    objectMap.put("balance_transaction", BalanceTransaction.class);
-    objectMap.put("bank_account", BankAccount.class);
-    objectMap.put("bitcoin_receiver", BitcoinReceiver.class);
-    objectMap.put("card", Card.class);
-    objectMap.put("charge", Charge.class);
-    objectMap.put("country_spec", CountrySpec.class);
-    objectMap.put("coupon", Coupon.class);
-    objectMap.put("customer", Customer.class);
-    objectMap.put("discount", Discount.class);
-    objectMap.put("dispute", Dispute.class);
-    objectMap.put("event", Event.class);
-    objectMap.put("exchange_rate", ExchangeRate.class);
-    objectMap.put("fee", BalanceTransaction.Fee.class);
-    objectMap.put("fee_refund", FeeRefund.class);
-    objectMap.put("file", File.class);
-    objectMap.put("file_upload", File.class);
-    objectMap.put("invoice", Invoice.class);
-    objectMap.put("invoice_line_item", InvoiceLineItem.class);
-    objectMap.put("invoiceitem", InvoiceItem.class);
-    objectMap.put("issuing.authorization", com.stripe.model.issuing.Authorization.class);
-    objectMap.put("issuing.card", com.stripe.model.issuing.Card.class);
-    objectMap.put("issuing.card_details", com.stripe.model.issuing.CardDetails.class);
-    objectMap.put("issuing.cardholder", com.stripe.model.issuing.Cardholder.class);
-    objectMap.put("issuing.dispute", com.stripe.model.issuing.Dispute.class);
-    objectMap.put("issuing.transaction", com.stripe.model.issuing.Transaction.class);
-    objectMap.put("order", Order.class);
-    objectMap.put("order_item", OrderItem.class);
-    objectMap.put("order_return", OrderReturn.class);
-    objectMap.put("payment_intent", PaymentIntent.class);
-    objectMap.put("payout", Payout.class);
-    objectMap.put("plan", Plan.class);
-    objectMap.put("product", Product.class);
-    objectMap.put("radar.value_list", com.stripe.model.radar.ValueList.class);
-    objectMap.put("radar.value_list_item", com.stripe.model.radar.ValueListItem.class);
-    objectMap.put("reporting.report_run", com.stripe.model.reporting.ReportRun.class);
-    objectMap.put("reporting.report_type", com.stripe.model.reporting.ReportType.class);
-    objectMap.put("refund", Refund.class);
-    objectMap.put("recipient", Recipient.class);
-    objectMap.put("review", Review.class);
-    objectMap.put("scheduled_query_run", com.stripe.model.sigma.ScheduledQueryRun.class);
-    objectMap.put("sku", Sku.class);
-    objectMap.put("source", Source.class);
-    objectMap.put("source_mandate_notification", SourceMandateNotification.class);
-    objectMap.put("source_transaction", SourceTransaction.class);
-    objectMap.put("subscription", Subscription.class);
-    objectMap.put("subscription_item", SubscriptionItem.class);
-    objectMap.put("summary", Transfer.Summary.class);
-    objectMap.put("terminal.connection_token", com.stripe.model.terminal.ConnectionToken.class);
-    objectMap.put("terminal.location", com.stripe.model.terminal.Location.class);
-    objectMap.put("terminal.reader", com.stripe.model.terminal.Reader.class);
-    objectMap.put("three_d_secure", ThreeDSecure.class);
-    objectMap.put("token", Token.class);
-    objectMap.put("transfer", Transfer.class);
-    objectMap.put("transfer_reversal", Reversal.class);
-  }
-
   private Object deserializeJsonPrimitive(JsonPrimitive element) {
     if (element.isBoolean()) {
       return element.getAsBoolean();
@@ -152,7 +86,7 @@ public class EventDataDeserializer implements JsonDeserializer<EventData> {
         }
       } else if ("object".equals(key)) {
         String type = element.getAsJsonObject().get("object").getAsString();
-        Class<? extends StripeObject> cl = objectMap.get(type);
+        Class<? extends StripeObject> cl = EventDataClassLookup.findClass(type);
         StripeObject object = ApiResource.GSON.fromJson(
             entry.getValue(), cl != null ? cl : StripeRawJsonObject.class);
         eventData.setObject(object);

--- a/src/main/java/com/stripe/net/ApiResource.java
+++ b/src/main/java/com/stripe/net/ApiResource.java
@@ -4,6 +4,7 @@ import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
+import com.google.gson.TypeAdapterFactory;
 import com.stripe.Stripe;
 import com.stripe.exception.InvalidRequestException;
 import com.stripe.exception.StripeException;
@@ -50,27 +51,34 @@ public abstract class ApiResource extends StripeObject {
     ApiResource.stripeResponseGetter = srg;
   }
 
-  public static final Gson GSON = new GsonBuilder()
-      .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-      .registerTypeAdapter(BalanceTransaction.class, new BalanceTransactionDeserializer())
-      .registerTypeAdapter(ChargeRefundCollection.class, new ChargeRefundCollectionDeserializer())
-      .registerTypeAdapter(Dispute.class, new DisputeDataDeserializer())
-      .registerTypeAdapter(EphemeralKey.class, new EphemeralKeyDeserializer())
-      .registerTypeAdapter(EventData.class, new EventDataDeserializer())
-      .registerTypeAdapter(EventRequest.class, new EventRequestDeserializer())
-      .registerTypeAdapter(ExpandableField.class, new ExpandableFieldDeserializer())
-      .registerTypeAdapter(FeeRefundCollection.class, new FeeRefundCollectionDeserializer())
-      .registerTypeAdapter(OrderItem.class, new OrderItemDeserializer())
-      .registerTypeAdapter(PaymentIntentSourceAction.class,
-          new PaymentIntentSourceActionDeserializer())
-      .registerTypeAdapter(Source.class, new SourceTypeDataDeserializer<Source>())
-      .registerTypeAdapter(SourceMandateNotification.class,
-          new SourceTypeDataDeserializer<SourceMandateNotification>())
-      .registerTypeAdapter(SourceTransaction.class,
-          new SourceTypeDataDeserializer<SourceTransaction>())
-      .registerTypeAdapter(StripeRawJsonObject.class, new StripeRawJsonObjectDeserializer())
-      .registerTypeAdapterFactory(new ExternalAccountTypeAdapterFactory())
-      .create();
+  public static final Gson GSON = createGson();
+
+  private static Gson createGson() {
+    GsonBuilder builder = new GsonBuilder()
+        .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+        .registerTypeAdapter(BalanceTransaction.class, new BalanceTransactionDeserializer())
+        .registerTypeAdapter(ChargeRefundCollection.class, new ChargeRefundCollectionDeserializer())
+        .registerTypeAdapter(Dispute.class, new DisputeDataDeserializer())
+        .registerTypeAdapter(EphemeralKey.class, new EphemeralKeyDeserializer())
+        .registerTypeAdapter(EventData.class, new EventDataDeserializer())
+        .registerTypeAdapter(EventRequest.class, new EventRequestDeserializer())
+        .registerTypeAdapter(ExpandableField.class, new ExpandableFieldDeserializer())
+        .registerTypeAdapter(FeeRefundCollection.class, new FeeRefundCollectionDeserializer())
+        .registerTypeAdapter(OrderItem.class, new OrderItemDeserializer())
+        .registerTypeAdapter(PaymentIntentSourceAction.class,
+            new PaymentIntentSourceActionDeserializer())
+        .registerTypeAdapter(Source.class, new SourceTypeDataDeserializer<Source>())
+        .registerTypeAdapter(SourceMandateNotification.class,
+            new SourceTypeDataDeserializer<SourceMandateNotification>())
+        .registerTypeAdapter(SourceTransaction.class,
+            new SourceTypeDataDeserializer<SourceTransaction>())
+        .registerTypeAdapter(StripeRawJsonObject.class, new StripeRawJsonObjectDeserializer());
+
+    for (TypeAdapterFactory factory : ApiResourceTypeAdapterFactoryProvider.getAll()) {
+      builder.registerTypeAdapterFactory(factory);
+    }
+    return builder.create();
+  }
 
   private static String className(Class<?> clazz) {
     // Convert CamelCase to snake_case

--- a/src/main/java/com/stripe/net/ApiResource.java
+++ b/src/main/java/com/stripe/net/ApiResource.java
@@ -22,7 +22,6 @@ import com.stripe.model.EventRequest;
 import com.stripe.model.EventRequestDeserializer;
 import com.stripe.model.ExpandableField;
 import com.stripe.model.ExpandableFieldDeserializer;
-import com.stripe.model.ExternalAccountTypeAdapterFactory;
 import com.stripe.model.FeeRefundCollection;
 import com.stripe.model.FeeRefundCollectionDeserializer;
 import com.stripe.model.HasId;

--- a/src/main/java/com/stripe/net/ApiResourceTypeAdapterFactoryProvider.java
+++ b/src/main/java/com/stripe/net/ApiResourceTypeAdapterFactoryProvider.java
@@ -5,7 +5,11 @@ import com.stripe.model.ExternalAccountTypeAdapterFactory;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ApiResourceTypeAdapterFactoryProvider {
+/**
+ * Provider for all {@link TypeAdapterFactory} required for deserializing subtypes of an
+ * interface or children of superclass.
+ */
+final class ApiResourceTypeAdapterFactoryProvider {
   private static final List<TypeAdapterFactory> factories = new ArrayList<>();
 
   static {

--- a/src/main/java/com/stripe/net/ApiResourceTypeAdapterFactoryProvider.java
+++ b/src/main/java/com/stripe/net/ApiResourceTypeAdapterFactoryProvider.java
@@ -1,0 +1,18 @@
+package com.stripe.net;
+
+import com.google.gson.TypeAdapterFactory;
+import com.stripe.model.ExternalAccountTypeAdapterFactory;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ApiResourceTypeAdapterFactoryProvider {
+  private static final List<TypeAdapterFactory> factories = new ArrayList<>();
+
+  static {
+    factories.add(new ExternalAccountTypeAdapterFactory());
+  }
+
+  public static List<TypeAdapterFactory> getAll() {
+    return factories;
+  }
+}


### PR DESCRIPTION
r? @ob-stripe 
cc @brandur-stripe @stripe/api-libraries 
- This PR has no behavior changes, but has 2 refactoring changes on deserialization components to be compatible with sdk-autogen; when new classes and deserializers are generated, they can be picked up by the non-autogen part of the code case.
 
- First, `ApiResourceTypeAdapterFactoryProvider` is introduced to provide for any auto-generated `TypeAdapterFactory` required for polymorphic deserialization. This provider bridges between non-autogen part of custom `GSON` object in `ApiResource`, registered with custom deserializer for expandable fields, events, and autogenerated part registered with any auto-generated adapter factories. 
  - The wip autogen now will generate at least 3 type adapter factories like [0], so it will only modify `ApiResourceTypeAdapterFactoryProvider` if there are changes in interface types without touching the `ApiResource`. (Side note: `...Deserializer` that addresses polymorphic object from its parent class will be replaced with the type factory adapter that deserialize the polymorphic object directly. See [1] for more details.)
```
  static {
    factories.add(new BalanceTransactionSourceTypeAdapterFactory());
    factories.add(new ExternalAccountSourceTypeAdapterFactory());
    // these 3 could be combined into one 
    factories.add(new PaymentIntentSourceTypeAdapterFactory());
    factories.add(new CustomerSourceTypeAdapterFactory());
    factories.add(new PaymentSourceTypeAdapterFactory());
  }
```
- Second, `EventDataClassLookup` is introduced to provide for java Class based on object type during event deserialization. This simply extracts out the old private `objectMap`. Similarly, the intention here is that as we add auto-generated resources, we want to make sure they are known in the existing `EventDataDeserializers`. The wip autogen now will look like this [2]

- These two classes when autogen is deployed and used, will be autogenerated and updated to reflect any changes in resources, but maintain the same interface. For now, they just port snippets from the existing code.
- These two classes has default access, so it will not be usable in the released jars -- not creating additional contracts to our clients. 

[0] https://github.com/stripe/stripe-java/blob/78c2c0dd42a4ecc7e0d8ab739554e789358aa092/src/main/java/com/stripe/net/ApiResourceTypeAdapterFactoryProvider.java
[1] https://git.corp.stripe.com/stripe-internal/stripe-java/pull/38/files
[2] https://github.com/stripe/stripe-java/blob/78c2c0dd42a4ecc7e0d8ab739554e789358aa092/src/main/java/com/stripe/model/EventDataClassLookup.java