### PR TITLE
Add support for new properties and params on Invoice and Subscription

### DIFF
--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -22,7 +22,7 @@ public class Invoice extends ApiResource implements MetadataStore<Invoice>, HasI
   Long amountDue;
   Long amountPaid;
   Long amountRemaining;
-  Long applicationFee;
+  Long applicationFeeAmount;
   Long attemptCount;
   Boolean attempted;
   Boolean autoAdvance;
@@ -64,7 +64,16 @@ public class Invoice extends ApiResource implements MetadataStore<Invoice>, HasI
   BigDecimal taxPercent;
   ThresholdReason thresholdReason;
   Long total;
+  TransferData transferData;
   Long webhooksDeliveredAt;
+
+  /**
+   * The {@code applicationFee} attribute.
+   *
+   * @deprecated Prefer using the {@code applicationFeeAmount} attribute instead.
+   */
+  @Deprecated
+  Long applicationFee;
 
   /**
    * The {@code closed} attribute.
@@ -449,5 +458,28 @@ public class Invoice extends ApiResource implements MetadataStore<Invoice>, HasI
   public static class ThresholdItemReason extends StripeObject {
     List<String> lineItemIds;
     Long usageGte;
+  }
+
+  public static class TransferData extends StripeObject {
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Account> destination;
+
+    // <editor-fold desc="destination">
+    public String getDestination() {
+      return (this.destination != null) ? this.destination.getId() : null;
+    }
+
+    public void setDestination(String destinationId) {
+      this.destination = setExpandableFieldId(destinationId, this.destination);
+
+    }
+
+    public Account getDestinationObject() {
+      return (this.destination != null) ? this.destination.getExpanded() : null;
+    }
+
+    public void setDestinationObject(Account c) {
+      this.destination = new ExpandableField<>(c.getId(), c);
+    }
+    // </editor-fold>
   }
 }

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -41,6 +41,7 @@ public class Subscription extends ApiResource implements MetadataStore<Subscript
   Long start;
   String status;
   BigDecimal taxPercent;
+  TransferData transferData;
   Long trialEnd;
   Long trialStart;
 
@@ -212,5 +213,28 @@ public class Subscription extends ApiResource implements MetadataStore<Subscript
   public static class BillingThresholds extends StripeObject {
     Long amountGte;
     Boolean resetBillingCycleAnchor;
+  }
+
+  public static class TransferData extends StripeObject {
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Account> destination;
+
+    // <editor-fold desc="destination">
+    public String getDestination() {
+      return (this.destination != null) ? this.destination.getId() : null;
+    }
+
+    public void setDestination(String destinationId) {
+      this.destination = setExpandableFieldId(destinationId, this.destination);
+
+    }
+
+    public Account getDestinationObject() {
+      return (this.destination != null) ? this.destination.getExpanded() : null;
+    }
+
+    public void setDestinationObject(Account c) {
+      this.destination = new ExpandableField<>(c.getId(), c);
+    }
+    // </editor-fold>
   }
 }

--- a/src/test/java/com/stripe/model/InvoiceTest.java
+++ b/src/test/java/com/stripe/model/InvoiceTest.java
@@ -21,7 +21,8 @@ public class InvoiceTest extends BaseStripeTest {
   }
 
   @Test
-  public void testDeserializeExpanded() throws Exception {
+  public void testDeserializeWithExpansions() throws Exception {
+    // TODO: Add support for expanding "transfer_data.destination" when stripe-mock supports it.
     final String[] expansions = {
       "charge",
       "customer",

--- a/src/test/java/com/stripe/model/SubscriptionTest.java
+++ b/src/test/java/com/stripe/model/SubscriptionTest.java
@@ -22,6 +22,28 @@ public class SubscriptionTest extends BaseStripeTest {
   }
 
   @Test
+  public void testDeserializeWithExpansions() throws Exception {
+    // TODO: Add support for expanding "transfer_data.destination" when stripe-mock supports it.
+    final String[] expansions = {
+      "customer",
+      "default_source",
+    };
+    final String data = getFixture("/v1/subscriptions/sub_123", expansions);
+    final Subscription subscription = ApiResource.GSON.fromJson(data, Subscription.class);
+    assertNotNull(subscription);
+
+    final Customer customer = subscription.getCustomerObject();
+    assertNotNull(customer);
+    assertNotNull(customer.getId());
+    assertEquals(subscription.getCustomer(), customer.getId());
+
+    final ExternalAccount defaultSource = subscription.getDefaultSourceObject();
+    assertNotNull(defaultSource);
+    assertNotNull(defaultSource.getId());
+    assertEquals(subscription.getDefaultSource(), defaultSource.getId());
+  }
+
+  @Test
   public void testDeserializeBigDecimal() {
     final String data = "{\"object\": \"subscription\", \"tax_percent\": 0.3}";
     final Subscription subscription = ApiResource.GSON.fromJson(data, Subscription.class);


### PR DESCRIPTION
* Add `transfer_data[destination]` to both
* Add `application_fee_amount` to Invoice

cc @stripe/api-libraries 

NOT asking for review yet as I want to double check that we don't need `on_behalf_of` for now.