### PR TITLE
Stop testing Oracle JDK for Java >= 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,12 +39,9 @@ matrix:
     - jdk: oraclejdk9
     - jdk: openjdk9
     - jdk: openjdk10
-    - jdk: oraclejdk11
     - jdk: openjdk11
-    - jdk: oraclejdk-ea
     - jdk: openjdk-ea
   allow_failures:
-    - jdk: oraclejdk-ea
     - jdk: openjdk-ea
 
 notifications:


### PR DESCRIPTION
r? @brandur-stripe @mickjermsurawong-stripe 
cc @stripe/api-libraries 

From Java 11 onwards, only test with OpenJDK.

From Oracle's [blog post](https://blogs.oracle.com/java-platform-group/oracle-jdk-releases-for-java-11-and-later):
> From Java 11 forward, therefore, Oracle JDK builds and OpenJDK builds will be essentially identical.

Also, the script used by Travis to install JDK versions is deprecating support for Oracle JDK (https://github.com/sormuras/bach/issues/33).
