### PR TITLE
Add support for expandable `transfer_data[destination]`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
 
 env:
   global:
-  - STRIPE_MOCK_VERSION=0.40.0
+  - STRIPE_MOCK_VERSION=0.40.1
 
 matrix:
   include:

--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -605,6 +605,25 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, HasId 
   @Setter
   @EqualsAndHashCode(callSuper = false)
   public static class TransferData extends StripeObject {
-    String destination;
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Account> destination;
+
+    // <editor-fold desc="destination">
+    public String getDestination() {
+      return (this.destination != null) ? this.destination.getId() : null;
+    }
+
+    public void setDestination(String destinationId) {
+      this.destination = setExpandableFieldId(destinationId, this.destination);
+
+    }
+
+    public Account getDestinationObject() {
+      return (this.destination != null) ? this.destination.getExpanded() : null;
+    }
+
+    public void setDestinationObject(Account c) {
+      this.destination = new ExpandableField<>(c.getId(), c);
+    }
+    // </editor-fold>
   }
 }

--- a/src/main/java/com/stripe/model/PaymentIntent.java
+++ b/src/main/java/com/stripe/model/PaymentIntent.java
@@ -306,7 +306,7 @@ public class PaymentIntent extends ApiResource implements MetadataStore<PaymentI
   @Setter
   @EqualsAndHashCode(callSuper = false)
   public static class TransferData extends StripeObject {
-    String destination;
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Account> destination;
 
     /**
      * The {@code amount} attribute.
@@ -315,5 +315,24 @@ public class PaymentIntent extends ApiResource implements MetadataStore<PaymentI
      */
     @Deprecated
     Long amount;
+
+    // <editor-fold desc="destination">
+    public String getDestination() {
+      return (this.destination != null) ? this.destination.getId() : null;
+    }
+
+    public void setDestination(String destinationId) {
+      this.destination = setExpandableFieldId(destinationId, this.destination);
+
+    }
+
+    public Account getDestinationObject() {
+      return (this.destination != null) ? this.destination.getExpanded() : null;
+    }
+
+    public void setDestinationObject(Account c) {
+      this.destination = new ExpandableField<>(c.getId(), c);
+    }
+    // </editor-fold>
   }
 }

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -35,7 +35,7 @@ import org.mockito.Mockito;
 
 public class BaseStripeTest {
   // If changing this number, please also change it in `.travis.yml`.
-  private static final String MOCK_MINIMUM_VERSION = "0.40.0";
+  private static final String MOCK_MINIMUM_VERSION = "0.40.1";
 
   private static String port;
 

--- a/src/test/java/com/stripe/model/ChargeTest.java
+++ b/src/test/java/com/stripe/model/ChargeTest.java
@@ -46,6 +46,7 @@ public class ChargeTest extends BaseStripeTest {
       "review",
       "source_transfer",
       "transfer",
+      "transfer_data.destination",
     };
     final String data = getFixture("/v1/charges/ch_123", expansions);
     final Charge charge = ApiResource.GSON.fromJson(data, Charge.class);
@@ -98,5 +99,10 @@ public class ChargeTest extends BaseStripeTest {
     assertNotNull(transfer);
     assertNotNull(transfer.getId());
     assertEquals(charge.getTransfer(), transfer.getId());
+
+    final Account transferDestination = charge.getTransferData().getDestinationObject();
+    assertNotNull(transferDestination);
+    assertNotNull(transferDestination.getId());
+    assertEquals(charge.getTransferData().getDestination(), transferDestination.getId());
   }
 }

--- a/src/test/java/com/stripe/model/PaymentIntentTest.java
+++ b/src/test/java/com/stripe/model/PaymentIntentTest.java
@@ -71,6 +71,7 @@ public class PaymentIntentTest extends BaseStripeTest {
       "on_behalf_of",
       "review",
       "source",
+      "transfer_data.destination",
     };
 
     final String data = getFixture("/v1/payment_intents/pi_123", expansions);
@@ -99,5 +100,10 @@ public class PaymentIntentTest extends BaseStripeTest {
     assertNotNull(source);
     assertNotNull(source.getId());
     assertEquals(resource.getSource(), source.getId());
+
+    final Account transferDestination = resource.getTransferData().getDestinationObject();
+    assertNotNull(transferDestination);
+    assertNotNull(transferDestination.getId());
+    assertEquals(resource.getTransferData().getDestination(), transferDestination.getId());
   }
 }


### PR DESCRIPTION
r? @ob-stripe @mickjermsurawong-stripe 
cc @stripe/api-libraries 