### PR TITLE
Pass version check flag to stripe-mock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
       tar -zxf "stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}_linux_amd64.tar.gz" -C "stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}/"
     fi
   - |
-    stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}/stripe-mock > /dev/null &
+    stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}/stripe-mock -strict-version-check > /dev/null &
     STRIPE_MOCK_PID=$!
   - export PATH="${PATH}:${PWD}/stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}"
 

--- a/src/test/java/com/stripe/StripeMockProcess.java
+++ b/src/test/java/com/stripe/StripeMockProcess.java
@@ -50,8 +50,7 @@ public class StripeMockProcess {
             "-spec",
             getPathSpec(),
             "-fixtures",
-            getPathFixture(),
-            "-strict-version-check"
+            getPathFixture()
         );
 
     try {

--- a/src/test/java/com/stripe/StripeMockProcess.java
+++ b/src/test/java/com/stripe/StripeMockProcess.java
@@ -50,7 +50,8 @@ public class StripeMockProcess {
             "-spec",
             getPathSpec(),
             "-fixtures",
-            getPathFixture()
+            getPathFixture(),
+            "-strict-version-check"
         );
 
     try {

--- a/src/test/java/com/stripe/functional/EphemeralKeyTest.java
+++ b/src/test/java/com/stripe/functional/EphemeralKeyTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 import com.stripe.BaseStripeTest;
+import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
 import com.stripe.model.EphemeralKey;
 import com.stripe.net.ApiResource;
@@ -21,8 +22,11 @@ public class EphemeralKeyTest extends BaseStripeTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("customer", "cus_123");
 
+    // In actual usage, version override is likely different from the pinned API version.
+    // Passing the same API version here to comply with stripe-mock `-strict-version-check`
+    // flag--it errors on passing API version different from that in OpenAPI spec.
     final RequestOptions options = RequestOptions.builder()
-        .setStripeVersionOverride("2017-05-25").build();
+        .setStripeVersionOverride(Stripe.API_VERSION).build();
 
     final EphemeralKey key = EphemeralKey.create(params, options);
 
@@ -52,8 +56,10 @@ public class EphemeralKeyTest extends BaseStripeTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("customer", "cus_123");
 
+    // Passing the same API version here to comply with stripe-mock `-strict-version-check`
+    // flag--it errors on passing API version different from that in OpenAPI spec.
     final RequestOptions options = RequestOptions.builder()
-        .setStripeVersionOverride("2017-05-25").build();
+        .setStripeVersionOverride(Stripe.API_VERSION).build();
 
     final EphemeralKey key = EphemeralKey.create(params, options);
 


### PR DESCRIPTION
- This passes `-strict-version-check` flag to stripe mock to ensure pinned library is testing against correct OpenAPI version of stripe-mock.
- The first commit failed with the error below, and passing override flag with pinned version resolved it.
```
com.stripe.functional.EphemeralKeyTest > testCreate FAILED
    com.stripe.exception.InvalidRequestException: Version sent in `Stripe-Version` header '2017-05-25' doesn't match version in OpenAPI specification '2019-03-14' which may have unintended consequences. This error was shown because stripe-mock  was started with `-stripe-version-check`.
```
r? @remi-stripe 
cc @stripe/api-libraries 