### PR TITLE
Forbid unused imports

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,7 +102,7 @@ test {
 }
 
 checkstyle {
-    toolVersion = '8.12'
+    toolVersion = '8.16'
 }
 
 cobertura {

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -134,6 +134,11 @@
             <message key="name.invalidPattern"
              value="Parameter name ''{0}'' must match pattern ''{1}''."/>
         </module>
+        <module name="LambdaParameterName">
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <message key="name.invalidPattern"
+                     value="Lambda parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
         <module name="CatchParameterName">
             <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
             <message key="name.invalidPattern"
@@ -246,5 +251,12 @@
             <property name="exceptionVariableName" value="expected"/>
         </module>
         <module name="CommentsIndentation"/>
+
+        <!-- Additional rules not in google_checks.xml -->
+        <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
+        <module name="RedundantImport"/>
+        <module name="UnusedImports">
+            <property name="processJavadoc" value="true"/>
+        </module>
     </module>
 </module>

--- a/src/main/java/com/stripe/model/ChargeRefundCollectionDeserializer.java
+++ b/src/main/java/com/stripe/model/ChargeRefundCollectionDeserializer.java
@@ -8,8 +8,6 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 import com.google.gson.reflect.TypeToken;
-import com.stripe.model.ExpandableField;
-import com.stripe.model.ExpandableFieldDeserializer;
 
 import java.lang.reflect.Type;
 import java.util.List;

--- a/src/main/java/com/stripe/model/FeeRefundCollectionDeserializer.java
+++ b/src/main/java/com/stripe/model/FeeRefundCollectionDeserializer.java
@@ -8,8 +8,6 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 import com.google.gson.reflect.TypeToken;
-import com.stripe.model.ExpandableField;
-import com.stripe.model.ExpandableFieldDeserializer;
 
 import java.lang.reflect.Type;
 import java.util.List;

--- a/src/main/java/com/stripe/model/Review.java
+++ b/src/main/java/com/stripe/model/Review.java
@@ -1,8 +1,6 @@
 package com.stripe.model;
 
 import com.stripe.exception.StripeException;
-import com.stripe.model.ExpandableField;
-import com.stripe.model.HasId;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 

--- a/src/main/java/com/stripe/model/radar/ValueListItem.java
+++ b/src/main/java/com/stripe/model/radar/ValueListItem.java
@@ -1,9 +1,7 @@
 package com.stripe.model.radar;
 
 import com.stripe.exception.StripeException;
-import com.stripe.model.File;
 import com.stripe.model.HasId;
-import com.stripe.model.StripeObject;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 

--- a/src/main/java/com/stripe/net/OAuth.java
+++ b/src/main/java/com/stripe/net/OAuth.java
@@ -6,10 +6,6 @@ import com.stripe.exception.InvalidRequestException;
 import com.stripe.exception.StripeException;
 import com.stripe.model.oauth.DeauthorizedAccount;
 import com.stripe.model.oauth.TokenResponse;
-import com.stripe.net.ApiResource;
-import com.stripe.net.LiveStripeResponseGetter;
-import com.stripe.net.RequestOptions;
-import com.stripe.net.StripeResponseGetter;
 
 import java.io.UnsupportedEncodingException;
 import java.util.Map;

--- a/src/test/java/com/stripe/model/AccountTest.java
+++ b/src/test/java/com/stripe/model/AccountTest.java
@@ -3,7 +3,6 @@ package com.stripe.model;
 import static org.junit.Assert.assertNotNull;
 
 import com.stripe.BaseStripeTest;
-import com.stripe.model.Account;
 import com.stripe.net.ApiResource;
 
 import org.junit.Test;

--- a/src/test/java/com/stripe/model/BalanceTransactionTest.java
+++ b/src/test/java/com/stripe/model/BalanceTransactionTest.java
@@ -4,8 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import com.stripe.BaseStripeTest;
-import com.stripe.model.BalanceTransaction;
-import com.stripe.model.BalanceTransactionCollection;
 import com.stripe.net.ApiResource;
 
 import java.util.List;

--- a/src/test/java/com/stripe/model/IssuerFraudRecordTest.java
+++ b/src/test/java/com/stripe/model/IssuerFraudRecordTest.java
@@ -7,8 +7,6 @@ import static org.junit.Assert.assertNull;
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import java.io.IOException;
-
 import org.junit.Test;
 
 public class IssuerFraudRecordTest extends BaseStripeTest {


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Update Checkstyle configuration to forbid unused or redundant imports going forward.
