### PR TITLE
Add support for expanding `latest_invoice` on `Subscription

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
 
 env:
   global:
-  - STRIPE_MOCK_VERSION=0.45.0
+  - STRIPE_MOCK_VERSION=0.47.0
 
 matrix:
   include:

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -34,6 +34,7 @@ public class Subscription extends ApiResource implements MetadataStore<Subscript
   Discount discount;
   Long endedAt;
   @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) SubscriptionItemCollection items;
+  @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) ExpandableField<Invoice> latestInvoice;
   Boolean livemode;
   @Getter(onMethod = @__({@Override})) Map<String, String> metadata;
   Plan plan;
@@ -78,6 +79,24 @@ public class Subscription extends ApiResource implements MetadataStore<Subscript
 
   public void setDefaultSourceObject(ExternalAccount c) {
     this.defaultSource = new ExpandableField<>(c.getId(), c);
+  }
+  // </editor-fold>
+
+  // <editor-fold desc="latestInvoice">
+  public String getLatestInvoice() {
+    return (this.latestInvoice != null) ? this.latestInvoice.getId() : null;
+  }
+
+  public void setLatestInvoice(String latestInvoiceId) {
+    this.latestInvoice = setExpandableFieldId(latestInvoiceId, this.latestInvoice);
+  }
+
+  public Invoice getLatestInvoiceObject() {
+    return (this.latestInvoice != null) ? this.latestInvoice.getExpanded() : null;
+  }
+
+  public void setLatestInvoiceObject(Invoice c) {
+    this.latestInvoice = new ExpandableField<>(c.getId(), c);
   }
   // </editor-fold>
 

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -35,7 +35,7 @@ import org.mockito.Mockito;
 
 public class BaseStripeTest {
   // If changing this number, please also change it in `.travis.yml`.
-  private static final String MOCK_MINIMUM_VERSION = "0.45.0";
+  private static final String MOCK_MINIMUM_VERSION = "0.47.0";
 
   private static String port;
 

--- a/src/test/java/com/stripe/model/ChargeTest.java
+++ b/src/test/java/com/stripe/model/ChargeTest.java
@@ -38,7 +38,6 @@ public class ChargeTest extends BaseStripeTest {
       "application",
       "balance_transaction",
       "customer",
-      "destination",
       "dispute",
       "invoice",
       "on_behalf_of",
@@ -63,10 +62,6 @@ public class ChargeTest extends BaseStripeTest {
     assertNotNull(customer);
     assertNotNull(customer.getId());
     assertEquals(charge.getCustomer(), customer.getId());
-    final Account destination = charge.getDestinationObject();
-    assertNotNull(destination);
-    assertNotNull(destination.getId());
-    assertEquals(charge.getDestination(), destination.getId());
     final Dispute dispute = charge.getDisputeObject();
     assertNotNull(dispute);
     assertNotNull(dispute.getId());

--- a/src/test/java/com/stripe/model/SubscriptionTest.java
+++ b/src/test/java/com/stripe/model/SubscriptionTest.java
@@ -27,6 +27,7 @@ public class SubscriptionTest extends BaseStripeTest {
     final String[] expansions = {
       "customer",
       "default_source",
+      "latest_invoice",
     };
     final String data = getFixture("/v1/subscriptions/sub_123", expansions);
     final Subscription subscription = ApiResource.GSON.fromJson(data, Subscription.class);
@@ -41,6 +42,11 @@ public class SubscriptionTest extends BaseStripeTest {
     assertNotNull(defaultSource);
     assertNotNull(defaultSource.getId());
     assertEquals(subscription.getDefaultSource(), defaultSource.getId());
+
+    final Invoice invoice = subscription.getLatestInvoiceObject();
+    assertNotNull(invoice);
+    assertNotNull(invoice.getId());
+    assertEquals(subscription.getLatestInvoice(), invoice.getId());
   }
 
   @Test


### PR DESCRIPTION
Add support for expanding `latest_invoice` on `Subscription. This also fixed a test that is now failing as `destination` on Charge is now undocumented and not in openapi anymore

r? @mickjermsurawong-stripe 
cc @stripe/api-libraries 