### PR TITLE
Upgrade to version 8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 8.0.0 - 2019-03-19
+* [#662](https://github.com/stripe/stripe-java/pull/662) Major version release. Supports a pinned API version 2019-03-14. Refer to our [migration guide for v8](https://github.com/stripe/stripe-java/wiki/Migration-guide-for-v8) for API upgrade guide and lists of backwards incompatible changes to watch out for.
+
 ## 7.29.0 - 2019-03-18
 * [#695](https://github.com/stripe/stripe-java/pull/695) Add support for `payment_intent` on `Charge`.
 

--- a/src/main/java/com/stripe/Stripe.java
+++ b/src/main/java/com/stripe/Stripe.java
@@ -10,7 +10,7 @@ public abstract class Stripe {
   private static final int DEFAULT_CONNECT_TIMEOUT = 30 * 1000;
   private static final int DEFAULT_READ_TIMEOUT = 80 * 1000;
 
-  public static final String API_VERSION = "2018-11-08";
+  public static final String API_VERSION = "2019-03-14";
   public static final String CONNECT_API_BASE = "https://connect.stripe.com";
   public static final String LIVE_API_BASE = "https://api.stripe.com";
   public static final String UPLOAD_API_BASE = "https://files.stripe.com";


### PR DESCRIPTION
r? @remi-stripe 
This bumps library version, and pin API version.
This will only go into beta branch. Will merge beta branch to master after I finalise the migration guide into wiki.