### PR TITLE
Add non-autogen typed params Event/File/EphemeralKeys

### DIFF
--- a/src/main/java/com/stripe/model/EphemeralKey.java
+++ b/src/main/java/com/stripe/model/EphemeralKey.java
@@ -5,6 +5,7 @@ import com.google.gson.annotations.SerializedName;
 import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
+import com.stripe.param.EphemeralKeyCreateParams;
 
 import java.util.List;
 import java.util.Map;
@@ -48,6 +49,21 @@ public class EphemeralKey extends ApiResource implements HasId {
   List<AssociatedObject> associatedObjects;
 
   transient String rawJson;
+
+  /**
+   * Creates an ephemeral API key for a given resource.
+   *
+   * @param params request parameters
+   * @param options request options. {@code stripeVersion} is required when creating ephemeral
+   *     keys. it must have non-null {@link RequestOptions#getStripeVersionOverride()}.
+   * @return the new ephemeral key
+   */
+  public static EphemeralKey create(EphemeralKeyCreateParams params, RequestOptions options)
+      throws StripeException {
+    return create(
+        params != null ? params.toMap(): (Map<String, Object>) null,
+        options);
+  }
 
   /**
    * Creates an ephemeral API key for a given resource.

--- a/src/main/java/com/stripe/model/EphemeralKey.java
+++ b/src/main/java/com/stripe/model/EphemeralKey.java
@@ -60,9 +60,8 @@ public class EphemeralKey extends ApiResource implements HasId {
    */
   public static EphemeralKey create(EphemeralKeyCreateParams params, RequestOptions options)
       throws StripeException {
-    return create(
-        params != null ? params.toMap(): (Map<String, Object>) null,
-        options);
+    checkNullTypedParams(classUrl(EphemeralKey.class), params);
+    return create(params.toMap(), options);
   }
 
   /**

--- a/src/main/java/com/stripe/model/Event.java
+++ b/src/main/java/com/stripe/model/Event.java
@@ -5,6 +5,7 @@ import com.google.gson.annotations.SerializedName;
 import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
+import com.stripe.param.EventListParams;
 
 import java.util.Map;
 
@@ -110,7 +111,28 @@ public class Event extends ApiResource implements HasId {
    * <a href="https://stripe.com/docs/api/events/object">event object</a> {@code api_version}
    * attribute (not according to your current Stripe API version or {@code Stripe-Version} header).
    */
+  public static EventCollection list(EventListParams params) throws StripeException {
+    return list(params, null);
+  }
+
+  /**
+   * List events, going back up to 30 days. Each event data is rendered according to Stripe API
+   * version at its creation time, specified in
+   * <a href="https://stripe.com/docs/api/events/object">event object</a> {@code api_version}
+   * attribute (not according to your current Stripe API version or {@code Stripe-Version} header).
+   */
   public static EventCollection list(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    return requestCollection(classUrl(Event.class), params, EventCollection.class, options);
+  }
+
+  /**
+   * List events, going back up to 30 days. Each event data is rendered according to Stripe API
+   * version at its creation time, specified in
+   * <a href="https://stripe.com/docs/api/events/object">event object</a> {@code api_version}
+   * attribute (not according to your current Stripe API version or {@code Stripe-Version} header).
+   */
+  public static EventCollection list(EventListParams params, RequestOptions options)
       throws StripeException {
     return requestCollection(classUrl(Event.class), params, EventCollection.class, options);
   }

--- a/src/main/java/com/stripe/model/File.java
+++ b/src/main/java/com/stripe/model/File.java
@@ -92,10 +92,8 @@ public class File extends ApiResource implements HasId {
    */
   public static File create(FileCreateParams params, RequestOptions options)
       throws StripeException {
-    return create(
-        params != null ? params.toMap() : (Map<String, Object>) null,
-        options
-    );
+    checkNullTypedParams(classUrl(File.class, Stripe.getUploadBase()), params);
+    return create(params.toMap(), options);
   }
 
   /**

--- a/src/main/java/com/stripe/model/File.java
+++ b/src/main/java/com/stripe/model/File.java
@@ -7,6 +7,7 @@ import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 
+import com.stripe.param.FileCreateParams;
 import java.util.Map;
 
 import lombok.EqualsAndHashCode;
@@ -72,6 +73,28 @@ public class File extends ApiResource implements HasId {
    */
   public static File create(Map<String, Object> params) throws StripeException {
     return create(params, (RequestOptions) null);
+  }
+
+  /**
+   * To upload a file to Stripe, you’ll need to send a request of type {@code multipart/form-data}.
+   * The request should contain the file you would like to upload, as well as the parameters for
+   * creating a file.
+   */
+  public static File create(FileCreateParams params) throws StripeException {
+    return create(params, (RequestOptions) null);
+  }
+
+  /**
+   * To upload a file to Stripe, you’ll need to send a request of type {@code multipart/form-data}.
+   * The request should contain the file you would like to upload, as well as the parameters for
+   * creating a file.
+   */
+  public static File create(FileCreateParams params, RequestOptions options)
+      throws StripeException {
+    return create(
+        params != null ? params.toMap() : (Map<String, Object>) null,
+        options
+    );
   }
 
   /**

--- a/src/main/java/com/stripe/model/File.java
+++ b/src/main/java/com/stripe/model/File.java
@@ -6,8 +6,9 @@ import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
-
 import com.stripe.param.FileCreateParams;
+import com.stripe.param.FileListParams;
+
 import java.util.Map;
 
 import lombok.EqualsAndHashCode;
@@ -121,6 +122,23 @@ public class File extends ApiResource implements HasId {
    * creation date, with the most recently created files appearing first.
    */
   public static FileCollection list(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    return requestCollection(classUrl(File.class), params, FileCollection.class, options);
+  }
+
+  /**
+   * Returns a list of the files that your account has access to. The files are returned sorted by
+   * creation date, with the most recently created files appearing first.
+   */
+  public static FileCollection list(FileListParams params) throws StripeException {
+    return list(params, (RequestOptions) null);
+  }
+
+  /**
+   * Returns a list of the files that your account has access to. The files are returned sorted by
+   * creation date, with the most recently created files appearing first.
+   */
+  public static FileCollection list(FileListParams params, RequestOptions options)
       throws StripeException {
     return requestCollection(classUrl(File.class), params, FileCollection.class, options);
   }

--- a/src/main/java/com/stripe/net/ApiResource.java
+++ b/src/main/java/com/stripe/net/ApiResource.java
@@ -166,6 +166,7 @@ public abstract class ApiResource extends StripeObject {
   public static <T> T request(ApiResource.RequestMethod method,
                               String url, ApiRequestParams params, Class<T> clazz,
                               RequestOptions options) throws StripeException {
+    checkNullTypedParams(url, params);
     return request(method, url, params.toMap(), clazz, options);
   }
 
@@ -179,6 +180,7 @@ public abstract class ApiResource extends StripeObject {
   public static <T extends StripeCollectionInterface<?>> T requestCollection(
       String url, ApiRequestParams params, Class<T> clazz, RequestOptions options)
       throws StripeException {
+    checkNullTypedParams(url, params);
     return requestCollection(url, params.toMap(), clazz, options);
   }
 
@@ -202,6 +204,19 @@ public abstract class ApiResource extends StripeObject {
     }
 
     return collection;
+  }
+
+  /**
+   * Invalidate null typed parameters.
+   * @param url     request url associated with the given parameters.
+   * @param params  typed parameters to check for null value.
+   */
+  public static void checkNullTypedParams(String url, ApiRequestParams params) {
+    if (params == null) {
+      throw new IllegalArgumentException(String.format("Found null params for %s. "
+          + "Please pass empty params using param builder via `builder().build()` instead.", url
+      ));
+    }
   }
 
   /**

--- a/src/main/java/com/stripe/param/EphemeralKeyCreateParams.java
+++ b/src/main/java/com/stripe/param/EphemeralKeyCreateParams.java
@@ -1,0 +1,81 @@
+package com.stripe.param;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.List;
+
+public class EphemeralKeyCreateParams extends ApiRequestParams {
+  /** The ID of the Customer you'd like to modify using the resulting ephemeral key. */
+  @SerializedName("customer")
+  String customer;
+
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /** The ID of the Issuing Card you'd like to access using the resulting ephemeral key. */
+  @SerializedName("issuing_card")
+  String issuingCard;
+
+  private EphemeralKeyCreateParams(String customer, List<String> expand, String issuingCard) {
+    this.customer = customer;
+    this.expand = expand;
+    this.issuingCard = issuingCard;
+  }
+
+  public static Builder builder() {
+    return new com.stripe.param.EphemeralKeyCreateParams.Builder();
+  }
+
+  public static class Builder {
+    private String customer;
+
+    private List<String> expand;
+
+    private String issuingCard;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public EphemeralKeyCreateParams build() {
+      return new EphemeralKeyCreateParams(this.customer, this.expand, this.issuingCard);
+    }
+
+    /** The ID of the Customer you'd like to modify using the resulting ephemeral key. */
+    public Builder setCustomer(String customer) {
+      this.customer = customer;
+      return this;
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * EphemeralKeyCreateParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * EphemeralKeyCreateParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /** The ID of the Issuing Card you'd like to access using the resulting ephemeral key. */
+    public Builder setIssuingCard(String issuingCard) {
+      this.issuingCard = issuingCard;
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/EventListParams.java
+++ b/src/main/java/com/stripe/param/EventListParams.java
@@ -1,0 +1,295 @@
+package com.stripe.param;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.List;
+
+public class EventListParams extends ApiRequestParams {
+  @SerializedName("created")
+  Object created;
+
+  /**
+   * Filter events by whether all webhooks were successfully delivered. If false, events which are
+   * still pending or have failed all delivery attempts to a webhook endpoint will be returned.
+   */
+  @SerializedName("delivery_success")
+  Boolean deliverySuccess;
+
+  /**
+   * A cursor for use in pagination. `ending_before` is an object ID that defines your place in the
+   * list. For instance, if you make a list request and receive 100 objects, starting with
+   * `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the
+   * previous page of the list.
+   */
+  @SerializedName("ending_before")
+  String endingBefore;
+
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+   * default is 10.
+   */
+  @SerializedName("limit")
+  Long limit;
+
+  /**
+   * A cursor for use in pagination. `starting_after` is an object ID that defines your place in the
+   * list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`,
+   * your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of
+   * the list.
+   */
+  @SerializedName("starting_after")
+  String startingAfter;
+
+  /**
+   * A string containing a specific event name, or group of events using * as a wildcard. The list
+   * will be filtered to include only events with a matching event property.
+   */
+  @SerializedName("type")
+  String type;
+
+  /**
+   * An array of up to 20 strings containing specific event names. The list will be filtered to
+   * include only events with a matching event property. You may pass either `type` or `types`, but
+   * not both.
+   */
+  @SerializedName("types")
+  List<String> types;
+
+  private EventListParams(
+      Object created,
+      Boolean deliverySuccess,
+      String endingBefore,
+      List<String> expand,
+      Long limit,
+      String startingAfter,
+      String type,
+      List<String> types) {
+    this.created = created;
+    this.deliverySuccess = deliverySuccess;
+    this.endingBefore = endingBefore;
+    this.expand = expand;
+    this.limit = limit;
+    this.startingAfter = startingAfter;
+    this.type = type;
+    this.types = types;
+  }
+
+  public static Builder builder() {
+    return new com.stripe.param.EventListParams.Builder();
+  }
+
+  public static class Builder {
+    private Object created;
+
+    private Boolean deliverySuccess;
+
+    private String endingBefore;
+
+    private List<String> expand;
+
+    private Long limit;
+
+    private String startingAfter;
+
+    private String type;
+
+    private List<String> types;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public EventListParams build() {
+      return new EventListParams(
+          this.created,
+          this.deliverySuccess,
+          this.endingBefore,
+          this.expand,
+          this.limit,
+          this.startingAfter,
+          this.type,
+          this.types);
+    }
+
+    public Builder setCreated(Created created) {
+      this.created = created;
+      return this;
+    }
+
+    public Builder setCreated(Long created) {
+      this.created = created;
+      return this;
+    }
+
+    /**
+     * Filter events by whether all webhooks were successfully delivered. If false, events which are
+     * still pending or have failed all delivery attempts to a webhook endpoint will be returned.
+     */
+    public Builder setDeliverySuccess(Boolean deliverySuccess) {
+      this.deliverySuccess = deliverySuccess;
+      return this;
+    }
+
+    /**
+     * A cursor for use in pagination. `ending_before` is an object ID that defines your place in
+     * the list. For instance, if you make a list request and receive 100 objects, starting with
+     * `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the
+     * previous page of the list.
+     */
+    public Builder setEndingBefore(String endingBefore) {
+      this.endingBefore = endingBefore;
+      return this;
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * EventListParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * EventListParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+     * default is 10.
+     */
+    public Builder setLimit(Long limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    /**
+     * A cursor for use in pagination. `starting_after` is an object ID that defines your place in
+     * the list. For instance, if you make a list request and receive 100 objects, ending with
+     * `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the
+     * next page of the list.
+     */
+    public Builder setStartingAfter(String startingAfter) {
+      this.startingAfter = startingAfter;
+      return this;
+    }
+
+    /**
+     * A string containing a specific event name, or group of events using * as a wildcard. The list
+     * will be filtered to include only events with a matching event property.
+     */
+    public Builder setType(String type) {
+      this.type = type;
+      return this;
+    }
+
+    /**
+     * Add an element to `types` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * EventListParams#types} for the field documentation.
+     */
+    public Builder addType(String element) {
+      if (this.types == null) {
+        this.types = new ArrayList<>();
+      }
+      this.types.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `types` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * EventListParams#types} for the field documentation.
+     */
+    public Builder addAllType(List<String> elements) {
+      if (this.types == null) {
+        this.types = new ArrayList<>();
+      }
+      this.types.addAll(elements);
+      return this;
+    }
+  }
+
+  public static class Created {
+    /** Minimum value to filter by (exclusive). */
+    @SerializedName("gt")
+    Long gt;
+
+    /** Minimum value to filter by (inclusive). */
+    @SerializedName("gte")
+    Long gte;
+
+    /** Maximum value to filter by (exclusive). */
+    @SerializedName("lt")
+    Long lt;
+
+    /** Maximum value to filter by (inclusive). */
+    @SerializedName("lte")
+    Long lte;
+
+    private Created(Long gt, Long gte, Long lt, Long lte) {
+      this.gt = gt;
+      this.gte = gte;
+      this.lt = lt;
+      this.lte = lte;
+    }
+
+    public static Builder builder() {
+      return new com.stripe.param.EventListParams.Created.Builder();
+    }
+
+    public static class Builder {
+      private Long gt;
+
+      private Long gte;
+
+      private Long lt;
+
+      private Long lte;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public Created build() {
+        return new Created(this.gt, this.gte, this.lt, this.lte);
+      }
+
+      /** Minimum value to filter by (exclusive). */
+      public Builder setGt(Long gt) {
+        this.gt = gt;
+        return this;
+      }
+
+      /** Minimum value to filter by (inclusive). */
+      public Builder setGte(Long gte) {
+        this.gte = gte;
+        return this;
+      }
+
+      /** Maximum value to filter by (exclusive). */
+      public Builder setLt(Long lt) {
+        this.lt = lt;
+        return this;
+      }
+
+      /** Maximum value to filter by (inclusive). */
+      public Builder setLte(Long lte) {
+        this.lte = lte;
+        return this;
+      }
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/FileCreateParams.java
+++ b/src/main/java/com/stripe/param/FileCreateParams.java
@@ -1,0 +1,253 @@
+package com.stripe.param;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+public class FileCreateParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * A file to upload. The file should follow the specifications of RFC 2388 (which defines file
+   * transfers for the `multipart/form-data` protocol).
+   *
+   * <p>Note this field is marked as transient to avoid JSON deserializer. Override
+   * {@link FileCreateParams#toMap()} makes sure that the returned map has this same file instance.
+   */
+  transient Object file;
+
+  /**
+   * Optional parameters to automatically create a [file link](#file_links) for the newly created
+   * file.
+   */
+  @SerializedName("file_link_data")
+  FileLinkData fileLinkData;
+
+  /**
+   * The purpose of the uploaded file. Possible values are `business_icon`, `business_logo`,
+   * `customer_signature`, `dispute_evidence`, `identity_document`, `pci_document`, or
+   * `tax_document_user_upload`
+   */
+  @SerializedName("purpose")
+  Purpose purpose;
+
+  private FileCreateParams(
+      List<String> expand, Object file, FileLinkData fileLinkData, Purpose purpose) {
+    this.expand = expand;
+    this.file = file;
+    this.fileLinkData = fileLinkData;
+    this.purpose = purpose;
+  }
+
+  public static Builder builder() {
+    return new com.stripe.param.FileCreateParams.Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Object file;
+
+    private FileLinkData fileLinkData;
+
+    private Purpose purpose;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public FileCreateParams build() {
+      return new FileCreateParams(this.expand, this.file, this.fileLinkData, this.purpose);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * FileCreateParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * FileCreateParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * A file to upload. The file should follow the specifications of RFC 2388 (which defines file
+     * transfers for the `multipart/form-data` protocol).
+     */
+    public Builder setFile(java.io.File file) {
+      this.file = file;
+      return this;
+    }
+
+    /**
+     * A file to upload. The file should follow the specifications of RFC 2388 (which defines file
+     * transfers for the `multipart/form-data` protocol).
+     */
+    public Builder setFile(java.io.FileInputStream file) {
+      this.file = file;
+      return this;
+    }
+
+    /**
+     * Optional parameters to automatically create a [file link](#file_links) for the newly created
+     * file.
+     */
+    public Builder setFileLinkData(FileLinkData fileLinkData) {
+      this.fileLinkData = fileLinkData;
+      return this;
+    }
+
+    /**
+     * The purpose of the uploaded file. Possible values are `business_icon`, `business_logo`,
+     * `customer_signature`, `dispute_evidence`, `identity_document`, `pci_document`, or
+     * `tax_document_user_upload`
+     */
+    public Builder setPurpose(Purpose purpose) {
+      this.purpose = purpose;
+      return this;
+    }
+  }
+
+  public static class FileLinkData {
+    /** Set this to `true` to create a file link for the newly created file. */
+    @SerializedName("create")
+    Boolean create;
+
+    /** A future timestamp after which the link will no longer be usable. */
+    @SerializedName("expires_at")
+    Long expiresAt;
+
+    /**
+     * Set of key-value pairs that you can attach to an object. This can be useful for storing
+     * additional information about the object in a structured format.
+     */
+    @SerializedName("metadata")
+    Map<String, String> metadata;
+
+    private FileLinkData(Boolean create, Long expiresAt, Map<String, String> metadata) {
+      this.create = create;
+      this.expiresAt = expiresAt;
+      this.metadata = metadata;
+    }
+
+    public static Builder builder() {
+      return new com.stripe.param.FileCreateParams.FileLinkData.Builder();
+    }
+
+    public static class Builder {
+      private Boolean create;
+
+      private Long expiresAt;
+
+      private Map<String, String> metadata;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public FileLinkData build() {
+        return new FileLinkData(this.create, this.expiresAt, this.metadata);
+      }
+
+      /** Set this to `true` to create a file link for the newly created file. */
+      public Builder setCreate(Boolean create) {
+        this.create = create;
+        return this;
+      }
+
+      /** A future timestamp after which the link will no longer be usable. */
+      public Builder setExpiresAt(Long expiresAt) {
+        this.expiresAt = expiresAt;
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `metadata` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * FileLinkData#metadata} for the field documentation.
+       */
+      public Builder putMetadata(String key, String value) {
+        if (this.metadata == null) {
+          this.metadata = new HashMap<>();
+        }
+        this.metadata.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `metadata` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link FileLinkData#metadata} for the field documentation.
+       */
+      public Builder putAllMetadata(Map<String, String> map) {
+        if (this.metadata == null) {
+          this.metadata = new HashMap<>();
+        }
+        this.metadata.putAll(map);
+        return this;
+      }
+    }
+  }
+
+  public enum Purpose implements ApiRequestParams.EnumParam {
+    @SerializedName("business_icon")
+    BUSINESS_ICON("business_icon"),
+
+    @SerializedName("business_logo")
+    BUSINESS_LOGO("business_logo"),
+
+    @SerializedName("customer_signature")
+    CUSTOMER_SIGNATURE("customer_signature"),
+
+    @SerializedName("dispute_evidence")
+    DISPUTE_EVIDENCE("dispute_evidence"),
+
+    @SerializedName("identity_document")
+    IDENTITY_DOCUMENT("identity_document"),
+
+    @SerializedName("pci_document")
+    PCI_DOCUMENT("pci_document"),
+
+    @SerializedName("tax_document_user_upload")
+    TAX_DOCUMENT_USER_UPLOAD("tax_document_user_upload");
+
+    @Getter(onMethod = @__({@Override}))
+    private final String value;
+
+    Purpose(String value) {
+      this.value = value;
+    }
+  }
+
+  /**
+   * Returns untyped parameters for file creation. Map value for {@code "file"} is the same
+   * instance of value set in {@link Builder#setFile(File)} or
+   * {@link Builder#setFile(java.io.FileInputStream)}; the file is not transformed or serialized
+   * at this level.
+   * @return Untyped parameters containing file object set in the builder.
+   */
+  @Override
+  public Map<String, Object> toMap() {
+    Object fileObject = this.file;
+    Map<String, Object> untypedParamWithPrimitiveTypes = super.toMap();
+    untypedParamWithPrimitiveTypes.put("file", fileObject);
+    return untypedParamWithPrimitiveTypes;
+  }
+}

--- a/src/main/java/com/stripe/param/FileListParams.java
+++ b/src/main/java/com/stripe/param/FileListParams.java
@@ -1,0 +1,272 @@
+package com.stripe.param;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+
+public class FileListParams extends ApiRequestParams {
+  @SerializedName("created")
+  Object created;
+
+  /**
+   * A cursor for use in pagination. `ending_before` is an object ID that defines your place in the
+   * list. For instance, if you make a list request and receive 100 objects, starting with
+   * `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the
+   * previous page of the list.
+   */
+  @SerializedName("ending_before")
+  String endingBefore;
+
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+   * default is 10.
+   */
+  @SerializedName("limit")
+  Long limit;
+
+  /**
+   * The file purpose to filter queries by. If none is provided, files will not be filtered by
+   * purpose.
+   */
+  @SerializedName("purpose")
+  Purpose purpose;
+
+  /**
+   * A cursor for use in pagination. `starting_after` is an object ID that defines your place in the
+   * list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`,
+   * your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of
+   * the list.
+   */
+  @SerializedName("starting_after")
+  String startingAfter;
+
+  private FileListParams(
+      Object created,
+      String endingBefore,
+      List<String> expand,
+      Long limit,
+      Purpose purpose,
+      String startingAfter) {
+    this.created = created;
+    this.endingBefore = endingBefore;
+    this.expand = expand;
+    this.limit = limit;
+    this.purpose = purpose;
+    this.startingAfter = startingAfter;
+  }
+
+  public static Builder builder() {
+    return new com.stripe.param.FileListParams.Builder();
+  }
+
+  public static class Builder {
+    private Object created;
+
+    private String endingBefore;
+
+    private List<String> expand;
+
+    private Long limit;
+
+    private Purpose purpose;
+
+    private String startingAfter;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public FileListParams build() {
+      return new FileListParams(
+          this.created,
+          this.endingBefore,
+          this.expand,
+          this.limit,
+          this.purpose,
+          this.startingAfter);
+    }
+
+    public Builder setCreated(Created created) {
+      this.created = created;
+      return this;
+    }
+
+    public Builder setCreated(Long created) {
+      this.created = created;
+      return this;
+    }
+
+    /**
+     * A cursor for use in pagination. `ending_before` is an object ID that defines your place in
+     * the list. For instance, if you make a list request and receive 100 objects, starting with
+     * `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the
+     * previous page of the list.
+     */
+    public Builder setEndingBefore(String endingBefore) {
+      this.endingBefore = endingBefore;
+      return this;
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * FileListParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * FileListParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+     * default is 10.
+     */
+    public Builder setLimit(Long limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    /**
+     * The file purpose to filter queries by. If none is provided, files will not be filtered by
+     * purpose.
+     */
+    public Builder setPurpose(Purpose purpose) {
+      this.purpose = purpose;
+      return this;
+    }
+
+    /**
+     * A cursor for use in pagination. `starting_after` is an object ID that defines your place in
+     * the list. For instance, if you make a list request and receive 100 objects, ending with
+     * `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the
+     * next page of the list.
+     */
+    public Builder setStartingAfter(String startingAfter) {
+      this.startingAfter = startingAfter;
+      return this;
+    }
+  }
+
+  public static class Created {
+    /** Minimum value to filter by (exclusive). */
+    @SerializedName("gt")
+    Long gt;
+
+    /** Minimum value to filter by (inclusive). */
+    @SerializedName("gte")
+    Long gte;
+
+    /** Maximum value to filter by (exclusive). */
+    @SerializedName("lt")
+    Long lt;
+
+    /** Maximum value to filter by (inclusive). */
+    @SerializedName("lte")
+    Long lte;
+
+    private Created(Long gt, Long gte, Long lt, Long lte) {
+      this.gt = gt;
+      this.gte = gte;
+      this.lt = lt;
+      this.lte = lte;
+    }
+
+    public static Builder builder() {
+      return new com.stripe.param.FileListParams.Created.Builder();
+    }
+
+    public static class Builder {
+      private Long gt;
+
+      private Long gte;
+
+      private Long lt;
+
+      private Long lte;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public Created build() {
+        return new Created(this.gt, this.gte, this.lt, this.lte);
+      }
+
+      /** Minimum value to filter by (exclusive). */
+      public Builder setGt(Long gt) {
+        this.gt = gt;
+        return this;
+      }
+
+      /** Minimum value to filter by (inclusive). */
+      public Builder setGte(Long gte) {
+        this.gte = gte;
+        return this;
+      }
+
+      /** Maximum value to filter by (exclusive). */
+      public Builder setLt(Long lt) {
+        this.lt = lt;
+        return this;
+      }
+
+      /** Maximum value to filter by (inclusive). */
+      public Builder setLte(Long lte) {
+        this.lte = lte;
+        return this;
+      }
+    }
+  }
+
+  public enum Purpose implements ApiRequestParams.EnumParam {
+    @SerializedName("business_icon")
+    BUSINESS_ICON("business_icon"),
+
+    @SerializedName("business_logo")
+    BUSINESS_LOGO("business_logo"),
+
+    @SerializedName("customer_signature")
+    CUSTOMER_SIGNATURE("customer_signature"),
+
+    @SerializedName("dispute_evidence")
+    DISPUTE_EVIDENCE("dispute_evidence"),
+
+    @SerializedName("finance_report_run")
+    FINANCE_REPORT_RUN("finance_report_run"),
+
+    @SerializedName("identity_document")
+    IDENTITY_DOCUMENT("identity_document"),
+
+    @SerializedName("pci_document")
+    PCI_DOCUMENT("pci_document"),
+
+    @SerializedName("sigma_scheduled_query")
+    SIGMA_SCHEDULED_QUERY("sigma_scheduled_query"),
+
+    @SerializedName("tax_document_user_upload")
+    TAX_DOCUMENT_USER_UPLOAD("tax_document_user_upload");
+
+    @Getter(onMethod = @__({@Override}))
+    private final String value;
+
+    Purpose(String value) {
+      this.value = value;
+    }
+  }
+}

--- a/src/test/java/com/stripe/functional/EphemeralKeyTest.java
+++ b/src/test/java/com/stripe/functional/EphemeralKeyTest.java
@@ -4,12 +4,14 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.google.common.collect.ImmutableMap;
 import com.stripe.BaseStripeTest;
 import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
 import com.stripe.model.EphemeralKey;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
+import com.stripe.param.EphemeralKeyCreateParams;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -42,6 +44,32 @@ public class EphemeralKeyTest extends BaseStripeTest {
   }
 
   @Test
+  public void testCreateWithTypedParams() throws StripeException {
+    EphemeralKeyCreateParams createParams = EphemeralKeyCreateParams
+        .builder()
+        .setCustomer("cust_123")
+        .setIssuingCard("card_123")
+        .build();
+
+    final RequestOptions options = RequestOptions.builder()
+        .setStripeVersionOverride(Stripe.API_VERSION).build();
+
+    final EphemeralKey key = EphemeralKey.create(createParams, options);
+
+    assertNotNull(key);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/ephemeral_keys",
+        ImmutableMap.of(
+            "customer", "cust_123",
+            "issuing_card", "card_123"
+        ),
+        null,
+        options
+    );
+  }
+
+  @Test
   public void testCreateWithoutApiVersionOverride() throws StripeException {
     final Map<String, Object> params = new HashMap<>();
     params.put("customer", "cus_123");
@@ -51,6 +79,14 @@ public class EphemeralKeyTest extends BaseStripeTest {
 
     assertThrows(IllegalArgumentException.class, () -> {
       EphemeralKey.create(params, options);
+    });
+
+    // create with typed params should have same validation behavior
+    EphemeralKeyCreateParams typedParams = EphemeralKeyCreateParams.builder()
+        .setCustomer("cust_123")
+        .build();
+    assertThrows(IllegalArgumentException.class, () -> {
+      EphemeralKey.create(typedParams, options);
     });
   }
 

--- a/src/test/java/com/stripe/functional/EphemeralKeyTest.java
+++ b/src/test/java/com/stripe/functional/EphemeralKeyTest.java
@@ -3,6 +3,7 @@ package com.stripe.functional;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
 import com.stripe.BaseStripeTest;
@@ -41,6 +42,14 @@ public class EphemeralKeyTest extends BaseStripeTest {
         null,
         options
     );
+  }
+
+  @Test
+  public void testThrowExceptionCreateWithNullTypedParams() {
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+      EphemeralKey.create((EphemeralKeyCreateParams) null, RequestOptions.getDefault());
+    });
+    assertTrue(exception.getMessage().contains("Found null params"));
   }
 
   @Test

--- a/src/test/java/com/stripe/functional/EventTest.java
+++ b/src/test/java/com/stripe/functional/EventTest.java
@@ -4,6 +4,7 @@ import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import com.google.common.collect.ImmutableMap;
 import com.stripe.BaseStripeTest;
 import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
@@ -11,6 +12,7 @@ import com.stripe.model.Event;
 import com.stripe.model.EventCollection;
 import com.stripe.model.StripeObject;
 import com.stripe.net.ApiResource;
+import com.stripe.param.EventListParams;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -44,6 +46,26 @@ public class EventTest extends BaseStripeTest {
         ApiResource.RequestMethod.GET,
         String.format("/v1/events"),
         params
+    );
+  }
+
+  @Test
+  public void testListWithTypedParams() throws StripeException {
+    EventListParams typedParams = EventListParams.builder()
+        .setLimit(1L)
+        .setType("charge.succeeded")
+        .build();
+
+    final EventCollection resources = Event.list(typedParams);
+
+    assertNotNull(resources);
+    verifyRequest(
+        ApiResource.RequestMethod.GET,
+        String.format("/v1/events"),
+        ImmutableMap.of(
+            "limit", 1L,
+            "type", "charge.succeeded"
+        )
     );
   }
 

--- a/src/test/java/com/stripe/functional/FileTest.java
+++ b/src/test/java/com/stripe/functional/FileTest.java
@@ -7,6 +7,7 @@ import com.stripe.exception.StripeException;
 import com.stripe.model.FileCollection;
 import com.stripe.net.ApiResource;
 
+import com.stripe.param.FileCreateParams;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -20,9 +21,8 @@ public class FileTest extends BaseStripeTest {
 
   @Test
   public void testCreateWithFile() throws StripeException {
-    final Map<String, Object> params = new HashMap<>();
-    params.put("purpose", "dispute_evidence");
-    params.put("file", new File(getClass().getResource("/test.png").getFile()));
+    File value = new File(getClass().getResource("/test.png").getFile());
+    final Map<String, Object> params = untypedCreateParams(value);
 
     final com.stripe.model.File file = com.stripe.model.File.create(params);
 
@@ -37,10 +37,38 @@ public class FileTest extends BaseStripeTest {
   }
 
   @Test
+  public void testCreateWithFileWithTypedParams() throws StripeException {
+    File fileObject = new File(getClass().getResource("/test.png").getFile());
+    FileCreateParams fileCreateParams = FileCreateParams.builder()
+        .setPurpose(FileCreateParams.Purpose.DISPUTE_EVIDENCE)
+        .setFile(fileObject)
+        .build();
+
+    final com.stripe.model.File file = com.stripe.model.File.create(fileCreateParams);
+
+    assertNotNull(file);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/files",
+        untypedCreateParams(fileObject),
+        ApiResource.RequestType.MULTIPART,
+        null
+    );
+  }
+
+  private Map<String, Object> untypedCreateParams(java.io.File file) {
+    final Map<String, Object> params = new HashMap<>();
+    params.put("purpose", "dispute_evidence");
+    params.put("file", file);
+    return params;
+  }
+
+  @Test
   public void testCreateWithStream() throws IOException, StripeException {
     final Map<String, Object> params = new HashMap<>();
     params.put("purpose", "dispute_evidence");
-    params.put("file", new FileInputStream(getClass().getResource("/test.png").getFile()));
+    FileInputStream value = new FileInputStream(getClass().getResource("/test.png").getFile());
+    params.put("file", value);
 
     final com.stripe.model.File file = com.stripe.model.File.create(params);
 

--- a/src/test/java/com/stripe/functional/FileTest.java
+++ b/src/test/java/com/stripe/functional/FileTest.java
@@ -2,12 +2,14 @@ package com.stripe.functional;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import com.google.common.collect.ImmutableMap;
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
 import com.stripe.model.FileCollection;
 import com.stripe.net.ApiResource;
-
 import com.stripe.param.FileCreateParams;
+import com.stripe.param.FileListParams;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -21,8 +23,9 @@ public class FileTest extends BaseStripeTest {
 
   @Test
   public void testCreateWithFile() throws StripeException {
-    File value = new File(getClass().getResource("/test.png").getFile());
-    final Map<String, Object> params = untypedCreateParams(value);
+    final Map<String, Object> params = new HashMap<>();
+    params.put("purpose", "dispute_evidence");
+    params.put("file", new File(getClass().getResource("/test.png").getFile()));
 
     final com.stripe.model.File file = com.stripe.model.File.create(params);
 
@@ -50,17 +53,13 @@ public class FileTest extends BaseStripeTest {
     verifyRequest(
         ApiResource.RequestMethod.POST,
         "/v1/files",
-        untypedCreateParams(fileObject),
+        ImmutableMap.of(
+            "purpose", "dispute_evidence",
+            "file", fileObject
+        ),
         ApiResource.RequestType.MULTIPART,
         null
     );
-  }
-
-  private Map<String, Object> untypedCreateParams(java.io.File file) {
-    final Map<String, Object> params = new HashMap<>();
-    params.put("purpose", "dispute_evidence");
-    params.put("file", file);
-    return params;
   }
 
   @Test
@@ -105,6 +104,24 @@ public class FileTest extends BaseStripeTest {
         ApiResource.RequestMethod.GET,
         "/v1/files",
         params
+    );
+  }
+
+  @Test
+  public void testListWithTypedParams() throws StripeException {
+    FileListParams params = FileListParams.builder()
+        .setLimit(1L)
+        .build();
+
+    final FileCollection files = com.stripe.model.File.list(params);
+
+    assertNotNull(files);
+    verifyRequest(
+        ApiResource.RequestMethod.GET,
+        "/v1/files",
+        ImmutableMap.of(
+            "limit", 1
+        )
     );
   }
 }

--- a/src/test/java/com/stripe/functional/FileTest.java
+++ b/src/test/java/com/stripe/functional/FileTest.java
@@ -1,12 +1,15 @@
 package com.stripe.functional;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
 import com.stripe.model.FileCollection;
 import com.stripe.net.ApiResource;
+import com.stripe.net.RequestOptions;
 import com.stripe.param.FileCreateParams;
 import com.stripe.param.FileListParams;
 
@@ -60,6 +63,14 @@ public class FileTest extends BaseStripeTest {
         ApiResource.RequestType.MULTIPART,
         null
     );
+  }
+
+  @Test
+  public void testThrowExceptionCreateWithNullTypedParams() {
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+      com.stripe.model.File.create((FileCreateParams) null, RequestOptions.getDefault());
+    });
+    assertTrue(exception.getMessage().contains("Found null params"));
   }
 
   @Test

--- a/src/test/java/com/stripe/param/FileCreateParamsTest.java
+++ b/src/test/java/com/stripe/param/FileCreateParamsTest.java
@@ -1,0 +1,44 @@
+package com.stripe.param;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class FileCreateParamsTest {
+
+  @Test
+  public void testToMapWithFileObject() {
+    java.io.File file = new File(getClass().getResource("/test.png").getFile());
+    FileCreateParams fileCreateParams = FileCreateParams.builder()
+        .setFile(file)
+        .setPurpose(FileCreateParams.Purpose.BUSINESS_ICON)
+        .build();
+
+    Map<String, Object> untypedParams = fileCreateParams.toMap();
+    // file object is not deserialized/transformed into something other than
+    // the value set in builder
+    assertSame(file, untypedParams.get("file"));
+    assertEquals(FileCreateParams.Purpose.BUSINESS_ICON.getValue(), untypedParams.get("purpose"));
+  }
+
+  @Test
+  public void testToMapWithFileInputStream() throws FileNotFoundException {
+    java.io.FileInputStream fileInputStream = new FileInputStream(getClass()
+        .getResource("/test.png").getFile());
+    FileCreateParams fileCreateParams = FileCreateParams.builder()
+        .setFile(fileInputStream)
+        .setPurpose(FileCreateParams.Purpose.BUSINESS_ICON)
+        .build();
+
+    Map<String, Object> untypedParams = fileCreateParams.toMap();
+    // file object is not deserialized/transformed into something other than
+    // the value set in builder
+    assertSame(fileInputStream, untypedParams.get("file"));
+    assertEquals(FileCreateParams.Purpose.BUSINESS_ICON.getValue(), untypedParams.get("purpose"));
+  }
+}

--- a/src/test/java/com/stripe/param/FileCreateParamsTest.java
+++ b/src/test/java/com/stripe/param/FileCreateParamsTest.java
@@ -1,7 +1,7 @@
 package com.stripe.param;
 
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.io.File;
 import java.io.FileInputStream;


### PR DESCRIPTION
- This PR implements typed params for the non-autogen classes: `Event`, `File` and `EphemeralKey`
- I used generator in this [branch](https://git.corp.stripe.com/stripe-internal/sdk-autogen-java/commit/9bee243aa18027104cbabec6487eb71caad8391f) to get parameters for the excluded files, and manually remove the special-case logic that we have 
- For file, there's additional handling of `File` and `FileInputStream` for typed params to make it compatible to the current untyped params usage. 
- For ones with custom logic in the method itself, I defer the calls to existing logic, and multi-part request that currently doesn't have interface for typed parameters.
- I did not add `EventRetrieve` and `FileRetrieve` params because they are essentially no-op params, having only expand while the model actually has nothing expandable.

- It's a large PR but reviewing by commit would be helpful. 



r? @ob-stripe @brandur-stripe 
cc @stripe/api-libraries 