### PR TITLE
Return unsafe deserialized event data object as Option

### DIFF
--- a/src/main/java/com/stripe/model/Event.java
+++ b/src/main/java/com/stripe/model/Event.java
@@ -38,7 +38,7 @@ public class Event extends ApiResource implements HasId {
    * <pre>
    *   Event event = getEvent(); // either from webhook or event endpoint
    *   EventDataObjectDeserializer deserializer = event.getDataObjectDeserializer();
-   *   StripeObject stripeObject = deserializer.getObject();
+   *   Optional&lt;StripeObject&gt; stripeObject = deserializer.getObject();
    * </pre>
    * You can ensure that webhook events has the same API version by creating
    * webhook endpoint specifying api version](https://stripe.com/docs/api/webhook_endpoints/create)

--- a/src/test/java/com/stripe/functional/EventTest.java
+++ b/src/test/java/com/stripe/functional/EventTest.java
@@ -1,7 +1,8 @@
 package com.stripe.functional;
 
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.Stripe;
@@ -14,6 +15,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 public class EventTest extends BaseStripeTest {
@@ -51,9 +53,9 @@ public class EventTest extends BaseStripeTest {
     // Suppose event has the same API version as the library's pinned version
     event.setApiVersion(Stripe.API_VERSION);
 
-    StripeObject stripeObject = event.getDataObjectDeserializer().getObject();
+    Optional<StripeObject> stripeObject = event.getDataObjectDeserializer().getObject();
 
-    assertNotNull(stripeObject);
+    assertTrue(stripeObject.isPresent());
   }
 
   @Test
@@ -62,10 +64,10 @@ public class EventTest extends BaseStripeTest {
     // Suppose event has different API version from the library's pinned version
     event.setApiVersion("2017-05-25");
 
-    StripeObject stripeObject = event.getDataObjectDeserializer().getObject();
+    Optional<StripeObject> stripeObject = event.getDataObjectDeserializer().getObject();
 
     // See compatibility helper in `EventDataObjectDeserializerTest` for
     // handling schema incompatibility
-    assertNull(stripeObject);
+    assertFalse(stripeObject.isPresent());
   }
 }

--- a/src/test/java/com/stripe/model/EventDataObjectDeserializerTest.java
+++ b/src/test/java/com/stripe/model/EventDataObjectDeserializerTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -57,9 +56,8 @@ public class EventDataObjectDeserializerTest extends BaseStripeTest {
     EventDataObjectDeserializer deserializer = stubIntegrationApiVersion(
         event.getDataObjectDeserializer(), CURRENT_EVENT_VERSION);
 
-    assertTrue(deserializer.deserialize());
-    assertNotNull(deserializer.getObject());
-    verifyDeserializedStripeObject(deserializer.getObject());
+    assertTrue(deserializer.getObject().isPresent());
+    verifyDeserializedStripeObject(deserializer.getObject().get());
   }
 
   @Test
@@ -74,7 +72,7 @@ public class EventDataObjectDeserializerTest extends BaseStripeTest {
     EventDataObjectDeserializer deserializer = stubIntegrationApiVersion(
         event.getDataObjectDeserializer(), NO_MATCH_VERSION);
 
-    assertFalse(deserializer.deserialize());
+    assertFalse(deserializer.getObject().isPresent());
 
     // although version mismatch, schema is still compatible
     // so force deserialization is successful
@@ -92,14 +90,12 @@ public class EventDataObjectDeserializerTest extends BaseStripeTest {
     EventDataObjectDeserializer deserializer = stubIntegrationApiVersion(
         event.getDataObjectDeserializer(), NO_MATCH_VERSION);
 
-    assertFalse(deserializer.deserialize());
-    // when it is unsafe, getting normal object returns nothing.
-    assertNull(deserializer.getObject());
+    assertFalse(deserializer.getObject().isPresent());
 
     StripeObject unsafeDeserialized = deserializer.deserializeUnsafe();
     assertNotNull(unsafeDeserialized);
     // successful forced deserialization, but getting object remains empty
-    assertNull(deserializer.getObject());
+    assertFalse(deserializer.getObject().isPresent());
   }
 
   @Test
@@ -111,7 +107,7 @@ public class EventDataObjectDeserializerTest extends BaseStripeTest {
     EventDataObjectDeserializer deserializer = stubIntegrationApiVersion(
         event.getDataObjectDeserializer(), OLD_EVENT_VERSION);
 
-    assertFalse(deserializer.deserialize());
+    assertFalse(deserializer.getObject().isPresent());
 
     try {
       deserializer.deserializeUnsafe();
@@ -135,7 +131,7 @@ public class EventDataObjectDeserializerTest extends BaseStripeTest {
     EventDataObjectDeserializer deserializer = stubIntegrationApiVersion(
         event.getDataObjectDeserializer(), NO_MATCH_VERSION);
 
-    assertFalse(deserializer.deserialize());
+    assertFalse(deserializer.getObject().isPresent());
 
     try {
       deserializer.deserializeUnsafe();
@@ -154,7 +150,7 @@ public class EventDataObjectDeserializerTest extends BaseStripeTest {
     final EventDataObjectDeserializer deserializer = stubIntegrationApiVersion(
         event.getDataObjectDeserializer(), NO_MATCH_VERSION);
 
-    assertFalse(deserializer.deserialize());
+    assertFalse(deserializer.getObject().isPresent());
 
     try {
       deserializer.deserializeUnsafe();


### PR DESCRIPTION
- Now that we support java language version > v8, we can use optional to support when the getting deserialized object from webhook.
- This replaces the boolean check method `deserialize` 

Currently, the expected integration will look like this.. 
```java
   Event event = Webhook.constructEvent(payload, sigHeader, secret);
   EventDataObjectDeserializer dataObjectDeserializer = event.getDataObjectDeserializer();
   if (dataObjectDeserializer.deserialize()) {
      StripeObject stripeObject = dataObjectDeserializer.getObject();
   }
```
The problem is rather, user might just go straight and `getObject()` which can be null if it is not safe.
Now
```java
   Event event = Webhook.constructEvent(payload, sigHeader, secret);
   EventDataObjectDeserializer dataObjectDeserializer = event.getDataObjectDeserializer();
   if (dataObjectDeserializer.getObject().isPresent()) {
     StripeObject stripeObject = dataObjectDeserializer.getObject().get();
     doSomething(stripeObject);
   } 
```
For unsafe workflow, it's still the same. User can force deserialization or can use compatability to make the Json compatible

The original implementation and discussion in here https://github.com/stripe/stripe-java/pull/654
r? @ob-stripe 
cc @stripe/api-libraries 