### PR TITLE
Best-attempt event read on version pinning

### DIFF
--- a/src/main/java/com/stripe/model/Event.java
+++ b/src/main/java/com/stripe/model/Event.java
@@ -1,5 +1,8 @@
 package com.stripe.model;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
@@ -19,7 +22,7 @@ public class Event extends ApiResource implements HasId {
   String account;
   String apiVersion;
   Long created;
-  EventData data;
+  TolerantRead<EventData> data;
   Boolean livemode;
   Long pendingWebhooks;
   EventRequest request;
@@ -69,6 +72,90 @@ public class Event extends ApiResource implements HasId {
   public static Event retrieve(String id, Map<String, Object> params, RequestOptions options)
       throws StripeException {
     return request(RequestMethod.GET, instanceUrl(Event.class, id), params, Event.class, options);
+  }
+
+  /**
+   * Deprecated in favor of more specific mode of reading data based on API version configured,
+   * and the failure during deserialization. When deserialization fails, result is null, and
+   * failure information should be checked. See {@link Event#rawReadDataOnFailure()} and
+   * {@link Event#getReadDataException()}.
+   * @return nullable event data.
+   */
+  @Deprecated
+  public EventData getData() {
+    if (data == null) {
+      return null;
+    }
+    if (canSafeReadData()) {
+      return data.getSafeData();
+    } else {
+      return data.getBestAttemptData();
+    }
+  }
+
+  /**
+   * Checks whether API version of the event matches that {@link Stripe#apiVersion} of this
+   * integration.
+   * @return true when the versions match.
+   */
+  public boolean canSafeReadData() {
+    return apiVersion != null && apiVersion.equals(Stripe.apiVersion);
+  }
+
+  /**
+   * When non-null, the deserialized data preserves high integrity because
+   * of strong correspondence between schema of Stripe response and the Java model class.
+   * @return Safe event data with high fidelity.
+   */
+  public EventData safeReadData() {
+    if (data == null) {
+      return null;
+    }
+    return data.getSafeData();
+  }
+
+  /**
+   * When non-null, the deserialized data is not guaranteed to to contain all the fields, because
+   * there can be mismatch between schema of Stripe response and the Java model class.
+   *
+   * @return Best attempt deserialized data.
+   */
+  public EventData bestAttemptReadData() {
+    if (data == null) {
+      return null;
+    }
+    return data.getBestAttemptData();
+  }
+
+  /**
+   * When non-null, gets raw JSON data that couldn't be successfully deserialized.
+   * The returned response can be mutated and will not affect the original data. This allows for
+   * evolving your JSON object to be compatible with that of current model class.
+   * @return raw JSON event data
+   */
+  public JsonObject rawReadDataOnFailure() {
+    if (data == null) {
+      return null;
+    }
+    return data.getRawDataOnFailure().deepCopy();
+  }
+
+  /**
+   * Flag whether read fails due to deserialization failure.
+   */
+  public boolean isReadDataFailure() {
+    return data != null && data.getRawDataOnFailure() != null && data.getReadException() != null;
+  }
+
+  /**
+   * Parsing exception during data deserialization. Other exceptions are not specifically handled.
+   * @return parsing exception.
+   */
+  public JsonParseException getReadDataException() {
+    if (data == null) {
+      return null;
+    }
+    return data.getReadException();
   }
   // </editor-fold>
 }

--- a/src/main/java/com/stripe/model/EventTypeAdapterFactory.java
+++ b/src/main/java/com/stripe/model/EventTypeAdapterFactory.java
@@ -1,0 +1,113 @@
+package com.stripe.model;
+
+import com.google.gson.ExclusionStrategy;
+import com.google.gson.FieldAttributes;
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+import java.lang.reflect.Type;
+
+public class EventTypeAdapterFactory implements TypeAdapterFactory {
+
+  private static final Gson GSON_EVENT = new GsonBuilder()
+      .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+      // excludes `data` field during automatic deserialization because we have custom handling
+      .setExclusionStrategies(new ExcludeEventDataFieldStrategy())
+      .create();
+
+  private static class ExcludeEventDataFieldStrategy implements ExclusionStrategy {
+    public boolean shouldSkipClass(Class<?> arg0) {
+      return false;
+    }
+
+    public boolean shouldSkipField(FieldAttributes f) {
+      return (f.getDeclaringClass() == Event.class && f.getName().equals("data"));
+    }
+  }
+
+  public static class EventSerializer implements JsonSerializer<Event> {
+    @Override
+    public JsonElement serialize(Event event, Type typeOfSrc, JsonSerializationContext context) {
+
+      // get event data from different read modes
+      JsonElement rawEventData;
+      if (event.isReadDataFailure()) {
+        rawEventData = event.rawReadDataOnFailure();
+      } else if (event.canSafeReadData()) {
+        rawEventData = context.serialize(event.safeReadData());
+      } else {
+        rawEventData = context.serialize(event.bestAttemptReadData());
+      }
+
+      // serialized content here has no `data` field due to the exclusion strategy
+      JsonObject serialized =  GSON_EVENT.toJsonTree(event, typeOfSrc).getAsJsonObject();
+      serialized.add("data", rawEventData);
+      return serialized;
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+    if (!Event.class.isAssignableFrom(type.getRawType())) {
+      return null;
+    }
+
+    final TypeAdapter<Event> eventTypeAdapter =
+        gson.getDelegateAdapter(this, TypeToken.get(Event.class));
+    final TypeAdapter<JsonElement> jsonElementAdapter = gson.getAdapter(JsonElement.class);
+    final TypeAdapter<EventData> eventDataAdapter = gson.getAdapter(EventData.class);
+
+    TypeAdapter<Event> resultCustomTypeAdapter =
+        new TypeAdapter<Event>() {
+          @Override
+          public void write(JsonWriter out, Event value) throws IOException {
+            eventTypeAdapter.write(out, value);
+          }
+
+          @Override
+          public Event read(JsonReader in) throws IOException {
+            JsonObject eventJsonObject = jsonElementAdapter.read(in).getAsJsonObject();
+
+            JsonObject eventDataJsonObject = eventJsonObject.getAsJsonObject("data");
+            eventJsonObject.remove("data");
+            // event starts without event data, to be set later depending on data deserialization
+            Event event = eventTypeAdapter.fromJsonTree(eventJsonObject);
+
+            TolerantRead<EventData> tolerantRead = new TolerantRead<>();
+
+            if (eventDataJsonObject == null) {
+              // no data set
+            } else if (event.canSafeReadData()) {
+              // when version matches, parsing exception should fail loudly
+              EventData safeEventData = eventDataAdapter.fromJsonTree(eventDataJsonObject);
+              tolerantRead.setSafeData(safeEventData);
+            } else {
+              // otherwise, we can afford handle parsing exception
+              try {
+                EventData bestAttemptEventData = eventDataAdapter.fromJsonTree(eventDataJsonObject);
+                tolerantRead.setBestAttemptData(bestAttemptEventData);
+              } catch (JsonParseException e) {
+                tolerantRead.setRawDataOnFailure(eventDataJsonObject);
+                tolerantRead.setReadException(e);
+              }
+            }
+            event.setData(tolerantRead);
+
+            return event;
+          }
+        };
+    return (TypeAdapter<T>) resultCustomTypeAdapter.nullSafe();
+  }
+}

--- a/src/main/java/com/stripe/model/StripeObject.java
+++ b/src/main/java/com/stripe/model/StripeObject.java
@@ -15,6 +15,7 @@ public abstract class StripeObject {
       .serializeNulls()
       .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
       .registerTypeAdapter(ExpandableField.class, new ExpandableFieldSerializer())
+      .registerTypeAdapter(Event.class, new EventTypeAdapterFactory.EventSerializer())
       .create();
 
   @Override

--- a/src/main/java/com/stripe/model/TolerantRead.java
+++ b/src/main/java/com/stripe/model/TolerantRead.java
@@ -1,0 +1,15 @@
+package com.stripe.model;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+final class TolerantRead<T extends StripeObject> {
+  private T safeData;
+  private T bestAttemptData;
+  private JsonObject rawDataOnFailure;
+  private JsonParseException readException;
+}

--- a/src/main/java/com/stripe/net/ApiResourceTypeAdapterFactoryProvider.java
+++ b/src/main/java/com/stripe/net/ApiResourceTypeAdapterFactoryProvider.java
@@ -1,6 +1,7 @@
 package com.stripe.net;
 
 import com.google.gson.TypeAdapterFactory;
+import com.stripe.model.EventTypeAdapterFactory;
 import com.stripe.model.ExternalAccountTypeAdapterFactory;
 import java.util.ArrayList;
 import java.util.List;
@@ -14,6 +15,7 @@ final class ApiResourceTypeAdapterFactoryProvider {
 
   static {
     factories.add(new ExternalAccountTypeAdapterFactory());
+    factories.add(new EventTypeAdapterFactory());
   }
 
   public static List<TypeAdapterFactory> getAll() {

--- a/src/test/java/com/stripe/model/EventDataDeserializerTest.java
+++ b/src/test/java/com/stripe/model/EventDataDeserializerTest.java
@@ -1,26 +1,121 @@
 package com.stripe.model;
 
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
+import com.google.gson.JsonParseException;
 import com.stripe.BaseStripeTest;
+import com.stripe.Stripe;
 import com.stripe.net.ApiResource;
-
+import java.io.IOException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class EventDataDeserializerTest extends BaseStripeTest {
 
-  @Test
-  public void testEventAccountApplicationDeauthorized() throws Exception {
-    final String data = getResourceAsString("/api_fixtures/account_application_deauthorized.json");
-    final Event event = ApiResource.GSON.fromJson(data, Event.class);
-    assertNotNull(event);
-    assertNotNull(event.getId());
-    assertNotNull(event.getData());
-    assertNotNull(event.getData().getObject());
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
 
-    final Application application = (Application) event.getData().getObject();
+  private static final String OLD_EVENT_VERSION = "2013-08-15";
+  private static final String CURRENT_EVENT_VERSION = "2017-08-15";
+  private static final String NO_MATCH_VERSION = "2000-08-15";
+
+  private String originalApiVersion;
+
+  @Before
+  public void saveOriginalApiVersion() {
+    originalApiVersion = Stripe.apiVersion;
+  }
+
+  @After
+  public void restoreOriginalStripeVersion() {
+    Stripe.apiVersion = originalApiVersion;
+  }
+
+  private void verifyDeserializedEventData(EventData eventData) {
+    final Application application = (Application) eventData.getObject();
     assertNotNull(application);
     assertNotNull(application.getId());
   }
 
+  private String getCurrentEventStringFixture() throws IOException {
+    return getResourceAsString("/api_fixtures/account_application_deauthorized.json");
+  }
+
+  private String getOldEventStringFixture() throws IOException {
+    return getResourceAsString(
+        "/api_fixtures/account_application_deauthorized_old_version.json");
+  }
+
+  @Test
+  public void testApiVersionMatchesGetSafeData() throws Exception {
+    Stripe.apiVersion = CURRENT_EVENT_VERSION;
+    final String data = getCurrentEventStringFixture();
+    final Event event = ApiResource.GSON.fromJson(data, Event.class);
+
+    assertEquals(Stripe.apiVersion, event.getApiVersion());
+
+    assertNotNull(event);
+    assertNotNull(event.getId());
+
+    assertNotNull(event.safeReadData());
+    verifyDeserializedEventData(event.safeReadData());
+  }
+
+  @Test
+  public void testApiVersionMismatchGetBestAttemptData() throws Exception {
+    Stripe.apiVersion = NO_MATCH_VERSION;
+    final String data = getCurrentEventStringFixture();
+    final Event event = ApiResource.GSON.fromJson(data, Event.class);
+
+    assertNotEquals(Stripe.apiVersion, event.getApiVersion());
+
+    assertNotNull(event);
+    assertNotNull(event.getId());
+
+    assertFalse(event.canSafeReadData());
+    assertNull(event.safeReadData());
+
+    assertNotNull(event.bestAttemptReadData());
+    verifyDeserializedEventData(event.bestAttemptReadData());
+  }
+
+  @Test
+  public void testFailsLoudlyApiVersionMatches() throws Exception {
+    Stripe.apiVersion = OLD_EVENT_VERSION;
+    // if version match, we should not tolerate parsing failure.
+    final String data = getOldEventStringFixture();
+    thrown.expect(JsonParseException.class);
+    ApiResource.GSON.fromJson(data, Event.class);
+  }
+
+  @Test
+  public void testHandlesFailureOnApiVersionMatches() throws Exception {
+    Stripe.apiVersion = NO_MATCH_VERSION;
+    final String data = getOldEventStringFixture();
+
+    final Event event = ApiResource.GSON.fromJson(data, Event.class);
+    assertNotNull(event);
+    assertNotNull(event.getId());
+
+    assertNull(event.safeReadData());
+    assertNull(event.bestAttemptReadData());
+
+    assertTrue(event.isReadDataFailure());
+    assertNotNull(event.rawReadDataOnFailure());
+
+    // name is not primitive, causing the failure
+    assertTrue(
+        event.rawReadDataOnFailure().getAsJsonObject("object").get("name").isJsonArray());
+    assertNotNull(event.getReadDataException());
+    assertTrue(event.getReadDataException().getMessage()
+        .contains("Expected STRING but was BEGIN_ARRAY at path $.name"));
+  }
 }

--- a/src/test/java/com/stripe/model/EventTest.java
+++ b/src/test/java/com/stripe/model/EventTest.java
@@ -26,6 +26,8 @@ public class EventTest extends BaseStripeTest {
   public void testReserialize() throws Exception {
     final String data = getResourceAsString("/api_fixtures/event_plan.json");
     final Event event = ApiResource.GSON.fromJson(data, Event.class);
+    EventData eventData = event.bestAttemptReadData();
+    assertNotNull(eventData);
 
     final Event reserializedEvent = ApiResource.GSON.fromJson(event.toJson(), Event.class);
 
@@ -39,5 +41,6 @@ public class EventTest extends BaseStripeTest {
     assertEquals(reserializedEvent.getRequest().getIdempotencyKey(),
         event.getRequest().getIdempotencyKey());
     assertEquals(reserializedEvent.getType(), event.getType());
+    assertEquals(reserializedEvent.bestAttemptReadData(), eventData);
   }
 }

--- a/src/test/resources/api_fixtures/account_application_deauthorized_old_version.json
+++ b/src/test/resources/api_fixtures/account_application_deauthorized_old_version.json
@@ -1,0 +1,17 @@
+{
+  "created": 1326853478,
+  "livemode": false,
+  "id": "evt_00000000000000",
+  "type": "account.application.deauthorized",
+  "object": "event",
+  "request": null,
+  "pending_webhooks": 1,
+  "api_version": "2013-08-15",
+  "data": {
+    "object": {
+      "id": "ca_00000000000000",
+      "object": "application",
+      "name": ["schema long time ago", "of 2013", "now invalid"]
+    }
+  }
+}


### PR DESCRIPTION
- This PR again should not be merged to master but to pre-autogen branch, similar to https://github.com/stripe/stripe-java/pull/651 (because pre-autogen branch without autogenerated code on top of it doesn't compile)
- This PR aims to make interface on reading `EventData` more explicit, having 3 the read mode: safe, best attempt, and raw read on failure.
- The proposed abstraction here has non-breaking interface `getData()` to existing integration, and has the same behavior except on failure case.
- This implementation here now still uses non-pinned version, but the intention here is to release with pinned version; sorry for the inconsistency here.
r? @ob-stripe @brandur-stripe 
cc @stripe/api-libraries 

The build fail now is due to jdk 11 failing to download.