### PR TITLE
Add public models for errors

### DIFF
--- a/src/main/java/com/stripe/exception/CardException.java
+++ b/src/main/java/com/stripe/exception/CardException.java
@@ -1,5 +1,8 @@
 package com.stripe.exception;
 
+import lombok.Getter;
+
+@Getter
 public class CardException extends StripeException {
   private static final long serialVersionUID = 2L;
 
@@ -16,17 +19,5 @@ public class CardException extends StripeException {
     this.param = param;
     this.declineCode = declineCode;
     this.charge = charge;
-  }
-
-  public String getParam() {
-    return param;
-  }
-
-  public String getDeclineCode() {
-    return declineCode;
-  }
-
-  public String getCharge() {
-    return charge;
   }
 }

--- a/src/main/java/com/stripe/exception/InvalidRequestException.java
+++ b/src/main/java/com/stripe/exception/InvalidRequestException.java
@@ -1,5 +1,8 @@
 package com.stripe.exception;
 
+import lombok.Getter;
+
+@Getter
 public class InvalidRequestException extends StripeException {
   private static final long serialVersionUID = 2L;
 
@@ -9,9 +12,5 @@ public class InvalidRequestException extends StripeException {
       Integer statusCode, Throwable e) {
     super(message, requestId, code, statusCode, e);
     this.param = param;
-  }
-
-  public String getParam() {
-    return param;
   }
 }

--- a/src/main/java/com/stripe/exception/SignatureVerificationException.java
+++ b/src/main/java/com/stripe/exception/SignatureVerificationException.java
@@ -1,5 +1,8 @@
 package com.stripe.exception;
 
+import lombok.Getter;
+
+@Getter
 public class SignatureVerificationException extends StripeException {
   private static final long serialVersionUID = 2L;
 
@@ -8,9 +11,5 @@ public class SignatureVerificationException extends StripeException {
   public SignatureVerificationException(String message, String sigHeader) {
     super(message, null, null, 0);
     this.sigHeader = sigHeader;
-  }
-
-  public String getSigHeader() {
-    return sigHeader;
   }
 }

--- a/src/main/java/com/stripe/exception/StripeException.java
+++ b/src/main/java/com/stripe/exception/StripeException.java
@@ -1,7 +1,19 @@
 package com.stripe.exception;
 
+import com.stripe.model.StripeError;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
 public abstract class StripeException extends Exception {
   private static final long serialVersionUID = 2L;
+
+  /**
+   * The error resource returned by Stripe's API that caused the exception.
+   */
+  @Setter
+  StripeError stripeError;
 
   private String code;
   private String requestId;
@@ -20,18 +32,6 @@ public abstract class StripeException extends Exception {
     this.code = code;
     this.requestId = requestId;
     this.statusCode = statusCode;
-  }
-
-  public String getCode() {
-    return code;
-  }
-
-  public String getRequestId() {
-    return requestId;
-  }
-
-  public Integer getStatusCode() {
-    return statusCode;
   }
 
   /**

--- a/src/main/java/com/stripe/exception/oauth/OAuthException.java
+++ b/src/main/java/com/stripe/exception/oauth/OAuthException.java
@@ -1,12 +1,23 @@
 package com.stripe.exception.oauth;
 
 import com.stripe.exception.StripeException;
+import com.stripe.model.oauth.OAuthError;
+
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * Base parent class for all OAuth exceptions.
  */
+@Getter
 public class OAuthException extends StripeException {
   private static final long serialVersionUID = 2L;
+
+  /**
+   * The error resource returned by Stripe's OAuth API that caused the exception.
+   */
+  @Setter
+  OAuthError oauthError;
 
   public OAuthException(String code, String description, String requestId, Integer statusCode,
       Throwable e) {

--- a/src/main/java/com/stripe/model/StripeError.java
+++ b/src/main/java/com/stripe/model/StripeError.java
@@ -1,0 +1,62 @@
+package com.stripe.model;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
+public class StripeError extends StripeObject {
+  /** For card errors, the ID of the failed charge. */
+  @SerializedName("charge")
+  String charge;
+
+  /**
+   * For some errors that could be handled programmatically, a short string indicating the [error
+   * code](/docs/error-codes) reported.
+   */
+  @SerializedName("code")
+  String code;
+
+  /**
+   * For card errors resulting from a card issuer decline, a short string indicating the [card
+   * issuer's reason for the decline](/docs/declines#issuer-declines) if they provide one.
+   */
+  @SerializedName("decline_code")
+  String declineCode;
+
+  /** A URL to more information about the [error code](/docs/error-codes) reported. */
+  @SerializedName("doc_url")
+  String docUrl;
+
+  /**
+   * A human-readable message providing more details about the error. For card errors, these
+   * messages can be shown to your users.
+   */
+  @SerializedName("message")
+  String message;
+
+  /**
+   * If the error is parameter-specific, the parameter related to the error. For example, you can
+   * use this to display a message near the correct form field.
+   */
+  @SerializedName("param")
+  String param;
+
+  // TODO: add `payment_method`
+
+  /**
+   * The source object for errors returned on a request involving a source.
+   */
+  @SerializedName("source")
+  ExternalAccount source;
+
+  /**
+   * The type of error returned. One of `api_connection_error`, `api_error`, `authentication_error`,
+   * `card_error`, `idempotency_error`, `invalid_request_error`, or `rate_limit_error`
+   */
+  @SerializedName("type")
+  String type;
+}

--- a/src/main/java/com/stripe/model/oauth/OAuthError.java
+++ b/src/main/java/com/stripe/model/oauth/OAuthError.java
@@ -1,0 +1,15 @@
+package com.stripe.model.oauth;
+
+import com.stripe.model.StripeObject;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
+public class OAuthError extends StripeObject {
+  String error;
+  String errorDescription;
+}

--- a/src/test/java/com/stripe/functional/ErrorTest.java
+++ b/src/test/java/com/stripe/functional/ErrorTest.java
@@ -1,0 +1,68 @@
+package com.stripe.functional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.stripe.BaseStripeTest;
+import com.stripe.Stripe;
+import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
+import com.stripe.exception.oauth.InvalidClientException;
+import com.stripe.model.Balance;
+import com.stripe.net.OAuth;
+
+import java.io.IOException;
+
+import lombok.Cleanup;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+
+import org.junit.Test;
+
+
+public class ErrorTest extends BaseStripeTest {
+  @Test
+  public void testStripeError() throws StripeException, IOException, InterruptedException {
+    InvalidRequestException exception = null;
+    @Cleanup MockWebServer server = new MockWebServer();
+    server.enqueue(new MockResponse().setResponseCode(400)
+        .setBody(getResourceAsString("/api_fixtures/error_invalid_request.json")));
+
+    Stripe.overrideApiBase(server.url("").toString());
+
+    try {
+      Balance.retrieve();
+    } catch (InvalidRequestException e) {
+      exception = e;
+    }
+
+    assertNotNull(exception);
+    assertEquals(Integer.valueOf(400), exception.getStatusCode());
+    assertNotNull(exception.getStripeError());
+    assertEquals("invalid_request_error", exception.getStripeError().getType());
+    assertNotNull(exception.getStripeError().getLastResponse());
+  }
+
+  @Test
+  public void testOAuthError() throws StripeException, IOException, InterruptedException {
+    InvalidClientException exception = null;
+    @Cleanup MockWebServer server = new MockWebServer();
+    server.enqueue(new MockResponse().setResponseCode(401)
+        .setBody(getResourceAsString("/oauth_fixtures/error_invalid_client.json")));
+
+    Stripe.overrideApiBase(server.url("").toString());
+
+    try {
+      OAuth.token(null, null);
+    } catch (InvalidClientException e) {
+      exception = e;
+    }
+
+    assertNotNull(exception);
+    assertEquals(Integer.valueOf(401), exception.getStatusCode());
+    assertNotNull(exception.getOauthError());
+    assertEquals("invalid_client", exception.getOauthError().getError());
+    assertNotNull(exception.getOauthError().getLastResponse());
+  }
+}

--- a/src/test/java/com/stripe/model/StripeErrorTest.java
+++ b/src/test/java/com/stripe/model/StripeErrorTest.java
@@ -1,0 +1,26 @@
+package com.stripe.model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.google.gson.JsonObject;
+import com.stripe.BaseStripeTest;
+import com.stripe.net.ApiResource;
+
+import org.junit.Test;
+
+public class StripeErrorTest extends BaseStripeTest {
+  @Test
+  public void testDeserialize() throws Exception {
+    final String data = getResourceAsString("/api_fixtures/error_invalid_request.json");
+    final JsonObject jsonObject = ApiResource.GSON.fromJson(data, JsonObject.class)
+        .getAsJsonObject("error");
+    final StripeError error = ApiResource.GSON.fromJson(jsonObject, StripeError.class);
+    assertNotNull(error);
+    assertEquals("parameter_unknown", error.getCode());
+    assertEquals("https://stripe.com/docs/error-codes/parameter-unknown", error.getDocUrl());
+    assertEquals("Received unknown parameter: foo", error.getMessage());
+    assertEquals("foo", error.getParam());
+    assertEquals("invalid_request_error", error.getType());
+  }
+}

--- a/src/test/java/com/stripe/model/oauth/OAuthErrorTest.java
+++ b/src/test/java/com/stripe/model/oauth/OAuthErrorTest.java
@@ -1,0 +1,22 @@
+package com.stripe.model.oauth;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.stripe.BaseStripeTest;
+import com.stripe.net.ApiResource;
+
+import org.junit.Test;
+
+public class OAuthErrorTest extends BaseStripeTest {
+  @Test
+  public void testDeserialize() throws Exception {
+    final String data = getResourceAsString("/oauth_fixtures/error_invalid_client.json");
+    final OAuthError error = ApiResource.GSON.fromJson(data, OAuthError.class);
+    assertNotNull(error);
+    assertEquals("invalid_client", error.getError());
+    assertEquals(
+        "No authentication was provided. Send your secret API key using the Authorization "
+        + "header, or as a client_secret POST parameter.", error.getErrorDescription());
+  }
+}

--- a/src/test/resources/api_fixtures/error_invalid_request.json
+++ b/src/test/resources/api_fixtures/error_invalid_request.json
@@ -1,0 +1,9 @@
+{
+  "error": {
+    "code": "parameter_unknown",
+    "doc_url": "https://stripe.com/docs/error-codes/parameter-unknown",
+    "message": "Received unknown parameter: foo",
+    "param": "foo",
+    "type": "invalid_request_error"
+  }
+}

--- a/src/test/resources/oauth_fixtures/error_invalid_client.json
+++ b/src/test/resources/oauth_fixtures/error_invalid_client.json
@@ -1,0 +1,4 @@
+{
+  "error": "invalid_client",
+  "error_description": "No authentication was provided. Send your secret API key using the Authorization header, or as a client_secret POST parameter."
+}


### PR DESCRIPTION
r? @mickjermsurawong-stripe @remi-stripe 
cc @scherr-stripe 

This PR adds two new publicly exposed models:
- `com.stripe.model.StripeError` for regular API errors
- `com.stripe.model.oauth.OAuthError` for OAuth errors

`StripeException` now has a `getError()` accessors that returns the `StripeError` instance, and similarly `OAuthException` has a `getOauthError()` that returns the `OAuthError` instance (overriding `getError()` isn't possible because `StripeError` and `OAuthError` aren't covariant).

Users can now also access the `StripeResponse` via `getLastResponse()` on the `StripeError` / `OAuthError` instance.

(I've also removed the manually defined getters in exception classes in favor of `@Getter`.)
