### PR TITLE
Changes to the Payment Intent APIs for the next API version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
 
 env:
   global:
-  - STRIPE_MOCK_VERSION=0.43.0
+  - STRIPE_MOCK_VERSION=0.44.0
 
 matrix:
   include:

--- a/src/main/java/com/stripe/model/PaymentIntent.java
+++ b/src/main/java/com/stripe/model/PaymentIntent.java
@@ -18,7 +18,6 @@ import lombok.Setter;
 public class PaymentIntent extends ApiResource implements MetadataStore<PaymentIntent>, HasId {
   @Getter(onMethod = @__({@Override})) String id;
   String object;
-  List<String> allowedSourceTypes;
   Long amount;
   Long amountCapturable;
   Long amountReceived;
@@ -36,8 +35,9 @@ public class PaymentIntent extends ApiResource implements MetadataStore<PaymentI
   PaymentIntentLastPaymentError lastPaymentError;
   Boolean livemode;
   @Getter(onMethod = @__({@Override})) Map<String, String> metadata;
-  PaymentIntentSourceAction nextSourceAction;
+  NextAction nextAction;
   @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Account> onBehalfOf;
+  List<String> paymentMethodTypes;
   String receiptEmail;
   @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Review> review;
   ShippingDetails shipping;
@@ -45,6 +45,26 @@ public class PaymentIntent extends ApiResource implements MetadataStore<PaymentI
   String statementDescriptor;
   TransferData transferData;
   String status;
+
+  /**
+   * The {@code allowedSourceTypes} attribute.
+   *
+   * @return the {@code allowedSourceTypes} attribute
+   * @deprecated Prefer using the {@link #paymentMethodTypes} attribute instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2019-02-11">API version 2019-02-11</a>
+   */
+  @Deprecated
+  List<String> allowedSourceTypes;
+
+  /**
+   * The {@code nextSourceAction} attribute.
+   *
+   * @return the {@code nextSourceAction} attribute
+   * @deprecated Prefer using the {@link #nextAction} attribute instead.
+   * @see <a href="https://stripe.com/docs/upgrades#2019-02-11">API version 2019-02-11</a>
+   */
+  @Deprecated
+  PaymentIntentSourceAction nextSourceAction;
 
   /**
    * The {@code returnUrl} attribute.
@@ -334,5 +354,21 @@ public class PaymentIntent extends ApiResource implements MetadataStore<PaymentI
       this.destination = new ExpandableField<>(c.getId(), c);
     }
     // </editor-fold>
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class NextAction extends StripeObject {
+    NextActionRedirectToUrl redirectToUrl;
+    String type;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class NextActionRedirectToUrl extends StripeObject {
+    String returnUrl;
+    String url;
   }
 }

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -35,7 +35,7 @@ import org.mockito.Mockito;
 
 public class BaseStripeTest {
   // If changing this number, please also change it in `.travis.yml`.
-  private static final String MOCK_MINIMUM_VERSION = "0.43.0";
+  private static final String MOCK_MINIMUM_VERSION = "0.44.0";
 
   private static String port;
 

--- a/src/test/java/com/stripe/functional/PaymentIntentTest.java
+++ b/src/test/java/com/stripe/functional/PaymentIntentTest.java
@@ -26,13 +26,13 @@ public class PaymentIntentTest extends BaseStripeTest {
 
   @Test
   public void testCreate() throws StripeException {
-    final List<String> allowedSourceTypes = new ArrayList<>();
-    allowedSourceTypes.add("card");
+    final List<String> paymentMethodTypes = new ArrayList<>();
+    paymentMethodTypes.add("card");
 
     final Map<String, Object> params = new HashMap<>();
-    params.put("allowed_source_types", allowedSourceTypes);
     params.put("amount", 1234);
     params.put("currency", "usd");
+    params.put("payment_method_types", paymentMethodTypes);
 
     final PaymentIntent paymentIntent = PaymentIntent.create(params);
 

--- a/src/test/java/com/stripe/model/PaymentIntentTest.java
+++ b/src/test/java/com/stripe/model/PaymentIntentTest.java
@@ -17,13 +17,13 @@ public class PaymentIntentTest extends BaseStripeTest {
     assertNotNull(resource);
     assertNotNull(resource.getId());
 
-    PaymentIntentSourceAction action =  resource.getNextSourceAction();
+    PaymentIntent.NextAction action =  resource.getNextAction();
     assertNotNull(action);
 
-    PaymentIntentSourceActionValueAuthorizeWithUrl actionAuthorize = action.getAuthorizeWithUrl();
-    assertNotNull(actionAuthorize);
-    assertEquals("https://stripe.com", actionAuthorize.getUrl());
-    assertEquals("https://stripe.com/return", actionAuthorize.getReturnUrl());
+    PaymentIntent.NextActionRedirectToUrl actionRedirect = action.getRedirectToUrl();
+    assertNotNull(actionRedirect);
+    assertEquals("https://stripe.com", actionRedirect.getUrl());
+    assertEquals("https://stripe.com/return", actionRedirect.getReturnUrl());
   }
 
   @Test
@@ -45,15 +45,36 @@ public class PaymentIntentTest extends BaseStripeTest {
     assertNotNull(source.getId());
   }
 
+  // Ensure version with `next_source_action` with `authorize_with_url` still works
+  @Test
+  public void testDeserializeNextSourceAction() throws Exception {
+    // Keep the fixture to have `action` deserialize properly
+    final PaymentIntent resource = ApiResource.GSON.fromJson(getResourceAsString(
+            "/api_fixtures/payment_intent_old_next_source_action_authorize_with_url.json"),
+        PaymentIntent.class);
+    assertNotNull(resource);
+    assertNotNull(resource.getId());
+
+    @SuppressWarnings("deprecation")
+    PaymentIntentSourceAction action =  resource.getNextSourceAction();
+    assertNotNull(action);
+
+    PaymentIntentSourceActionValueAuthorizeWithUrl actionAuthorize = action.getAuthorizeWithUrl();
+    assertNotNull(actionAuthorize);
+    assertEquals("https://stripe.com", actionAuthorize.getUrl());
+    assertEquals("https://stripe.com/return", actionAuthorize.getReturnUrl());
+  }
+
   // Ensure legacy version of `next_source_action` with `value` still works
   @Test
   public void testDeserializeSourceActionValue() throws Exception {
     // Keep the fixture to have `action` deserialize properly
-    final PaymentIntent resource = ApiResource.GSON.fromJson(
-        getResourceAsString("/api_fixtures/payment_intent_old_value.json"), PaymentIntent.class);
+    final PaymentIntent resource = ApiResource.GSON.fromJson(getResourceAsString(
+          "/api_fixtures/payment_intent_old_next_source_action_value.json"), PaymentIntent.class);
     assertNotNull(resource);
     assertNotNull(resource.getId());
 
+    @SuppressWarnings("deprecation")
     PaymentIntentSourceAction action =  resource.getNextSourceAction();
     assertNotNull(action);
 

--- a/src/test/resources/api_fixtures/payment_intent_last_payment_error.json
+++ b/src/test/resources/api_fixtures/payment_intent_last_payment_error.json
@@ -1,9 +1,6 @@
 {
     "id": "pi_123",
     "object": "payment_intent",
-    "allowed_source_types": [
-        "card"
-    ],
     "amount": 100,
     "amount_capturable": 0,
     "amount_received": 0,
@@ -52,6 +49,9 @@
     "livemode": false,
     "next_source_action": null,
     "on_behalf_of": null,
+    "payment_method_types": [
+        "card"
+    ],
     "receipt_email": null,
     "return_url": null,
     "review": null,

--- a/src/test/resources/api_fixtures/payment_intent_old_next_source_action_authorize_with_url.json
+++ b/src/test/resources/api_fixtures/payment_intent_old_next_source_action_authorize_with_url.json
@@ -1,6 +1,9 @@
 {
   "id": "pi_123",
   "object": "payment_intent",
+  "allowed_source_types": [
+    "card"
+  ],
   "amount": 1099,
   "amount_capturable": 1000,
   "amount_received": 0,
@@ -30,18 +33,15 @@
   "metadata": {
     "order_id": "123456789"
   },
-  "on_behalf_of": null,
-  "payment_method_types": [
-    "card"
-  ],
-  "receipt_email": "test@stripe.com",
-  "next_action": {
-    "redirect_to_url": {
+  "next_source_action": {
+    "authorize_with_url": {
       "return_url": "https://stripe.com/return",
       "url": "https://stripe.com"
     },
-    "type": "redirect_to_url"
+    "type": "authorize_with_url"
   },
+  "on_behalf_of": null,
+  "receipt_email": "test@stripe.com",
   "return_url": null,
   "shipping": {
     "address": {

--- a/src/test/resources/api_fixtures/payment_intent_old_next_source_action_value.json
+++ b/src/test/resources/api_fixtures/payment_intent_old_next_source_action_value.json
@@ -1,9 +1,6 @@
 {
   "id": "pi_123",
   "object": "payment_intent",
-  "allowed_source_types": [
-    "card"
-  ],
   "amount": 1099,
   "amount_capturable": 1000,
   "amount_received": 0,
@@ -40,6 +37,9 @@
     }
   },
   "on_behalf_of": null,
+  "payment_method_types": [
+    "card"
+  ],
   "receipt_email": "test@stripe.com",
   "return_url": null,
   "shipping": {

--- a/src/test/resources/api_fixtures/payment_intent_with_expansions.json
+++ b/src/test/resources/api_fixtures/payment_intent_with_expansions.json
@@ -1,7 +1,7 @@
 {
   "id": "pi_123",
   "object": "payment_intent",
-  "allowed_source_types": [
+  "payment_method_types": [
     "card"
   ],
   "amount": 1099,


### PR DESCRIPTION
We are going to ship some changes to the Payment Intent APIs in the next API version. Though are fairly self-contained and pave the way for future changes. Changes are:

* `status`: remove `require_source` and `require_source_action` and add `requires_payment_method` and `requires_action`
* `next_source_action` renamed to `next_action`
* `allowed_source_types` renamed to `payment_method_types`
* `authorize_with_url` renamed to `redirect_to_url` both in the type of next action and in the hash that describes that next action.

cc @stripe/api-libraries @danwang-stripe 

cc @mickjermsurawong-stripe To confirm naming for the new classes make sense (now that they are inline)