### PR TITLE
Start testing Java 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ matrix:
     - jdk: openjdk9
     - jdk: openjdk10
     - jdk: openjdk11
+    - jdk: openjdk12
     - jdk: openjdk-ea
   allow_failures:
     - jdk: openjdk-ea

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,13 @@ version = VERSION_NAME
 tasks.withType(JavaCompile) {
     options.compilerArgs << "-Xlint:all" << "-Xlint:-options" << "-Xlint:-processing"
     options.encoding = 'UTF-8'
+
+    options.errorprone {
+      // This check is broken in Java 12.  See https://github.com/google/error-prone/issues/1257
+      if ((JavaVersion.current().majorVersion as Integer) > 11) {
+        check('Finally', net.ltgt.gradle.errorprone.CheckSeverity.OFF)
+      }
+    }
 }
 
 compileJava {


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Start testing Java 12.

I had to disable a specific ErrorProne check with Java 12 because of an issue with ErrorProne itself (cf. https://github.com/stripe/stripe-java/pull/703#issuecomment-491465260). Once they fix the issue, we can re-enable the check.