### PR TITLE
Update build gradle maven url to point to sonatype.org over https

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     repositories {
         jcenter()
         //Add only for SNAPSHOT versions
-        //maven { url "http://oss.sonatype.org/content/repositories/snapshots/" }
+        //maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
     }
     dependencies {
         classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.11.0"


### PR DESCRIPTION
It's currently in a comment but if folks ever uncomment we'd like them to pull it in over https.