### PR TITLE
Add test and documentation to make event deserialization clearer

### DIFF
--- a/src/main/java/com/stripe/model/Event.java
+++ b/src/main/java/com/stripe/model/Event.java
@@ -33,6 +33,19 @@ public class Event extends ApiResource implements HasId {
 
   /**
    * Get deserialization helper to handle failure due to schema incompatibility.
+   * When event API version matches that of the library's pinned version,
+   * the following integration pattern is safe.
+   * <pre>
+   *   Event event = getEvent(); // either from webhook or event endpoint
+   *   EventDataObjectDeserializer deserializer = event.getDataObjectDeserializer();
+   *   StripeObject stripeObject = deserializer.getObject();
+   * </pre>
+   * You can ensure that webhook events has the same API version by creating
+   * webhook endpoint specifying api version](https://stripe.com/docs/api/webhook_endpoints/create)
+   * as {@link com.stripe.Stripe#API_VERSION}.
+   * For reading from old webhook endpoints or old events with potential schema
+   * incompatibility, see {@link EventDataObjectDeserializer#deserialize()} and
+   * {@link EventDataObjectDeserializer#deserializeUnsafe()}.
    */
   public EventDataObjectDeserializer getDataObjectDeserializer() {
     return new EventDataObjectDeserializer(apiVersion, type, data.object);

--- a/src/main/java/com/stripe/model/EventData.java
+++ b/src/main/java/com/stripe/model/EventData.java
@@ -19,7 +19,8 @@ public class EventData extends StripeObject {
   Map<String, Object> previousAttributes;
 
   /**
-   * Deprecated in favor of getting {@code StripeObject} from {@link EventDataObjectDeserializer}.
+   * Deprecated in favor of getting {@code StripeObject} from
+   * {@link Event#getDataObjectDeserializer()} and {@link EventDataObjectDeserializer#getObject()}.
    * Throws {@link JsonParseException} deserialization failure due to general invalid JSON,
    * or more specifically when JSON data and model class have incompatible schemas.
    * @return deserialized stripe object for event data.

--- a/src/test/java/com/stripe/functional/EventTest.java
+++ b/src/test/java/com/stripe/functional/EventTest.java
@@ -1,11 +1,14 @@
 package com.stripe.functional;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import com.stripe.BaseStripeTest;
+import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
 import com.stripe.model.Event;
 import com.stripe.model.EventCollection;
+import com.stripe.model.StripeObject;
 import com.stripe.net.ApiResource;
 
 import java.util.HashMap;
@@ -40,5 +43,29 @@ public class EventTest extends BaseStripeTest {
         String.format("/v1/events"),
         params
     );
+  }
+
+  @Test
+  public void tesGetDataObjectWithSameApiVersion() throws StripeException {
+    final Event event = Event.retrieve(EVENT_ID);
+    // Suppose event has the same API version as the library's pinned version
+    event.setApiVersion(Stripe.API_VERSION);
+
+    StripeObject stripeObject = event.getDataObjectDeserializer().getObject();
+
+    assertNotNull(stripeObject);
+  }
+
+  @Test
+  public void tesGetDataObjectWithDifferentApiVersion() throws StripeException {
+    final Event event = Event.retrieve(EVENT_ID);
+    // Suppose event has different API version from the library's pinned version
+    event.setApiVersion("2017-05-25");
+
+    StripeObject stripeObject = event.getDataObjectDeserializer().getObject();
+
+    // See compatibility helper in `EventDataObjectDeserializerTest` for
+    // handling schema incompatibility
+    assertNull(stripeObject);
   }
 }


### PR DESCRIPTION
r? @ob-stripe  @remi-stripe 
- This PR improves java doc on the new pattern of deserializing event data object.
 - Documents how creating webhook with pinned api version ensure safe event deserialization
 - Add functional tests in `Event` to illustrate high-level outcome of event with same/different api versions

cc @codylerum 