### PR TITLE
Use ErrorProne in builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ plugins {
     id 'java'
     id 'maven'
     id 'io.franzbecker.gradle-lombok' version '2.1'
+    id "net.ltgt.errorprone" version "0.7.1"
     id 'checkstyle'
     id 'net.saliman.cobertura' version '2.6.0'
     id 'com.github.kt3k.coveralls' version '2.8.2'
@@ -43,6 +44,8 @@ repositories {
 
 dependencies {
     compile group: 'com.google.code.gson', name: 'gson', version:'2.8.5'
+    errorprone group: 'com.google.errorprone', name: 'error_prone_core', version: '2.3.3'
+    errorproneJavac group: 'com.google.errorprone', name: 'javac', version:'9+181-r4173-1'
     testCompile group: 'com.google.guava', name: 'guava', version:'27.1-jre'
     testCompile group: 'org.mockito', name: 'mockito-core', version:'2.25.1'
     testRuntime group: 'org.slf4j', name: 'slf4j-api', version: '1.7.26'

--- a/src/test/java/com/stripe/model/SubscriptionTest.java
+++ b/src/test/java/com/stripe/model/SubscriptionTest.java
@@ -50,6 +50,7 @@ public class SubscriptionTest extends BaseStripeTest {
   }
 
   @Test
+  @SuppressWarnings("BigDecimalEquals")
   public void testDeserializeBigDecimal() {
     final String data = "{\"object\": \"subscription\", \"tax_percent\": 0.3}";
     final Subscription subscription = ApiResource.GSON.fromJson(data, Subscription.class);


### PR DESCRIPTION
r? @mickjermsurawong-stripe 
cc @stripe/api-libraries 

Use [ErrorProne](http://errorprone.info/) in builds.

Fixes #497.

There were only three issues remaining, two of which I think we can ignore:
- `ScheduledQueryRun.Error`: ErrorProne complains that `Error` is a builtin class in `java.lang` and we should change the name. Given that `ScheduledQueryRun.Error` is a nested class and it's very unlikely any user would import it directly, I think it's safe to ignore this.
- `assertTrue(subscription.getTaxPercent().equals(new BigDecimal("0.3")))`: ErrorProne warns that `BigDecimal.equals` compares the scale of the representation as well as the value (i.e. `1.0 != 1.00`). This is actually desirable in our case, so this is a false positive.

~~Unfortunately, the last one is another missing `@Override` in autogenerated code, here:~~ https://github.com/stripe/stripe-java/blob/7518b68b389d1675762d79dc0dcce29424cfdff4/src/main/java/com/stripe/model/ExternalAccountTypeAdapterFactory.java#L83

~~Not sure how hard it would be to fix this. wdyt?~~ Fixed, thanks Mick!
