### PR TITLE
Upgrade to JUnit 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,10 +44,11 @@ repositories {
 dependencies {
     compile group: 'com.google.code.gson', name: 'gson', version:'2.8.5'
     testCompile group: 'com.google.guava', name: 'guava', version:'27.1-jre'
-    testCompile group: 'junit', name: 'junit', version:'4.12'
     testCompile group: 'org.mockito', name: 'mockito-core', version:'2.25.1'
     testRuntime group: 'org.slf4j', name: 'slf4j-api', version: '1.7.26'
     testImplementation 'com.squareup.okhttp3:mockwebserver:3.14.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.4.1'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.4.1'
 }
 
 jar {
@@ -95,6 +96,7 @@ javadoc {
 apply from: 'deploy.gradle'
 
 test {
+    useJUnitPlatform()
     testLogging {
         events "passed", "skipped", "failed"
         exceptionFormat "full"

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -26,9 +26,9 @@ import java.util.Map;
 
 import lombok.Cleanup;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
@@ -65,7 +65,7 @@ public class BaseStripeTest {
   /**
    * Checks that stripe-mock is running and up-to-date.
    */
-  @BeforeClass
+  @BeforeAll
   public static void checkStripeMock() throws Exception {
     if (StripeMockProcess.start()) {
       port = StripeMockProcess.getPort();
@@ -107,7 +107,7 @@ public class BaseStripeTest {
    * Activates usage of stripe-mock by overriding the API host and putting a test key
    * into the environment. This is required independent of how stripe-mock is started.
    */
-  @Before
+  @BeforeEach
   public void setUpStripeMockUsage() {
     this.origApiBase = Stripe.getApiBase();
     this.origUploadBase = Stripe.getUploadBase();
@@ -128,7 +128,7 @@ public class BaseStripeTest {
    * Deactivates usage stripe-mock by returning the API host to whatever it was
    * before stripe-mock was activated.
    */
-  @After
+  @AfterEach
   public void tearDownStripeMockUsage() {
     ApiResource.setStripeResponseGetter(new LiveStripeResponseGetter());
 

--- a/src/test/java/com/stripe/DocumentationTest.java
+++ b/src/test/java/com/stripe/DocumentationTest.java
@@ -1,8 +1,8 @@
 package com.stripe;
 
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.base.Joiner;
 
@@ -18,7 +18,7 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DocumentationTest {
 
@@ -35,13 +35,13 @@ public class DocumentationTest {
     final File changelogFile = new File("CHANGELOG.md").getAbsoluteFile();
 
     assertTrue(
+        changelogFile.exists(),
         String.format("Expected CHANGELOG file to exist, but it doesn't. (path is %s).",
-            changelogFile.getAbsolutePath()),
-        changelogFile.exists());
+            changelogFile.getAbsolutePath()));
     assertTrue(
+        changelogFile.isFile(),
         String.format("Expected CHANGELOG to be a file, but it isn't. (path is %s).",
-            changelogFile.getAbsolutePath()),
-        changelogFile.isFile());
+            changelogFile.getAbsolutePath()));
 
     try (final BufferedReader reader = new BufferedReader(new InputStreamReader(
         new FileInputStream(changelogFile), StandardCharsets.UTF_8))) {
@@ -73,13 +73,13 @@ public class DocumentationTest {
     final File readmeFile = new File("README.md").getAbsoluteFile();
 
     assertTrue(
+        readmeFile.exists(),
         String.format("Expected README.md file to exist, but it doesn't. (path is %s).",
-            readmeFile.getAbsolutePath()),
-        readmeFile.exists());
+            readmeFile.getAbsolutePath()));
     assertTrue(
+        readmeFile.isFile(),
         String.format("Expected README.md to be a file, but it doesn't. (path is %s).",
-            readmeFile.getAbsolutePath()),
-        readmeFile.isFile());
+            readmeFile.getAbsolutePath()));
 
     try (final BufferedReader reader = new BufferedReader(new InputStreamReader(
         new FileInputStream(readmeFile), StandardCharsets.UTF_8))) {
@@ -97,7 +97,7 @@ public class DocumentationTest {
       final String message = String.format(
           "Expected %d mentions of the stripe-java version in the Readme, but found %d:%n%s",
           expectedMentionsOfVersion, mentioningLines.size(), Joiner.on(", ").join(mentioningLines));
-      assertSame(message, expectedMentionsOfVersion, mentioningLines.size());
+      assertSame(expectedMentionsOfVersion, mentioningLines.size(), message);
     }
   }
 
@@ -107,13 +107,9 @@ public class DocumentationTest {
     final File gradleFile = new File("gradle.properties").getAbsoluteFile();
 
     assertTrue(
+        gradleFile.exists(),
         String.format("Expected gradle.properties file to exist, but it doesn't. (path is %s).",
-            gradleFile.getAbsolutePath()),
-        gradleFile.exists());
-    assertTrue(
-        String.format("Expected gradle.properties to be a file, but it doesn't. (path is %s).",
-            gradleFile.getAbsolutePath()),
-            gradleFile.isFile());
+            gradleFile.getAbsolutePath()));
 
     try (final BufferedReader reader = new BufferedReader(new InputStreamReader(
         new FileInputStream(gradleFile), StandardCharsets.UTF_8))) {

--- a/src/test/java/com/stripe/functional/AccountLinkTest.java
+++ b/src/test/java/com/stripe/functional/AccountLinkTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -10,7 +10,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AccountLinkTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/functional/AccountTest.java
+++ b/src/test/java/com/stripe/functional/AccountTest.java
@@ -1,7 +1,7 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -14,7 +14,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AccountTest extends BaseStripeTest {
   public static final String ACCOUNT_ID = "acct_123";

--- a/src/test/java/com/stripe/functional/ApplePayDomainTest.java
+++ b/src/test/java/com/stripe/functional/ApplePayDomainTest.java
@@ -1,7 +1,7 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -12,7 +12,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ApplePayDomainTest extends BaseStripeTest {
   public static final String DOMAIN_ID = "apftw_123";

--- a/src/test/java/com/stripe/functional/ApplicationFeeTest.java
+++ b/src/test/java/com/stripe/functional/ApplicationFeeTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -11,7 +11,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ApplicationFeeTest extends BaseStripeTest {
   public static final String FEE_ID = "fee_123";

--- a/src/test/java/com/stripe/functional/BalanceTest.java
+++ b/src/test/java/com/stripe/functional/BalanceTest.java
@@ -1,13 +1,13 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
 import com.stripe.model.Balance;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BalanceTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/functional/BalanceTransactionTest.java
+++ b/src/test/java/com/stripe/functional/BalanceTransactionTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -11,7 +11,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BalanceTransactionTest extends BaseStripeTest {
   public static final String RESOURCE_ID = "bt_123";

--- a/src/test/java/com/stripe/functional/BankAccountTest.java
+++ b/src/test/java/com/stripe/functional/BankAccountTest.java
@@ -1,8 +1,8 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -18,7 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BankAccountTest extends BaseStripeTest {
   public static final String CUSTOMER_ID = "cus_123";

--- a/src/test/java/com/stripe/functional/CardTest.java
+++ b/src/test/java/com/stripe/functional/CardTest.java
@@ -1,8 +1,8 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CardTest extends BaseStripeTest {
   public static final String CUSTOMER_ID = "cus_123";

--- a/src/test/java/com/stripe/functional/ChargeTest.java
+++ b/src/test/java/com/stripe/functional/ChargeTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -13,7 +13,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ChargeTest extends BaseStripeTest {
   public static final String CHARGE_ID = "ch_123";

--- a/src/test/java/com/stripe/functional/CountrySpecTest.java
+++ b/src/test/java/com/stripe/functional/CountrySpecTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -11,7 +11,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CountrySpecTest extends BaseStripeTest {
   public static final String COUNTRY_SPEC_ID = "US";

--- a/src/test/java/com/stripe/functional/CouponTest.java
+++ b/src/test/java/com/stripe/functional/CouponTest.java
@@ -1,7 +1,7 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -12,7 +12,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CouponTest extends BaseStripeTest {
   public static final String COUPON_ID = "COUPON_ID";

--- a/src/test/java/com/stripe/functional/CustomerTest.java
+++ b/src/test/java/com/stripe/functional/CustomerTest.java
@@ -1,7 +1,7 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -12,7 +12,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 public class CustomerTest extends BaseStripeTest {

--- a/src/test/java/com/stripe/functional/DisputeTest.java
+++ b/src/test/java/com/stripe/functional/DisputeTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -11,7 +11,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DisputeTest extends BaseStripeTest {
   public static final String DISPUTE_ID = "dp_123";

--- a/src/test/java/com/stripe/functional/EphemeralKeyTest.java
+++ b/src/test/java/com/stripe/functional/EphemeralKeyTest.java
@@ -1,7 +1,8 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -12,7 +13,7 @@ import com.stripe.net.RequestOptions;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class EphemeralKeyTest extends BaseStripeTest {
 
@@ -36,7 +37,7 @@ public class EphemeralKeyTest extends BaseStripeTest {
     );
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testCreateWithoutApiVersionOverride() throws StripeException {
     final Map<String, Object> params = new HashMap<>();
     params.put("customer", "cus_123");
@@ -44,7 +45,9 @@ public class EphemeralKeyTest extends BaseStripeTest {
     final RequestOptions options = RequestOptions.getDefault();
     assertNull(options.getStripeVersionOverride());
 
-    EphemeralKey.create(params, options);
+    assertThrows(IllegalArgumentException.class, () -> {
+      EphemeralKey.create(params, options);
+    });
   }
 
   @Test

--- a/src/test/java/com/stripe/functional/ErrorTest.java
+++ b/src/test/java/com/stripe/functional/ErrorTest.java
@@ -1,7 +1,7 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.Stripe;
@@ -18,7 +18,7 @@ import lombok.Cleanup;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 public class ErrorTest extends BaseStripeTest {

--- a/src/test/java/com/stripe/functional/EventTest.java
+++ b/src/test/java/com/stripe/functional/EventTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -11,7 +11,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class EventTest extends BaseStripeTest {
   public static final String EVENT_ID = "evt_123";

--- a/src/test/java/com/stripe/functional/ExchangeRateTest.java
+++ b/src/test/java/com/stripe/functional/ExchangeRateTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -11,7 +11,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ExchangeRateTest extends BaseStripeTest {
   public static final String CURRENCY = "usd";

--- a/src/test/java/com/stripe/functional/FeeRefundTest.java
+++ b/src/test/java/com/stripe/functional/FeeRefundTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -12,7 +12,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FeeRefundTest extends BaseStripeTest {
   public static final String FEE_ID = "fee_123";

--- a/src/test/java/com/stripe/functional/FileLinkTest.java
+++ b/src/test/java/com/stripe/functional/FileLinkTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -11,7 +11,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FileLinkTest extends BaseStripeTest {
   public static final String FILE_LINK_ID = "link_123";

--- a/src/test/java/com/stripe/functional/FileTest.java
+++ b/src/test/java/com/stripe/functional/FileTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -13,7 +13,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FileTest extends BaseStripeTest {
   public static final String FILE_ID = "file_123";

--- a/src/test/java/com/stripe/functional/InvoiceItemTest.java
+++ b/src/test/java/com/stripe/functional/InvoiceItemTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -11,7 +11,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 public class InvoiceItemTest extends BaseStripeTest {

--- a/src/test/java/com/stripe/functional/InvoiceTest.java
+++ b/src/test/java/com/stripe/functional/InvoiceTest.java
@@ -1,7 +1,7 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -12,7 +12,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 public class InvoiceTest extends BaseStripeTest {

--- a/src/test/java/com/stripe/functional/IssuerFraudRecordTest.java
+++ b/src/test/java/com/stripe/functional/IssuerFraudRecordTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -12,7 +12,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class IssuerFraudRecordTest extends BaseStripeTest {
   public static final String RECORD_ID = "issfr_123";

--- a/src/test/java/com/stripe/functional/LoginLinkTest.java
+++ b/src/test/java/com/stripe/functional/LoginLinkTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -8,7 +8,7 @@ import com.stripe.model.Account;
 import com.stripe.model.LoginLink;
 import com.stripe.net.ApiResource;
 import java.io.IOException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LoginLinkTest extends BaseStripeTest {
   public static final String ACCOUNT_ID = "acct_123";

--- a/src/test/java/com/stripe/functional/OrderReturnTest.java
+++ b/src/test/java/com/stripe/functional/OrderReturnTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -11,7 +11,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OrderReturnTest extends BaseStripeTest {
   public static final String RETURN_ID = "orret_123";

--- a/src/test/java/com/stripe/functional/OrderTest.java
+++ b/src/test/java/com/stripe/functional/OrderTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -12,7 +12,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OrderTest extends BaseStripeTest {
   public static final String ORDER_ID = "or_123";

--- a/src/test/java/com/stripe/functional/PaymentIntentTest.java
+++ b/src/test/java/com/stripe/functional/PaymentIntentTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -13,7 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PaymentIntentTest extends BaseStripeTest {
   public static final String PAYMENT_INTENT_ID = "pi_123";

--- a/src/test/java/com/stripe/functional/PaymentMethodTest.java
+++ b/src/test/java/com/stripe/functional/PaymentMethodTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -11,7 +11,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PaymentMethodTest extends BaseStripeTest {
   public static final String PAYMENT_METHOD_ID = "pm_123";

--- a/src/test/java/com/stripe/functional/PayoutTest.java
+++ b/src/test/java/com/stripe/functional/PayoutTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -11,7 +11,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PayoutTest extends BaseStripeTest {
   public static final String PAYOUT_ID = "po_123";

--- a/src/test/java/com/stripe/functional/PersonTest.java
+++ b/src/test/java/com/stripe/functional/PersonTest.java
@@ -1,8 +1,8 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -14,7 +14,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PersonTest extends BaseStripeTest {
   public static final String ACCOUNT_ID = "cus_123";

--- a/src/test/java/com/stripe/functional/PlanTest.java
+++ b/src/test/java/com/stripe/functional/PlanTest.java
@@ -1,7 +1,7 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -12,7 +12,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PlanTest extends BaseStripeTest {
   public static final String PLAN_ID = "gold";

--- a/src/test/java/com/stripe/functional/ProductTest.java
+++ b/src/test/java/com/stripe/functional/ProductTest.java
@@ -1,7 +1,7 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -14,7 +14,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ProductTest extends BaseStripeTest {
   public static final String PRODUCT_ID = "prod_123";

--- a/src/test/java/com/stripe/functional/RecipientTest.java
+++ b/src/test/java/com/stripe/functional/RecipientTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -11,7 +11,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Recipients are deprecated. All tests have been removed; the Java APIs will

--- a/src/test/java/com/stripe/functional/RefundTest.java
+++ b/src/test/java/com/stripe/functional/RefundTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -11,7 +11,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 public class RefundTest extends BaseStripeTest {

--- a/src/test/java/com/stripe/functional/RequestOptionsTest.java
+++ b/src/test/java/com/stripe/functional/RequestOptionsTest.java
@@ -1,8 +1,8 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.Stripe;
@@ -11,7 +11,7 @@ import com.stripe.model.Balance;
 import com.stripe.net.RequestOptions;
 import com.stripe.net.StripeResponse;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RequestOptionsTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/functional/ReversalTest.java
+++ b/src/test/java/com/stripe/functional/ReversalTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -12,7 +12,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ReversalTest extends BaseStripeTest {
   public static final String TRANSFER_ID = "tr_123";

--- a/src/test/java/com/stripe/functional/ReviewTest.java
+++ b/src/test/java/com/stripe/functional/ReviewTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -11,7 +11,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ReviewTest extends BaseStripeTest {
   public static final String REVIEW_ID = "prv_123";

--- a/src/test/java/com/stripe/functional/SkuTest.java
+++ b/src/test/java/com/stripe/functional/SkuTest.java
@@ -1,8 +1,8 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -13,7 +13,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SkuTest extends BaseStripeTest {
   public static final String SKU_ID = "sku_123";

--- a/src/test/java/com/stripe/functional/SourceTest.java
+++ b/src/test/java/com/stripe/functional/SourceTest.java
@@ -1,7 +1,8 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.InvalidRequestException;
@@ -16,7 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SourceTest extends BaseStripeTest {
   public static final String SOURCE_ID = "src_123";
@@ -121,12 +122,14 @@ public class SourceTest extends BaseStripeTest {
     );
   }
 
-  @Test(expected = InvalidRequestException.class)
+  @Test
   public void testDetachUnattachedSource() throws StripeException {
     final Source source = getSourceFixture();
     source.setCustomer(null);
 
-    source.detach();
+    assertThrows(InvalidRequestException.class, () -> {
+      source.detach();
+    });
   }
 
   @Test

--- a/src/test/java/com/stripe/functional/StripeResponseTest.java
+++ b/src/test/java/com/stripe/functional/StripeResponseTest.java
@@ -1,10 +1,7 @@
 package com.stripe.functional;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -16,7 +13,7 @@ import com.stripe.net.StripeResponse;
 import java.util.HashMap;
 import java.util.UUID;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class StripeResponseTest extends BaseStripeTest {
   @Test
@@ -28,7 +25,7 @@ public class StripeResponseTest extends BaseStripeTest {
     final Customer customer = Customer.create(null, requestOptions);
     final Customer retrievedCustomer = Customer.retrieve(customer.getId(), requestOptions);
     final StripeResponse response = retrievedCustomer.getLastResponse();
-    assertThat(response, instanceOf(StripeResponse.class));
+    assertTrue(response instanceof StripeResponse);
     assertEquals(200, response.code());
     assertEquals(idempotencyKey, response.idempotencyKey());
     assertTrue(response.requestId().startsWith("req_"));
@@ -39,7 +36,7 @@ public class StripeResponseTest extends BaseStripeTest {
   public void testResponseIncludedList() throws StripeException {
     final CustomerCollection customers = Customer.list(new HashMap<String, Object>());
     final StripeResponse response = customers.getLastResponse();
-    assertThat(response, instanceOf(StripeResponse.class));
+    assertTrue(response instanceof StripeResponse);
     assertEquals(200, response.code());
     assertTrue(response.requestId().startsWith("req_"));
     assertTrue(response.body().length() > 0);

--- a/src/test/java/com/stripe/functional/SubscriptionItemTest.java
+++ b/src/test/java/com/stripe/functional/SubscriptionItemTest.java
@@ -1,7 +1,7 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -13,7 +13,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SubscriptionItemTest extends BaseStripeTest {
   public static final String ITEM_ID = "si_123";

--- a/src/test/java/com/stripe/functional/SubscriptionScheduleTest.java
+++ b/src/test/java/com/stripe/functional/SubscriptionScheduleTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -12,7 +12,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SubscriptionScheduleTest extends BaseStripeTest {
   public static final String SCHEDULE_ID = "sub_sched_123";

--- a/src/test/java/com/stripe/functional/SubscriptionTest.java
+++ b/src/test/java/com/stripe/functional/SubscriptionTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -13,7 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SubscriptionTest extends BaseStripeTest {
   public static final String SUBSCRIPTION_ID = "sub_123";

--- a/src/test/java/com/stripe/functional/TelemetryTest.java
+++ b/src/test/java/com/stripe/functional/TelemetryTest.java
@@ -1,8 +1,8 @@
 package com.stripe.functional;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.Stripe;
@@ -20,7 +20,8 @@ import java.util.concurrent.TimeUnit;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 
 public class TelemetryTest extends BaseStripeTest {

--- a/src/test/java/com/stripe/functional/ThreeDSecureTest.java
+++ b/src/test/java/com/stripe/functional/ThreeDSecureTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -10,7 +10,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ThreeDSecureTest extends BaseStripeTest {
   public static final String TDS_ID = "tds_123";

--- a/src/test/java/com/stripe/functional/TokenTest.java
+++ b/src/test/java/com/stripe/functional/TokenTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -11,7 +11,7 @@ import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TokenTest extends BaseStripeTest {
   public static final String TOKEN_ID = "tok_123";

--- a/src/test/java/com/stripe/functional/TopupTest.java
+++ b/src/test/java/com/stripe/functional/TopupTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -11,7 +11,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TopupTest extends BaseStripeTest {
   public static final String TOPUP_ID = "tu_123";

--- a/src/test/java/com/stripe/functional/TransferTest.java
+++ b/src/test/java/com/stripe/functional/TransferTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -11,7 +11,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TransferTest extends BaseStripeTest {
   public static final String TRANSFER_ID = "tr_123";

--- a/src/test/java/com/stripe/functional/UsageRecordTest.java
+++ b/src/test/java/com/stripe/functional/UsageRecordTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -10,7 +10,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class UsageRecordTest extends BaseStripeTest {
   private static final String SUBSCRIPTION_ITEM_ID = "si_123";

--- a/src/test/java/com/stripe/functional/WebhookEndpointTest.java
+++ b/src/test/java/com/stripe/functional/WebhookEndpointTest.java
@@ -1,7 +1,7 @@
 package com.stripe.functional;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -14,7 +14,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class WebhookEndpointTest extends BaseStripeTest {
   public static final String WEBHOOK_ENDPOINT_ID = "we_123";

--- a/src/test/java/com/stripe/functional/issuing/AuthorizationTest.java
+++ b/src/test/java/com/stripe/functional/issuing/AuthorizationTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional.issuing;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -11,7 +11,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 public class AuthorizationTest extends BaseStripeTest {

--- a/src/test/java/com/stripe/functional/issuing/CardTest.java
+++ b/src/test/java/com/stripe/functional/issuing/CardTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional.issuing;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -12,7 +12,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 public class CardTest extends BaseStripeTest {

--- a/src/test/java/com/stripe/functional/issuing/CardholderTest.java
+++ b/src/test/java/com/stripe/functional/issuing/CardholderTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional.issuing;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -11,7 +11,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 public class CardholderTest extends BaseStripeTest {

--- a/src/test/java/com/stripe/functional/issuing/DisputeTest.java
+++ b/src/test/java/com/stripe/functional/issuing/DisputeTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional.issuing;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -11,7 +11,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 public class DisputeTest extends BaseStripeTest {

--- a/src/test/java/com/stripe/functional/issuing/TransactionTest.java
+++ b/src/test/java/com/stripe/functional/issuing/TransactionTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional.issuing;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -11,7 +11,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 public class TransactionTest extends BaseStripeTest {

--- a/src/test/java/com/stripe/functional/radar/ValueListItemTest.java
+++ b/src/test/java/com/stripe/functional/radar/ValueListItemTest.java
@@ -1,7 +1,7 @@
 package com.stripe.functional.radar;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -12,7 +12,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ValueListItemTest extends BaseStripeTest {
   public static final String VALUE_LIST_ID = "rsli_123";

--- a/src/test/java/com/stripe/functional/radar/ValueListTest.java
+++ b/src/test/java/com/stripe/functional/radar/ValueListTest.java
@@ -1,7 +1,7 @@
 package com.stripe.functional.radar;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -12,7 +12,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ValueListTest extends BaseStripeTest {
   public static final String VALUE_LIST_ID = "rsl_123";

--- a/src/test/java/com/stripe/functional/reporting/ReportRunTest.java
+++ b/src/test/java/com/stripe/functional/reporting/ReportRunTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional.reporting;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -11,7 +11,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 public class ReportRunTest extends BaseStripeTest {

--- a/src/test/java/com/stripe/functional/reporting/ReportTypeTest.java
+++ b/src/test/java/com/stripe/functional/reporting/ReportTypeTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional.reporting;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -11,7 +11,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 public class ReportTypeTest extends BaseStripeTest {

--- a/src/test/java/com/stripe/functional/sigma/ScheduledQueryRunTest.java
+++ b/src/test/java/com/stripe/functional/sigma/ScheduledQueryRunTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional.sigma;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -11,7 +11,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 public class ScheduledQueryRunTest extends BaseStripeTest {

--- a/src/test/java/com/stripe/functional/terminal/ConnectionTokenTest.java
+++ b/src/test/java/com/stripe/functional/terminal/ConnectionTokenTest.java
@@ -1,6 +1,6 @@
 package com.stripe.functional.terminal;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -10,7 +10,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ConnectionTokenTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/functional/terminal/LocationTest.java
+++ b/src/test/java/com/stripe/functional/terminal/LocationTest.java
@@ -1,7 +1,7 @@
 package com.stripe.functional.terminal;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -12,7 +12,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LocationTest extends BaseStripeTest {
   public static final String LOCATION_ID = "loc_123";

--- a/src/test/java/com/stripe/functional/terminal/ReaderTest.java
+++ b/src/test/java/com/stripe/functional/terminal/ReaderTest.java
@@ -1,7 +1,7 @@
 package com.stripe.functional.terminal;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
@@ -12,7 +12,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ReaderTest extends BaseStripeTest {
   public static final String READER_ID = "rdr_123";

--- a/src/test/java/com/stripe/model/AccountLinkTest.java
+++ b/src/test/java/com/stripe/model/AccountLinkTest.java
@@ -1,12 +1,12 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AccountLinkTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/AccountTest.java
+++ b/src/test/java/com/stripe/model/AccountTest.java
@@ -1,12 +1,12 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AccountTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/ApplePayDomainTest.java
+++ b/src/test/java/com/stripe/model/ApplePayDomainTest.java
@@ -1,11 +1,11 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ApplePayDomainTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/ApplicationFeeTest.java
+++ b/src/test/java/com/stripe/model/ApplicationFeeTest.java
@@ -1,13 +1,13 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ApplicationFeeTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/BalanceTest.java
+++ b/src/test/java/com/stripe/model/BalanceTest.java
@@ -1,11 +1,11 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BalanceTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/BalanceTransactionTest.java
+++ b/src/test/java/com/stripe/model/BalanceTransactionTest.java
@@ -1,14 +1,14 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BalanceTransactionTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/BankAccountTest.java
+++ b/src/test/java/com/stripe/model/BankAccountTest.java
@@ -1,11 +1,11 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BankAccountTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/CardTest.java
+++ b/src/test/java/com/stripe/model/CardTest.java
@@ -1,11 +1,11 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CardTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/ChargeLevel3Test.java
+++ b/src/test/java/com/stripe/model/ChargeLevel3Test.java
@@ -1,11 +1,11 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ChargeLevel3Test extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/ChargeOutcomeTest.java
+++ b/src/test/java/com/stripe/model/ChargeOutcomeTest.java
@@ -1,11 +1,11 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ChargeOutcomeTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/ChargeTest.java
+++ b/src/test/java/com/stripe/model/ChargeTest.java
@@ -1,13 +1,13 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ChargeTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/CountrySpecTest.java
+++ b/src/test/java/com/stripe/model/CountrySpecTest.java
@@ -1,11 +1,11 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CountrySpecTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/CouponTest.java
+++ b/src/test/java/com/stripe/model/CouponTest.java
@@ -1,11 +1,11 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CouponTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/DisputeTest.java
+++ b/src/test/java/com/stripe/model/DisputeTest.java
@@ -1,13 +1,13 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DisputeTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/EphemeralKeyTest.java
+++ b/src/test/java/com/stripe/model/EphemeralKeyTest.java
@@ -1,12 +1,12 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class EphemeralKeyTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/EventDataDeserializerTest.java
+++ b/src/test/java/com/stripe/model/EventDataDeserializerTest.java
@@ -1,11 +1,11 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class EventDataDeserializerTest extends BaseStripeTest {
 

--- a/src/test/java/com/stripe/model/EventDataObjectDeserializerTest.java
+++ b/src/test/java/com/stripe/model/EventDataObjectDeserializerTest.java
@@ -1,32 +1,30 @@
 package com.stripe.model;
 
-import static junit.framework.TestCase.assertTrue;
-import static junit.framework.TestCase.fail;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonPrimitive;
+
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.EventDataObjectDeserializationException;
 import com.stripe.net.ApiResource;
+
 import java.io.IOException;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+
+import org.junit.jupiter.api.Test;
+
 import org.mockito.Mockito;
 
 public class EventDataObjectDeserializerTest extends BaseStripeTest {
-
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
-
   private static final String OLD_EVENT_VERSION = "2013-08-15";
   private static final String CURRENT_EVENT_VERSION = "2017-08-15";
   private static final String NO_MATCH_VERSION = "2000-08-15";
@@ -108,7 +106,7 @@ public class EventDataObjectDeserializerTest extends BaseStripeTest {
   public void testFailureOnApiVersionMatch() throws Exception {
     final String data = getOldEventStringFixture();
     final Event event = ApiResource.GSON.fromJson(data, Event.class);
-    
+
     assertEquals(OLD_EVENT_VERSION, event.getApiVersion());
     EventDataObjectDeserializer deserializer = stubIntegrationApiVersion(
         event.getDataObjectDeserializer(), OLD_EVENT_VERSION);

--- a/src/test/java/com/stripe/model/EventTest.java
+++ b/src/test/java/com/stripe/model/EventTest.java
@@ -1,12 +1,12 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class EventTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/ExchangeRateTest.java
+++ b/src/test/java/com/stripe/model/ExchangeRateTest.java
@@ -1,11 +1,11 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ExchangeRateTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/ExpandableFieldDeserializerTest.java
+++ b/src/test/java/com/stripe/model/ExpandableFieldDeserializerTest.java
@@ -1,8 +1,8 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
@@ -13,7 +13,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ExpandableFieldDeserializerTest extends BaseStripeTest {
 

--- a/src/test/java/com/stripe/model/ExpandableFieldSerializerTest.java
+++ b/src/test/java/com/stripe/model/ExpandableFieldSerializerTest.java
@@ -1,10 +1,10 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.stripe.BaseStripeTest;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ExpandableFieldSerializerTest extends BaseStripeTest {
 

--- a/src/test/java/com/stripe/model/FeeRefundTest.java
+++ b/src/test/java/com/stripe/model/FeeRefundTest.java
@@ -1,13 +1,13 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FeeRefundTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/FileLinkTest.java
+++ b/src/test/java/com/stripe/model/FileLinkTest.java
@@ -1,13 +1,13 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FileLinkTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/FileTest.java
+++ b/src/test/java/com/stripe/model/FileTest.java
@@ -1,11 +1,11 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FileTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/InvoiceItemTest.java
+++ b/src/test/java/com/stripe/model/InvoiceItemTest.java
@@ -1,13 +1,13 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class InvoiceItemTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/InvoiceTest.java
+++ b/src/test/java/com/stripe/model/InvoiceTest.java
@@ -1,13 +1,13 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class InvoiceTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/IssuerFraudRecordTest.java
+++ b/src/test/java/com/stripe/model/IssuerFraudRecordTest.java
@@ -1,13 +1,13 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class IssuerFraudRecordTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/LoginLinkTest.java
+++ b/src/test/java/com/stripe/model/LoginLinkTest.java
@@ -1,11 +1,11 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LoginLinkTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/OrderItemTest.java
+++ b/src/test/java/com/stripe/model/OrderItemTest.java
@@ -1,8 +1,8 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.google.gson.reflect.TypeToken;
 import com.stripe.BaseStripeTest;
@@ -10,7 +10,7 @@ import com.stripe.net.ApiResource;
 
 import java.lang.reflect.Type;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OrderItemTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/OrderReturnTest.java
+++ b/src/test/java/com/stripe/model/OrderReturnTest.java
@@ -1,13 +1,13 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OrderReturnTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/OrderTest.java
+++ b/src/test/java/com/stripe/model/OrderTest.java
@@ -1,12 +1,12 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OrderTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/PagingIteratorTest.java
+++ b/src/test/java/com/stripe/model/PagingIteratorTest.java
@@ -1,6 +1,6 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.stripe.BaseStripeTest;
@@ -15,8 +15,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
@@ -49,7 +49,7 @@ public class PagingIteratorTest extends BaseStripeTest {
   /**
    * Sets the mock page fixtures.
    */
-  @Before
+  @BeforeEach
   public void setUpMockPages() throws IOException, StripeException {
     final List<String> pages = new ArrayList<>();
     pages.add(getResourceAsString("/model_fixtures/pageable_model_page_0.json"));

--- a/src/test/java/com/stripe/model/PaymentIntentTest.java
+++ b/src/test/java/com/stripe/model/PaymentIntentTest.java
@@ -1,12 +1,12 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PaymentIntentTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/PaymentMethodTest.java
+++ b/src/test/java/com/stripe/model/PaymentMethodTest.java
@@ -1,11 +1,11 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PaymentMethodTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/PayoutTest.java
+++ b/src/test/java/com/stripe/model/PayoutTest.java
@@ -1,13 +1,13 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
 import java.io.IOException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PayoutTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/PersonTest.java
+++ b/src/test/java/com/stripe/model/PersonTest.java
@@ -1,12 +1,12 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PersonTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/PlanTest.java
+++ b/src/test/java/com/stripe/model/PlanTest.java
@@ -1,13 +1,13 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PlanTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/ProductTest.java
+++ b/src/test/java/com/stripe/model/ProductTest.java
@@ -1,12 +1,12 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ProductTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/RefundTest.java
+++ b/src/test/java/com/stripe/model/RefundTest.java
@@ -1,12 +1,12 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RefundTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/ReversalTest.java
+++ b/src/test/java/com/stripe/model/ReversalTest.java
@@ -1,13 +1,13 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ReversalTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/ReviewTest.java
+++ b/src/test/java/com/stripe/model/ReviewTest.java
@@ -1,12 +1,12 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ReviewTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/SkuTest.java
+++ b/src/test/java/com/stripe/model/SkuTest.java
@@ -1,13 +1,13 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SkuTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/SourceMandateNotificationTest.java
+++ b/src/test/java/com/stripe/model/SourceMandateNotificationTest.java
@@ -1,11 +1,11 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SourceMandateNotificationTest extends BaseStripeTest {
   private void verifyResource(SourceMandateNotification mandateNotification) {

--- a/src/test/java/com/stripe/model/SourceTest.java
+++ b/src/test/java/com/stripe/model/SourceTest.java
@@ -1,12 +1,12 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SourceTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/SourceTransactionTest.java
+++ b/src/test/java/com/stripe/model/SourceTransactionTest.java
@@ -1,11 +1,11 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SourceTransactionTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/StandardizationTest.java
+++ b/src/test/java/com/stripe/model/StandardizationTest.java
@@ -1,6 +1,6 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -18,7 +18,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Simple test to make sure stripe-java provides consistent bindings.
@@ -98,11 +98,11 @@ public class StandardizationTest {
           continue;
         }
         assertTrue(
+            RequestOptions.class.isAssignableFrom(finalParamType),
             String.format("Methods on %ss like %s.%s should take a final "
                   +       "parameter as a %s parameter, but got %s.%n",
                 ApiResource.class.getSimpleName(), model.getSimpleName(), method.getName(),
-                RequestOptions.class.getSimpleName(), finalParamType.getCanonicalName()),
-            RequestOptions.class.isAssignableFrom(finalParamType));
+                RequestOptions.class.getSimpleName(), finalParamType.getCanonicalName()));
       }
     }
   }

--- a/src/test/java/com/stripe/model/StripeErrorTest.java
+++ b/src/test/java/com/stripe/model/StripeErrorTest.java
@@ -1,13 +1,13 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.google.gson.JsonObject;
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class StripeErrorTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/SubscriptionItemTest.java
+++ b/src/test/java/com/stripe/model/SubscriptionItemTest.java
@@ -1,12 +1,12 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SubscriptionItemTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/SubscriptionScheduleRevisionTest.java
+++ b/src/test/java/com/stripe/model/SubscriptionScheduleRevisionTest.java
@@ -1,11 +1,11 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SubscriptionScheduleRevisionTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/SubscriptionScheduleTest.java
+++ b/src/test/java/com/stripe/model/SubscriptionScheduleTest.java
@@ -1,12 +1,12 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SubscriptionScheduleTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/SubscriptionTest.java
+++ b/src/test/java/com/stripe/model/SubscriptionTest.java
@@ -1,15 +1,15 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
 import java.math.BigDecimal;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SubscriptionTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/ThreeDSecureTest.java
+++ b/src/test/java/com/stripe/model/ThreeDSecureTest.java
@@ -1,12 +1,12 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ThreeDSecureTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/TokenTest.java
+++ b/src/test/java/com/stripe/model/TokenTest.java
@@ -1,12 +1,12 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TokenTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/TopupTest.java
+++ b/src/test/java/com/stripe/model/TopupTest.java
@@ -1,13 +1,13 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TopupTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/TransferTest.java
+++ b/src/test/java/com/stripe/model/TransferTest.java
@@ -1,13 +1,13 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TransferTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/UsageRecordSummaryTest.java
+++ b/src/test/java/com/stripe/model/UsageRecordSummaryTest.java
@@ -1,12 +1,12 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class UsageRecordSummaryTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/UsageRecordTest.java
+++ b/src/test/java/com/stripe/model/UsageRecordTest.java
@@ -1,12 +1,12 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class UsageRecordTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/WebhookEndpointTest.java
+++ b/src/test/java/com/stripe/model/WebhookEndpointTest.java
@@ -1,11 +1,11 @@
 package com.stripe.model;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class WebhookEndpointTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/issuing/AuthorizationTest.java
+++ b/src/test/java/com/stripe/model/issuing/AuthorizationTest.java
@@ -1,12 +1,12 @@
 package com.stripe.model.issuing;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AuthorizationTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/issuing/CardDetailsTest.java
+++ b/src/test/java/com/stripe/model/issuing/CardDetailsTest.java
@@ -1,12 +1,12 @@
 package com.stripe.model.issuing;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CardDetailsTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/issuing/CardTest.java
+++ b/src/test/java/com/stripe/model/issuing/CardTest.java
@@ -1,12 +1,12 @@
 package com.stripe.model.issuing;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CardTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/issuing/CardholderTest.java
+++ b/src/test/java/com/stripe/model/issuing/CardholderTest.java
@@ -1,12 +1,12 @@
 package com.stripe.model.issuing;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CardholderTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/issuing/DisputeTest.java
+++ b/src/test/java/com/stripe/model/issuing/DisputeTest.java
@@ -1,12 +1,12 @@
 package com.stripe.model.issuing;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DisputeTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/issuing/TransactionTest.java
+++ b/src/test/java/com/stripe/model/issuing/TransactionTest.java
@@ -1,13 +1,13 @@
 package com.stripe.model.issuing;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.model.BalanceTransaction;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TransactionTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/oauth/OAuthErrorTest.java
+++ b/src/test/java/com/stripe/model/oauth/OAuthErrorTest.java
@@ -1,12 +1,12 @@
 package com.stripe.model.oauth;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OAuthErrorTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/radar/ValueListItemTest.java
+++ b/src/test/java/com/stripe/model/radar/ValueListItemTest.java
@@ -1,12 +1,12 @@
 package com.stripe.model.radar;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ValueListItemTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/radar/ValueListTest.java
+++ b/src/test/java/com/stripe/model/radar/ValueListTest.java
@@ -1,12 +1,12 @@
 package com.stripe.model.radar;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ValueListTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/reporting/ReportRunTest.java
+++ b/src/test/java/com/stripe/model/reporting/ReportRunTest.java
@@ -1,12 +1,12 @@
 package com.stripe.model.reporting;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ReportRunTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/reporting/ReportTypeTest.java
+++ b/src/test/java/com/stripe/model/reporting/ReportTypeTest.java
@@ -1,12 +1,12 @@
 package com.stripe.model.reporting;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ReportTypeTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/sigma/ScheduledQueryRunTest.java
+++ b/src/test/java/com/stripe/model/sigma/ScheduledQueryRunTest.java
@@ -1,12 +1,12 @@
 package com.stripe.model.sigma;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ScheduledQueryRunTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/terminal/ConnectionTokenTest.java
+++ b/src/test/java/com/stripe/model/terminal/ConnectionTokenTest.java
@@ -1,11 +1,11 @@
 package com.stripe.model.terminal;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ConnectionTokenTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/terminal/ExternalAccountDeserializationTest.java
+++ b/src/test/java/com/stripe/model/terminal/ExternalAccountDeserializationTest.java
@@ -1,29 +1,24 @@
 package com.stripe.model;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import java.util.List;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+
+import org.junit.jupiter.api.Test;
 
 public class ExternalAccountDeserializationTest extends BaseStripeTest {
-
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
-
   @Test
   public void testDeserializeBankAccount() throws Exception {
     final String data = getResourceAsString("/api_fixtures/bank_account.json");
     final ExternalAccount externalAccount = ApiResource.GSON.fromJson(data, ExternalAccount.class);
     assertNotNull(externalAccount);
-    assertTrue("External account should be a bank account",
-        externalAccount instanceof BankAccount);
+    assertTrue(externalAccount instanceof BankAccount, "External account should be a bank account");
     BankAccount bankAccount = (BankAccount) externalAccount;
     assertEquals(bankAccount.getObject(), "bank_account");
   }
@@ -33,7 +28,7 @@ public class ExternalAccountDeserializationTest extends BaseStripeTest {
     final String data = getResourceAsString("/api_fixtures/card.json");
     final ExternalAccount externalAccount = ApiResource.GSON.fromJson(data, ExternalAccount.class);
     assertNotNull(externalAccount);
-    assertTrue("External account should be a card", externalAccount instanceof Card);
+    assertTrue(externalAccount instanceof Card, "External account should be a card");
     Card card = (Card) externalAccount;
     assertEquals(card.getObject(), "card");
   }
@@ -48,13 +43,17 @@ public class ExternalAccountDeserializationTest extends BaseStripeTest {
         ExternalAccount.class
     );
     assertNotNull(externalAccount);
-    assertTrue("External account should be an unknown subtype",
-        externalAccount instanceof ExternalAccountTypeAdapterFactory.UnknownSubType);
-    thrown.expectMessage(
+    assertTrue(
+        externalAccount instanceof ExternalAccountTypeAdapterFactory.UnknownSubType,
+        "External account should be an unknown subtype");
+
+    Throwable exception = assertThrows(UnsupportedOperationException.class, () -> {
+      externalAccount.delete();
+    });
+    assertEquals(
         "Unknown subtype of ExternalAccount with id: bar_123, object: unknown_bar, does not "
-            + "implement method: delete. Please contact support@stripe.com for assistance.");
-    thrown.expect(UnsupportedOperationException.class);
-    externalAccount.delete();
+        + "implement method: delete. Please contact support@stripe.com for assistance.",
+        exception.getMessage());
   }
 
   @Test
@@ -86,4 +85,3 @@ public class ExternalAccountDeserializationTest extends BaseStripeTest {
     }
   }
 }
-

--- a/src/test/java/com/stripe/model/terminal/LocationTest.java
+++ b/src/test/java/com/stripe/model/terminal/LocationTest.java
@@ -1,11 +1,11 @@
 package com.stripe.model.terminal;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LocationTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/model/terminal/ReaderTest.java
+++ b/src/test/java/com/stripe/model/terminal/ReaderTest.java
@@ -1,11 +1,11 @@
 package com.stripe.model.terminal;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ReaderTest extends BaseStripeTest {
   @Test

--- a/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
+++ b/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
@@ -1,7 +1,7 @@
 package com.stripe.net;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
@@ -17,13 +17,13 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class LiveStripeResponseGetterTest {
   LiveStripeResponseGetter srg;
 
-  @Before
+  @BeforeEach
   public void before() {
     srg = new LiveStripeResponseGetter();
   }

--- a/src/test/java/com/stripe/net/OAuthTest.java
+++ b/src/test/java/com/stripe/net/OAuthTest.java
@@ -1,6 +1,6 @@
 package com.stripe.net;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.AuthenticationException;
@@ -17,7 +17,7 @@ import java.net.URLDecoder;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OAuthTest extends BaseStripeTest {
   private static Map<String, String> splitQuery(String query) throws UnsupportedEncodingException {

--- a/src/test/java/com/stripe/net/RequestOptionsTest.java
+++ b/src/test/java/com/stripe/net/RequestOptionsTest.java
@@ -1,9 +1,9 @@
 package com.stripe.net;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RequestOptionsTest {
 

--- a/src/test/java/com/stripe/net/StripeHeadersTest.java
+++ b/src/test/java/com/stripe/net/StripeHeadersTest.java
@@ -1,6 +1,6 @@
 package com.stripe.net;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.stripe.BaseStripeTest;
 
@@ -9,7 +9,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class StripeHeadersTest extends BaseStripeTest {
 

--- a/src/test/java/com/stripe/net/StripeResponseTest.java
+++ b/src/test/java/com/stripe/net/StripeResponseTest.java
@@ -1,9 +1,7 @@
 package com.stripe.net;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.stripe.BaseStripeTest;
 
@@ -12,7 +10,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class StripeResponseTest extends BaseStripeTest {
   String chargeBody;
@@ -50,7 +48,7 @@ public class StripeResponseTest extends BaseStripeTest {
   public void testHeaders() {
     final Map<String, List<String>> headerMap = generateHeaderMap();
     final StripeResponse stripeResponse = new StripeResponse(200, chargeBody, headerMap);
-    assertThat(stripeResponse.headers(), instanceOf(StripeHeaders.class));
+    assertTrue(stripeResponse.headers() instanceof StripeHeaders);
   }
 
   @Test


### PR DESCRIPTION
r? @mickjermsurawong-stripe @remi-stripe 
cc @stripe/api-libraries 

Upgrade to JUnit 5.

Lots of noise here, sorry! The main changes are:
- `org.junit.Assert` -> `org.junit.jupiter.api.Assertions`
- some assertion methods like `assertTrue` and `assertSame` now take the failed assertion message as their last argument instead of their first
- checking for thrown exception is now done via `assertThrows`
