### PR TITLE
Basic primitives for typed params 

### DIFF
--- a/src/main/java/com/stripe/model/EventData.java
+++ b/src/main/java/com/stripe/model/EventData.java
@@ -16,6 +16,13 @@ public class EventData extends StripeObject {
    * should be deferred to the user. See the now deprecated method {@link EventData#getObject()}.
    */
   JsonObject object;
+
+  /**
+   * Object containing the names of the attributes that have changed, and their previous values
+   * (sent along only with *.updated events). The untyped object here is composed of
+   * {@code Map<String, Object>}, {@code List<Object>}, and basic Java data types.
+   * The array was represented as {@code Object[]} in `stripe-java` below 8.x.
+   */
   Map<String, Object> previousAttributes;
 
   /**

--- a/src/main/java/com/stripe/model/EventDataDeserializer.java
+++ b/src/main/java/com/stripe/model/EventDataDeserializer.java
@@ -1,68 +1,19 @@
 package com.stripe.model;
 
-import com.google.gson.JsonArray;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
-import com.google.gson.JsonPrimitive;
 import com.stripe.net.ApiResource;
-
+import com.stripe.net.UntypedMapDeserializer;
 import java.lang.reflect.Type;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 
 public class EventDataDeserializer implements JsonDeserializer<EventData> {
 
-  private Object deserializeJsonPrimitive(JsonPrimitive element) {
-    if (element.isBoolean()) {
-      return element.getAsBoolean();
-    } else if (element.isNumber()) {
-      return element.getAsNumber();
-    } else {
-      return element.getAsString();
-    }
-  }
-
-  private Object[] deserializeJsonArray(JsonArray arr) {
-    Object[] elems = new Object[arr.size()];
-    Iterator<JsonElement> elemIter = arr.iterator();
-    int i = 0;
-    while (elemIter.hasNext()) {
-      JsonElement elem = elemIter.next();
-      elems[i++] = deserializeJsonElement(elem);
-    }
-    return elems;
-  }
-
-  private Object deserializeJsonElement(JsonElement element) {
-    if (element.isJsonNull()) {
-      return null;
-    } else if (element.isJsonObject()) {
-      Map<String, Object> valueMap = new HashMap<>();
-      populateMapFromJsonObject(valueMap, element.getAsJsonObject());
-      return valueMap;
-    } else if (element.isJsonPrimitive()) {
-      return deserializeJsonPrimitive(element.getAsJsonPrimitive());
-    } else if (element.isJsonArray()) {
-      return deserializeJsonArray(element.getAsJsonArray());
-    } else {
-      System.err.println("Unknown JSON element type for element " + element + ". "
-          + "If you're seeing this messaage, it's probably a bug in the Stripe Java "
-          + "library. Please contact us by email at support@stripe.com.");
-      return null;
-    }
-  }
-
-  private void populateMapFromJsonObject(Map<String, Object> objMap, JsonObject jsonObject) {
-    for (Map.Entry<String, JsonElement> entry : jsonObject.entrySet()) {
-      String key = entry.getKey();
-      JsonElement element = entry.getValue();
-      objMap.put(key, deserializeJsonElement(element));
-    }
-  }
+  private static final UntypedMapDeserializer UNTYPED_MAP_DESERIALIZER =
+      new UntypedMapDeserializer();
 
   /**
    * Deserializes the JSON payload contained in an event's {@code data} attribute into an
@@ -80,8 +31,8 @@ public class EventDataDeserializer implements JsonDeserializer<EventData> {
         if (element.isJsonNull()) {
           eventData.setPreviousAttributes(null);
         } else if (element.isJsonObject()) {
-          Map<String, Object> previousAttributes = new HashMap<>();
-          populateMapFromJsonObject(previousAttributes, element.getAsJsonObject());
+          Map<String, Object> previousAttributes =
+              UNTYPED_MAP_DESERIALIZER.deserialize(element.getAsJsonObject());
           eventData.setPreviousAttributes(previousAttributes);
         }
       } else if ("object".equals(key)) {

--- a/src/main/java/com/stripe/model/EventDataDeserializer.java
+++ b/src/main/java/com/stripe/model/EventDataDeserializer.java
@@ -5,8 +5,10 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
+
 import com.stripe.net.ApiResource;
 import com.stripe.net.UntypedMapDeserializer;
+
 import java.lang.reflect.Type;
 import java.util.Map;
 

--- a/src/main/java/com/stripe/net/ApiRequestParams.java
+++ b/src/main/java/com/stripe/net/ApiRequestParams.java
@@ -9,6 +9,7 @@ import com.google.gson.TypeAdapterFactory;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+
 import java.io.IOException;
 import java.util.Map;
 

--- a/src/main/java/com/stripe/net/ApiRequestParams.java
+++ b/src/main/java/com/stripe/net/ApiRequestParams.java
@@ -1,0 +1,67 @@
+package com.stripe.net;
+
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+import java.util.Map;
+
+public abstract class ApiRequestParams {
+
+  public interface Enum {
+    String getValue();
+  }
+
+  private static final Gson GSON = new GsonBuilder()
+      .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+      .registerTypeAdapterFactory(new HasEmptyEnumTypeAdapterFactory())
+      .create();
+
+  private static final UntypedMapDeserializer UNTYPED_MAP_DESERIALIZER =
+      new UntypedMapDeserializer();
+
+  private static class HasEmptyEnumTypeAdapterFactory implements TypeAdapterFactory {
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+      if (!Enum.class.isAssignableFrom(type.getRawType())) {
+        return null;
+      }
+
+      TypeAdapter<Enum> paramEnum = new TypeAdapter<Enum>() {
+        @Override
+        public void write(JsonWriter out, Enum value) throws IOException {
+          if (value.getValue().equals("")) {
+            // need to restore serialize null setting
+            // not to affect other fields
+            boolean previousSetting = out.getSerializeNulls();
+            out.setSerializeNulls(true);
+            out.nullValue();
+            out.setSerializeNulls(previousSetting);
+          } else {
+            out.value(value.getValue());
+          }
+        }
+
+        @Override
+        public Enum read(JsonReader in) {
+          throw new UnsupportedOperationException(
+              "No deserialization is expected from this private type adapter for enum param.");
+        }
+      };
+      return (TypeAdapter<T>) paramEnum.nullSafe();
+    }
+  }
+
+  public Map<String, Object> toMap() {
+    JsonObject json = GSON.toJsonTree(this).getAsJsonObject();
+    return UNTYPED_MAP_DESERIALIZER.deserialize(json);
+  }
+}
+

--- a/src/main/java/com/stripe/net/ApiResource.java
+++ b/src/main/java/com/stripe/net/ApiResource.java
@@ -164,10 +164,22 @@ public abstract class ApiResource extends StripeObject {
   }
 
   public static <T> T request(ApiResource.RequestMethod method,
+                              String url, ApiRequestParams params, Class<T> clazz,
+                              RequestOptions options) throws StripeException {
+    return request(method, url, params.toMap(), clazz, options);
+  }
+
+  public static <T> T request(ApiResource.RequestMethod method,
                 String url, Map<String, Object> params, Class<T> clazz,
                 RequestOptions options) throws StripeException {
     return ApiResource.stripeResponseGetter.request(method, url, params, clazz,
         ApiResource.RequestType.NORMAL, options);
+  }
+
+  public static <T extends StripeCollectionInterface<?>> T requestCollection(
+      String url, ApiRequestParams params, Class<T> clazz, RequestOptions options)
+      throws StripeException {
+    return requestCollection(url, params.toMap(), clazz, options);
   }
 
   /**

--- a/src/main/java/com/stripe/net/UntypedMapDeserializer.java
+++ b/src/main/java/com/stripe/net/UntypedMapDeserializer.java
@@ -4,15 +4,17 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 
 public class UntypedMapDeserializer {
   /**
    * Deserialize JSON into untyped map.
-   * {@code JsonArray} is represented as {@code Object[]}.
+   * {@code JsonArray} is represented as {@code List<Object>}.
    * {@code JsonObject} is represented as {@code Map<String, Object>}.
    * {@code JsonPrimitive} is represented as String, Number, or Boolean.
    *
@@ -58,13 +60,12 @@ public class UntypedMapDeserializer {
     }
   }
 
-  private Object[] deserializeJsonArray(JsonArray arr) {
-    Object[] elems = new Object[arr.size()];
+  private List<Object> deserializeJsonArray(JsonArray arr) {
+    List<Object> elems = new ArrayList<>(arr.size());
     Iterator<JsonElement> elemIter = arr.iterator();
-    int i = 0;
     while (elemIter.hasNext()) {
       JsonElement elem = elemIter.next();
-      elems[i++] = deserializeJsonElement(elem);
+      elems.add(deserializeJsonElement(elem));
     }
     return elems;
   }

--- a/src/main/java/com/stripe/net/UntypedMapDeserializer.java
+++ b/src/main/java/com/stripe/net/UntypedMapDeserializer.java
@@ -1,0 +1,71 @@
+package com.stripe.net;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+
+public class UntypedMapDeserializer {
+  /**
+   * Deserialize JSON into untyped map.
+   * {@code JsonArray} is represented as {@code Object[]}.
+   * {@code JsonObject} is represented as {@code Map<String, Object>}.
+   * {@code JsonPrimitive} is represented as String, Number, or Boolean.
+   *
+   * @param jsonObject  JSON to convert into untyped map
+   * @return untyped map without dependency on JSON representation.
+   */
+  public Map<String, Object> deserialize(JsonObject jsonObject) {
+    Map<String, Object> objMap = new HashMap<>();
+    for (Map.Entry<String, JsonElement> entry : jsonObject.entrySet()) {
+      String key = entry.getKey();
+      JsonElement element = entry.getValue();
+      // JsonElement is super class of all JSON standard types:
+      // array, null, primitive, and object
+      objMap.put(key, deserializeJsonElement(element));
+    }
+    return objMap;
+  }
+
+  private Object deserializeJsonElement(JsonElement element) {
+    if (element.isJsonNull()) {
+      return null;
+    } else if (element.isJsonObject()) {
+      return deserialize(element.getAsJsonObject());
+    } else if (element.isJsonPrimitive()) {
+      return deserializeJsonPrimitive(element.getAsJsonPrimitive());
+    } else if (element.isJsonArray()) {
+      return deserializeJsonArray(element.getAsJsonArray());
+    } else {
+      System.err.println("Unknown JSON element type for element " + element + ". "
+          + "If you're seeing this message, it's probably a bug in the Stripe Java "
+          + "library. Please contact us by email at support@stripe.com.");
+      return null;
+    }
+  }
+
+  private Object deserializeJsonPrimitive(JsonPrimitive element) {
+    if (element.isBoolean()) {
+      return element.getAsBoolean();
+    } else if (element.isNumber()) {
+      return element.getAsNumber();
+    } else {
+      return element.getAsString();
+    }
+  }
+
+  private Object[] deserializeJsonArray(JsonArray arr) {
+    Object[] elems = new Object[arr.size()];
+    Iterator<JsonElement> elemIter = arr.iterator();
+    int i = 0;
+    while (elemIter.hasNext()) {
+      JsonElement elem = elemIter.next();
+      elems[i++] = deserializeJsonElement(elem);
+    }
+    return elems;
+  }
+}

--- a/src/main/java/com/stripe/net/UntypedMapDeserializer.java
+++ b/src/main/java/com/stripe/net/UntypedMapDeserializer.java
@@ -10,7 +10,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-
+/**
+ * Deserializer to convert JSON object into an untyped map. While we strive to provide more
+ * typed content in this library, there are instances we need to convert our specific choice of
+ * JSON representation (using GSON) to a generic {@code Map<String, Object>}.
+ */
 public class UntypedMapDeserializer {
   /**
    * Deserialize JSON into untyped map.

--- a/src/main/java/com/stripe/net/UntypedMapDeserializer.java
+++ b/src/main/java/com/stripe/net/UntypedMapDeserializer.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -4,12 +4,14 @@ import static org.mockito.Mockito.reset;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+
 import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.LiveStripeResponseGetter;
 import com.stripe.net.OAuth;
 import com.stripe.net.RequestOptions;
 import com.stripe.net.StripeResponseGetter;
+
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -23,10 +25,13 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import lombok.Cleanup;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -4,14 +4,12 @@ import static org.mockito.Mockito.reset;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-
 import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.LiveStripeResponseGetter;
 import com.stripe.net.OAuth;
 import com.stripe.net.RequestOptions;
 import com.stripe.net.StripeResponseGetter;
-
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -24,14 +22,11 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-
 import java.util.Set;
 import lombok.Cleanup;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
-
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 

--- a/src/test/java/com/stripe/net/ApiRequestParamsTest.java
+++ b/src/test/java/com/stripe/net/ApiRequestParamsTest.java
@@ -1,0 +1,66 @@
+package com.stripe.net;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+
+import java.util.Map;
+import org.junit.Test;
+
+public class ApiRequestParamsTest {
+
+  enum ParamCode implements ApiRequestParams.Enum {
+    EMPTY(""),
+    OTHER("other_foo");
+
+    private final String value;
+
+    ParamCode(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String getValue() {
+      return this.value;
+    }
+  }
+
+  private static class ConcreteApiRequestParams extends ApiRequestParams {
+    private ParamCode foo;
+    private ParamCode bar;
+
+    public void setFoo(ParamCode foo) {
+      this.foo = foo;
+    }
+
+    public void setBar(ParamCode bar) {
+      this.bar = bar;
+    }
+  }
+
+  @Test
+  public void testToMapWithEmptyEnumToNull() {
+    ConcreteApiRequestParams paramRequest = new ConcreteApiRequestParams();
+    paramRequest.setFoo(ParamCode.EMPTY);
+    paramRequest.setBar(null);
+    Map<String, Object> paramMap = paramRequest.toMap();
+
+    // present key but null value
+    assertTrue(paramMap.containsKey("foo"));
+    assertNull(paramMap.get("foo"));
+
+    // inherently null field should not be deserialized
+    assertFalse(paramMap.containsKey("bar"));
+  }
+
+  @Test
+  public void testToMapWithNonEmpty() {
+    ConcreteApiRequestParams paramRequest = new ConcreteApiRequestParams();
+    paramRequest.setFoo(ParamCode.OTHER);
+    Map<String, Object> paramMap = paramRequest.toMap();
+
+    assertEquals(1, paramMap.size());
+    assertEquals(ParamCode.OTHER.getValue(), paramMap.get("foo"));
+  }
+}

--- a/src/test/java/com/stripe/net/ApiRequestParamsTest.java
+++ b/src/test/java/com/stripe/net/ApiRequestParamsTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 
 import java.util.Map;
+
 import org.junit.Test;
 
 public class ApiRequestParamsTest {

--- a/src/test/java/com/stripe/net/UntypedMapDeserializerTest.java
+++ b/src/test/java/com/stripe/net/UntypedMapDeserializerTest.java
@@ -1,0 +1,107 @@
+package com.stripe.net;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import java.math.BigDecimal;
+import java.util.Map;
+import org.junit.Test;
+
+public class UntypedMapDeserializerTest {
+
+  private UntypedMapDeserializer untypedMapDeserializer = new UntypedMapDeserializer();
+
+  @Test
+  public void testMapOfArray() {
+    JsonObject jsonObject = jsonObject(
+        "foo_array", jsonArray(jsonString("foo1"), jsonString("foo2")));
+    Map<String, Object> untyped = untypedMapDeserializer.deserialize(jsonObject);
+    Object[] fooArray = (Object[]) untyped.get("foo_array");
+    assertEquals("foo1", fooArray[0]);
+    assertEquals("foo2", fooArray[1]);
+  }
+
+  @Test
+  public void testMapOfMap() {
+    JsonObject nestedJsonObject = new JsonObject();
+    nestedJsonObject.add("inner_foo1", jsonString("foo1"));
+    nestedJsonObject.add("inner_foo2", jsonString("foo2"));
+    JsonObject jsonObject = jsonObject("foo", nestedJsonObject);
+
+    Map<String, Object> untyped = untypedMapDeserializer.deserialize(jsonObject);
+    Map<String, Object> innerFoo = (Map<String, Object>) untyped.get("foo");
+    assertEquals("foo1", innerFoo.get("inner_foo1"));
+    assertEquals("foo2", innerFoo.get("inner_foo2"));
+  }
+
+  @Test
+  public void testMapOfPrimitive() {
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.add("foo_long", jsonNumber(123L));
+    jsonObject.add("foo_big_decimal", jsonNumber(new BigDecimal("0.33")));
+    jsonObject.add("foo_double", jsonNumber(1.0 / 3));
+    jsonObject.add("foo_string", jsonString("bar"));
+    jsonObject.add("foo_null_instance", JsonNull.INSTANCE);
+    jsonObject.add("foo_null", null);
+
+    Map<String, Object> untyped = untypedMapDeserializer.deserialize(jsonObject);
+    assertEquals(123L, untyped.get("foo_long"));
+    assertEquals(new BigDecimal("0.33"), untyped.get("foo_big_decimal"));
+    assertEquals(0.3333, (Double) untyped.get("foo_double"), 0.0001);
+    assertEquals("bar", untyped.get("foo_string"));
+    assertEquals(null, untyped.get("foo_null_instance"));
+    assertEquals(null, untyped.get("foo_null"));
+  }
+
+  @Test
+  public void testMapOfEmptyMap() {
+    JsonObject jsonObject = new JsonObject();
+    JsonObject nestedJsonObject = new JsonObject();
+    jsonObject.add("empty_map", nestedJsonObject);
+
+    Map<String, Object> untyped = untypedMapDeserializer.deserialize(jsonObject);
+    Map emptyMap = (Map) untyped.get("empty_map");
+    assertEquals(0, emptyMap.size());
+  }
+
+  @Test
+  public void testMapOfArrayOfMap() {
+    JsonObject jsonObject = new JsonObject();
+    // "array": [{"foo": 2}, {"bar": 3}]
+    jsonObject.add("foo_array", jsonArray(
+        jsonObject("foo", jsonNumber(2L)),
+        jsonObject("bar", jsonNumber(3L)))
+    );
+    Map<String, Object> untyped = untypedMapDeserializer.deserialize(jsonObject);
+    Object[] objects = (Object[]) untyped.get("foo_array");
+    assertEquals(ImmutableMap.of("foo", 2L), objects[0]);
+    assertEquals(ImmutableMap.of("bar", 3L), objects[1]);
+  }
+
+  private JsonArray jsonArray(JsonElement... elements) {
+    JsonArray jsonArray = new JsonArray();
+    for (JsonElement primitive : elements) {
+      jsonArray.add(primitive);
+    }
+    return jsonArray;
+  }
+
+  private JsonPrimitive jsonString(String string) {
+    return new JsonPrimitive(string);
+  }
+
+  private JsonPrimitive jsonNumber(Number number) {
+    return new JsonPrimitive(number);
+  }
+
+  private JsonObject jsonObject(String key, JsonElement element) {
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.add(key, element);
+    return jsonObject;
+  }
+}

--- a/src/test/java/com/stripe/net/UntypedMapDeserializerTest.java
+++ b/src/test/java/com/stripe/net/UntypedMapDeserializerTest.java
@@ -8,9 +8,11 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
+
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
+
 import org.junit.Test;
 
 public class UntypedMapDeserializerTest {

--- a/src/test/java/com/stripe/net/UntypedMapDeserializerTest.java
+++ b/src/test/java/com/stripe/net/UntypedMapDeserializerTest.java
@@ -9,6 +9,7 @@ import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Map;
 import org.junit.Test;
 
@@ -21,9 +22,9 @@ public class UntypedMapDeserializerTest {
     JsonObject jsonObject = jsonObject(
         "foo_array", jsonArray(jsonString("foo1"), jsonString("foo2")));
     Map<String, Object> untyped = untypedMapDeserializer.deserialize(jsonObject);
-    Object[] fooArray = (Object[]) untyped.get("foo_array");
-    assertEquals("foo1", fooArray[0]);
-    assertEquals("foo2", fooArray[1]);
+    List<Object> fooArray = (List<Object>) untyped.get("foo_array");
+    assertEquals("foo1", fooArray.get(0));
+    assertEquals("foo2", fooArray.get(1));
   }
 
   @Test
@@ -78,9 +79,9 @@ public class UntypedMapDeserializerTest {
         jsonObject("bar", jsonNumber(3L)))
     );
     Map<String, Object> untyped = untypedMapDeserializer.deserialize(jsonObject);
-    Object[] objects = (Object[]) untyped.get("foo_array");
-    assertEquals(ImmutableMap.of("foo", 2L), objects[0]);
-    assertEquals(ImmutableMap.of("bar", 3L), objects[1]);
+    List<Object> objects = (List<Object>) untyped.get("foo_array");
+    assertEquals(ImmutableMap.of("foo", 2L), objects.get(0));
+    assertEquals(ImmutableMap.of("bar", 3L), objects.get(1));
   }
 
   private JsonArray jsonArray(JsonElement... elements) {


### PR DESCRIPTION
- This PR adds support for autogen typed params. The usage examples of generated code in https://github.com/stripe/stripe-java/pull/680
- It adds abstract class `ApiRequestParams` to be extended by top-level params, and an inner interface `ApiRequestParams.Enum`. df04964
  - `ApiRequestParams` exposes to `toMap` making it compatible with the form-encoding logic. This map is obtained from GSON using the serialized name annotation generated. 
  - `ApiRequestParams.Enum` has getter for its raw value, this is used in custom serializer to convert `EMPTY` enum into null value in the param map. The `EMPTY` enum (used to unset values in some API) is equivalent to empty string "" in OpenAPI spec, but our [current implementation](https://github.com/stripe/stripe-java/blob/master/src/main/java/com/stripe/net/LiveStripeResponseGetter.java#L365-L368) requires it to be explicit `null`
```java
public class FooParams extends ApiRequestParams {
  String fooString;
  FooEnum fooEnum;

  public FooEnum implements ApiRequestParams.Enum {
    @SerializedName("my_foo")
    MY_FOO("my_foo"),
    @SerializedName("")
    EMPTY("my_foo");
    // implemented method required by enum
    @Getter private final String value
  }
}
```
- This PR also does refactoring in extracting common logic from converting GSON to map that is used in `EventDataDeserializer`.  6c020c8.
- The final logic added here is to add comparison logic in the `ParamMapMatcher` in testing. This allows more comparison of untyped Map that is robust to difference in `Object[]` vs `List<Object`, and `Long` vs `Integer` f22e048
r? @ob-stripe 
cc @stripe/api-libraries  