### PR TITLE
Update doc on previous attributes array representation

### DIFF
--- a/src/main/java/com/stripe/model/EventData.java
+++ b/src/main/java/com/stripe/model/EventData.java
@@ -21,7 +21,7 @@ public class EventData extends StripeObject {
    * Object containing the names of the attributes that have changed, and their previous values
    * (sent along only with *.updated events). The untyped object here is composed of
    * {@code Map<String, Object>}, {@code List<Object>}, and basic Java data types.
-   * The array was represented as {@code Object[]} in `stripe-java` below 8.x.
+   * The array was previously represented as {@code Object[]} in `stripe-java` below v9.x
    */
   Map<String, Object> previousAttributes;
 

--- a/src/main/java/com/stripe/model/EventDataObjectDeserializer.java
+++ b/src/main/java/com/stripe/model/EventDataObjectDeserializer.java
@@ -16,7 +16,7 @@ import lombok.EqualsAndHashCode;
  * however, corresponds to a specific version pinned to this library {@link Stripe#API_VERSION}.
  * Thus, only data object with same API versions is guaranteed to deserialize safely.
  *
- * <p>To avoid this API version of event webhook mismatch, create a new webhook endpoint with
+ * <p>To avoid this problem of API version mismatch, create a new webhook endpoint
  * `api_versions` corresponding to {@link Stripe#API_VERSION}. For more information, see
  * <a href="https://stripe.com/docs/api/webhook_endpoints/create">API reference</a>
  *


### PR DESCRIPTION
- The doc is out-dated saying that version below 8.x has `Object[]`
r? @ob-stripe 