### PR TITLE
[generated] source: spec3.sdk.yaml@spec-a4dbef8 in master

### DIFF
--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -73,6 +73,9 @@ public class Charge extends ApiResource implements BalanceTransactionSource, Met
   @Setter(lombok.AccessLevel.NONE)
   ExpandableField<BalanceTransaction> balanceTransaction;
 
+  @SerializedName("billing_details")
+  PaymentMethod.BillingDetails billingDetails;
+
   /**
    * If the charge was created without capturing, this Boolean represents whether it is still
    * uncaptured or has since been captured.

--- a/src/main/java/com/stripe/model/PaymentMethod.java
+++ b/src/main/java/com/stripe/model/PaymentMethod.java
@@ -320,7 +320,7 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
     @Setter
     @EqualsAndHashCode(callSuper = false)
     public static class ThreeDSecureUsage extends StripeObject {
-      /** 3D Secure is support on this card. */
+      /** Whether 3D Secure is supported on this card. */
       @SerializedName("supported")
       Boolean supported;
     }


### PR DESCRIPTION
r? @remi-stripe 
- Last bit to be compatible with 7.28.
- Add `billing_details` on Charge in pay-server #137513 (confirmed that without gates removed fixture will be generated correctly, both billing details and payment method details)
cc @stripe/api-libraries  