### PR TITLE
Better handling of namespaced resources

### DIFF
--- a/src/main/java/com/stripe/net/ApiResource.java
+++ b/src/main/java/com/stripe/net/ApiResource.java
@@ -86,18 +86,13 @@ public abstract class ApiResource extends StripeObject {
         .replaceAll("([a-z0-9])([A-Z])", "$1_$2")
         .toLowerCase();
 
-    // Issuing or Sigma resources are in their own package. Until we can support adding OBJECT_NAME
-    // to all classes, we use this dirty trick to properly format the API endpoints
-    if (clazz.getName().contains("com.stripe.model.issuing.")) {
-      className = "issuing/" + className;
-    } else if (clazz.getName().contains("com.stripe.model.sigma.")) {
-      className = "sigma/" + className;
-    } else if (clazz.getName().contains("com.stripe.model.radar.")) {
-      className = "radar/" + className;
-    } else if (clazz.getName().contains("com.stripe.model.reporting.")) {
-      className = "reporting/" + className;
-    } else if (clazz.getName().contains("com.stripe.model.terminal.")) {
-      className = "terminal/" + className;
+    // Handle namespaced resources by checking if the class is in a sub-package, and if so prepend
+    // it to the class name
+    String[] parts = clazz.getPackage().getName().split("\\.");
+    assert parts.length == 3 || parts.length == 4;
+    if (parts.length == 4) {
+      // The first three parts are always "com.stripe.model", the fourth part is the sub-package
+      className = parts[3] + "/" + className;
     }
 
     // Handle special cases


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Better handling of namespaced resources, by using the sub-package's name as the namespace (e.g. if the sub-package is `com.stripe.model.issuing`, `issuing` is the resource's namespace).

This way we don't have to manually add new namespaces.

This is still a bit too implicit / magic for my taste and I'd rather we explicitly declare the full Stripe object name in each model class, but we can do that later.