### PR TITLE
Fix remaining ErrorProne warnings

### DIFF
--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -527,6 +527,7 @@ public class BaseStripeTest {
     }
   }
 
+  @SuppressWarnings("unchecked")
   private static Boolean compareParamObjects(Object thisValue, Object otherValue) {
     if (thisValue == null) {
       return otherValue == null;

--- a/src/test/java/com/stripe/net/ApiRequestParamsTest.java
+++ b/src/test/java/com/stripe/net/ApiRequestParamsTest.java
@@ -28,6 +28,7 @@ public class ApiRequestParamsTest {
     }
   }
 
+  @SuppressWarnings("unused")
   private static class ConcreteApiRequestParams extends ApiRequestParams {
     @SerializedName("foo_enum")
     private ApiRequestParams.EnumParam foo;

--- a/src/test/java/com/stripe/net/UntypedMapDeserializerTest.java
+++ b/src/test/java/com/stripe/net/UntypedMapDeserializerTest.java
@@ -20,6 +20,7 @@ public class UntypedMapDeserializerTest {
   private UntypedMapDeserializer untypedMapDeserializer = new UntypedMapDeserializer();
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testMapOfArray() {
     JsonObject jsonObject = jsonObject(
         "foo_array", jsonArray(jsonString("foo1"), jsonString("foo2")));
@@ -30,6 +31,7 @@ public class UntypedMapDeserializerTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testMapOfMap() {
     JsonObject nestedJsonObject = new JsonObject();
     nestedJsonObject.add("inner_foo1", jsonString("foo1"));
@@ -62,17 +64,19 @@ public class UntypedMapDeserializerTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testMapOfEmptyMap() {
     JsonObject jsonObject = new JsonObject();
     JsonObject nestedJsonObject = new JsonObject();
     jsonObject.add("empty_map", nestedJsonObject);
 
     Map<String, Object> untyped = untypedMapDeserializer.deserialize(jsonObject);
-    Map emptyMap = (Map) untyped.get("empty_map");
+    Map<String, Object> emptyMap = (Map<String, Object>) untyped.get("empty_map");
     assertEquals(0, emptyMap.size());
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testMapOfArrayOfMap() {
     JsonObject jsonObject = new JsonObject();
     // "array": [{"foo": 2}, {"bar": 3}]


### PR DESCRIPTION
r? @mickjermsurawong-stripe 
cc @stripe/api-libraries 

The last remaining Error Prone warnings are all false positives. I've added `@SuppressWarnings` annotations to silence them.

(Note: This PR targets the `autogen-params` branch.)