### PR TITLE
Configure Gradle signing plugin to use gpg-agent

### DIFF
--- a/deploy.gradle
+++ b/deploy.gradle
@@ -94,7 +94,12 @@ afterEvaluate { project ->
     signing {
         required { isReleaseBuild() &&
         (gradle.taskGraph.hasTask("uploadArchives") || gradle.taskGraph.hasTask("publish"))}
+        useGpgCmd()
         sign configurations.archives
+    }
+
+    tasks.withType(Sign) {
+        onlyIf { isReleaseBuild() && project.hasProperty('signing.gnupg.keyName') }
     }
 
     task makeJavadocs(type: Javadoc, dependsOn: delombok) {


### PR DESCRIPTION
r? @brandur-stripe @hans-stripe 

This PR configures the Gradle signing plugin to use gpg-agent instead of old-style GPG keyring files: https://docs.gradle.org/current/userguide/signing_plugin.html#sec:using_gpg_agent.

This needs to be coordinated with a change to our internal release tool, so let's not merge this just yet! You can test this PR by calling `./gradlew clean sign`, or if you want to specify a custom GPG dir and key ID (like the release tool will):
```
GNUPGHOME="/path/to/gnupg" GRADLE_OPTS="-Dorg.gradle.project.signing.gnupg.keyName=12345678" ./gradlew clean sign
```