### PR TITLE
Add Stripe client telemetry to request headers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version:'4.12'
     testCompile group: 'org.mockito', name: 'mockito-core', version:'2.22.0'
     testRuntime group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:3.12.1'
 }
 
 jar {

--- a/src/main/java/com/stripe/Stripe.java
+++ b/src/main/java/com/stripe/Stripe.java
@@ -18,8 +18,8 @@ public abstract class Stripe {
   public static volatile String apiKey;
   public static volatile String apiVersion;
   public static volatile String clientId;
-  public static volatile String partnerId;
   public static volatile boolean enableTelemetry = false;
+  public static volatile String partnerId;
 
   // Note that URLConnection reserves the value of 0 to mean "infinite
   // timeout", so we use -1 here to represent an unset value which should

--- a/src/main/java/com/stripe/Stripe.java
+++ b/src/main/java/com/stripe/Stripe.java
@@ -19,6 +19,7 @@ public abstract class Stripe {
   public static volatile String apiVersion;
   public static volatile String clientId;
   public static volatile String partnerId;
+  public static volatile boolean enableTelemetry = false;
 
   // Note that URLConnection reserves the value of 0 to mean "infinite
   // timeout", so we use -1 here to represent an unset value which should

--- a/src/main/java/com/stripe/net/ClientTelemetryPayload.java
+++ b/src/main/java/com/stripe/net/ClientTelemetryPayload.java
@@ -3,6 +3,6 @@ package com.stripe.net;
 import com.google.gson.annotations.SerializedName;
 
 public class ClientTelemetryPayload {
-    @SerializedName("last_request_metrics")
-    public RequestMetrics lastRequestMetrics;
+  @SerializedName("last_request_metrics")
+  public RequestMetrics lastRequestMetrics;
 }

--- a/src/main/java/com/stripe/net/ClientTelemetryPayload.java
+++ b/src/main/java/com/stripe/net/ClientTelemetryPayload.java
@@ -1,0 +1,8 @@
+package com.stripe.net;
+
+import com.google.gson.annotations.SerializedName;
+
+public class ClientTelemetryPayload {
+    @SerializedName("last_request_metrics")
+    public RequestMetrics lastRequestMetrics;
+}

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -535,11 +535,11 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
       ApiResource.RequestMethod method, String url, Map<String, Object> params,
       Class<T> clazz, ApiResource.RequestType type, RequestOptions options)
       throws StripeException {
-    long requestStart = System.currentTimeMillis();
+    long requestStartMs = System.currentTimeMillis();
 
     StripeResponse response = rawRequest(method, url, params, type, options);
 
-    long requestDurationMS = System.currentTimeMillis() - requestStart;
+    long requestDurationMs = System.currentTimeMillis() - requestStartMs;
 
     int responseCode = response.code();
     String responseBody = response.body();
@@ -562,7 +562,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
     }
 
     if (Stripe.enableTelemetry && prevRequestMetrics.size() < MAX_REQUEST_METRICS_BUFFER_SIZE) {
-      prevRequestMetrics.add(new RequestMetrics(requestId, requestDurationMS));
+      prevRequestMetrics.add(new RequestMetrics(requestId, requestDurationMs));
     }
 
     return resource;

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -474,7 +474,6 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
     if (options == null) {
       options = RequestOptions.getDefault();
     }
-
     String originalDnsCacheTtl = null;
     Boolean allowedToSetTtl = true;
 

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -154,7 +154,8 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 
     RequestMetrics lastRequestMetrics = prevRequestMetrics.poll();
     if (Stripe.enableTelemetry && lastRequestMetrics != null) {
-      headers.put("X-Stripe-Client-Telemetry", ApiResource.GSON.toJson(lastRequestMetrics.payload()));
+      headers.put("X-Stripe-Client-Telemetry",
+          ApiResource.GSON.toJson(lastRequestMetrics.payload()));
     }
 
     return headers;
@@ -393,7 +394,8 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
     String charge;
   }
 
-  private static ConcurrentLinkedQueue<RequestMetrics> prevRequestMetrics = new ConcurrentLinkedQueue<RequestMetrics>();
+  private static ConcurrentLinkedQueue<RequestMetrics> prevRequestMetrics =
+      new ConcurrentLinkedQueue<RequestMetrics>();
 
   // represents OAuth API errors returned as JSON
   // handleOAuthError uses this class to raise the appropriate OAuthException

--- a/src/main/java/com/stripe/net/RequestMetrics.java
+++ b/src/main/java/com/stripe/net/RequestMetrics.java
@@ -1,21 +1,22 @@
 package com.stripe.net;
 
-public class RequestMetrics {
-    public String request_id;
-    public long request_duration_ms;
+import com.google.gson.annotations.SerializedName;
 
-    public class Payload {
-        public RequestMetrics last_request_metrics;
-    }
+public class RequestMetrics {
+    @SerializedName("request_id")
+    public String requestId;
+
+    @SerializedName("request_duration_ms")
+    public long requestDurationMs;
 
     public RequestMetrics(String requestId, long requestDurationMS) {
-        this.request_id = requestId;
-        this.request_duration_ms = requestDurationMS;
+        this.requestId = requestId;
+        this.requestDurationMs = requestDurationMS;
     }
 
-    public Payload payload() {
-        Payload p = new Payload();
-        p.last_request_metrics = this;
+    public ClientTelemetryPayload payload() {
+        ClientTelemetryPayload p = new ClientTelemetryPayload();
+        p.lastRequestMetrics = this;
         return p;
     }
 }

--- a/src/main/java/com/stripe/net/RequestMetrics.java
+++ b/src/main/java/com/stripe/net/RequestMetrics.java
@@ -3,20 +3,23 @@ package com.stripe.net;
 import com.google.gson.annotations.SerializedName;
 
 public class RequestMetrics {
-    @SerializedName("request_id")
-    public String requestId;
+  @SerializedName("request_id")
+  public String requestId;
 
-    @SerializedName("request_duration_ms")
-    public long requestDurationMs;
+  @SerializedName("request_duration_ms")
+  public long requestDurationMs;
 
-    public RequestMetrics(String requestId, long requestDurationMS) {
-        this.requestId = requestId;
-        this.requestDurationMs = requestDurationMS;
-    }
+  public RequestMetrics(String requestId, long requestDurationMS) {
+    this.requestId = requestId;
+    this.requestDurationMs = requestDurationMS;
+  }
 
-    public ClientTelemetryPayload payload() {
-        ClientTelemetryPayload p = new ClientTelemetryPayload();
-        p.lastRequestMetrics = this;
-        return p;
-    }
+  /**
+   * Constructs the JSON payload to be sent in the X-Stripe-Client-Telemetry header.
+   */
+  public ClientTelemetryPayload payload() {
+    ClientTelemetryPayload p = new ClientTelemetryPayload();
+    p.lastRequestMetrics = this;
+    return p;
+  }
 }

--- a/src/main/java/com/stripe/net/RequestMetrics.java
+++ b/src/main/java/com/stripe/net/RequestMetrics.java
@@ -1,0 +1,21 @@
+package com.stripe.net;
+
+public class RequestMetrics {
+    public String request_id;
+    public long request_duration_ms;
+
+    public class Payload {
+        public RequestMetrics last_request_metrics;
+    }
+
+    public RequestMetrics(String requestId, long requestDurationMS) {
+        this.request_id = requestId;
+        this.request_duration_ms = requestDurationMS;
+    }
+
+    public Payload payload() {
+        Payload p = new Payload();
+        p.last_request_metrics = this;
+        return p;
+    }
+}

--- a/src/test/java/com/stripe/functional/BalanceTest.java
+++ b/src/test/java/com/stripe/functional/BalanceTest.java
@@ -1,21 +1,13 @@
 package com.stripe.functional;
 
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-
-import com.stripe.Stripe;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
 import com.stripe.model.Balance;
 import com.stripe.net.ApiResource;
 
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.Test;
-
-import java.io.IOException;
 
 public class BalanceTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/functional/BalanceTest.java
+++ b/src/test/java/com/stripe/functional/BalanceTest.java
@@ -1,13 +1,21 @@
 package com.stripe.functional;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import com.stripe.Stripe;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
 import com.stripe.model.Balance;
 import com.stripe.net.ApiResource;
 
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.Test;
+
+import java.io.IOException;
 
 public class BalanceTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/functional/TelemetryTest.java
+++ b/src/test/java/com/stripe/functional/TelemetryTest.java
@@ -1,15 +1,15 @@
 package com.stripe.functional;
 
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNull;
+import static junit.framework.TestCase.assertTrue;
+
 import com.stripe.BaseStripeTest;
 import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
 import com.stripe.model.Balance;
 import com.stripe.net.ApiResource;
 import com.stripe.net.ClientTelemetryPayload;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
-import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -17,14 +17,20 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.*;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Test;
+
 
 public class TelemetryTest extends BaseStripeTest {
   @Test
   public void testTelemetryEnabled() throws StripeException, IOException, InterruptedException {
     MockWebServer server = new MockWebServer();
-    server.enqueue(new MockResponse().setBody("{}").addHeader("Request-Id", "req_1").setBodyDelay(30, TimeUnit.MILLISECONDS));
-    server.enqueue(new MockResponse().setBody("{}").addHeader("Request-Id", "req_2").setBodyDelay(70, TimeUnit.MILLISECONDS));
+    server.enqueue(new MockResponse().setBody("{}").addHeader("Request-Id", "req_1")
+        .setBodyDelay(30, TimeUnit.MILLISECONDS));
+    server.enqueue(new MockResponse().setBody("{}").addHeader("Request-Id", "req_2")
+        .setBodyDelay(70, TimeUnit.MILLISECONDS));
     server.enqueue(new MockResponse().setBody("{}").addHeader("Request-Id", "req_3"));
     server.start();
 
@@ -38,7 +44,8 @@ public class TelemetryTest extends BaseStripeTest {
     Balance b2 = Balance.retrieve();
     RecordedRequest request2 = server.takeRequest();
     String telemetry1 = request2.getHeader("X-Stripe-Client-Telemetry");
-    ClientTelemetryPayload payload1 = ApiResource.GSON.fromJson(telemetry1, ClientTelemetryPayload.class);
+    ClientTelemetryPayload payload1 = ApiResource.GSON.fromJson(
+        telemetry1, ClientTelemetryPayload.class);
     assertEquals(payload1.lastRequestMetrics.requestId, "req_1");
     assertTrue(payload1.lastRequestMetrics.requestDurationMs > 30);
     assertTrue(payload1.lastRequestMetrics.requestDurationMs < 60);
@@ -46,7 +53,8 @@ public class TelemetryTest extends BaseStripeTest {
     Balance b3 = Balance.retrieve();
     RecordedRequest request3 = server.takeRequest();
     String telemetry2 = request3.getHeader("X-Stripe-Client-Telemetry");
-    ClientTelemetryPayload payload2 = ApiResource.GSON.fromJson(telemetry2, ClientTelemetryPayload.class);
+    ClientTelemetryPayload payload2 = ApiResource.GSON.fromJson(
+        telemetry2, ClientTelemetryPayload.class);
     assertEquals(payload2.lastRequestMetrics.requestId, "req_2");
     assertTrue(payload2.lastRequestMetrics.requestDurationMs > 70);
     assertTrue(payload2.lastRequestMetrics.requestDurationMs < 100);
@@ -81,7 +89,8 @@ public class TelemetryTest extends BaseStripeTest {
     MockWebServer server = new MockWebServer();
 
     for (int i = 0; i < 20; i++) {
-      server.enqueue(new MockResponse().setBody("{}").addHeader("Request-Id", "req_" + i));
+      server.enqueue(new MockResponse().setBody("{}")
+          .addHeader("Request-Id", "req_" + i));
     }
     server.start();
 
@@ -102,7 +111,7 @@ public class TelemetryTest extends BaseStripeTest {
     // the first 10 requests will not contain telemetry
     ArrayList<Thread> threads = new ArrayList<>();
     for (int i = 0; i < 10; i++) {
-        threads.add(new Thread(work));
+      threads.add(new Thread(work));
     }
     for (int i = 0; i < 10; i++) {
       threads.get(i).start();
@@ -134,7 +143,8 @@ public class TelemetryTest extends BaseStripeTest {
     for (int i = 0; i < 10; i++) {
       RecordedRequest request = server.takeRequest();
       String telemetry2 = request.getHeader("X-Stripe-Client-Telemetry");
-      ClientTelemetryPayload payload = ApiResource.GSON.fromJson(telemetry2, ClientTelemetryPayload.class);
+      ClientTelemetryPayload payload = ApiResource.GSON.fromJson(
+          telemetry2, ClientTelemetryPayload.class);
       seenRequestIds.add(payload.lastRequestMetrics.requestId);
     }
 

--- a/src/test/java/com/stripe/functional/TelemetryTest.java
+++ b/src/test/java/com/stripe/functional/TelemetryTest.java
@@ -110,10 +110,9 @@ public class TelemetryTest extends BaseStripeTest {
     // the first 10 requests will not contain telemetry
     ArrayList<Thread> threads = new ArrayList<>();
     for (int i = 0; i < 10; i++) {
-      threads.add(new Thread(work));
-    }
-    for (int i = 0; i < 10; i++) {
-      threads.get(i).start();
+      Thread t = new Thread(work);
+      threads.add(t);
+      t.start();
     }
     for (int i = 0; i < 10; i++) {
       threads.get(i).join();
@@ -122,15 +121,13 @@ public class TelemetryTest extends BaseStripeTest {
 
     // the following 10 requests will contain telemetry
     for (int i = 0; i < 10; i++) {
-      threads.add(new Thread(work));
-    }
-    for (int i = 0; i < 10; i++) {
-      threads.get(i).start();
+      Thread t = new Thread(work);
+      threads.add(t);
+      t.start();
     }
     for (int i = 0; i < 10; i++) {
       threads.get(i).join();
     }
-    threads.clear();
 
     Set<String> seenRequestIds = new HashSet<>();
 
@@ -141,9 +138,9 @@ public class TelemetryTest extends BaseStripeTest {
 
     for (int i = 0; i < 10; i++) {
       RecordedRequest request = server.takeRequest();
-      String telemetry2 = request.getHeader("X-Stripe-Client-Telemetry");
+      String telemetry = request.getHeader("X-Stripe-Client-Telemetry");
       ClientTelemetryPayload payload = ApiResource.GSON.fromJson(
-          telemetry2, ClientTelemetryPayload.class);
+          telemetry, ClientTelemetryPayload.class);
       seenRequestIds.add(payload.lastRequestMetrics.requestId);
     }
 

--- a/src/test/java/com/stripe/functional/TelemetryTest.java
+++ b/src/test/java/com/stripe/functional/TelemetryTest.java
@@ -48,7 +48,6 @@ public class TelemetryTest extends BaseStripeTest {
         telemetry1, ClientTelemetryPayload.class);
     assertEquals(payload1.lastRequestMetrics.requestId, "req_1");
     assertTrue(payload1.lastRequestMetrics.requestDurationMs > 30);
-    assertTrue(payload1.lastRequestMetrics.requestDurationMs < 130);
 
     Balance b3 = Balance.retrieve();
     RecordedRequest request3 = server.takeRequest();
@@ -57,7 +56,6 @@ public class TelemetryTest extends BaseStripeTest {
         telemetry2, ClientTelemetryPayload.class);
     assertEquals(payload2.lastRequestMetrics.requestId, "req_2");
     assertTrue(payload2.lastRequestMetrics.requestDurationMs > 120);
-    assertTrue(payload2.lastRequestMetrics.requestDurationMs < 220);
 
     server.shutdown();
   }

--- a/src/test/java/com/stripe/functional/TelemetryTest.java
+++ b/src/test/java/com/stripe/functional/TelemetryTest.java
@@ -30,7 +30,7 @@ public class TelemetryTest extends BaseStripeTest {
     server.enqueue(new MockResponse().setBody("{}").addHeader("Request-Id", "req_1")
         .setBodyDelay(30, TimeUnit.MILLISECONDS));
     server.enqueue(new MockResponse().setBody("{}").addHeader("Request-Id", "req_2")
-        .setBodyDelay(70, TimeUnit.MILLISECONDS));
+        .setBodyDelay(120, TimeUnit.MILLISECONDS));
     server.enqueue(new MockResponse().setBody("{}").addHeader("Request-Id", "req_3"));
     server.start();
 
@@ -48,7 +48,7 @@ public class TelemetryTest extends BaseStripeTest {
         telemetry1, ClientTelemetryPayload.class);
     assertEquals(payload1.lastRequestMetrics.requestId, "req_1");
     assertTrue(payload1.lastRequestMetrics.requestDurationMs > 30);
-    assertTrue(payload1.lastRequestMetrics.requestDurationMs < 60);
+    assertTrue(payload1.lastRequestMetrics.requestDurationMs < 130);
 
     Balance b3 = Balance.retrieve();
     RecordedRequest request3 = server.takeRequest();
@@ -56,8 +56,8 @@ public class TelemetryTest extends BaseStripeTest {
     ClientTelemetryPayload payload2 = ApiResource.GSON.fromJson(
         telemetry2, ClientTelemetryPayload.class);
     assertEquals(payload2.lastRequestMetrics.requestId, "req_2");
-    assertTrue(payload2.lastRequestMetrics.requestDurationMs > 70);
-    assertTrue(payload2.lastRequestMetrics.requestDurationMs < 100);
+    assertTrue(payload2.lastRequestMetrics.requestDurationMs > 120);
+    assertTrue(payload2.lastRequestMetrics.requestDurationMs < 220);
 
     server.shutdown();
   }

--- a/src/test/java/com/stripe/functional/TelemetryTest.java
+++ b/src/test/java/com/stripe/functional/TelemetryTest.java
@@ -1,0 +1,75 @@
+package com.stripe.functional;
+
+import com.stripe.BaseStripeTest;
+import com.stripe.Stripe;
+import com.stripe.exception.StripeException;
+import com.stripe.model.Balance;
+import com.stripe.net.ApiResource;
+import com.stripe.net.ClientTelemetryPayload;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+
+public class TelemetryTest extends BaseStripeTest {
+  @Test
+  public void testTelemetryEnabled() throws StripeException, IOException, InterruptedException {
+    MockWebServer server = new MockWebServer();
+    server.enqueue(new MockResponse().setBody("{}").addHeader("Request-Id", "req_1").setBodyDelay(30, TimeUnit.MILLISECONDS));
+    server.enqueue(new MockResponse().setBody("{}").addHeader("Request-Id", "req_2").setBodyDelay(70, TimeUnit.MILLISECONDS));
+    server.enqueue(new MockResponse().setBody("{}").addHeader("Request-Id", "req_3"));
+    server.start();
+
+    Stripe.overrideApiBase(server.url("").toString());
+    Stripe.enableTelemetry = true;
+
+    Balance b1 = Balance.retrieve();
+    RecordedRequest request1 = server.takeRequest();
+    assertNull(request1.getHeader("X-Stripe-Client-Telemetry"));
+
+    Balance b2 = Balance.retrieve();
+    RecordedRequest request2 = server.takeRequest();
+    String telemetry1 = request2.getHeader("X-Stripe-Client-Telemetry");
+    ClientTelemetryPayload payload1 = ApiResource.GSON.fromJson(telemetry1, ClientTelemetryPayload.class);
+    assertEquals(payload1.lastRequestMetrics.requestId, "req_1");
+    assertTrue(payload1.lastRequestMetrics.requestDurationMs > 30);
+    assertTrue(payload1.lastRequestMetrics.requestDurationMs < 60);
+
+    Balance b3 = Balance.retrieve();
+    RecordedRequest request3 = server.takeRequest();
+    String telemetry2 = request3.getHeader("X-Stripe-Client-Telemetry");
+    ClientTelemetryPayload payload2 = ApiResource.GSON.fromJson(telemetry2, ClientTelemetryPayload.class);
+    assertEquals(payload2.lastRequestMetrics.requestId, "req_2");
+    assertTrue(payload2.lastRequestMetrics.requestDurationMs > 70);
+    assertTrue(payload2.lastRequestMetrics.requestDurationMs < 100);
+
+    server.shutdown();
+  }
+
+  @Test
+  public void testTelemetryDisabled() throws StripeException, IOException, InterruptedException {
+    MockWebServer server = new MockWebServer();
+    server.enqueue(new MockResponse().setBody("{}").addHeader("Request-Id", "req_1"));
+    server.enqueue(new MockResponse().setBody("{}").addHeader("Request-Id", "req_2"));
+    server.enqueue(new MockResponse().setBody("{}").addHeader("Request-Id", "req_3"));
+    server.start();
+
+    Stripe.overrideApiBase(server.url("").toString());
+    Stripe.enableTelemetry = false;
+
+    Balance b1 = Balance.retrieve();
+    RecordedRequest request1 = server.takeRequest();
+    assertNull(request1.getHeader("X-Stripe-Client-Telemetry"));
+
+    Balance b2 = Balance.retrieve();
+    RecordedRequest request2 = server.takeRequest();
+    assertNull(request2.getHeader("X-Stripe-Client-Telemetry"));
+
+    server.shutdown();
+  }
+}

--- a/src/test/java/com/stripe/functional/TelemetryTest.java
+++ b/src/test/java/com/stripe/functional/TelemetryTest.java
@@ -90,7 +90,8 @@ public class TelemetryTest extends BaseStripeTest {
 
     for (int i = 0; i < 20; i++) {
       server.enqueue(new MockResponse().setBody("{}")
-          .addHeader("Request-Id", "req_" + i));
+          .addHeader("Request-Id", "req_" + i)
+          .setBodyDelay(50, TimeUnit.MILLISECONDS));
     }
     server.start();
 


### PR DESCRIPTION
Adds opt-in client telemetry similar to https://github.com/stripe/stripe-node/pull/557, https://github.com/stripe/stripe-go/pull/766, https://github.com/stripe/stripe-ruby/pull/696, etc.

Request metrics are recorded in `LiveStripeResponseGetter` and stored on a thread safe buffer using `ConcurrentLinkedQueue`. If the buffer exceeds 100 elements, metrics are dropped. When a request is sent, if the buffer is not empty, one of the metrics is popped off and sent as JSON in the `X-Stripe-Client-Telemetry` header.

Clients can enable the telemetry using:

```java
Stripe.enableTelemetry = true;
```

r? @brandur-stripe 
cc @dcarney-stripe @akropp-stripe 