### PR TITLE
Add support for Account and Person API changes for 2019-02-18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
 
 env:
   global:
-  - STRIPE_MOCK_VERSION=0.44.0
+  - STRIPE_MOCK_VERSION=0.45.0
 
 matrix:
   include:

--- a/src/main/java/com/stripe/model/Account.java
+++ b/src/main/java/com/stripe/model/Account.java
@@ -7,6 +7,7 @@ import com.stripe.net.RequestOptions;
 import java.util.List;
 import java.util.Map;
 
+import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -17,39 +18,66 @@ import lombok.Setter;
 public class Account extends ApiResource implements HasId, MetadataStore<Account> {
   @Getter(onMethod = @__({@Override})) String id;
   String object;
-  String businessLogo;
-  String businessName;
-  String businessPrimaryColor;
-  String businessUrl;
+  BusinessProfile businessProfile;
+  String businessType;
+  Capabilities capabilities;
   Boolean chargesEnabled;
+  Company company;
   String country;
   Long created;
-  Boolean debitNegativeBalances;
-  DeclineChargeOn declineChargeOn;
   String defaultCurrency;
   Boolean deleted;
   Boolean detailsSubmitted;
-  String displayName;
   String email;
   ExternalAccountCollection externalAccounts;
-  Keys keys;
-  LegalEntity legalEntity;
+  Person individual;
   LoginLinkCollection loginLinks;
-  @Getter(onMethod = @__({@Override})) Map<String, String> metadata;
-  PayoutSchedule payoutSchedule;
-  String payoutStatementDescriptor;
+  Map<String, String> metadata;
   Boolean payoutsEnabled;
-  String productDescription;
-  String statementDescriptor;
-  Address supportAddress;
-  String supportEmail;
-  String supportPhone;
-  String supportUrl;
-  String timezone;
+  Requirements requirements;
+  Settings settings;
   TosAcceptance tosAcceptance;
-  Boolean transfersEnabled;
   String type;
-  Verification verification;
+
+  /**
+   * The {@code business_logo_large} attribute.
+   *
+   * @see <a href="https://stripe.com/docs/upgrades#2019-02-19">API version 2019-02-19</a>
+   */
+  @Deprecated
+  String businessLogoLarge;
+
+  /**
+   * The {@code business_logo} attribute.
+   *
+   * @see <a href="https://stripe.com/docs/upgrades#2019-02-19">API version 2019-02-19</a>
+   */
+  @Deprecated
+  String businessLogo;
+
+  /**
+   * The {@code business_name} attribute.
+   *
+   * @see <a href="https://stripe.com/docs/upgrades#2019-02-19">API version 2019-02-19</a>
+   */
+  @Deprecated
+  String businessName;
+
+  /**
+   * The {@code business_primary_color} attribute.
+   *
+   * @see <a href="https://stripe.com/docs/upgrades#2019-02-19">API version 2019-02-19</a>
+   */
+  @Deprecated
+  String businessPrimaryColor;
+
+  /**
+   * The {@code business_url} attribute.
+   *
+   * @see <a href="https://stripe.com/docs/upgrades#2019-02-19">API version 2019-02-19</a>
+   */
+  @Deprecated
+  String businessUrl;
 
   /**
    * The {@code currencies_supported} attribute.
@@ -62,6 +90,38 @@ public class Account extends ApiResource implements HasId, MetadataStore<Account
   List<String> currenciesSupported;
 
   /**
+   * The {@code decline_charge_on} attribute.
+   *
+   * @see <a href="https://stripe.com/docs/upgrades#2019-02-19">API version 2019-02-19</a>
+   */
+  @Deprecated
+  DeclineChargeOn declineChargeOn;
+
+  /**
+   * The {@code debit_negative_balances} attribute.
+   *
+   * @see <a href="https://stripe.com/docs/upgrades#2019-02-19">API version 2019-02-19</a>
+   */
+  @Deprecated
+  Boolean debitNegativeBalances;
+
+  /**
+   * The {@code keys} attribute.
+   *
+   * @see <a href="https://stripe.com/docs/upgrades#2019-02-19">API version 2019-02-19</a>
+   */
+  @Deprecated
+  Keys keys;
+
+  /**
+   * The {@code legal_entity} attribute.
+   *
+   * @see <a href="https://stripe.com/docs/upgrades#2019-02-19">API version 2019-02-19</a>
+   */
+  @Deprecated
+  LegalEntity legalEntity;
+
+  /**
    * The {@code managed} attribute.
    *
    * @deprecated Prefer using the {@link #type} attribute instead.
@@ -71,6 +131,87 @@ public class Account extends ApiResource implements HasId, MetadataStore<Account
   Boolean managed;
 
   /**
+   * The {@code mcc} attribute.
+   *
+   * @see <a href="https://stripe.com/docs/upgrades#2019-02-19">API version 2019-02-19</a>
+   */
+  @Deprecated
+  String mcc;
+
+  /**
+   * The {@code payout_schedule} attribute.
+   *
+   * @see <a href="https://stripe.com/docs/upgrades#2019-02-19">API version 2019-02-19</a>
+   */
+  @Deprecated
+  PayoutSchedule payoutSchedule;
+
+  /**
+   * The {@code payout_statement_descriptor} attribute.
+   *
+   * @see <a href="https://stripe.com/docs/upgrades#2019-02-19">API version 2019-02-19</a>
+   */
+  @Deprecated
+  String payoutStatementDescriptor;
+
+  /**
+   * The {@code product_description} attribute.
+   *
+   * @see <a href="https://stripe.com/docs/upgrades#2019-02-19">API version 2019-02-19</a>
+   */
+  @Deprecated
+  String productDescription;
+
+  /**
+   * The {@code statement_descriptor} attribute.
+   *
+   * @see <a href="https://stripe.com/docs/upgrades#2019-02-19">API version 2019-02-19</a>
+   */
+  @Deprecated
+  String statementDescriptor;
+
+  /**
+   * The {@code support_address} attribute.
+   *
+   * @see <a href="https://stripe.com/docs/upgrades#2019-02-19">API version 2019-02-19</a>
+   */
+  @Deprecated
+  Address supportAddress;
+
+  /**
+   * The {@code support_email} attribute.
+   *
+   * @see <a href="https://stripe.com/docs/upgrades#2019-02-19">API version 2019-02-19</a>
+   */
+  @Deprecated
+  String supportEmail;
+
+  /**
+   * The {@code support_phone} attribute.
+   *
+   * @see <a href="https://stripe.com/docs/upgrades#2019-02-19">API version 2019-02-19</a>
+   */
+  @Deprecated
+  String supportPhone;
+
+  /**
+   * The {@code support_url} attribute.
+   *
+   * @see <a href="https://stripe.com/docs/upgrades#2019-02-19">API version 2019-02-19</a>
+   */
+  @Deprecated
+  String supportUrl;
+
+  /**
+   * The {@code transfers_enabled} attribute.
+   *
+   * @deprecated Prefer using the {@link #payoutsEnabled} attribute instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2017-04-06">API version 2017-04-06</a>
+   */
+  @Deprecated
+  Boolean transfersEnabled;
+
+  /**
    * The {@code transfer_schedule} attribute.
    *
    * @deprecated Prefer using the {@link #payoutSchedule} attribute instead.
@@ -78,6 +219,14 @@ public class Account extends ApiResource implements HasId, MetadataStore<Account
    */
   @Deprecated
   TransferSchedule transferSchedule;
+
+  /**
+   * The {@code verification} attribute.
+   *
+   * @see <a href="https://stripe.com/docs/upgrades#2019-02-19">API version 2019-02-19</a>
+   */
+  @Deprecated
+  Verification verification;
 
   // <editor-fold desc="create">
   /**
@@ -261,17 +410,95 @@ public class Account extends ApiResource implements HasId, MetadataStore<Account
   @Getter
   @Setter
   @EqualsAndHashCode(callSuper = false)
-  public static class DeclineChargeOn extends StripeObject {
-    Boolean avsFailure;
-    Boolean cvcFailure;
+  public static class BusinessProfile extends StripeObject {
+    String mcc;
+    String name;
+    String productDescription;
+    Address supportAddress;
+    String supportEmail;
+    String supportPhone;
+    String supportUrl;
+    String url;
   }
 
   @Getter
   @Setter
   @EqualsAndHashCode(callSuper = false)
-  public static class Keys extends StripeObject {
-    String publishable;
-    String secret;
+  public static class Capabilities extends StripeObject {
+    String cardPayments;
+    String legacyPayments;
+    String platformPayments;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class Company extends StripeObject {
+    Address address;
+    Person.JapanAddress addressKana;
+    Person.JapanAddress addressKanji;
+    Boolean directorsProvided;
+    String name;
+    String nameKana;
+    String nameKanji;
+    Boolean ownersProvided;
+    String phone;
+    Boolean taxIdProvided;
+    String taxIdRegistrar;
+    Boolean vatIdProvided;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class SettingsBranding extends StripeObject {
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<File> icon;
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<File> logo;
+    String primaryColor;
+
+    // <editor-fold desc="icon">
+    public String getIcon() {
+      return (this.icon != null) ? this.icon.getId() : null;
+    }
+
+    public void setIcon(String iconId) {
+      this.icon = setExpandableFieldId(iconId, this.icon);
+    }
+
+    public File getIconObject() {
+      return (this.icon != null) ? this.icon.getExpanded() : null;
+    }
+
+    public void setIconObject(File c) {
+      this.icon = new ExpandableField<>(c.getId(), c);
+    }
+    // </editor-fold>
+
+    // <editor-fold desc="logo">
+    public String getLogo() {
+      return (this.logo != null) ? this.logo.getId() : null;
+    }
+
+    public void setLogo(String logoId) {
+      this.logo = setExpandableFieldId(logoId, this.logo);
+    }
+
+    public File getLogoObject() {
+      return (this.logo != null) ? this.logo.getExpanded() : null;
+    }
+
+    public void setLogoObject(File c) {
+      this.logo = new ExpandableField<>(c.getId(), c);
+    }
+    // </editor-fold>
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class DeclineChargeOn extends StripeObject {
+    Boolean avsFailure;
+    Boolean cvcFailure;
   }
 
   @Getter
@@ -287,6 +514,60 @@ public class Account extends ApiResource implements HasId, MetadataStore<Account
   @Getter
   @Setter
   @EqualsAndHashCode(callSuper = false)
+  public static class Requirements extends StripeObject {
+    Long currentDeadline;
+    List<String> currentlyDue;
+    String disabledReason;
+    List<String> eventuallyDue;
+    List<String> pastDue;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class SettingsCardPayments extends StripeObject {
+    DeclineChargeOn declineOn;
+    String statementDescriptorPrefix;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class SettingsDashboard extends StripeObject {
+    String displayName;
+    String timezone;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class SettingsPayments extends StripeObject {
+    String statementDescriptor;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class SettingsPayouts extends StripeObject {
+    Boolean debitNegativeBalances;
+    PayoutSchedule schedule;
+    String statementDescriptor;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class Settings extends StripeObject {
+    SettingsBranding branding;
+    SettingsCardPayments cardPayments;
+    SettingsDashboard dashboard;
+    SettingsPayments payments;
+    SettingsPayouts payouts;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
   public static class TosAcceptance extends StripeObject {
     Long date;
     String ip;
@@ -296,6 +577,16 @@ public class Account extends ApiResource implements HasId, MetadataStore<Account
   @Getter
   @Setter
   @EqualsAndHashCode(callSuper = false)
+  @Deprecated
+  public static class Keys extends StripeObject {
+    String publishable;
+    String secret;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  @Deprecated
   public static class TransferSchedule extends StripeObject {
     Long delayDays;
     String interval;
@@ -306,6 +597,7 @@ public class Account extends ApiResource implements HasId, MetadataStore<Account
   @Getter
   @Setter
   @EqualsAndHashCode(callSuper = false)
+  @Deprecated
   public static class Verification extends StripeObject {
     Boolean contacted;
     String disabledReason;

--- a/src/main/java/com/stripe/model/Person.java
+++ b/src/main/java/com/stripe/model/Person.java
@@ -10,6 +10,7 @@ import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 
+import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -39,6 +40,7 @@ public class Person extends ApiResource implements MetadataStore<Person>, HasId 
   String maidenName;
   @Getter(onMethod = @__({@Override})) Map<String, String> metadata;
   String phone;
+  Relationship relationship;
   Requirements requirements;
   @SerializedName("ssn_last_4_provided") Boolean ssnLast4Provided;
   Verification verification;
@@ -84,8 +86,6 @@ public class Person extends ApiResource implements MetadataStore<Person>, HasId 
     return null;
   }
 
-  // TODO: Move this to a top level class instead of duplicating
-  // with the LegalEntity resource
   @Getter
   @Setter
   @EqualsAndHashCode(callSuper = false)
@@ -95,8 +95,6 @@ public class Person extends ApiResource implements MetadataStore<Person>, HasId 
     Long year;
   }
 
-  // TODO: Move this to a top level class instead of duplicating
-  // with the LegalEntity resource
   @Getter
   @Setter
   @EqualsAndHashCode(callSuper = false)
@@ -116,11 +114,25 @@ public class Person extends ApiResource implements MetadataStore<Person>, HasId 
   public static class Relationship extends StripeObject {
     Boolean accountOpener;
     Boolean director;
-    Boolean executive;
     Boolean owner;
     BigDecimal percentOwnership;
-    Boolean representative;
     String title;
+
+    /**
+     * The {@code executive} attribute.
+     * @deprecated This is not required anymore.
+     * @see <a href="https://stripe.com/docs/upgrades#2019-02-19">API version 2019-02-19</a>
+     */
+    @Deprecated
+    Boolean executive;
+
+    /**
+     * The {@code representative} attribute.
+     * @deprecated This is not required anymore.
+     * @see <a href="https://stripe.com/docs/upgrades#2019-02-19">API version 2019-02-19</a>
+     */
+    @Deprecated
+    Boolean representative;
   }
 
   @Getter
@@ -132,16 +144,175 @@ public class Person extends ApiResource implements MetadataStore<Person>, HasId 
     List<String> pastDue;
   }
 
-  // TODO: Move this to a top level class instead of duplicating
-  // with the LegalEntity resource
   @Getter
   @Setter
   @EqualsAndHashCode(callSuper = false)
   public static class Verification extends StripeObject {
     String details;
     String detailsCode;
-    String document;
-    String documentBack;
+    VerificationDocument documentSubObject;
     String status;
+
+    /**
+     * The {@code document} attribute.
+     *
+     * @return the {@code document} attribute
+     * @deprecated Prefer using the {@link #getDocumentSubObject} method instead.
+     * @see <a href="https://stripe.com/docs/upgrades#2019-02-19">API version 2019-02-19</a>
+     */
+    @Deprecated
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<File> document;
+
+    /**
+     * The {@code document_back} attribute.
+     *
+     * @return the {@code document_back} attribute
+     * @deprecated Prefer using the {@link #getDocumentSubObject} method instead.
+     * @see <a href="https://stripe.com/docs/upgrades#2019-02-19">API version 2019-02-19</a>
+     */
+    @Deprecated
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<File> documentBack;
+
+    // <editor-fold desc="document">
+    /**
+     * Gets the {@code document} attribute.
+     *
+     * @return the {@code document} attribute
+     * @deprecated Prefer using the {@link #getDocumentSubObject} method instead.
+     * @see <a href="https://stripe.com/docs/upgrades#2019-02-19">API version 2019-02-19</a>
+     */
+    @Deprecated
+    public String getDocument() {
+      return (this.document != null) ? this.document.getId() : null;
+    }
+
+    /**
+     * Sets the {@code document} attribute.
+     *
+     * @deprecated Prefer using the {@link #setDocumentSubObject} method instead.
+     * @see <a href="https://stripe.com/docs/upgrades#2019-02-19">API version 2019-02-19</a>
+     */
+    @Deprecated
+    public void setDocument(String id) {
+      this.document = ApiResource.setExpandableFieldId(id, this.document);
+    }
+
+    /**
+     * Gets the {@code document} attribute.
+     *
+     * @return the {@code document} attribute
+     * @deprecated Prefer using the {@link #getDocumentSubObject} method instead.
+     * @see <a href="https://stripe.com/docs/upgrades#2019-02-19">API version 2019-02-19</a>
+     */
+    @Deprecated
+    public File getDocumentObject() {
+      return (this.document != null) ? this.document.getExpanded() : null;
+    }
+
+    /**
+     * Sets the {@code document} attribute.
+     *
+     * @deprecated Prefer using the {@link #setDocumentSubObject} method instead.
+     * @see <a href="https://stripe.com/docs/upgrades#2019-02-19">API version 2019-02-19</a>
+     */
+    @Deprecated
+    public void setDocumentObject(File expandableObject) {
+      this.document = new ExpandableField<File>(expandableObject.getId(), expandableObject);
+    }
+    // </editor-fold>
+
+    // <editor-fold desc="documentBack">
+    /**
+     * Gets the {@code document_back} attribute.
+     *
+     * @return the {@code document_back} attribute
+     * @deprecated Prefer using the {@link #getDocumentSubObject} method instead.
+     * @see <a href="https://stripe.com/docs/upgrades#2019-02-19">API version 2019-02-19</a>
+     */
+    @Deprecated
+    public String getDocumentBack() {
+      return (this.documentBack != null) ? this.documentBack.getId() : null;
+    }
+
+    /**
+     * Sets the {@code document_back} attribute.
+     *
+     * @deprecated Prefer using the {@link #setDocumentSubObject} method instead.
+     * @see <a href="https://stripe.com/docs/upgrades#2019-02-19">API version 2019-02-19</a>
+     */
+    @Deprecated
+    public void setDocumentBack(String id) {
+      this.documentBack = ApiResource.setExpandableFieldId(id, this.documentBack);
+    }
+
+    /**
+     * Gets the {@code document_back} attribute.
+     *
+     * @return the {@code document_back} attribute
+     * @deprecated Prefer using the {@link #getDocumentSubObject} method instead.
+     * @see <a href="https://stripe.com/docs/upgrades#2019-02-19">API version 2019-02-19</a>
+     */
+    @Deprecated
+    public File getDocumentBackObject() {
+      return (this.documentBack != null) ? this.documentBack.getExpanded() : null;
+    }
+
+    /**
+     * Sets the {@code document_back} attribute.
+     *
+     * @deprecated Prefer using the {@link #setDocumentSubObject} method instead.
+     * @see <a href="https://stripe.com/docs/upgrades#2019-02-19">API version 2019-02-19</a>
+     */
+    @Deprecated
+    public void setDocumentBackObject(File expandableObject) {
+      this.documentBack = new ExpandableField<File>(expandableObject.getId(), expandableObject);
+    }
+    // </editor-fold>
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class VerificationDocument extends StripeObject {
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<File> back;
+    String details;
+    String detailsCode;
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<File> front;
+
+    // <editor-fold desc="back">
+    public String getBack() {
+      return (this.back != null) ? this.back.getId() : null;
+    }
+
+    public void setBack(String id) {
+      this.back = ApiResource.setExpandableFieldId(id, this.back);
+    }
+
+    public File getBackObject() {
+      return (this.back != null) ? this.back.getExpanded() : null;
+    }
+
+    public void setBackObject(File expandableObject) {
+      this.back = new ExpandableField<File>(expandableObject.getId(), expandableObject);
+    }
+    // </editor-fold>
+
+    // <editor-fold desc="front">
+    public String getFront() {
+      return (this.front != null) ? this.front.getId() : null;
+    }
+
+    public void setFront(String id) {
+      this.front = ApiResource.setExpandableFieldId(id, this.front);
+    }
+
+    public File getFrontObject() {
+      return (this.front != null) ? this.front.getExpanded() : null;
+    }
+
+    public void setFrontObject(File expandableObject) {
+      this.front = new ExpandableField<File>(expandableObject.getId(), expandableObject);
+    }
+    // </editor-fold>
   }
 }

--- a/src/main/java/com/stripe/model/PersonVerificationDeserializer.java
+++ b/src/main/java/com/stripe/model/PersonVerificationDeserializer.java
@@ -1,0 +1,89 @@
+package com.stripe.model;
+
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+
+import java.lang.reflect.Type;
+
+public class PersonVerificationDeserializer implements JsonDeserializer<Person.Verification> {
+  /**
+   * Deserializes a person.verification JSON payload into a {@link Person.Verification} object.
+   */
+  @Override
+  public Person.Verification deserialize(JsonElement json, Type typeOfT,
+      JsonDeserializationContext context) throws JsonParseException {
+    Gson gson = new GsonBuilder()
+        .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+        .registerTypeAdapter(ExpandableField.class, new ExpandableFieldDeserializer())
+        .create();
+    if (json.isJsonNull()) {
+      return null;
+    }
+
+    if (!json.isJsonObject()) {
+      throw new JsonParseException(
+          "Person.Verification type was not an object, which is problematic.");
+    }
+    // Before API version 2019-02-19, `document` was an expandable file, i.e. either a string (a
+    // file ID) or a File object. From API version 2019-02-19 on, `document` is a
+    // `Person.VerificationDocument`.
+    JsonObject verificationAsJsonObject = json.getAsJsonObject();
+
+    JsonElement rawDocument = verificationAsJsonObject.get("document");
+
+    String documentString = null;
+    File documentFile = null;
+    Person.VerificationDocument documentSubObject = null;
+
+    if (rawDocument.isJsonPrimitive()) {
+      JsonPrimitive documentJsonPrimitive = rawDocument.getAsJsonPrimitive();
+      if (!documentJsonPrimitive.isString()) {
+        throw new JsonParseException(
+            "document field on a Person.Verification was a primitive non-string type.");
+      }
+      // document is a string, i.e. an old-style unexpanded document
+      documentString = documentJsonPrimitive.getAsString();
+    } else if (rawDocument.isJsonObject()) {
+      JsonObject documentJsonObject = rawDocument.getAsJsonObject();
+      if (documentJsonObject.has("object")) {
+        // document is a JSON object and has an `object` key, so it's an old-style expanded File
+        // object
+        documentFile = gson.fromJson(documentJsonObject, File.class);
+      } else {
+        // document is a JSON object and doesn't have an `object` key, so it's a new-style
+        // Person.VerificationDocument object
+        documentSubObject = gson.fromJson(documentJsonObject, Person.VerificationDocument.class);
+      }
+    } else if (!rawDocument.isJsonNull()) {
+      throw new JsonParseException(
+          "document field on a Person.Verification was a non-primitive, non-object type.");
+    }
+    verificationAsJsonObject.remove("document");
+    Person.Verification parsedData = gson.fromJson(json, typeOfT);
+    if (documentFile != null) {
+      setDocumentFile(parsedData, documentFile);
+    } else {
+      setDocumentString(parsedData, documentString);
+    }
+    parsedData.setDocumentSubObject(documentSubObject);
+
+    return parsedData;
+  }
+
+  @SuppressWarnings("deprecation")
+  private static void setDocumentString(Person.Verification verification, String documentString) {
+    verification.setDocument(documentString);
+  }
+
+  @SuppressWarnings("deprecation")
+  private static void setDocumentFile(Person.Verification verification, File documentFile) {
+    verification.setDocumentObject(documentFile);
+  }
+}

--- a/src/main/java/com/stripe/net/ApiResource.java
+++ b/src/main/java/com/stripe/net/ApiResource.java
@@ -29,6 +29,8 @@ import com.stripe.model.OrderItem;
 import com.stripe.model.OrderItemDeserializer;
 import com.stripe.model.PaymentIntentSourceAction;
 import com.stripe.model.PaymentIntentSourceActionDeserializer;
+import com.stripe.model.Person;
+import com.stripe.model.PersonVerificationDeserializer;
 import com.stripe.model.Source;
 import com.stripe.model.SourceMandateNotification;
 import com.stripe.model.SourceTransaction;
@@ -66,6 +68,7 @@ public abstract class ApiResource extends StripeObject {
         .registerTypeAdapter(OrderItem.class, new OrderItemDeserializer())
         .registerTypeAdapter(PaymentIntentSourceAction.class,
             new PaymentIntentSourceActionDeserializer())
+        .registerTypeAdapter(Person.Verification.class, new PersonVerificationDeserializer())
         .registerTypeAdapter(Source.class, new SourceTypeDataDeserializer<Source>())
         .registerTypeAdapter(SourceMandateNotification.class,
             new SourceTypeDataDeserializer<SourceMandateNotification>())

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -35,7 +35,7 @@ import org.mockito.Mockito;
 
 public class BaseStripeTest {
   // If changing this number, please also change it in `.travis.yml`.
-  private static final String MOCK_MINIMUM_VERSION = "0.44.0";
+  private static final String MOCK_MINIMUM_VERSION = "0.45.0";
 
   private static String port;
 

--- a/src/test/java/com/stripe/functional/AccountTest.java
+++ b/src/test/java/com/stripe/functional/AccountTest.java
@@ -81,10 +81,8 @@ public class AccountTest extends BaseStripeTest {
   public void testUpdate() throws StripeException {
     final Account account = getAccountFixture();
 
-    final Map<String, Object> legalEntity = new HashMap<>();
-    legalEntity.put("type", "individual");
     final Map<String, Object> params = new HashMap<>();
-    params.put("legal_entity", legalEntity);
+    params.put("business_type", "individual");
 
     final Account updatedAccount = account.update(params);
 

--- a/src/test/java/com/stripe/model/AccountTest.java
+++ b/src/test/java/com/stripe/model/AccountTest.java
@@ -1,5 +1,6 @@
 package com.stripe.model;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import com.stripe.BaseStripeTest;
@@ -14,5 +15,28 @@ public class AccountTest extends BaseStripeTest {
     final Account resource = ApiResource.GSON.fromJson(data, Account.class);
     assertNotNull(resource);
     assertNotNull(resource.getId());
+  }
+
+  @Test
+  public void testDeserializeWithExpansions() throws Exception {
+    final String[] expansions = {
+      "settings.branding.icon",
+      "settings.branding.logo",
+    };
+    final String data = getFixture("/v1/accounts/acct_123", expansions);
+
+    final Account resource = ApiResource.GSON.fromJson(data, Account.class);
+    assertNotNull(resource);
+    assertNotNull(resource.getId());
+
+    final File icon = resource.getSettings().getBranding().getIconObject();
+    assertNotNull(icon);
+    assertNotNull(icon.getId());
+    assertEquals(resource.getSettings().getBranding().getIcon(), icon.getId());
+
+    final File logo = resource.getSettings().getBranding().getLogoObject();
+    assertNotNull(logo);
+    assertNotNull(logo.getId());
+    assertEquals(resource.getSettings().getBranding().getLogo(), logo.getId());
   }
 }

--- a/src/test/java/com/stripe/model/ChargeTest.java
+++ b/src/test/java/com/stripe/model/ChargeTest.java
@@ -33,9 +33,9 @@ public class ChargeTest extends BaseStripeTest {
 
   @Test
   public void testDeserializeWithExpansions() throws Exception {
+    // TODO: add support back for expanding application_fee once stripe-mock supports it.
     final String[] expansions = {
       "application",
-      "application_fee",
       "balance_transaction",
       "customer",
       "destination",
@@ -55,10 +55,6 @@ public class ChargeTest extends BaseStripeTest {
     assertNotNull(application);
     assertNotNull(application.getId());
     assertEquals(charge.getApplication(), application.getId());
-    final ApplicationFee applicationFee = charge.getApplicationFeeObject();
-    assertNotNull(applicationFee);
-    assertNotNull(applicationFee.getId());
-    assertEquals(charge.getApplicationFee(), applicationFee.getId());
     final BalanceTransaction balanceTransaction = charge.getBalanceTransactionObject();
     assertNotNull(balanceTransaction);
     assertNotNull(balanceTransaction.getId());

--- a/src/test/java/com/stripe/model/PersonTest.java
+++ b/src/test/java/com/stripe/model/PersonTest.java
@@ -1,6 +1,8 @@
 package com.stripe.model;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
@@ -14,5 +16,69 @@ public class PersonTest extends BaseStripeTest {
     final Person resource = ApiResource.GSON.fromJson(data, Person.class);
     assertNotNull(resource);
     assertNotNull(resource.getId());
+  }
+
+  @Test
+  public void testDeserializeWithExpansions() throws Exception {
+    final String[] expansions = {
+      "verification.document.back",
+      "verification.document.front",
+    };
+    final String data = getFixture("/v1/accounts/acct_123/persons/person_123", expansions);
+    final Person resource = ApiResource.GSON.fromJson(data, Person.class);
+    assertNotNull(resource);
+    assertNotNull(resource.getId());
+    assertNotNull(resource.getVerification());
+
+    final Person.VerificationDocument verifDoc = resource.getVerification().getDocumentSubObject();
+    assertNotNull(verifDoc);
+
+    final File back = verifDoc.getBackObject();
+    assertNotNull(back);
+    assertNotNull(back.getId());
+    assertEquals(verifDoc.getBack(), back.getId());
+
+    final File front = verifDoc.getFrontObject();
+    assertNotNull(front);
+    assertNotNull(front.getId());
+    assertEquals(verifDoc.getFront(), front.getId());
+
+    // Old document format (pre 2019-02-19)
+    assertNull(resource.getVerification().getDocument());
+    assertNull(resource.getVerification().getDocumentObject());
+  }
+
+  @Test
+  public void testDeserializeOldDocumentUnexpanded() throws Exception {
+    final String data = getResourceAsString("/api_fixtures/person_old_document_unexpanded.json");
+    final Person resource = ApiResource.GSON.fromJson(data, Person.class);
+    assertNotNull(resource);
+    assertNotNull(resource.getId());
+    assertNotNull(resource.getVerification());
+
+    assertNotNull(resource.getVerification().getDocument());
+
+    // Expanded attribute
+    assertNull(resource.getVerification().getDocumentObject());
+
+    // New document format (2019-09-19)
+    assertNull(resource.getVerification().getDocumentSubObject());
+  }
+
+  @Test
+  public void testDeserializeOldDocumentExpanded() throws Exception {
+    final String data = getResourceAsString("/api_fixtures/person_old_document_expanded.json");
+    final Person resource = ApiResource.GSON.fromJson(data, Person.class);
+    assertNotNull(resource);
+    assertNotNull(resource.getId());
+    assertNotNull(resource.getVerification());
+
+    // Expanded attribute
+    assertNotNull(resource.getVerification().getDocumentObject());
+    assertEquals(resource.getVerification().getDocumentObject().getId(),
+        resource.getVerification().getDocument());
+
+    // New document format (2019-09-19)
+    assertNull(resource.getVerification().getDocumentSubObject());
   }
 }

--- a/src/test/resources/api_fixtures/person_old_document_expanded.json
+++ b/src/test/resources/api_fixtures/person_old_document_expanded.json
@@ -1,0 +1,51 @@
+{
+  "account": "acct_123",
+  "created": 1234567890,
+  "dob": {
+    "day": null,
+    "month": null,
+    "year": null
+  },
+  "first_name": null,
+  "id": "person_123",
+  "last_name": null,
+  "metadata": {
+  },
+  "object": "person",
+  "relationship": {
+    "account_opener": false,
+    "director": false,
+    "owner": false,
+    "percent_ownership": null,
+    "title": null
+  },
+  "requirements": {
+    "currently_due": [],
+    "eventually_due": [],
+    "past_due": []
+  },
+  "ssn_last_4_provided": false,
+  "verification": {
+    "details": null,
+    "details_code": null,
+    "document": {
+      "created": 1234567890,
+      "filename": "file_123",
+      "id": "file_123",
+      "links": {
+        "data": [],
+        "has_more": false,
+        "object": "list",
+        "url": "/v1/file_links?file=file_123"
+      },
+      "object": "file",
+      "purpose": "identity_document",
+      "size": 9863,
+      "title": null,
+      "type": "png",
+      "url": null
+    },
+    "document_back": null,
+    "status": "unverified"
+  }
+}

--- a/src/test/resources/api_fixtures/person_old_document_unexpanded.json
+++ b/src/test/resources/api_fixtures/person_old_document_unexpanded.json
@@ -1,0 +1,35 @@
+{
+  "account": "acct_123",
+  "created": 1234567890,
+  "dob": {
+    "day": null,
+    "month": null,
+    "year": null
+  },
+  "first_name": null,
+  "id": "person_123",
+  "last_name": null,
+  "metadata": {
+  },
+  "object": "person",
+  "relationship": {
+    "account_opener": false,
+    "director": false,
+    "owner": false,
+    "percent_ownership": null,
+    "title": null
+  },
+  "requirements": {
+    "currently_due": [],
+    "eventually_due": [],
+    "past_due": []
+  },
+  "ssn_last_4_provided": false,
+  "verification": {
+    "details": null,
+    "details_code": null,
+    "document": "file_123",
+    "document_back": null,
+    "status": "unverified"
+  }
+}


### PR DESCRIPTION
This PR contains the changes related to the new API version `2019-02-19`. This changes the `Account` and `Person` resources extensively but keeps the backwards compatible approach.

r? @ob-stripe 
cc @stripe/api-libraries 