### PR TITLE
Fix encoding of nested parameters in multipart requests

### DIFF
--- a/src/test/java/com/stripe/functional/FileTest.java
+++ b/src/test/java/com/stripe/functional/FileTest.java
@@ -47,6 +47,10 @@ public class FileTest extends BaseStripeTest {
     File fileObject = new File(getClass().getResource("/test.png").getFile());
     FileCreateParams fileCreateParams = FileCreateParams.builder()
         .setPurpose(FileCreateParams.Purpose.DISPUTE_EVIDENCE)
+        .setFileLinkData(FileCreateParams.FileLinkData.builder()
+            .setCreate(true)
+            .setExpiresAt(123L)
+            .build())
         .setFile(fileObject)
         .build();
 
@@ -58,7 +62,11 @@ public class FileTest extends BaseStripeTest {
         "/v1/files",
         ImmutableMap.of(
             "purpose", "dispute_evidence",
-            "file", fileObject
+            "file", fileObject,
+            "file_link_data", ImmutableMap.of(
+                "create", true,
+                "expires_at", 123
+            )
         ),
         ApiResource.RequestType.MULTIPART,
         null


### PR DESCRIPTION
- This fixes encoding of nested params in multipart request. Currently, we assume that parameters used in multipart request is one-level deep and contains file object at root-level.
- This PR allows nested params, and makes assumption of root-level file object explicit.
- This is similar to the problem addressed in php https://github.com/stripe/stripe-php/pull/624

r? @ob-stripe 
cc @remi-stripe @stripe/api-libraries 