### PR TITLE
Rename param enums and add test to verify enum polymorphism 

### DIFF
--- a/src/main/java/com/stripe/net/ApiRequestParams.java
+++ b/src/main/java/com/stripe/net/ApiRequestParams.java
@@ -25,7 +25,7 @@ public abstract class ApiRequestParams {
    * expects. Internally, it used in custom serialization
    * {@link ApiRequestParams.HasEmptyEnumTypeAdapterFactory} converting empty string enum to null.
    */
-  public interface Enum {
+  public interface EnumParam {
     String getValue();
   }
 
@@ -41,13 +41,13 @@ public abstract class ApiRequestParams {
     @SuppressWarnings("unchecked")
     @Override
     public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
-      if (!Enum.class.isAssignableFrom(type.getRawType())) {
+      if (!EnumParam.class.isAssignableFrom(type.getRawType())) {
         return null;
       }
 
-      TypeAdapter<Enum> paramEnum = new TypeAdapter<Enum>() {
+      TypeAdapter<EnumParam> paramEnum = new TypeAdapter<EnumParam>() {
         @Override
-        public void write(JsonWriter out, Enum value) throws IOException {
+        public void write(JsonWriter out, EnumParam value) throws IOException {
           if (value.getValue().equals("")) {
             // need to restore serialize null setting
             // not to affect other fields
@@ -61,7 +61,7 @@ public abstract class ApiRequestParams {
         }
 
         @Override
-        public Enum read(JsonReader in) {
+        public EnumParam read(JsonReader in) {
           throw new UnsupportedOperationException(
               "No deserialization is expected from this private type adapter for enum param.");
         }
@@ -77,7 +77,7 @@ public abstract class ApiRequestParams {
    * prior integrations using the untyped params map
    * {@link ApiResource#request(ApiResource.RequestMethod, String, Map, Class, RequestOptions)}.
    *
-   * <p>The peculiarity of this conversion is that `EMPTY` {@link ApiRequestParams.Enum} with raw
+   * <p>The peculiarity of this conversion is that `EMPTY` {@link EnumParam} with raw
    * value of empty string will be converted to null. This is compatible with the existing
    * contract enforcing no empty string in the untyped map params.
    *

--- a/src/main/java/com/stripe/param/common/EmptyParam.java
+++ b/src/main/java/com/stripe/param/common/EmptyParam.java
@@ -1,0 +1,19 @@
+package com.stripe.param.common;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+
+public enum EmptyParam implements ApiRequestParams.EnumParam {
+  @SerializedName("")
+  EMPTY("");
+  private final String value;
+
+  EmptyParam(String value) {
+    this.value = value;
+  }
+
+  @Override
+  public String getValue() {
+    return this.value;
+  }
+}

--- a/src/test/java/com/stripe/net/ApiRequestParamsTest.java
+++ b/src/test/java/com/stripe/net/ApiRequestParamsTest.java
@@ -5,15 +5,16 @@ import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 
+import com.google.gson.annotations.SerializedName;
+import com.stripe.param.common.EmptyParam;
 import java.util.Map;
 
+import lombok.Setter;
 import org.junit.Test;
 
 public class ApiRequestParamsTest {
-
-  enum ParamCode implements ApiRequestParams.Enum {
-    EMPTY(""),
-    OTHER("other_foo");
+  enum ParamCode implements ApiRequestParams.EnumParam {
+    OTHER("other");
 
     private final String value;
 
@@ -28,14 +29,32 @@ public class ApiRequestParamsTest {
   }
 
   private static class ConcreteApiRequestParams extends ApiRequestParams {
-    private ParamCode foo;
-    private ParamCode bar;
+    @SerializedName("foo_enum")
+    private ApiRequestParams.EnumParam foo;
+    @SerializedName("bar_enum")
+    private ApiRequestParams.EnumParam bar;
 
+    @Setter
+    @SerializedName("baz_string")
+    private String bazString;
+    @Setter
+    @SerializedName("boo_code")
+    private ParamCode booCode;
+
+    // Overloaded setters for polymorphic enum, allowing the empty enum
     public void setFoo(ParamCode foo) {
       this.foo = foo;
     }
 
+    public void setFoo(EmptyParam foo) {
+      this.foo = foo;
+    }
+
     public void setBar(ParamCode bar) {
+      this.bar = bar;
+    }
+
+    public void setBar(EmptyParam bar) {
       this.bar = bar;
     }
   }
@@ -43,16 +62,31 @@ public class ApiRequestParamsTest {
   @Test
   public void testToMapWithEmptyEnumToNull() {
     ConcreteApiRequestParams paramRequest = new ConcreteApiRequestParams();
-    paramRequest.setFoo(ParamCode.EMPTY);
-    paramRequest.setBar(null);
+    // The ordering of param definition is important to verify that deserializer to null works
+    // correctly.
+    // With empty string enum "" we are okay serialize to null value, so this switch
+    // mode of the serializer. After that finish writing this empty enum, we are back to dropping
+    // null key.
+    paramRequest.setFoo(EmptyParam.EMPTY);
+    paramRequest.setBar((ParamCode) null);
     Map<String, Object> paramMap = paramRequest.toMap();
 
     // present key but null value
-    assertTrue(paramMap.containsKey("foo"));
-    assertNull(paramMap.get("foo"));
+    assertTrue(paramMap.containsKey("foo_enum"));
+    assertNull(paramMap.get("foo_enum"));
 
     // inherently null field should not be deserialized
-    assertFalse(paramMap.containsKey("bar"));
+    assertFalse(paramMap.containsKey("bar_enum"));
+
+    // Test the reverse, just in case the param model definition has different order
+    paramRequest = new ConcreteApiRequestParams();
+    paramRequest.setFoo((ParamCode) null);
+    paramRequest.setBar(EmptyParam.EMPTY);
+    paramMap = paramRequest.toMap();
+    assertTrue(paramMap.containsKey("bar_enum"));
+    assertNull(paramMap.get("bar_enum"));
+
+    assertFalse(paramMap.containsKey("foo_enum"));
   }
 
   @Test
@@ -62,6 +96,42 @@ public class ApiRequestParamsTest {
     Map<String, Object> paramMap = paramRequest.toMap();
 
     assertEquals(1, paramMap.size());
-    assertEquals(ParamCode.OTHER.getValue(), paramMap.get("foo"));
+    assertEquals(ParamCode.OTHER.getValue(), paramMap.get("foo_enum"));
+  }
+
+  @Test
+  public void testToMapWithEmptyStringDoesNotGetAffected() {
+    ConcreteApiRequestParams paramRequest = new ConcreteApiRequestParams();
+    paramRequest.setFoo(EmptyParam.EMPTY);
+
+    paramRequest.setBazString("");
+    Map<String, Object> paramMap = paramRequest.toMap();
+
+    assertEquals(2, paramMap.size());
+
+    // present key but null value
+    assertTrue(paramMap.containsKey("foo_enum"));
+    assertNull(paramMap.get("foo_enum"));
+
+    assertTrue(paramMap.containsKey("baz_string"));
+    assertEquals("", paramMap.get("baz_string"));
+  }
+
+  @Test
+  public void testToMapWithNormalParamDoesNotGetAffected() {
+    ConcreteApiRequestParams paramRequest = new ConcreteApiRequestParams();
+    paramRequest.setFoo(EmptyParam.EMPTY);
+
+    paramRequest.setBooCode(ParamCode.OTHER);
+    Map<String, Object> paramMap = paramRequest.toMap();
+
+    assertEquals(2, paramMap.size());
+
+    // present key but null value
+    assertTrue(paramMap.containsKey("foo_enum"));
+    assertNull(paramMap.get("foo_enum"));
+
+    assertTrue(paramMap.containsKey("boo_code"));
+    assertEquals(ParamCode.OTHER.getValue(), paramMap.get("boo_code"));
   }
 }


### PR DESCRIPTION
- This PR renames `ApiRequestParams.Enum` to `ApiRequestParams.EnumParam`, and 
introduces `Empty` to `EmptyParam` in a param common package.
- This adds more test to reflect the polymorphic of enum that we accept both empty and non-empty enum in the same field
r? @ob-stripe 
cc @stripe/api-libraries 