### PR TITLE
Make `customer` expandable on `Invoice`

### DIFF
--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -32,7 +32,7 @@ public class Invoice extends ApiResource implements MetadataStore<Invoice>, HasI
   Long created;
   String currency;
   List<CustomField> customFields;
-  String customer;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Customer> customer;
   Long date;
   @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
       ExpandableField<ExternalAccount> defaultSource;
@@ -97,6 +97,24 @@ public class Invoice extends ApiResource implements MetadataStore<Invoice>, HasI
 
   public void setChargeObject(Charge charge) {
     this.charge = new ExpandableField<>(charge.getId(), charge);
+  }
+  // </editor-fold>
+
+  // <editor-fold desc="customer">
+  public String getCustomer() {
+    return (this.customer != null) ? this.customer.getId() : null;
+  }
+
+  public void setCustomer(String customerId) {
+    this.customer = setExpandableFieldId(customerId, this.customer);
+  }
+
+  public Customer getCustomerObject() {
+    return (this.customer != null) ? this.customer.getExpanded() : null;
+  }
+
+  public void setCustomerObject(Customer customer) {
+    this.customer = new ExpandableField<>(customer.getId(), customer);
   }
   // </editor-fold>
 

--- a/src/test/java/com/stripe/model/InvoiceTest.java
+++ b/src/test/java/com/stripe/model/InvoiceTest.java
@@ -24,6 +24,7 @@ public class InvoiceTest extends BaseStripeTest {
   public void testDeserializeExpanded() throws Exception {
     final String[] expansions = {
       "charge",
+      "customer",
     };
     final String data = getFixture("/v1/invoices/in_123", expansions);
     final Invoice invoice = ApiResource.GSON.fromJson(data, Invoice.class);
@@ -33,5 +34,9 @@ public class InvoiceTest extends BaseStripeTest {
     assertNotNull(charge);
     assertNotNull(charge.getId());
     assertEquals(invoice.getCharge(), charge.getId());
+    final Customer customer = invoice.getCustomerObject();
+    assertNotNull(customer);
+    assertNotNull(customer.getId());
+    assertEquals(invoice.getCustomer(), customer.getId());
   }
 }


### PR DESCRIPTION
Fixes https://github.com/stripe/stripe-java/issues/674

r? @mickjermsurawong-stripe 
cc @stripe/api-libraries 
