### PR TITLE
Upgrade to Gradle 5.3.1 and fix signing issue

### DIFF
--- a/deploy.gradle
+++ b/deploy.gradle
@@ -119,7 +119,6 @@ afterEvaluate { project ->
     }
 
     artifacts {
-        archives jar
         archives sourcesJar
         archives makeJavadocsJar
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.3.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
r? @mickjermsurawong-stripe 
cc @stripe/api-libraries @hans-stripe 

This fixes the signature issue we ran into yesterday. The problem is described in [this comment](https://github.com/gradle/gradle/issues/8213#issuecomment-453966130):
> The `com.vanniktech.maven.publish` unconditionally adds the `jar` task to `configurations.archives.artifacts` where it has already been added by the `java` plugin thus causing the duplicate.

We're not using the `com.vanniktech.maven.publish` plugin, but we had the same issue: we manually added the `jar` task to `configurations.archives.artifacts`.

After removing the `jar` task from `configurations.archives.artifacts`, I've verified that things work as expected:
```
$ GNUPGHOME="/path/to/gnupg" GRADLE_OPTS="-Dorg.gradle.project.signing.gnupg.keyName=C33033E4B583FE612EDE877C05D02D3D57ABFF46" ./gradlew clean sign
...
BUILD SUCCESSFUL in 50s
8 actionable tasks: 7 executed, 1 up-to-date

$ ls -l build/libs
total 15848
-rw-r--r--  1 ob  staff  5201573 Apr 10 10:31 stripe-java-9.0.0-javadoc.jar
-rw-r--r--  1 ob  staff      508 Apr 10 10:31 stripe-java-9.0.0-javadoc.jar.asc
-rw-r--r--  1 ob  staff   795820 Apr 10 10:31 stripe-java-9.0.0-sources.jar
-rw-r--r--  1 ob  staff      508 Apr 10 10:31 stripe-java-9.0.0-sources.jar.asc
-rw-r--r--  1 ob  staff  1763670 Apr 10 10:30 stripe-java-9.0.0.jar
-rw-r--r--  1 ob  staff      508 Apr 10 10:31 stripe-java-9.0.0.jar.asc

$ gpg --verify build/libs/stripe-java-9.0.0.jar.asc build/libs/stripe-java-9.0.0.jar
gpg: Signature made Wed Apr 10 10:31:27 2019 PDT
gpg:                using RSA key C33033E4B583FE612EDE877C05D02D3D57ABFF46
gpg: Good signature from "Stripe <support@stripe.com>" [expired]
gpg:                 aka "Stripe <security@stripe.com>" [expired]
gpg: Note: This key has expired!
Primary key fingerprint: C330 33E4 B583 FE61 2EDE  877C 05D0 2D3D 57AB FF46

$ gpg --verify build/libs/stripe-java-9.0.0-sources.jar.asc build/libs/stripe-java-9.0.0-sources.jar
gpg: Signature made Wed Apr 10 10:31:27 2019 PDT
gpg:                using RSA key C33033E4B583FE612EDE877C05D02D3D57ABFF46
gpg: Good signature from "Stripe <support@stripe.com>" [expired]
gpg:                 aka "Stripe <security@stripe.com>" [expired]
gpg: Note: This key has expired!
Primary key fingerprint: C330 33E4 B583 FE61 2EDE  877C 05D0 2D3D 57AB FF46

$ gpg --verify build/libs/stripe-java-9.0.0-javadoc.jar.asc build/libs/stripe-java-9.0.0-javadoc.jar
gpg: Signature made Wed Apr 10 10:31:27 2019 PDT
gpg:                using RSA key C33033E4B583FE612EDE877C05D02D3D57ABFF46
gpg: Good signature from "Stripe <support@stripe.com>" [expired]
gpg:                 aka "Stripe <security@stripe.com>" [expired]
gpg: Note: This key has expired!
Primary key fingerprint: C330 33E4 B583 FE61 2EDE  877C 05D0 2D3D 57AB FF46
``` 

Fixes #733.