### PR TITLE
Add support for Subscription Schedule APIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
 
 env:
   global:
-  - STRIPE_MOCK_VERSION=0.43.0
+  - STRIPE_MOCK_VERSION=0.44.0
 
 matrix:
   include:

--- a/src/main/java/com/stripe/model/Customer.java
+++ b/src/main/java/com/stripe/model/Customer.java
@@ -4,6 +4,7 @@ import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
+import java.util.List;
 import java.util.Map;
 
 import lombok.AccessLevel;
@@ -28,6 +29,7 @@ public class Customer extends ApiResource implements MetadataStore<Customer>, Ha
   Discount discount;
   String email;
   String invoicePrefix;
+  InvoiceSettings invoiceSettings;
   Boolean livemode;
   @Getter(onMethod = @__({@Override})) Map<String, String> metadata;
   ShippingDetails shipping;
@@ -233,6 +235,14 @@ public class Customer extends ApiResource implements MetadataStore<Customer>, Ha
   public static class NextRecurringCharge extends StripeObject {
     Long amount;
     String date;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class InvoiceSettings extends StripeObject {
+    List<Invoice.CustomField> customFields;
+    String footer;
   }
 
   @Getter

--- a/src/main/java/com/stripe/model/EventDataClassLookup.java
+++ b/src/main/java/com/stripe/model/EventDataClassLookup.java
@@ -63,6 +63,8 @@ final class EventDataClassLookup {
     classLookup.put("source_transaction", SourceTransaction.class);
     classLookup.put("subscription", Subscription.class);
     classLookup.put("subscription_item", SubscriptionItem.class);
+    classLookup.put("subscription_schedule", SubscriptionSchedule.class);
+    classLookup.put("subscription_schedule_revision", SubscriptionScheduleRevision.class);
     classLookup.put("summary", Transfer.Summary.class);
     classLookup.put("terminal.connection_token", com.stripe.model.terminal.ConnectionToken.class);
     classLookup.put("terminal.location", com.stripe.model.terminal.Location.class);

--- a/src/main/java/com/stripe/model/SubscriptionSchedule.java
+++ b/src/main/java/com/stripe/model/SubscriptionSchedule.java
@@ -1,0 +1,486 @@
+package com.stripe.model;
+
+import com.google.gson.annotations.SerializedName;
+
+import com.stripe.exception.StripeException;
+import com.stripe.net.ApiResource;
+import com.stripe.net.RequestOptions;
+
+import java.math.BigDecimal;
+
+import java.util.List;
+import java.util.Map;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
+public class SubscriptionSchedule extends ApiResource
+    implements MetadataStore<SubscriptionSchedule>, HasId {
+  /**
+   * Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will
+   * attempt to pay the underlying subscription at the end of each billing cycle using the default
+   * source attached to the customer. When sending an invoice, Stripe will email your customer an
+   * invoice with payment instructions.
+   */
+  @SerializedName("billing")
+  String billing;
+
+  /**
+   * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
+   * billing period.
+   */
+  @SerializedName("billing_thresholds")
+  Subscription.BillingThresholds billingThresholds;
+
+  /**
+   * Time at which the subscription schedule was canceled. Measured in seconds since the Unix epoch.
+   */
+  @SerializedName("canceled_at")
+  Long canceledAt;
+
+  /**
+   * Time at which the subscription schedule was completed. Measured in seconds since the Unix
+   * epoch.
+   */
+  @SerializedName("completed_at")
+  Long completedAt;
+
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  @SerializedName("created")
+  Long created;
+
+  /**
+   * Object representing the start and end dates for the current phase of the subscription schedule,
+   * if it is `active`.
+   */
+  @SerializedName("current_phase")
+  CurrentPhase currentPhase;
+
+  /** ID of the customer who owns the subscription schedule. */
+  @SerializedName("customer")
+  @Getter(lombok.AccessLevel.NONE)
+  @Setter(lombok.AccessLevel.NONE)
+  ExpandableField<Customer> customer;
+
+  /** Unique identifier for the object. */
+  @Getter(onMethod = @__({@Override}))
+  @SerializedName("id")
+  String id;
+
+  /** The subscription schedule's default invoice settings. */
+  @SerializedName("invoice_settings")
+  InvoiceSettings invoiceSettings;
+
+  /**
+   * Has the value `true` if the object exists in live mode or the value `false` if the object
+   * exists in test mode.
+   */
+  @SerializedName("livemode")
+  Boolean livemode;
+
+  /**
+   * Set of key-value pairs that you can attach to an object. This can be useful for storing
+   * additional information about the object in a structured format.
+   */
+  @SerializedName("metadata")
+  Map<String, String> metadata;
+
+  /** String representing the object's type. Objects of the same type share the same value. */
+  @SerializedName("object")
+  String object;
+
+  /** Configuration for the subscription schedule's phases. */
+  @SerializedName("phases")
+  List<Phase> phases;
+
+  /**
+   * Time at which the subscription schedule was released. Measured in seconds since the Unix epoch.
+   */
+  @SerializedName("released_at")
+  Long releasedAt;
+
+  /** ID of the subscription once managed by the subscription schedule (if it is released). */
+  @SerializedName("released_subscription")
+  String releasedSubscription;
+
+  /** Behavior of the subscription schedule and underlying subscription when it ends. */
+  @SerializedName("renewal_behavior")
+  String renewalBehavior;
+
+  /**
+   * Interval and duration at which the subscription schedule renews for when it ends if
+   * `renewal_behavior` is `renew`.
+   */
+  @SerializedName("renewal_interval")
+  RenewalInterval renewalInterval;
+
+  /** ID of the current revision of the subscription schedule. */
+  @SerializedName("revision")
+  String revision;
+
+  /** Possible values are `not_started`, `active`, `completed`, `released`, and `canceled`. */
+  @SerializedName("status")
+  String status;
+
+  /** ID of the subscription managed by the subscription schedule. */
+  @SerializedName("subscription")
+  @Getter(lombok.AccessLevel.NONE)
+  @Setter(lombok.AccessLevel.NONE)
+  ExpandableField<Subscription> subscription;
+
+  /** Get id of expandable `customer` object. */
+  public String getCustomer() {
+    return (this.customer != null) ? this.customer.getId() : null;
+  }
+
+  public void setCustomer(String id) {
+    this.customer = ApiResource.setExpandableFieldId(id, this.customer);
+  }
+
+  /** Get expanded `customer`. */
+  public Customer getCustomerObject() {
+    return (this.customer != null) ? this.customer.getExpanded() : null;
+  }
+
+  public void setCustomerObject(Customer expandableObject) {
+    this.customer = new ExpandableField<Customer>(expandableObject.getId(), expandableObject);
+  }
+
+  /** Get id of expandable `subscription` object. */
+  public String getSubscription() {
+    return (this.subscription != null) ? this.subscription.getId() : null;
+  }
+
+  public void setSubscription(String id) {
+    this.subscription = ApiResource.setExpandableFieldId(id, this.subscription);
+  }
+
+  /** Get expanded `subscription`. */
+  public Subscription getSubscriptionObject() {
+    return (this.subscription != null) ? this.subscription.getExpanded() : null;
+  }
+
+  public void setSubscriptionObject(Subscription expandableObject) {
+    this.subscription =
+        new ExpandableField<Subscription>(expandableObject.getId(), expandableObject);
+  }
+
+  // <editor-fold desc="cancel">
+  /**
+   * Cancel a subscription schedule.
+   */
+  public SubscriptionSchedule cancel() throws StripeException {
+    return this.cancel((RequestOptions) null);
+  }
+
+  /**
+   * Cancel a subscription schedule.
+   */
+  public SubscriptionSchedule cancel(RequestOptions options) throws StripeException {
+    return cancel(null, options);
+  }
+
+  /**
+   * Cancel a subscription schedule.
+   */
+  public SubscriptionSchedule cancel(Map<String, Object> params) throws StripeException {
+    return this.cancel(params, null);
+  }
+
+  /**
+   * Cancel a subscription schedule.
+   */
+  public SubscriptionSchedule cancel(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    return request(RequestMethod.POST, String.format("%s/cancel",
+        instanceUrl(SubscriptionSchedule.class, this.getId())), params, SubscriptionSchedule.class,
+            options);
+  }
+  // </editor-fold>
+
+  // <editor-fold desc="create">
+  /**
+   * Create a subscription schedule.
+   */
+  public static SubscriptionSchedule create(Map<String, Object> params) throws StripeException {
+    return create(params, (RequestOptions) null);
+  }
+
+  /**
+   * Create a subscription schedule.
+   */
+  public static SubscriptionSchedule create(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    return request(RequestMethod.POST, classUrl(SubscriptionSchedule.class), params,
+        SubscriptionSchedule.class, options);
+  }
+  // </editor-fold>
+
+  // <editor-fold desc="list">
+  /**
+   * List all subscription schedules.
+   */
+  public static SubscriptionScheduleCollection list(Map<String, Object> params)
+      throws StripeException {
+    return list(params, null);
+  }
+
+  /**
+   * List all subscription schedules.
+   */
+  public static SubscriptionScheduleCollection list(Map<String, Object> params,
+      RequestOptions options)
+      throws StripeException {
+    return requestCollection(classUrl(SubscriptionSchedule.class), params,
+        SubscriptionScheduleCollection.class, options);
+  }
+  // </editor-fold>
+
+  // <editor-fold desc="release">
+  /**
+   * Release a subscription schedule.
+   */
+  public SubscriptionSchedule release() throws StripeException {
+    return this.release((RequestOptions) null);
+  }
+
+  /**
+   * Release a subscription schedule.
+   */
+  public SubscriptionSchedule release(RequestOptions options) throws StripeException {
+    return release(null, options);
+  }
+
+  /**
+   * Release a subscription schedule.
+   */
+  public SubscriptionSchedule release(Map<String, Object> params) throws StripeException {
+    return this.release(params, null);
+  }
+
+  /**
+   * Release a subscription schedule.
+   */
+  public SubscriptionSchedule release(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    return request(RequestMethod.POST, String.format("%s/release",
+        instanceUrl(SubscriptionSchedule.class, this.getId())), params,
+            SubscriptionSchedule.class, options);
+  }
+  // </editor-fold>
+
+  // <editor-fold desc="retrieve">
+  /**
+   * Retrieve a subscription schedule.
+   */
+  public static SubscriptionSchedule retrieve(String id) throws StripeException {
+    return retrieve(id, (RequestOptions) null);
+  }
+
+  /**
+   * Retrieve a subscription schedule.
+   */
+  public static SubscriptionSchedule retrieve(String id, RequestOptions options)
+      throws StripeException {
+    return retrieve(id, null, options);
+  }
+
+  /**
+   * Retrieve a subscription schedule.
+   */
+  public static SubscriptionSchedule retrieve(String id, Map<String, Object> params,
+      RequestOptions options)
+      throws StripeException {
+    return request(RequestMethod.GET, instanceUrl(SubscriptionSchedule.class, id), params,
+        SubscriptionSchedule.class, options);
+  }
+  // </editor-fold>
+
+  // <editor-fold desc="update">
+  /**
+   * Update a subscription schedule.
+   */
+  @Override
+  public SubscriptionSchedule update(Map<String, Object> params) throws StripeException {
+    return update(params, (RequestOptions) null);
+  }
+
+  /**
+   * Update a subscription schedule.
+   */
+  @Override
+  public SubscriptionSchedule update(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    return request(RequestMethod.POST, instanceUrl(SubscriptionSchedule.class, this.id), params,
+        SubscriptionSchedule.class, options);
+  }
+  // </editor-fold>
+
+  // <editor-fold desc="revisions">
+  /**
+   * List a subscription schedule's revisions.
+   */
+  public SubscriptionScheduleRevisionCollection revisions()
+      throws StripeException {
+    return revisions(null, null);
+  }
+
+  /**
+   * List a subscription schedule's revisions.
+   */
+  public SubscriptionScheduleRevisionCollection revisions(Map<String, Object> params)
+      throws StripeException {
+    return revisions(params, null);
+  }
+
+  /**
+   * List a subscription schedule's revisions.
+   */
+  public SubscriptionScheduleRevisionCollection revisions(Map<String, Object> params,
+      RequestOptions options) throws StripeException {
+    String url = instanceUrl(SubscriptionSchedule.class, this.getId()) + "/revisions";
+    return requestCollection(url, params, SubscriptionScheduleRevisionCollection.class, options);
+  }
+  // </editor-fold>
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class CurrentPhase extends StripeObject {
+    @SerializedName("end_date")
+    Long endDate;
+
+    @SerializedName("start_date")
+    Long startDate;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class InvoiceSettings extends StripeObject {
+    /**
+     * Number of days within which a customer must pay invoices generated by this subscription
+     * schedule. This value will be `null` for subscription schedules where
+     * `billing=charge_automatically`.
+     */
+    @SerializedName("days_until_due")
+    Long daysUntilDue;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class Phase extends ApiResource {
+    /**
+     * A non-negative decimal between 0 and 100, with at most two decimal places. This represents
+     * the percentage of the subscription invoice subtotal that will be transferred to the
+     * application owner's Stripe account during this phase of the schedule.
+     */
+    @SerializedName("application_fee_percent")
+    BigDecimal applicationFeePercent;
+
+    /** ID of the coupon to use during this phase of the subscription schedule. */
+    @SerializedName("coupon")
+    @Getter(lombok.AccessLevel.NONE)
+    @Setter(lombok.AccessLevel.NONE)
+    ExpandableField<Coupon> coupon;
+
+    /** The end of this phase of the subscription schedule. */
+    @SerializedName("end_date")
+    Long endDate;
+
+    /** Plans to subscribe during this phase of the subscription schedule. */
+    @SerializedName("plans")
+    List<PhaseItem> plans;
+
+    /** The start of this phase of the subscription schedule. */
+    @SerializedName("start_date")
+    Long startDate;
+
+    /**
+     * If provided, each invoice created during this phase of the subscription schedule will apply
+     * the tax rate, increasing the amount billed to the customer.
+     */
+    @SerializedName("tax_percent")
+    BigDecimal taxPercent;
+
+    /** When the trial ends within the phase. */
+    @SerializedName("trial_end")
+    Long trialEnd;
+
+    /** Get id of expandable `coupon` object. */
+    public String getCoupon() {
+      return (this.coupon != null) ? this.coupon.getId() : null;
+    }
+
+    public void setCoupon(String id) {
+      this.coupon = ApiResource.setExpandableFieldId(id, this.coupon);
+    }
+
+    /** Get expanded `coupon`. */
+    public Coupon getCouponObject() {
+      return (this.coupon != null) ? this.coupon.getExpanded() : null;
+    }
+
+    public void setCouponObject(Coupon expandableObject) {
+      this.coupon = new ExpandableField<Coupon>(expandableObject.getId(), expandableObject);
+    }
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class PhaseItem extends StripeObject {
+    /**
+     * Define thresholds at which an invoice will be sent, and the related subscription advanced to
+     * a new billing period.
+     */
+    @SerializedName("billing_thresholds")
+    SubscriptionItem.BillingThresholds billingThresholds;
+
+    /** ID of the plan to which the customer should be subscribed. */
+    @SerializedName("plan")
+    @Getter(lombok.AccessLevel.NONE)
+    @Setter(lombok.AccessLevel.NONE)
+    ExpandableField<Plan> plan;
+
+    /** Quantity of the plan to which the customer should be subscribed. */
+    @SerializedName("quantity")
+    Long quantity;
+
+    /** Get id of expandable `plan` object. */
+    public String getPlan() {
+      return (this.plan != null) ? this.plan.getId() : null;
+    }
+
+    public void setPlan(String id) {
+      this.plan = ApiResource.setExpandableFieldId(id, this.plan);
+    }
+
+    /** Get expanded `plan`. */
+    public Plan getPlanObject() {
+      return (this.plan != null) ? this.plan.getExpanded() : null;
+    }
+
+    public void setPlanObject(Plan expandableObject) {
+      this.plan = new ExpandableField<Plan>(expandableObject.getId(), expandableObject);
+    }
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class RenewalInterval extends StripeObject {
+    /** Interval at which to renew the subscription schedule for when it ends. */
+    @SerializedName("interval")
+    String interval;
+
+    /** Number of intervals to renew the subscription schedule for when it ends. */
+    @SerializedName("length")
+    Long length;
+  }
+}

--- a/src/main/java/com/stripe/model/SubscriptionScheduleCollection.java
+++ b/src/main/java/com/stripe/model/SubscriptionScheduleCollection.java
@@ -1,0 +1,3 @@
+package com.stripe.model;
+
+public class SubscriptionScheduleCollection extends StripeCollection<SubscriptionSchedule> {}

--- a/src/main/java/com/stripe/model/SubscriptionScheduleRevision.java
+++ b/src/main/java/com/stripe/model/SubscriptionScheduleRevision.java
@@ -1,0 +1,67 @@
+package com.stripe.model;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+import java.util.Map;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
+public class SubscriptionScheduleRevision extends StripeObject implements HasId {
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  @SerializedName("created")
+  Long created;
+
+  /** Unique identifier for the object. */
+  @Getter(onMethod = @__({@Override}))
+  @SerializedName("id")
+  String id;
+
+  @SerializedName("invoice_settings")
+  SubscriptionSchedule.InvoiceSettings invoiceSettings;
+
+  /**
+   * Has the value `true` if the object exists in live mode or the value `false` if the object
+   * exists in test mode.
+   */
+  @SerializedName("livemode")
+  Boolean livemode;
+
+  /**
+   * Set of key-value pairs that you can attach to an object. This can be useful for storing
+   * additional information about the object in a structured format.
+   */
+  @SerializedName("metadata")
+  Map<String, String> metadata;
+
+  /** String representing the object's type. Objects of the same type share the same value. */
+  @SerializedName("object")
+  String object;
+
+  /** Configuration for the subscription schedule's phases. */
+  @SerializedName("phases")
+  List<SubscriptionSchedule.Phase> phases;
+
+  @SerializedName("previous_revision")
+  String previousRevision;
+
+  /** Behavior of the subscription schedule and underlying subscription when it ends. */
+  @SerializedName("renewal_behavior")
+  String renewalBehavior;
+
+  /**
+   * Interval and duration at which the subscription schedule renews for when it ends if
+   * `renewal_behavior` is `renew`.
+   */
+  @SerializedName("renewal_interval")
+  SubscriptionSchedule.RenewalInterval renewalInterval;
+
+  /** ID of the subscription schedule the revision points to. */
+  @SerializedName("schedule")
+  String schedule;
+}

--- a/src/main/java/com/stripe/model/SubscriptionScheduleRevisionCollection.java
+++ b/src/main/java/com/stripe/model/SubscriptionScheduleRevisionCollection.java
@@ -1,0 +1,56 @@
+package com.stripe.model;
+
+import com.stripe.Stripe;
+import com.stripe.exception.StripeException;
+import com.stripe.net.ApiResource;
+import com.stripe.net.RequestOptions;
+import java.util.Map;
+
+public class SubscriptionScheduleRevisionCollection
+    extends StripeCollection<SubscriptionScheduleRevision> {
+  /** Retrieves the list of subscription schedule revisions for a subscription schedule. */
+  public SubscriptionScheduleRevisionCollection list(Map<String, Object> params)
+      throws StripeException {
+    return list(params, (RequestOptions) null);
+  }
+
+  /** Retrieves the list of subscription schedule revisions for a subscription schedule. */
+  public SubscriptionScheduleRevisionCollection list(
+      Map<String, Object> params, RequestOptions options) throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), this.getUrl());
+    return ApiResource.requestCollection(
+        url, params, SubscriptionScheduleRevisionCollection.class, options);
+  }
+
+  /**
+   * Retrieves the details of an existing subscription schedule revision. You only need to supply
+   * the unique subscription schedule revision identifier that was returned upon subscription
+   * schedule creation or retrieval.
+   */
+  public SubscriptionScheduleRevision retrieve(String id) throws StripeException {
+    return retrieve(id, (Map<String, Object>) null, (RequestOptions) null);
+  }
+
+  /**
+   * Retrieves the details of an existing subscription schedule revision. You only need to supply
+   * the unique subscription schedule revision identifier that was returned upon subscription
+   * schedule creation or retrieval.
+   */
+  public SubscriptionScheduleRevision retrieve(String id, RequestOptions options)
+      throws StripeException {
+    return retrieve(id, (Map<String, Object>) null, options);
+  }
+
+  /**
+   * Retrieves the details of an existing subscription schedule revision. You only need to supply
+   * the unique subscription schedule revision identifier that was returned upon subscription
+   * schedule creation or retrieval.
+   */
+  public SubscriptionScheduleRevision retrieve(
+      String id, Map<String, Object> params, RequestOptions options) throws StripeException {
+    String url =
+        String.format("%s%s", Stripe.getApiBase(), String.format("%s/%s", this.getUrl(), id));
+    return ApiResource.request(
+        ApiResource.RequestMethod.GET, url, params, SubscriptionScheduleRevision.class, options);
+  }
+}

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -35,7 +35,7 @@ import org.mockito.Mockito;
 
 public class BaseStripeTest {
   // If changing this number, please also change it in `.travis.yml`.
-  private static final String MOCK_MINIMUM_VERSION = "0.43.0";
+  private static final String MOCK_MINIMUM_VERSION = "0.44.0";
 
   private static String port;
 

--- a/src/test/java/com/stripe/functional/PaymentIntentTest.java
+++ b/src/test/java/com/stripe/functional/PaymentIntentTest.java
@@ -26,13 +26,13 @@ public class PaymentIntentTest extends BaseStripeTest {
 
   @Test
   public void testCreate() throws StripeException {
-    final List<String> allowedSourceTypes = new ArrayList<>();
-    allowedSourceTypes.add("card");
+    final List<String> paymentMethodTypes = new ArrayList<>();
+    paymentMethodTypes.add("card");
 
     final Map<String, Object> params = new HashMap<>();
-    params.put("allowed_source_types", allowedSourceTypes);
     params.put("amount", 1234);
     params.put("currency", "usd");
+    params.put("payment_method_types", paymentMethodTypes);
 
     final PaymentIntent paymentIntent = PaymentIntent.create(params);
 

--- a/src/test/java/com/stripe/functional/SubscriptionScheduleTest.java
+++ b/src/test/java/com/stripe/functional/SubscriptionScheduleTest.java
@@ -1,0 +1,136 @@
+package com.stripe.functional;
+
+import static org.junit.Assert.assertNotNull;
+
+import com.stripe.BaseStripeTest;
+import com.stripe.exception.StripeException;
+import com.stripe.model.SubscriptionSchedule;
+import com.stripe.model.SubscriptionScheduleCollection;
+import com.stripe.model.SubscriptionScheduleRevisionCollection;
+import com.stripe.net.ApiResource;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+public class SubscriptionScheduleTest extends BaseStripeTest {
+  public static final String SCHEDULE_ID = "sub_sched_123";
+
+  private SubscriptionSchedule getSubscriptionScheduleFixture() throws StripeException {
+    final SubscriptionSchedule schedule = SubscriptionSchedule.retrieve(SCHEDULE_ID);
+    resetNetworkSpy();
+    return schedule;
+  }
+
+  @Test
+  public void testCancel() throws StripeException {
+    final SubscriptionSchedule schedule = getSubscriptionScheduleFixture();
+
+    final Map<String, Object> params = new HashMap<>();
+    params.put("invoice_now", true);
+
+    final SubscriptionSchedule canceledSchedule = schedule.cancel(params);
+
+    assertNotNull(canceledSchedule);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        String.format("/v1/subscription_schedules/%s/cancel", schedule.getId()),
+        params
+    );
+  }
+
+  @Test
+  public void testCreate() throws StripeException {
+    final Map<String, Object> params = new HashMap<>();
+    params.put("customer", "cus_123");
+
+    final SubscriptionSchedule schedule = SubscriptionSchedule.create(params);
+
+    assertNotNull(schedule);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/subscription_schedules",
+        params
+    );
+  }
+
+  @Test
+  public void testList() throws StripeException {
+    final Map<String, Object> params = new HashMap<>();
+    params.put("limit", 1);
+
+    final SubscriptionScheduleCollection schedules = SubscriptionSchedule.list(params);
+
+    assertNotNull(schedules);
+    verifyRequest(
+        ApiResource.RequestMethod.GET,
+        "/v1/subscription_schedules",
+        params
+    );
+  }
+
+  @Test
+  public void testRelease() throws StripeException {
+    final SubscriptionSchedule schedule = getSubscriptionScheduleFixture();
+
+    final Map<String, Object> params = new HashMap<>();
+    params.put("preserve_cancel_date", true);
+
+    final SubscriptionSchedule releasedSchedule = schedule.release(params);
+
+    assertNotNull(releasedSchedule);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        String.format("/v1/subscription_schedules/%s/release", schedule.getId()),
+        params
+    );
+  }
+
+  @Test
+  public void testRetrieve() throws StripeException {
+    final SubscriptionSchedule schedule = SubscriptionSchedule.retrieve(SCHEDULE_ID);
+
+    assertNotNull(schedule);
+    verifyRequest(
+        ApiResource.RequestMethod.GET,
+        String.format("/v1/subscription_schedules/%s", SCHEDULE_ID)
+    );
+  }
+
+  @Test
+  public void testUpdate() throws StripeException {
+    final SubscriptionSchedule schedule = getSubscriptionScheduleFixture();
+
+    final Map<String, Object> metadata = new HashMap<>();
+    metadata.put("foo", "bar");
+    final Map<String, Object> params = new HashMap<>();
+    params.put("metadata", metadata);
+
+    final SubscriptionSchedule updatedSubscriptionSchedule = schedule.update(params);
+
+    assertNotNull(updatedSubscriptionSchedule);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        String.format("/v1/subscription_schedules/%s", schedule.getId()),
+        params
+    );
+  }
+
+  @Test
+  public void testRevisions() throws StripeException {
+    final SubscriptionSchedule schedule = getSubscriptionScheduleFixture();
+
+    final Map<String, Object> params = new HashMap<>();
+    params.put("limit", 1);
+
+    final SubscriptionScheduleRevisionCollection revisions = schedule.revisions(params);
+
+    assertNotNull(revisions);
+    verifyRequest(
+        ApiResource.RequestMethod.GET,
+        String.format("/v1/subscription_schedules/%s/revisions", schedule.getId()),
+        params
+    );
+  }
+}

--- a/src/test/java/com/stripe/model/SubscriptionScheduleRevisionTest.java
+++ b/src/test/java/com/stripe/model/SubscriptionScheduleRevisionTest.java
@@ -1,0 +1,20 @@
+package com.stripe.model;
+
+import static org.junit.Assert.assertNotNull;
+
+import com.stripe.BaseStripeTest;
+import com.stripe.net.ApiResource;
+
+import org.junit.Test;
+
+public class SubscriptionScheduleRevisionTest extends BaseStripeTest {
+  @Test
+  public void testDeserialize() throws Exception {
+    final String data = getFixture(
+        "/v1/subscription_schedules/sub_sched_123/revisions/sub_sched_rev_123");
+    final SubscriptionScheduleRevision resource = ApiResource.GSON.fromJson(data,
+        SubscriptionScheduleRevision.class);
+    assertNotNull(resource);
+    assertNotNull(resource.getId());
+  }
+}

--- a/src/test/java/com/stripe/model/SubscriptionScheduleTest.java
+++ b/src/test/java/com/stripe/model/SubscriptionScheduleTest.java
@@ -1,0 +1,46 @@
+package com.stripe.model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.stripe.BaseStripeTest;
+import com.stripe.net.ApiResource;
+
+import org.junit.Test;
+
+public class SubscriptionScheduleTest extends BaseStripeTest {
+  @Test
+  public void testDeserialize() throws Exception {
+    final String data = getFixture("/v1/subscription_schedules/sub_sched_123");
+    final SubscriptionSchedule resource = ApiResource.GSON.fromJson(data,
+        SubscriptionSchedule.class);
+    assertNotNull(resource);
+    assertNotNull(resource.getId());
+  }
+
+  @Test
+  public void testDeserializeWithExpansions() throws Exception {
+    // TODO: support expanding "phases.coupon" and "phases.plans.plan" with stripe-mock
+    final String[] expansions = {
+      "customer",
+      "subscription"
+    };
+
+    final String data = getFixture("/v1/subscription_schedules/sub_sched_123", expansions);
+
+    final SubscriptionSchedule resource = ApiResource.GSON.fromJson(data,
+        SubscriptionSchedule.class);
+    assertNotNull(resource);
+    assertNotNull(resource.getId());
+
+    final Customer customer = resource.getCustomerObject();
+    assertNotNull(customer);
+    assertNotNull(customer.getId());
+    assertEquals(resource.getCustomer(), customer.getId());
+
+    final Subscription subscription = resource.getSubscriptionObject();
+    assertNotNull(subscription);
+    assertNotNull(subscription.getId());
+    assertEquals(resource.getSubscription(), subscription.getId());
+  }
+}


### PR DESCRIPTION
Add support for Subscription Schedule APIs

* Add Subscription Schedule
* Add Subscription Schedule Revisions
* Add `invoice_settings` on the Customer

cc @stripe/api-libraries 