### PR TITLE
Add support for `transfer_data[amount]` on Charge

### DIFF
--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -606,6 +606,7 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, HasId 
   @Setter
   @EqualsAndHashCode(callSuper = false)
   public static class TransferData extends StripeObject {
+    Long amount;
     @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Account> destination;
 
     // <editor-fold desc="destination">


### PR DESCRIPTION
We decided to support `transfer_data[amount]` on Charges for 2/19, at least for a few months. We think developers should use `application_fee_amount` instead but many integrations already used `destination[amount]` and would be quite blocked if we removed this.

r? @mickjermsurawong-stripe  
cc @stripe/api-libraries 