### PR TITLE
Add new properties to `TransferReversal`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
 
 env:
   global:
-  - STRIPE_MOCK_VERSION=0.40.1
+  - STRIPE_MOCK_VERSION=0.43.0
 
 matrix:
   include:

--- a/src/main/java/com/stripe/model/Reversal.java
+++ b/src/main/java/com/stripe/model/Reversal.java
@@ -22,7 +22,11 @@ public class Reversal extends ApiResource implements MetadataStore<Transfer>, Ha
       ExpandableField<BalanceTransaction> balanceTransaction;
   Long created;
   String currency;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+      ExpandableField<Refund> destinationPaymentRefund;
   @Getter(onMethod = @__({@Override})) Map<String, String> metadata;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+      ExpandableField<Refund> sourceRefund;
   @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Transfer> transfer;
 
   // <editor-fold desc="balanceTransaction">
@@ -40,6 +44,44 @@ public class Reversal extends ApiResource implements MetadataStore<Transfer>, Ha
 
   public void setBalanceTransactionObject(BalanceTransaction c) {
     this.balanceTransaction = new ExpandableField<>(c.getId(), c);
+  }
+  // </editor-fold>
+
+  // <editor-fold desc="destinationPaymentRefund">
+  public String getDestinationPaymentRefund() {
+    return (this.destinationPaymentRefund != null) ? this.destinationPaymentRefund.getId() : null;
+  }
+
+  public void setDestinationPaymentRefund(String destinationPaymentRefundId) {
+    this.destinationPaymentRefund = setExpandableFieldId(destinationPaymentRefundId,
+        this.destinationPaymentRefund);
+  }
+
+  public Refund getDestinationPaymentRefundObject() {
+    return (this.destinationPaymentRefund != null)
+        ? this.destinationPaymentRefund.getExpanded() : null;
+  }
+
+  public void setDestinationPaymentRefundObject(Refund c) {
+    this.destinationPaymentRefund = new ExpandableField<>(c.getId(), c);
+  }
+  // </editor-fold>
+
+  // <editor-fold desc="sourceRefund">
+  public String getSourceRefund() {
+    return (this.sourceRefund != null) ? this.sourceRefund.getId() : null;
+  }
+
+  public void setSourceRefund(String sourceRefundId) {
+    this.sourceRefund = setExpandableFieldId(sourceRefundId, this.sourceRefund);
+  }
+
+  public Refund getSourceRefundObject() {
+    return (this.sourceRefund != null) ? this.sourceRefund.getExpanded() : null;
+  }
+
+  public void setSourceRefundObject(Refund c) {
+    this.sourceRefund = new ExpandableField<>(c.getId(), c);
   }
   // </editor-fold>
 

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -35,7 +35,7 @@ import org.mockito.Mockito;
 
 public class BaseStripeTest {
   // If changing this number, please also change it in `.travis.yml`.
-  private static final String MOCK_MINIMUM_VERSION = "0.40.1";
+  private static final String MOCK_MINIMUM_VERSION = "0.43.0";
 
   private static String port;
 

--- a/src/test/java/com/stripe/model/ReversalTest.java
+++ b/src/test/java/com/stripe/model/ReversalTest.java
@@ -25,15 +25,30 @@ public class ReversalTest extends BaseStripeTest {
   public void testDeserializeWithExpansions() throws Exception {
     final String[] expansions = {
       "balance_transaction",
+      "destination_payment_refund",
+      "source_refund",
       "transfer",
     };
     final String data = getFixture("/v1/transfers/tr_123/reversals/trr_123", expansions);
     final Reversal reversal = ApiResource.GSON.fromJson(data, Reversal.class);
     assertNotNull(reversal);
+
     final BalanceTransaction balanceTransaction = reversal.getBalanceTransactionObject();
     assertNotNull(balanceTransaction);
     assertNotNull(balanceTransaction.getId());
     assertEquals(reversal.getBalanceTransaction(), balanceTransaction.getId());
+
+    final Refund destinationPaymentRefund = reversal.getDestinationPaymentRefundObject();
+    assertNotNull(destinationPaymentRefund);
+    assertNotNull(destinationPaymentRefund.getId());
+    assertEquals(reversal.getDestinationPaymentRefund(), destinationPaymentRefund.getId());
+
+    final Refund sourceRefund = reversal.getSourceRefundObject();
+    assertNotNull(sourceRefund);
+    assertNotNull(sourceRefund.getId());
+    assertEquals(reversal.getSourceRefund(), sourceRefund.getId());
+
+
     final Transfer transfer = reversal.getTransferObject();
     assertNotNull(transfer);
     assertNotNull(transfer.getId());


### PR DESCRIPTION
Add support for `destination_payment_refund` and `source_refund` on `TransferReversal`.

cc @stripe/api-libraries @carley-stripe 

NOT asking for review yet as those properties are not expandable and I want to make sure it's expected to avoid a future breaking change.