### PR TITLE
Introduce version pinning for autogen

### DIFF
--- a/src/main/java/com/stripe/Stripe.java
+++ b/src/main/java/com/stripe/Stripe.java
@@ -10,11 +10,11 @@ public abstract class Stripe {
   private static final int DEFAULT_CONNECT_TIMEOUT = 30 * 1000;
   private static final int DEFAULT_READ_TIMEOUT = 80 * 1000;
 
-  public static final String LIVE_API_BASE = "https://api.stripe.com";
+  public static final String API_VERSION = "2018-11-08";
   public static final String CONNECT_API_BASE = "https://connect.stripe.com";
+  public static final String LIVE_API_BASE = "https://api.stripe.com";
   public static final String UPLOAD_API_BASE = "https://files.stripe.com";
   public static final String VERSION = "7.14.0";
-  public static final String API_VERSION = "2018-11-08";
 
   public static volatile String apiKey;
   public static volatile String apiVersion;

--- a/src/main/java/com/stripe/Stripe.java
+++ b/src/main/java/com/stripe/Stripe.java
@@ -14,6 +14,7 @@ public abstract class Stripe {
   public static final String CONNECT_API_BASE = "https://connect.stripe.com";
   public static final String UPLOAD_API_BASE = "https://files.stripe.com";
   public static final String VERSION = "7.14.0";
+  public static final String API_VERSION = "2018-11-08";
 
   public static volatile String apiKey;
   public static volatile String apiVersion;

--- a/src/main/java/com/stripe/model/EphemeralKey.java
+++ b/src/main/java/com/stripe/model/EphemeralKey.java
@@ -30,14 +30,14 @@ public class EphemeralKey extends ApiResource implements HasId {
    *
    * @param params request parameters
    * @param options request options. {@code stripeVersion} is required when creating ephemeral
-   *     keys.
+   *     keys. it must have non-null {@link RequestOptions#getStripeVersionOverride()}.
    * @return the new ephemeral key
    */
   public static EphemeralKey create(Map<String, Object> params, RequestOptions options)
       throws StripeException {
-    if (options.getStripeVersionOnBehalfOf() == null) {
-      throw new IllegalArgumentException("`stripeVersionOnBehalfOf` must be specified in "
-          + "RequestOptions");
+    if (options.getStripeVersionOverride() == null) {
+      throw new IllegalArgumentException("`stripeVersionOverride` must be specified in "
+          + "RequestOptions with stripe version of your mobile client.");
     }
 
     return request(RequestMethod.POST, classUrl(EphemeralKey.class), params, EphemeralKey.class,

--- a/src/main/java/com/stripe/model/EphemeralKey.java
+++ b/src/main/java/com/stripe/model/EphemeralKey.java
@@ -35,8 +35,9 @@ public class EphemeralKey extends ApiResource implements HasId {
    */
   public static EphemeralKey create(Map<String, Object> params, RequestOptions options)
       throws StripeException {
-    if (options.getStripeVersion() == null) {
-      throw new IllegalArgumentException("stripeVersion must be specified in RequestOptions");
+    if (options.getStripeVersionOnBehalfOf() == null) {
+      throw new IllegalArgumentException("`stripeVersionOnBehalfOf` must be specified in "
+          + "RequestOptions");
     }
 
     return request(RequestMethod.POST, classUrl(EphemeralKey.class), params, EphemeralKey.class,

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -140,8 +140,16 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
       propertyMap.put("application", ApiResource.GSON.toJson(Stripe.getAppInfo()));
     }
     headers.put("X-Stripe-Client-User-Agent", ApiResource.GSON.toJson(propertyMap));
-    if (options.getStripeVersion() != null) {
+
+    // for some API, the client is making request on behalf of other clients
+    // (like mobile for ephemeral key), so we set this value first if present.
+    if (options.getStripeVersionOnBehalfOf() != null) {
+      headers.put("Stripe-Version", options.getStripeVersionOnBehalfOf());
+    } else if (options.getStripeVersion() != null) {
       headers.put("Stripe-Version", options.getStripeVersion());
+    } else {
+      throw new IllegalStateException("Either `stripeVersion`, or `stripeVersionOnBehalfOf` "
+          + "value must be set.");
     }
     if (options.getIdempotencyKey() != null) {
       headers.put("Idempotency-Key", options.getIdempotencyKey());

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -141,14 +141,14 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
     }
     headers.put("X-Stripe-Client-User-Agent", ApiResource.GSON.toJson(propertyMap));
 
-    // for some API, the client is making request on behalf of other clients
-    // (like mobile for ephemeral key), so we set this value first if present.
-    if (options.getStripeVersionOnBehalfOf() != null) {
-      headers.put("Stripe-Version", options.getStripeVersionOnBehalfOf());
+    // for some APIs, the client is making request on behalf of other clients
+    // (like mobile for ephemeral key), so Stripe-Version is override instead of the pinned value.
+    if (options.getStripeVersionOverride() != null) {
+      headers.put("Stripe-Version", options.getStripeVersionOverride());
     } else if (options.getStripeVersion() != null) {
       headers.put("Stripe-Version", options.getStripeVersion());
     } else {
-      throw new IllegalStateException("Either `stripeVersion`, or `stripeVersionOnBehalfOf` "
+      throw new IllegalStateException("Either `stripeVersion`, or `stripeVersionOverride` "
           + "value must be set.");
     }
     if (options.getIdempotencyKey() != null) {

--- a/src/main/java/com/stripe/net/RequestOptions.java
+++ b/src/main/java/com/stripe/net/RequestOptions.java
@@ -119,11 +119,13 @@ public class RequestOptions {
     return new RequestOptionsBuilder();
   }
 
+  /**
+   * Convert request options to builder, retaining invariant values for the integration.
+   * @return option builder.
+   */
   public RequestOptionsBuilder toBuilder() {
     return new RequestOptionsBuilder()
-        .setApiKey(this.apiKey)
-        .setStripeVersionOnBehalfOf(this.stripeVersionOnBehalfOf)
-        .setStripeAccount(this.stripeAccount);
+        .setApiKey(this.apiKey).setStripeAccount(this.stripeAccount);
   }
 
   public static final class RequestOptionsBuilder {
@@ -177,7 +179,6 @@ public class RequestOptions {
      * to explicit Stripe resources -- it intends to make request on behalf of others, makes
      * request with their API version, and simply passes the raw values along. Example for this is
      * {@link com.stripe.model.EphemeralKey#create(Map, RequestOptions)}.
-     *
      * Setting this value in typical scenario will result in deserialization error
      * as the model classes has schema according to the pinned {@link Stripe#API_VERSION} and not
      * the {@code stripeVersionOnBehalfOf}

--- a/src/main/java/com/stripe/net/RequestOptions.java
+++ b/src/main/java/com/stripe/net/RequestOptions.java
@@ -18,22 +18,22 @@ public class RequestOptions {
    */
   private final String stripeVersion = Stripe.API_VERSION;
   /**
-   * Stripe version when made on behalf of others. This can be used when the returned response
-   * will not be deserialized into the current classes pinned to {@link Stripe#VERSION}.
+   * Stripe version override when made on behalf of others. This can be used when the returned
+   * response will not be deserialized into the current classes pinned to {@link Stripe#VERSION}.
    */
-  private final String stripeVersionOnBehalfOf;
+  private final String stripeVersionOverride;
 
   private final int connectTimeout;
   private final int readTimeout;
 
   private RequestOptions(String apiKey, String clientId, String idempotencyKey,
-                         String stripeAccount, String stripeVersionOnBehalfOf,
+                         String stripeAccount, String stripeVersionOverride,
                          int connectTimeout, int readTimeout) {
     this.apiKey = apiKey;
     this.clientId = clientId;
     this.idempotencyKey = idempotencyKey;
     this.stripeAccount = stripeAccount;
-    this.stripeVersionOnBehalfOf = stripeVersionOnBehalfOf;
+    this.stripeVersionOverride = stripeVersionOverride;
     this.connectTimeout = connectTimeout;
     this.readTimeout = readTimeout;
   }
@@ -58,8 +58,8 @@ public class RequestOptions {
     return stripeVersion;
   }
 
-  public String getStripeVersionOnBehalfOf() {
-    return stripeVersionOnBehalfOf;
+  public String getStripeVersionOverride() {
+    return stripeVersionOverride;
   }
 
   public int getReadTimeout() {
@@ -99,9 +99,9 @@ public class RequestOptions {
         that.stripeVersion != null) {
       return false;
     }
-    if (stripeVersionOnBehalfOf != null
-        ? stripeVersionOnBehalfOf.equals(that.stripeVersionOnBehalfOf) :
-        that.stripeVersionOnBehalfOf == null) {
+    if (stripeVersionOverride != null
+        ? !stripeVersionOverride.equals(that.stripeVersionOverride) :
+        that.stripeVersionOverride != null) {
       return false;
     }
 
@@ -109,7 +109,7 @@ public class RequestOptions {
       return false;
     }
 
-    return readTimeout != that.readTimeout;
+    return readTimeout == that.readTimeout;
   }
 
   @Override
@@ -119,7 +119,7 @@ public class RequestOptions {
     result = 31 * result + (idempotencyKey != null ? idempotencyKey.hashCode() : 0);
     result = 31 * result + (stripeAccount != null ? stripeAccount.hashCode() : 0);
     result = 31 * result + (stripeVersion != null ? stripeVersion.hashCode() : 0);
-    result = 31 * result + (stripeVersionOnBehalfOf != null ? stripeVersionOnBehalfOf.hashCode()
+    result = 31 * result + (stripeVersionOverride != null ? stripeVersionOverride.hashCode()
         : 0);
     result = 31 * result + connectTimeout;
     result = 31 * result + readTimeout;
@@ -144,7 +144,7 @@ public class RequestOptions {
     private String clientId;
     private String idempotencyKey;
     private String stripeAccount;
-    private String stripeVersionOnBehalfOf;
+    private String stripeVersionOverride;
     private int connectTimeout;
     private int readTimeout;
 
@@ -246,28 +246,29 @@ public class RequestOptions {
       return setStripeAccount(null);
     }
 
-    public String getStripeVersionOnBehalfOf() {
-      return this.stripeVersionOnBehalfOf;
+    public String getStripeVersionOverride() {
+      return this.stripeVersionOverride;
     }
 
     /**
-     * Do not use this except for in API where JSON response is not fully deserialize into
-     * to explicit Stripe resources -- it intends to make request on behalf of others, makes
-     * request with their API version, and simply passes the raw values along. Example for this is
+     * Do not use this except for in API where JSON response is not fully deserialized into
+     * to explicit Stripe classes, but only passed to other clients as raw data -- essentially
+     * making request on behalf of others with their API version. One example is in
      * {@link com.stripe.model.EphemeralKey#create(Map, RequestOptions)}.
-     * Setting this value in typical scenario will result in deserialization error
-     * as the model classes has schema according to the pinned {@link Stripe#API_VERSION} and not
-     * the {@code stripeVersionOnBehalfOf}
-     * @param stripeVersionOnBehalfOf stripe version of the client to make request on behalf of
+     * Setting this value in a typical scenario will result in deserialization error
+     * as the model classes have schema according to the pinned {@link Stripe#API_VERSION} and not
+     * the {@code stripeVersionOverride}
+     * @param stripeVersionOverride stripe version override which belongs to the client to make
+     *                              request on behalf of.
      * @return option builder
      */
-    public RequestOptionsBuilder setStripeVersionOnBehalfOf(String stripeVersionOnBehalfOf) {
-      this.stripeVersionOnBehalfOf = normalizeStripeVersion(stripeVersionOnBehalfOf);
+    public RequestOptionsBuilder setStripeVersionOverride(String stripeVersionOverride) {
+      this.stripeVersionOverride = normalizeStripeVersion(stripeVersionOverride);
       return this;
     }
 
-    public RequestOptionsBuilder clearStripeVersionOnBehalfOf() {
-      return setStripeVersionOnBehalfOf(null);
+    public RequestOptionsBuilder clearStripeVersionOverride() {
+      return setStripeVersionOverride(null);
     }
 
     /**
@@ -279,7 +280,7 @@ public class RequestOptions {
           normalizeClientId(this.clientId),
           normalizeIdempotencyKey(this.idempotencyKey),
           normalizeStripeAccount(this.stripeAccount),
-          normalizeStripeVersion(this.stripeVersionOnBehalfOf),
+          normalizeStripeVersion(this.stripeVersionOverride),
           connectTimeout,
           readTimeout);
     }

--- a/src/test/java/com/stripe/functional/EphemeralKeyTest.java
+++ b/src/test/java/com/stripe/functional/EphemeralKeyTest.java
@@ -1,6 +1,7 @@
 package com.stripe.functional;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.Stripe;
@@ -17,19 +18,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class EphemeralKeyTest extends BaseStripeTest {
-  public static final String KEY_ID = "ephkey_123";
-
-  private String oldApiVersion;
-
-  @Before
-  public void saveOldStripeVersion() {
-    oldApiVersion = Stripe.apiVersion;
-  }
-
-  @After
-  public void restoreOldStripeVersion() {
-    Stripe.apiVersion = oldApiVersion;
-  }
 
   @Test
   public void testCreate() throws StripeException {
@@ -38,7 +26,8 @@ public class EphemeralKeyTest extends BaseStripeTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("customer", "cus_123");
 
-    final RequestOptions options = RequestOptions.builder().setStripeVersion("2017-05-25").build();
+    final RequestOptions options = RequestOptions.builder()
+        .setStripeVersionOnBehalfOf("2017-05-25").build();
 
     final EphemeralKey key = EphemeralKey.create(params, options);
 
@@ -53,13 +42,14 @@ public class EphemeralKeyTest extends BaseStripeTest {
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testCreateWithoutApiVersion() throws StripeException {
+  public void testCreateWithoutApiVersionOnBehalf() throws StripeException {
     Stripe.apiVersion = null;
 
     final Map<String, Object> params = new HashMap<>();
     params.put("customer", "cus_123");
 
     final RequestOptions options = RequestOptions.getDefault();
+    assertNull(options.getStripeVersionOnBehalfOf());
 
     EphemeralKey.create(params, options);
   }
@@ -69,7 +59,7 @@ public class EphemeralKeyTest extends BaseStripeTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("customer", "cus_123");
 
-    final RequestOptions options = RequestOptions.builder().setStripeVersion("2017-05-25").build();
+    final RequestOptions options = RequestOptions.builder().setStripeVersionOnBehalfOf("2017-05-25").build();
 
     final EphemeralKey key = EphemeralKey.create(params, options);
 

--- a/src/test/java/com/stripe/functional/EphemeralKeyTest.java
+++ b/src/test/java/com/stripe/functional/EphemeralKeyTest.java
@@ -13,8 +13,6 @@ import com.stripe.net.RequestOptions;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 public class EphemeralKeyTest extends BaseStripeTest {
@@ -59,7 +57,8 @@ public class EphemeralKeyTest extends BaseStripeTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("customer", "cus_123");
 
-    final RequestOptions options = RequestOptions.builder().setStripeVersionOnBehalfOf("2017-05-25").build();
+    final RequestOptions options = RequestOptions.builder()
+        .setStripeVersionOnBehalfOf("2017-05-25").build();
 
     final EphemeralKey key = EphemeralKey.create(params, options);
 

--- a/src/test/java/com/stripe/functional/EphemeralKeyTest.java
+++ b/src/test/java/com/stripe/functional/EphemeralKeyTest.java
@@ -25,7 +25,7 @@ public class EphemeralKeyTest extends BaseStripeTest {
     params.put("customer", "cus_123");
 
     final RequestOptions options = RequestOptions.builder()
-        .setStripeVersionOnBehalfOf("2017-05-25").build();
+        .setStripeVersionOverride("2017-05-25").build();
 
     final EphemeralKey key = EphemeralKey.create(params, options);
 
@@ -40,14 +40,14 @@ public class EphemeralKeyTest extends BaseStripeTest {
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testCreateWithoutApiVersionOnBehalf() throws StripeException {
+  public void testCreateWithoutApiVersionOverride() throws StripeException {
     Stripe.apiVersion = null;
 
     final Map<String, Object> params = new HashMap<>();
     params.put("customer", "cus_123");
 
     final RequestOptions options = RequestOptions.getDefault();
-    assertNull(options.getStripeVersionOnBehalfOf());
+    assertNull(options.getStripeVersionOverride());
 
     EphemeralKey.create(params, options);
   }
@@ -58,7 +58,7 @@ public class EphemeralKeyTest extends BaseStripeTest {
     params.put("customer", "cus_123");
 
     final RequestOptions options = RequestOptions.builder()
-        .setStripeVersionOnBehalfOf("2017-05-25").build();
+        .setStripeVersionOverride("2017-05-25").build();
 
     final EphemeralKey key = EphemeralKey.create(params, options);
 

--- a/src/test/java/com/stripe/functional/RequestOptionsTest.java
+++ b/src/test/java/com/stripe/functional/RequestOptionsTest.java
@@ -2,8 +2,10 @@ package com.stripe.functional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import com.stripe.BaseStripeTest;
+import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
 import com.stripe.model.Balance;
 import com.stripe.net.RequestOptions;
@@ -13,18 +15,18 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 public class RequestOptionsTest extends BaseStripeTest {
-  @Ignore // stripe-mock doesn't send a Stripe-Version header
   @Test
   public void testApiVersion() throws StripeException {
-    final String apiVersion = "2017-05-25";
-
-    final RequestOptions options = RequestOptions.builder().setStripeVersion(apiVersion).build();
+    final RequestOptions options = RequestOptions.builder().build();
+    assertEquals(Stripe.API_VERSION, options.getStripeVersion());
+    assertNull(options.getStripeVersionOnBehalfOf());
 
     final Balance balance = Balance.retrieve(options);
     final StripeResponse response = balance.getLastResponse();
 
     assertNotNull(response);
-    assertEquals(apiVersion, response.headers().get("Stripe-Version"));
+    // stripe-mock doesn't send back a Stripe-Version header in the response.
+    // assertEquals(Stripe.API_VERSION, response.headers().get("Stripe-Version"));
   }
 
   @Test

--- a/src/test/java/com/stripe/functional/RequestOptionsTest.java
+++ b/src/test/java/com/stripe/functional/RequestOptionsTest.java
@@ -18,7 +18,7 @@ public class RequestOptionsTest extends BaseStripeTest {
   public void testApiVersion() throws StripeException {
     final RequestOptions options = RequestOptions.builder().build();
     assertEquals(Stripe.API_VERSION, options.getStripeVersion());
-    assertNull(options.getStripeVersionOnBehalfOf());
+    assertNull(options.getStripeVersionOverride());
 
     final Balance balance = Balance.retrieve(options);
     final StripeResponse response = balance.getLastResponse();
@@ -41,5 +41,4 @@ public class RequestOptionsTest extends BaseStripeTest {
     assertNotNull(response);
     assertEquals(idempotencyKey, response.headers().get("Idempotency-Key"));
   }
-
 }

--- a/src/test/java/com/stripe/functional/RequestOptionsTest.java
+++ b/src/test/java/com/stripe/functional/RequestOptionsTest.java
@@ -11,7 +11,6 @@ import com.stripe.model.Balance;
 import com.stripe.net.RequestOptions;
 import com.stripe.net.StripeResponse;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class RequestOptionsTest extends BaseStripeTest {
@@ -42,4 +41,5 @@ public class RequestOptionsTest extends BaseStripeTest {
     assertNotNull(response);
     assertEquals(idempotencyKey, response.headers().get("Idempotency-Key"));
   }
+
 }

--- a/src/test/java/com/stripe/functional/StripeResponseTest.java
+++ b/src/test/java/com/stripe/functional/StripeResponseTest.java
@@ -24,7 +24,6 @@ public class StripeResponseTest extends BaseStripeTest {
   public void testResponseIncluded() throws StripeException {
     final String idempotencyKey = UUID.randomUUID().toString();
     final RequestOptions requestOptions = RequestOptions.builder()
-        .setStripeVersion(Stripe.apiVersion)
         .setIdempotencyKey(idempotencyKey)
         .build();
     final Customer customer = Customer.create(null, requestOptions);

--- a/src/test/java/com/stripe/functional/StripeResponseTest.java
+++ b/src/test/java/com/stripe/functional/StripeResponseTest.java
@@ -7,7 +7,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import com.stripe.BaseStripeTest;
-import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
 import com.stripe.model.Customer;
 import com.stripe.model.CustomerCollection;

--- a/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
+++ b/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
@@ -190,4 +190,18 @@ public class LiveStripeResponseGetterTest {
     assertEquals("https://myawesomeplugin.info", appMap.get("url"));
     assertEquals("pp_partner_1234", appMap.get("partner_id"));
   }
+
+  @Test
+  public void testStripeVersion() {
+    final RequestOptions optionsOnBehalfOf = new RequestOptionsBuilder()
+        .setStripeVersionOnBehalfOf("2015-05-05").build();
+    assertEquals(
+        "2015-05-05",
+        LiveStripeResponseGetter.getHeaders(optionsOnBehalfOf).get("Stripe-Version"));
+
+    final RequestOptions options = new RequestOptionsBuilder().build();
+    assertEquals(
+        Stripe.API_VERSION,
+        LiveStripeResponseGetter.getHeaders(options).get("Stripe-Version"));
+  }
 }

--- a/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
+++ b/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
@@ -193,11 +193,11 @@ public class LiveStripeResponseGetterTest {
 
   @Test
   public void testStripeVersion() {
-    final RequestOptions optionsOnBehalfOf = new RequestOptionsBuilder()
-        .setStripeVersionOnBehalfOf("2015-05-05").build();
+    final RequestOptions versionOverrideOpts = new RequestOptionsBuilder()
+        .setStripeVersionOverride("2015-05-05").build();
     assertEquals(
         "2015-05-05",
-        LiveStripeResponseGetter.getHeaders(optionsOnBehalfOf).get("Stripe-Version"));
+        LiveStripeResponseGetter.getHeaders(versionOverrideOpts).get("Stripe-Version"));
 
     final RequestOptions options = new RequestOptionsBuilder().build();
     assertEquals(

--- a/src/test/java/com/stripe/net/RequestOptionsTest.java
+++ b/src/test/java/com/stripe/net/RequestOptionsTest.java
@@ -6,6 +6,7 @@ import static junit.framework.TestCase.assertNull;
 import org.junit.Test;
 
 public class RequestOptionsTest {
+
   @Test
   public void testPersistentValuesInToBuilder() {
     RequestOptions opts = RequestOptions.builder()
@@ -27,5 +28,18 @@ public class RequestOptionsTest {
     assertNull(optsRebuilt.getStripeVersionOnBehalfOf());
     assertEquals(0, optsRebuilt.getReadTimeout());
     assertEquals(0, optsRebuilt.getConnectTimeout());
+  }
+
+  @Test
+  public void testStripeVersionOnBehalfOf() {
+    String stripeVersionOnBehalfOf = "2015-05-05";
+
+    RequestOptions.RequestOptionsBuilder builder = RequestOptions.builder()
+        .setStripeVersionOnBehalfOf(stripeVersionOnBehalfOf);
+
+    assertEquals(stripeVersionOnBehalfOf, builder.getStripeVersionOnBehalfOf());
+
+    builder.clearStripeVersionOnBehalfOf();
+    assertNull(builder.getStripeVersionOnBehalfOf());
   }
 }

--- a/src/test/java/com/stripe/net/RequestOptionsTest.java
+++ b/src/test/java/com/stripe/net/RequestOptionsTest.java
@@ -11,35 +11,61 @@ public class RequestOptionsTest {
   public void testPersistentValuesInToBuilder() {
     RequestOptions opts = RequestOptions.builder()
         .setApiKey("sk_foo")
-        .setStripeAccount("acct_bar")
         .setClientId("123")
         .setIdempotencyKey("123")
-        .setStripeVersionOnBehalfOf("2015-05-05")
+        .setStripeAccount("acct_bar")
+        .setStripeVersionOverride("2015-05-05")
         .setConnectTimeout(100)
         .setReadTimeout(100).build();
 
     RequestOptions optsRebuilt = opts.toBuilder().build();
 
+    // only api keys and account should persist
+    // assuming these are stable across a given stripe integration
     assertEquals("sk_foo", optsRebuilt.getApiKey());
     assertEquals("acct_bar", optsRebuilt.getStripeAccount());
 
     assertNull(optsRebuilt.getClientId());
     assertNull(optsRebuilt.getIdempotencyKey());
-    assertNull(optsRebuilt.getStripeVersionOnBehalfOf());
+    assertNull(optsRebuilt.getStripeVersionOverride());
     assertEquals(0, optsRebuilt.getReadTimeout());
     assertEquals(0, optsRebuilt.getConnectTimeout());
   }
 
   @Test
-  public void testStripeVersionOnBehalfOf() {
-    String stripeVersionOnBehalfOf = "2015-05-05";
+  public void testStripeVersionOverride() {
+    String stripeVersionOverride = "2015-05-05";
 
     RequestOptions.RequestOptionsBuilder builder = RequestOptions.builder()
-        .setStripeVersionOnBehalfOf(stripeVersionOnBehalfOf);
+        .setStripeVersionOverride(stripeVersionOverride);
 
-    assertEquals(stripeVersionOnBehalfOf, builder.getStripeVersionOnBehalfOf());
+    assertEquals(stripeVersionOverride, builder.getStripeVersionOverride());
 
-    builder.clearStripeVersionOnBehalfOf();
-    assertNull(builder.getStripeVersionOnBehalfOf());
+    builder.clearStripeVersionOverride();
+    assertNull(builder.getStripeVersionOverride());
+  }
+
+  @Test
+  public void testHashCodeEqualOverride() {
+    RequestOptions opts1 = RequestOptions.builder()
+        .setApiKey("sk_foo")
+        .setClientId("123")
+        .setIdempotencyKey("123")
+        .setStripeAccount("acct_bar")
+        .setStripeVersionOverride("2015-05-05")
+        .setConnectTimeout(100)
+        .setReadTimeout(200).build();
+
+    RequestOptions opts2 = RequestOptions.builder()
+        .setApiKey("sk_foo")
+        .setClientId("123")
+        .setIdempotencyKey("123")
+        .setStripeAccount("acct_bar")
+        .setStripeVersionOverride("2015-05-05")
+        .setConnectTimeout(100)
+        .setReadTimeout(200).build();
+
+    assertEquals(opts1, opts2);
+    assertEquals(opts1.hashCode(), opts2.hashCode());
   }
 }

--- a/src/test/java/com/stripe/net/RequestOptionsTest.java
+++ b/src/test/java/com/stripe/net/RequestOptionsTest.java
@@ -1,0 +1,31 @@
+package com.stripe.net;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNull;
+
+import org.junit.Test;
+
+public class RequestOptionsTest {
+  @Test
+  public void testPersistentValuesInToBuilder() {
+    RequestOptions opts = RequestOptions.builder()
+        .setApiKey("sk_foo")
+        .setStripeAccount("acct_bar")
+        .setClientId("123")
+        .setIdempotencyKey("123")
+        .setStripeVersionOnBehalfOf("2015-05-05")
+        .setConnectTimeout(100)
+        .setReadTimeout(100).build();
+
+    RequestOptions optsRebuilt = opts.toBuilder().build();
+
+    assertEquals("sk_foo", optsRebuilt.getApiKey());
+    assertEquals("acct_bar", optsRebuilt.getStripeAccount());
+
+    assertNull(optsRebuilt.getClientId());
+    assertNull(optsRebuilt.getIdempotencyKey());
+    assertNull(optsRebuilt.getStripeVersionOnBehalfOf());
+    assertEquals(0, optsRebuilt.getReadTimeout());
+    assertEquals(0, optsRebuilt.getConnectTimeout());
+  }
+}


### PR DESCRIPTION
- This should not be merged to master but to `mickjermsurawong/autogen-pre-master` branch, but i'm basing here on master to show compatibility and to pass master tests first.
- The only complication is in `EphemeralKey` that does not use the static version. (This class is together with File, Event, are not autogenerated).
  - Introduces `stripeVersionOnBehalfOf` for request options. This is different from both [.NET](https://github.com/stripe/stripe-dotnet/blob/master/src/Stripe.net/Services/EphemeralKeys/EphemeralKeyService.cs#L39-L46) and [Go](https://github.com/stripe/stripe-go/blob/master/ephemeralkey/client.go#L24-L26). where it takes version as the method params. I think that it would be better continue the pattern of header-related values to request option, and not in the parameters map.
r? @brandur-stripe 
cc @stripe/api-libraries 