### PR TITLE
fix test pulled in from local during deploy

### DIFF
--- a/src/test/java/com/stripe/functional/EventTest.java
+++ b/src/test/java/com/stripe/functional/EventTest.java
@@ -52,7 +52,6 @@ public class EventTest extends BaseStripeTest {
     event.setApiVersion(Stripe.API_VERSION);
 
     StripeObject stripeObject = event.getDataObjectDeserializer().getObject();
-    event.getData().getObject()
 
     assertNotNull(stripeObject);
   }


### PR DESCRIPTION
r? @ob-stripe 
This PR reverts the dirty change accidentally got included during deploy