### PR TITLE
Encode ID in url path

### DIFF
--- a/src/main/java/com/stripe/model/Account.java
+++ b/src/main/java/com/stripe/model/Account.java
@@ -151,7 +151,10 @@ public class Account extends ApiResource implements PaymentSource, MetadataStore
   public static Account retrieve(String account, Map<String, Object> params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/accounts/%s", account));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/accounts/%s", ApiResource.urlEncodeId(account)));
     return request(ApiResource.RequestMethod.GET, url, params, Account.class, options);
   }
 
@@ -159,7 +162,10 @@ public class Account extends ApiResource implements PaymentSource, MetadataStore
   public static Account retrieve(
       String account, AccountRetrieveParams params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/accounts/%s", account));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/accounts/%s", ApiResource.urlEncodeId(account)));
     return request(ApiResource.RequestMethod.GET, url, params, Account.class, options);
   }
 
@@ -195,7 +201,10 @@ public class Account extends ApiResource implements PaymentSource, MetadataStore
   @Override
   public Account update(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/accounts/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/accounts/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Account.class, options);
   }
 
@@ -229,7 +238,10 @@ public class Account extends ApiResource implements PaymentSource, MetadataStore
    */
   public Account update(AccountUpdateParams params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/accounts/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/accounts/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Account.class, options);
   }
 
@@ -375,7 +387,10 @@ public class Account extends ApiResource implements PaymentSource, MetadataStore
    */
   public Account delete(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/accounts/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/accounts/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.DELETE, url, params, Account.class, options);
   }
 
@@ -398,7 +413,9 @@ public class Account extends ApiResource implements PaymentSource, MetadataStore
   public Account reject(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/accounts/%s/reject", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/accounts/%s/reject", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Account.class, options);
   }
 
@@ -421,7 +438,9 @@ public class Account extends ApiResource implements PaymentSource, MetadataStore
   public Account reject(AccountRejectParams params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/accounts/%s/reject", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/accounts/%s/reject", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Account.class, options);
   }
 
@@ -449,7 +468,9 @@ public class Account extends ApiResource implements PaymentSource, MetadataStore
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/accounts/%s/persons", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/accounts/%s/persons", ApiResource.urlEncodeId(this.getId())));
     return requestCollection(url, params, PersonCollection.class, options);
   }
 
@@ -469,7 +490,9 @@ public class Account extends ApiResource implements PaymentSource, MetadataStore
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/accounts/%s/persons", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/accounts/%s/persons", ApiResource.urlEncodeId(this.getId())));
     return requestCollection(url, params, PersonCollection.class, options);
   }
 

--- a/src/main/java/com/stripe/model/ApplePayDomain.java
+++ b/src/main/java/com/stripe/model/ApplePayDomain.java
@@ -111,7 +111,9 @@ public class ApplePayDomain extends ApiResource implements HasId {
       String domain, Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/apple_pay/domains/%s", domain));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/apple_pay/domains/%s", ApiResource.urlEncodeId(domain)));
     return request(ApiResource.RequestMethod.GET, url, params, ApplePayDomain.class, options);
   }
 
@@ -121,7 +123,9 @@ public class ApplePayDomain extends ApiResource implements HasId {
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/apple_pay/domains/%s", domain));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/apple_pay/domains/%s", ApiResource.urlEncodeId(domain)));
     return request(ApiResource.RequestMethod.GET, url, params, ApplePayDomain.class, options);
   }
 
@@ -145,7 +149,9 @@ public class ApplePayDomain extends ApiResource implements HasId {
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/apple_pay/domains/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/apple_pay/domains/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.DELETE, url, params, ApplePayDomain.class, options);
   }
 }

--- a/src/main/java/com/stripe/model/ApplicationFee.java
+++ b/src/main/java/com/stripe/model/ApplicationFee.java
@@ -255,7 +255,10 @@ public class ApplicationFee extends ApiResource implements BalanceTransactionSou
   public static ApplicationFee retrieve(
       String id, Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/application_fees/%s", id));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/application_fees/%s", ApiResource.urlEncodeId(id)));
     return request(ApiResource.RequestMethod.GET, url, params, ApplicationFee.class, options);
   }
 
@@ -267,7 +270,10 @@ public class ApplicationFee extends ApiResource implements BalanceTransactionSou
       String id, ApplicationFeeRetrieveParams params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/application_fees/%s", id));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/application_fees/%s", ApiResource.urlEncodeId(id)));
     return request(ApiResource.RequestMethod.GET, url, params, ApplicationFee.class, options);
   }
 }

--- a/src/main/java/com/stripe/model/BalanceTransaction.java
+++ b/src/main/java/com/stripe/model/BalanceTransaction.java
@@ -170,7 +170,10 @@ public class BalanceTransaction extends ApiResource implements HasId {
   public static BalanceTransaction retrieve(
       String id, Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/balance/history/%s", id));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/balance/history/%s", ApiResource.urlEncodeId(id)));
     return request(ApiResource.RequestMethod.GET, url, params, BalanceTransaction.class, options);
   }
 
@@ -179,7 +182,10 @@ public class BalanceTransaction extends ApiResource implements HasId {
       String id, BalanceTransactionRetrieveParams params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/balance/history/%s", id));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/balance/history/%s", ApiResource.urlEncodeId(id)));
     return request(ApiResource.RequestMethod.GET, url, params, BalanceTransaction.class, options);
   }
 

--- a/src/main/java/com/stripe/model/BankAccount.java
+++ b/src/main/java/com/stripe/model/BankAccount.java
@@ -187,13 +187,18 @@ public class BankAccount extends ApiResource
               "%s%s",
               Stripe.getApiBase(),
               String.format(
-                  "/v1/accounts/%s/external_accounts/%s", this.getAccount(), this.getId()));
+                  "/v1/accounts/%s/external_accounts/%s",
+                  ApiResource.urlEncodeId(this.getAccount()),
+                  ApiResource.urlEncodeId(this.getId())));
     } else if (this.getCustomer() != null) {
       url =
           String.format(
               "%s%s",
               Stripe.getApiBase(),
-              String.format("/v1/customers/%s/sources/%s", this.getCustomer(), this.getId()));
+              String.format(
+                  "/v1/customers/%s/sources/%s",
+                  ApiResource.urlEncodeId(this.getCustomer()),
+                  ApiResource.urlEncodeId(this.getId())));
     } else {
       throw new InvalidRequestException(
           "Unable to construct url because [account, customer] field(s) are all null",
@@ -243,7 +248,9 @@ public class BankAccount extends ApiResource
               "%s%s",
               Stripe.getApiBase(),
               String.format(
-                  "/v1/accounts/%s/external_accounts/%s", this.getAccount(), this.getId()));
+                  "/v1/accounts/%s/external_accounts/%s",
+                  ApiResource.urlEncodeId(this.getAccount()),
+                  ApiResource.urlEncodeId(this.getId())));
     } else {
       throw new InvalidRequestException(
           "Unable to construct url because [account] field(s) are all null",
@@ -292,7 +299,10 @@ public class BankAccount extends ApiResource
           String.format(
               "%s%s",
               Stripe.getApiBase(),
-              String.format("/v1/customers/%s/sources/%s", this.getCustomer(), this.getId()));
+              String.format(
+                  "/v1/customers/%s/sources/%s",
+                  ApiResource.urlEncodeId(this.getCustomer()),
+                  ApiResource.urlEncodeId(this.getId())));
     } else {
       throw new InvalidRequestException(
           "Unable to construct url because [customer] field(s) are all null",
@@ -350,13 +360,18 @@ public class BankAccount extends ApiResource
               "%s%s",
               Stripe.getApiBase(),
               String.format(
-                  "/v1/accounts/%s/external_accounts/%s", this.getAccount(), this.getId()));
+                  "/v1/accounts/%s/external_accounts/%s",
+                  ApiResource.urlEncodeId(this.getAccount()),
+                  ApiResource.urlEncodeId(this.getId())));
     } else if (this.getCustomer() != null) {
       url =
           String.format(
               "%s%s",
               Stripe.getApiBase(),
-              String.format("/v1/customers/%s/sources/%s", this.getCustomer(), this.getId()));
+              String.format(
+                  "/v1/customers/%s/sources/%s",
+                  ApiResource.urlEncodeId(this.getCustomer()),
+                  ApiResource.urlEncodeId(this.getId())));
     } else {
       throw new InvalidRequestException(
           "Unable to construct url because [account, customer] field(s) are all null",
@@ -394,7 +409,9 @@ public class BankAccount extends ApiResource
               "%s%s",
               Stripe.getApiBase(),
               String.format(
-                  "/v1/customers/%s/sources/%s/verify", this.getCustomer(), this.getId()));
+                  "/v1/customers/%s/sources/%s/verify",
+                  ApiResource.urlEncodeId(this.getCustomer()),
+                  ApiResource.urlEncodeId(this.getId())));
     } else {
       throw new InvalidRequestException(
           "Unable to construct url because [customer] field(s) are all null",
@@ -422,7 +439,9 @@ public class BankAccount extends ApiResource
               "%s%s",
               Stripe.getApiBase(),
               String.format(
-                  "/v1/customers/%s/sources/%s/verify", this.getCustomer(), this.getId()));
+                  "/v1/customers/%s/sources/%s/verify",
+                  ApiResource.urlEncodeId(this.getCustomer()),
+                  ApiResource.urlEncodeId(this.getId())));
     } else {
       throw new InvalidRequestException(
           "Unable to construct url because [customer] field(s) are all null",

--- a/src/main/java/com/stripe/model/BitcoinReceiver.java
+++ b/src/main/java/com/stripe/model/BitcoinReceiver.java
@@ -186,7 +186,10 @@ public class BitcoinReceiver extends ApiResource implements PaymentSource {
   public static BitcoinReceiver retrieve(
       String id, Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/bitcoin/receivers/%s", id));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/bitcoin/receivers/%s", ApiResource.urlEncodeId(id)));
     return request(ApiResource.RequestMethod.GET, url, params, BitcoinReceiver.class, options);
   }
 
@@ -195,7 +198,10 @@ public class BitcoinReceiver extends ApiResource implements PaymentSource {
       String id, BitcoinReceiverRetrieveParams params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/bitcoin/receivers/%s", id));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/bitcoin/receivers/%s", ApiResource.urlEncodeId(id)));
     return request(ApiResource.RequestMethod.GET, url, params, BitcoinReceiver.class, options);
   }
 }

--- a/src/main/java/com/stripe/model/Card.java
+++ b/src/main/java/com/stripe/model/Card.java
@@ -289,13 +289,18 @@ public class Card extends ApiResource
               "%s%s",
               Stripe.getApiBase(),
               String.format(
-                  "/v1/accounts/%s/external_accounts/%s", this.getAccount(), this.getId()));
+                  "/v1/accounts/%s/external_accounts/%s",
+                  ApiResource.urlEncodeId(this.getAccount()),
+                  ApiResource.urlEncodeId(this.getId())));
     } else if (this.getCustomer() != null) {
       url =
           String.format(
               "%s%s",
               Stripe.getApiBase(),
-              String.format("/v1/customers/%s/sources/%s", this.getCustomer(), this.getId()));
+              String.format(
+                  "/v1/customers/%s/sources/%s",
+                  ApiResource.urlEncodeId(this.getCustomer()),
+                  ApiResource.urlEncodeId(this.getId())));
     } else {
       throw new InvalidRequestException(
           "Unable to construct url because [account, customer] field(s) are all null",
@@ -339,7 +344,9 @@ public class Card extends ApiResource
               "%s%s",
               Stripe.getApiBase(),
               String.format(
-                  "/v1/accounts/%s/external_accounts/%s", this.getAccount(), this.getId()));
+                  "/v1/accounts/%s/external_accounts/%s",
+                  ApiResource.urlEncodeId(this.getAccount()),
+                  ApiResource.urlEncodeId(this.getId())));
     } else {
       throw new InvalidRequestException(
           "Unable to construct url because [account] field(s) are all null",
@@ -382,7 +389,10 @@ public class Card extends ApiResource
           String.format(
               "%s%s",
               Stripe.getApiBase(),
-              String.format("/v1/customers/%s/sources/%s", this.getCustomer(), this.getId()));
+              String.format(
+                  "/v1/customers/%s/sources/%s",
+                  ApiResource.urlEncodeId(this.getCustomer()),
+                  ApiResource.urlEncodeId(this.getId())));
     } else {
       throw new InvalidRequestException(
           "Unable to construct url because [customer] field(s) are all null",
@@ -439,13 +449,18 @@ public class Card extends ApiResource
               "%s%s",
               Stripe.getApiBase(),
               String.format(
-                  "/v1/accounts/%s/external_accounts/%s", this.getAccount(), this.getId()));
+                  "/v1/accounts/%s/external_accounts/%s",
+                  ApiResource.urlEncodeId(this.getAccount()),
+                  ApiResource.urlEncodeId(this.getId())));
     } else if (this.getCustomer() != null) {
       url =
           String.format(
               "%s%s",
               Stripe.getApiBase(),
-              String.format("/v1/customers/%s/sources/%s", this.getCustomer(), this.getId()));
+              String.format(
+                  "/v1/customers/%s/sources/%s",
+                  ApiResource.urlEncodeId(this.getCustomer()),
+                  ApiResource.urlEncodeId(this.getId())));
     } else {
       throw new InvalidRequestException(
           "Unable to construct url because [account, customer] field(s) are all null",

--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -627,7 +627,9 @@ public class Charge extends ApiResource implements BalanceTransactionSource, Met
   public static Charge retrieve(String charge, Map<String, Object> params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/charges/%s", charge));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(), String.format("/v1/charges/%s", ApiResource.urlEncodeId(charge)));
     return request(ApiResource.RequestMethod.GET, url, params, Charge.class, options);
   }
 
@@ -639,7 +641,9 @@ public class Charge extends ApiResource implements BalanceTransactionSource, Met
   public static Charge retrieve(String charge, ChargeRetrieveParams params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/charges/%s", charge));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(), String.format("/v1/charges/%s", ApiResource.urlEncodeId(charge)));
     return request(ApiResource.RequestMethod.GET, url, params, Charge.class, options);
   }
 
@@ -659,7 +663,10 @@ public class Charge extends ApiResource implements BalanceTransactionSource, Met
   @Override
   public Charge update(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/charges/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/charges/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Charge.class, options);
   }
 
@@ -677,7 +684,10 @@ public class Charge extends ApiResource implements BalanceTransactionSource, Met
    */
   public Charge update(ChargeUpdateParams params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/charges/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/charges/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Charge.class, options);
   }
 
@@ -732,7 +742,9 @@ public class Charge extends ApiResource implements BalanceTransactionSource, Met
   public Charge capture(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/charges/%s/capture", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/charges/%s/capture", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Charge.class, options);
   }
 
@@ -761,7 +773,9 @@ public class Charge extends ApiResource implements BalanceTransactionSource, Met
   public Charge capture(ChargeCaptureParams params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/charges/%s/capture", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/charges/%s/capture", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Charge.class, options);
   }
 

--- a/src/main/java/com/stripe/model/CountrySpec.java
+++ b/src/main/java/com/stripe/model/CountrySpec.java
@@ -97,7 +97,10 @@ public class CountrySpec extends ApiResource implements HasId {
   public static CountrySpec retrieve(
       String country, Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/country_specs/%s", country));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/country_specs/%s", ApiResource.urlEncodeId(country)));
     return request(ApiResource.RequestMethod.GET, url, params, CountrySpec.class, options);
   }
 
@@ -106,7 +109,10 @@ public class CountrySpec extends ApiResource implements HasId {
       String country, CountrySpecRetrieveParams params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/country_specs/%s", country));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/country_specs/%s", ApiResource.urlEncodeId(country)));
     return request(ApiResource.RequestMethod.GET, url, params, CountrySpec.class, options);
   }
 

--- a/src/main/java/com/stripe/model/Coupon.java
+++ b/src/main/java/com/stripe/model/Coupon.java
@@ -220,7 +220,9 @@ public class Coupon extends ApiResource implements HasId, MetadataStore<Coupon> 
   public static Coupon retrieve(String coupon, Map<String, Object> params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/coupons/%s", coupon));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(), String.format("/v1/coupons/%s", ApiResource.urlEncodeId(coupon)));
     return request(ApiResource.RequestMethod.GET, url, params, Coupon.class, options);
   }
 
@@ -228,7 +230,9 @@ public class Coupon extends ApiResource implements HasId, MetadataStore<Coupon> 
   public static Coupon retrieve(String coupon, CouponRetrieveParams params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/coupons/%s", coupon));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(), String.format("/v1/coupons/%s", ApiResource.urlEncodeId(coupon)));
     return request(ApiResource.RequestMethod.GET, url, params, Coupon.class, options);
   }
 
@@ -248,7 +252,10 @@ public class Coupon extends ApiResource implements HasId, MetadataStore<Coupon> 
   @Override
   public Coupon update(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/coupons/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/coupons/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Coupon.class, options);
   }
 
@@ -266,7 +273,10 @@ public class Coupon extends ApiResource implements HasId, MetadataStore<Coupon> 
    */
   public Coupon update(CouponUpdateParams params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/coupons/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/coupons/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Coupon.class, options);
   }
 
@@ -308,7 +318,10 @@ public class Coupon extends ApiResource implements HasId, MetadataStore<Coupon> 
    */
   public Coupon delete(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/coupons/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/coupons/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.DELETE, url, params, Coupon.class, options);
   }
 }

--- a/src/main/java/com/stripe/model/Customer.java
+++ b/src/main/java/com/stripe/model/Customer.java
@@ -228,7 +228,10 @@ public class Customer extends ApiResource implements HasId, MetadataStore<Custom
   public static Customer retrieve(
       String customer, Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/customers/%s", customer));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/customers/%s", ApiResource.urlEncodeId(customer)));
     return request(ApiResource.RequestMethod.GET, url, params, Customer.class, options);
   }
 
@@ -240,7 +243,10 @@ public class Customer extends ApiResource implements HasId, MetadataStore<Custom
       String customer, CustomerRetrieveParams params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/customers/%s", customer));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/customers/%s", ApiResource.urlEncodeId(customer)));
     return request(ApiResource.RequestMethod.GET, url, params, Customer.class, options);
   }
 
@@ -281,7 +287,10 @@ public class Customer extends ApiResource implements HasId, MetadataStore<Custom
   public Customer update(Map<String, Object> params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/customers/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/customers/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Customer.class, options);
   }
 
@@ -320,7 +329,10 @@ public class Customer extends ApiResource implements HasId, MetadataStore<Custom
   public Customer update(CustomerUpdateParams params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/customers/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/customers/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Customer.class, options);
   }
 
@@ -355,7 +367,10 @@ public class Customer extends ApiResource implements HasId, MetadataStore<Custom
   public Customer delete(Map<String, Object> params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/customers/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/customers/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.DELETE, url, params, Customer.class, options);
   }
 
@@ -374,7 +389,9 @@ public class Customer extends ApiResource implements HasId, MetadataStore<Custom
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/customers/%s/discount", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/customers/%s/discount", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.DELETE, url, params, Discount.class, options);
   }
 

--- a/src/main/java/com/stripe/model/Dispute.java
+++ b/src/main/java/com/stripe/model/Dispute.java
@@ -169,7 +169,10 @@ public class Dispute extends ApiResource
   public static Dispute retrieve(String dispute, Map<String, Object> params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/disputes/%s", dispute));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/disputes/%s", ApiResource.urlEncodeId(dispute)));
     return request(ApiResource.RequestMethod.GET, url, params, Dispute.class, options);
   }
 
@@ -177,7 +180,10 @@ public class Dispute extends ApiResource
   public static Dispute retrieve(
       String dispute, DisputeRetrieveParams params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/disputes/%s", dispute));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/disputes/%s", ApiResource.urlEncodeId(dispute)));
     return request(ApiResource.RequestMethod.GET, url, params, Dispute.class, options);
   }
 
@@ -209,7 +215,10 @@ public class Dispute extends ApiResource
   @Override
   public Dispute update(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/disputes/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/disputes/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Dispute.class, options);
   }
 
@@ -239,7 +248,10 @@ public class Dispute extends ApiResource
    */
   public Dispute update(DisputeUpdateParams params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/disputes/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/disputes/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Dispute.class, options);
   }
 
@@ -286,7 +298,9 @@ public class Dispute extends ApiResource
   public Dispute close(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/disputes/%s/close", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/disputes/%s/close", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Dispute.class, options);
   }
 
@@ -311,7 +325,9 @@ public class Dispute extends ApiResource
   public Dispute close(DisputeCloseParams params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/disputes/%s/close", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/disputes/%s/close", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Dispute.class, options);
   }
 

--- a/src/main/java/com/stripe/model/ExchangeRate.java
+++ b/src/main/java/com/stripe/model/ExchangeRate.java
@@ -90,7 +90,9 @@ public class ExchangeRate extends ApiResource implements HasId {
       String currency, Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/exchange_rates/%s", currency));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/exchange_rates/%s", ApiResource.urlEncodeId(currency)));
     return request(ApiResource.RequestMethod.GET, url, params, ExchangeRate.class, options);
   }
 
@@ -100,7 +102,9 @@ public class ExchangeRate extends ApiResource implements HasId {
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/exchange_rates/%s", currency));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/exchange_rates/%s", ApiResource.urlEncodeId(currency)));
     return request(ApiResource.RequestMethod.GET, url, params, ExchangeRate.class, options);
   }
 }

--- a/src/main/java/com/stripe/model/ExternalAccountCollection.java
+++ b/src/main/java/com/stripe/model/ExternalAccountCollection.java
@@ -51,7 +51,10 @@ public class ExternalAccountCollection extends StripeCollection<ExternalAccount>
   public ExternalAccount retrieve(String id, Map<String, Object> params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("%s/%s", this.getUrl(), id));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("%s/%s", this.getUrl(), ApiResource.urlEncodeId(id)));
     return ApiResource.request(
         ApiResource.RequestMethod.GET, url, params, ExternalAccount.class, options);
   }
@@ -61,7 +64,10 @@ public class ExternalAccountCollection extends StripeCollection<ExternalAccount>
       String id, ExternalAccountCollectionRetrieveParams params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("%s/%s", this.getUrl(), id));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("%s/%s", this.getUrl(), ApiResource.urlEncodeId(id)));
     return ApiResource.request(
         ApiResource.RequestMethod.GET, url, params, ExternalAccount.class, options);
   }

--- a/src/main/java/com/stripe/model/FeeRefund.java
+++ b/src/main/java/com/stripe/model/FeeRefund.java
@@ -126,7 +126,9 @@ public class FeeRefund extends ApiResource
           String.format(
               "%s%s",
               Stripe.getApiBase(),
-              String.format("/v1/application_fees/%s/refunds/%s", this.getFee(), this.getId()));
+              String.format(
+                  "/v1/application_fees/%s/refunds/%s",
+                  ApiResource.urlEncodeId(this.getFee()), ApiResource.urlEncodeId(this.getId())));
     } else {
       throw new InvalidRequestException(
           "Unable to construct url because [fee] field(s) are all null", null, null, null, 0, null);
@@ -158,7 +160,9 @@ public class FeeRefund extends ApiResource
           String.format(
               "%s%s",
               Stripe.getApiBase(),
-              String.format("/v1/application_fees/%s/refunds/%s", this.getFee(), this.getId()));
+              String.format(
+                  "/v1/application_fees/%s/refunds/%s",
+                  ApiResource.urlEncodeId(this.getFee()), ApiResource.urlEncodeId(this.getId())));
     } else {
       throw new InvalidRequestException(
           "Unable to construct url because [fee] field(s) are all null", null, null, null, 0, null);

--- a/src/main/java/com/stripe/model/FeeRefundCollection.java
+++ b/src/main/java/com/stripe/model/FeeRefundCollection.java
@@ -148,7 +148,10 @@ public class FeeRefundCollection extends StripeCollection<FeeRefund> {
   public FeeRefund retrieve(String id, Map<String, Object> params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("%s/%s", this.getUrl(), id));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("%s/%s", this.getUrl(), ApiResource.urlEncodeId(id)));
     return ApiResource.request(
         ApiResource.RequestMethod.GET, url, params, FeeRefund.class, options);
   }
@@ -162,7 +165,10 @@ public class FeeRefundCollection extends StripeCollection<FeeRefund> {
       String id, FeeRefundCollectionRetrieveParams params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("%s/%s", this.getUrl(), id));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("%s/%s", this.getUrl(), ApiResource.urlEncodeId(id)));
     return ApiResource.request(
         ApiResource.RequestMethod.GET, url, params, FeeRefund.class, options);
   }

--- a/src/main/java/com/stripe/model/FileLink.java
+++ b/src/main/java/com/stripe/model/FileLink.java
@@ -98,7 +98,9 @@ public class FileLink extends ApiResource implements HasId, MetadataStore<FileLi
   public static FileLink retrieve(String link, Map<String, Object> params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/file_links/%s", link));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(), String.format("/v1/file_links/%s", ApiResource.urlEncodeId(link)));
     return request(ApiResource.RequestMethod.GET, url, params, FileLink.class, options);
   }
 
@@ -106,7 +108,9 @@ public class FileLink extends ApiResource implements HasId, MetadataStore<FileLi
   public static FileLink retrieve(
       String link, FileLinkRetrieveParams params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/file_links/%s", link));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(), String.format("/v1/file_links/%s", ApiResource.urlEncodeId(link)));
     return request(ApiResource.RequestMethod.GET, url, params, FileLink.class, options);
   }
 
@@ -146,7 +150,9 @@ public class FileLink extends ApiResource implements HasId, MetadataStore<FileLi
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/file_links/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/file_links/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, FileLink.class, options);
   }
 
@@ -160,7 +166,9 @@ public class FileLink extends ApiResource implements HasId, MetadataStore<FileLi
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/file_links/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/file_links/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, FileLink.class, options);
   }
 

--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -636,7 +636,10 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
   public static Invoice retrieve(String invoice, Map<String, Object> params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/invoices/%s", invoice));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/invoices/%s", ApiResource.urlEncodeId(invoice)));
     return request(ApiResource.RequestMethod.GET, url, params, Invoice.class, options);
   }
 
@@ -644,7 +647,10 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
   public static Invoice retrieve(
       String invoice, InvoiceRetrieveParams params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/invoices/%s", invoice));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/invoices/%s", ApiResource.urlEncodeId(invoice)));
     return request(ApiResource.RequestMethod.GET, url, params, Invoice.class, options);
   }
 
@@ -676,7 +682,10 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
   @Override
   public Invoice update(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/invoices/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/invoices/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Invoice.class, options);
   }
 
@@ -706,7 +715,10 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
    */
   public Invoice update(InvoiceUpdateParams params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/invoices/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/invoices/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Invoice.class, options);
   }
 
@@ -744,7 +756,10 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
    */
   public Invoice delete(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/invoices/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/invoices/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.DELETE, url, params, Invoice.class, options);
   }
 
@@ -791,7 +806,9 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
   public Invoice pay(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/invoices/%s/pay", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/invoices/%s/pay", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Invoice.class, options);
   }
 
@@ -816,7 +833,9 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
   public Invoice pay(InvoicePayParams params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/invoices/%s/pay", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/invoices/%s/pay", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Invoice.class, options);
   }
 
@@ -852,7 +871,9 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/invoices/%s/finalize", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/invoices/%s/finalize", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Invoice.class, options);
   }
 
@@ -872,7 +893,9 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/invoices/%s/finalize", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/invoices/%s/finalize", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Invoice.class, options);
   }
 
@@ -932,7 +955,9 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/invoices/%s/send", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/invoices/%s/send", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Invoice.class, options);
   }
 
@@ -964,7 +989,9 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/invoices/%s/send", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/invoices/%s/send", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Invoice.class, options);
   }
 
@@ -1001,7 +1028,9 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
     String url =
         String.format(
             "%s%s",
-            Stripe.getApiBase(), String.format("/v1/invoices/%s/mark_uncollectible", this.getId()));
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/invoices/%s/mark_uncollectible", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Invoice.class, options);
   }
 
@@ -1022,7 +1051,9 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
     String url =
         String.format(
             "%s%s",
-            Stripe.getApiBase(), String.format("/v1/invoices/%s/mark_uncollectible", this.getId()));
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/invoices/%s/mark_uncollectible", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Invoice.class, options);
   }
 
@@ -1062,7 +1093,9 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/invoices/%s/void", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/invoices/%s/void", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Invoice.class, options);
   }
 
@@ -1084,7 +1117,9 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/invoices/%s/void", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/invoices/%s/void", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Invoice.class, options);
   }
 

--- a/src/main/java/com/stripe/model/InvoiceItem.java
+++ b/src/main/java/com/stripe/model/InvoiceItem.java
@@ -266,7 +266,9 @@ public class InvoiceItem extends ApiResource implements HasId, MetadataStore<Inv
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/invoiceitems/%s", invoiceitem));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/invoiceitems/%s", ApiResource.urlEncodeId(invoiceitem)));
     return request(ApiResource.RequestMethod.GET, url, params, InvoiceItem.class, options);
   }
 
@@ -276,7 +278,9 @@ public class InvoiceItem extends ApiResource implements HasId, MetadataStore<Inv
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/invoiceitems/%s", invoiceitem));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/invoiceitems/%s", ApiResource.urlEncodeId(invoiceitem)));
     return request(ApiResource.RequestMethod.GET, url, params, InvoiceItem.class, options);
   }
 
@@ -298,7 +302,9 @@ public class InvoiceItem extends ApiResource implements HasId, MetadataStore<Inv
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/invoiceitems/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/invoiceitems/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, InvoiceItem.class, options);
   }
 
@@ -318,7 +324,9 @@ public class InvoiceItem extends ApiResource implements HasId, MetadataStore<Inv
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/invoiceitems/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/invoiceitems/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, InvoiceItem.class, options);
   }
 
@@ -354,7 +362,9 @@ public class InvoiceItem extends ApiResource implements HasId, MetadataStore<Inv
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/invoiceitems/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/invoiceitems/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.DELETE, url, params, InvoiceItem.class, options);
   }
 }

--- a/src/main/java/com/stripe/model/IssuerFraudRecord.java
+++ b/src/main/java/com/stripe/model/IssuerFraudRecord.java
@@ -148,7 +148,9 @@ public class IssuerFraudRecord extends ApiResource implements HasId {
     String url =
         String.format(
             "%s%s",
-            Stripe.getApiBase(), String.format("/v1/issuer_fraud_records/%s", issuerFraudRecord));
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/issuer_fraud_records/%s", ApiResource.urlEncodeId(issuerFraudRecord)));
     return request(ApiResource.RequestMethod.GET, url, params, IssuerFraudRecord.class, options);
   }
 
@@ -164,7 +166,9 @@ public class IssuerFraudRecord extends ApiResource implements HasId {
     String url =
         String.format(
             "%s%s",
-            Stripe.getApiBase(), String.format("/v1/issuer_fraud_records/%s", issuerFraudRecord));
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/issuer_fraud_records/%s", ApiResource.urlEncodeId(issuerFraudRecord)));
     return request(ApiResource.RequestMethod.GET, url, params, IssuerFraudRecord.class, options);
   }
 }

--- a/src/main/java/com/stripe/model/LoginLink.java
+++ b/src/main/java/com/stripe/model/LoginLink.java
@@ -39,7 +39,9 @@ public class LoginLink extends ApiResource {
       String account, Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/accounts/%s/login_links", account));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/accounts/%s/login_links", ApiResource.urlEncodeId(account)));
     return request(ApiResource.RequestMethod.POST, url, params, LoginLink.class, options);
   }
 
@@ -54,7 +56,9 @@ public class LoginLink extends ApiResource {
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/accounts/%s/login_links", account));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/accounts/%s/login_links", ApiResource.urlEncodeId(account)));
     return request(ApiResource.RequestMethod.POST, url, params, LoginLink.class, options);
   }
 }

--- a/src/main/java/com/stripe/model/Order.java
+++ b/src/main/java/com/stripe/model/Order.java
@@ -261,7 +261,10 @@ public class Order extends ApiResource implements HasId, MetadataStore<Order> {
    */
   public static Order retrieve(String id, Map<String, Object> params, RequestOptions options)
       throws StripeException {
-    String url = String.format("%s%s", Stripe.getApiBase(), String.format("/v1/orders/%s", id));
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(), String.format("/v1/orders/%s", ApiResource.urlEncodeId(id)));
     return request(ApiResource.RequestMethod.GET, url, params, Order.class, options);
   }
 
@@ -271,7 +274,10 @@ public class Order extends ApiResource implements HasId, MetadataStore<Order> {
    */
   public static Order retrieve(String id, OrderRetrieveParams params, RequestOptions options)
       throws StripeException {
-    String url = String.format("%s%s", Stripe.getApiBase(), String.format("/v1/orders/%s", id));
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(), String.format("/v1/orders/%s", ApiResource.urlEncodeId(id)));
     return request(ApiResource.RequestMethod.GET, url, params, Order.class, options);
   }
 
@@ -291,7 +297,10 @@ public class Order extends ApiResource implements HasId, MetadataStore<Order> {
   @Override
   public Order update(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/orders/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/orders/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Order.class, options);
   }
 
@@ -309,7 +318,10 @@ public class Order extends ApiResource implements HasId, MetadataStore<Order> {
    */
   public Order update(OrderUpdateParams params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/orders/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/orders/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Order.class, options);
   }
 
@@ -332,7 +344,9 @@ public class Order extends ApiResource implements HasId, MetadataStore<Order> {
   public Order pay(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/orders/%s/pay", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/orders/%s/pay", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Order.class, options);
   }
 
@@ -345,7 +359,9 @@ public class Order extends ApiResource implements HasId, MetadataStore<Order> {
   public Order pay(OrderPayParams params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/orders/%s/pay", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/orders/%s/pay", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Order.class, options);
   }
 
@@ -389,7 +405,9 @@ public class Order extends ApiResource implements HasId, MetadataStore<Order> {
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/orders/%s/returns", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/orders/%s/returns", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, OrderReturn.class, options);
   }
 
@@ -413,7 +431,9 @@ public class Order extends ApiResource implements HasId, MetadataStore<Order> {
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/orders/%s/returns", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/orders/%s/returns", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, OrderReturn.class, options);
   }
 

--- a/src/main/java/com/stripe/model/OrderReturn.java
+++ b/src/main/java/com/stripe/model/OrderReturn.java
@@ -168,7 +168,10 @@ public class OrderReturn extends ApiResource implements HasId {
   public static OrderReturn retrieve(String id, Map<String, Object> params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/order_returns/%s", id));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/order_returns/%s", ApiResource.urlEncodeId(id)));
     return request(ApiResource.RequestMethod.GET, url, params, OrderReturn.class, options);
   }
 
@@ -180,7 +183,10 @@ public class OrderReturn extends ApiResource implements HasId {
   public static OrderReturn retrieve(
       String id, OrderReturnRetrieveParams params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/order_returns/%s", id));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/order_returns/%s", ApiResource.urlEncodeId(id)));
     return request(ApiResource.RequestMethod.GET, url, params, OrderReturn.class, options);
   }
 }

--- a/src/main/java/com/stripe/model/PaymentIntent.java
+++ b/src/main/java/com/stripe/model/PaymentIntent.java
@@ -437,7 +437,10 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
   public static PaymentIntent retrieve(
       String intent, Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/payment_intents/%s", intent));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/payment_intents/%s", ApiResource.urlEncodeId(intent)));
     return request(ApiResource.RequestMethod.GET, url, params, PaymentIntent.class, options);
   }
 
@@ -455,7 +458,10 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
       String intent, PaymentIntentRetrieveParams params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/payment_intents/%s", intent));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/payment_intents/%s", ApiResource.urlEncodeId(intent)));
     return request(ApiResource.RequestMethod.GET, url, params, PaymentIntent.class, options);
   }
 
@@ -471,7 +477,9 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/payment_intents/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/payment_intents/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, PaymentIntent.class, options);
   }
 
@@ -485,7 +493,9 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/payment_intents/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/payment_intents/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, PaymentIntent.class, options);
   }
 
@@ -606,7 +616,8 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
     String url =
         String.format(
             "%s%s",
-            Stripe.getApiBase(), String.format("/v1/payment_intents/%s/confirm", this.getId()));
+            Stripe.getApiBase(),
+            String.format("/v1/payment_intents/%s/confirm", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, PaymentIntent.class, options);
   }
 
@@ -669,7 +680,8 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
     String url =
         String.format(
             "%s%s",
-            Stripe.getApiBase(), String.format("/v1/payment_intents/%s/confirm", this.getId()));
+            Stripe.getApiBase(),
+            String.format("/v1/payment_intents/%s/confirm", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, PaymentIntent.class, options);
   }
 
@@ -730,7 +742,8 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
     String url =
         String.format(
             "%s%s",
-            Stripe.getApiBase(), String.format("/v1/payment_intents/%s/cancel", this.getId()));
+            Stripe.getApiBase(),
+            String.format("/v1/payment_intents/%s/cancel", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, PaymentIntent.class, options);
   }
 
@@ -763,7 +776,8 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
     String url =
         String.format(
             "%s%s",
-            Stripe.getApiBase(), String.format("/v1/payment_intents/%s/cancel", this.getId()));
+            Stripe.getApiBase(),
+            String.format("/v1/payment_intents/%s/cancel", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, PaymentIntent.class, options);
   }
 
@@ -824,7 +838,8 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
     String url =
         String.format(
             "%s%s",
-            Stripe.getApiBase(), String.format("/v1/payment_intents/%s/capture", this.getId()));
+            Stripe.getApiBase(),
+            String.format("/v1/payment_intents/%s/capture", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, PaymentIntent.class, options);
   }
 
@@ -857,7 +872,8 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
     String url =
         String.format(
             "%s%s",
-            Stripe.getApiBase(), String.format("/v1/payment_intents/%s/capture", this.getId()));
+            Stripe.getApiBase(),
+            String.format("/v1/payment_intents/%s/capture", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, PaymentIntent.class, options);
   }
 

--- a/src/main/java/com/stripe/model/PaymentMethod.java
+++ b/src/main/java/com/stripe/model/PaymentMethod.java
@@ -151,7 +151,9 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/payment_methods/%s", paymentMethod));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/payment_methods/%s", ApiResource.urlEncodeId(paymentMethod)));
     return request(ApiResource.RequestMethod.GET, url, params, PaymentMethod.class, options);
   }
 
@@ -161,7 +163,9 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/payment_methods/%s", paymentMethod));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/payment_methods/%s", ApiResource.urlEncodeId(paymentMethod)));
     return request(ApiResource.RequestMethod.GET, url, params, PaymentMethod.class, options);
   }
 
@@ -177,7 +181,9 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/payment_methods/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/payment_methods/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, PaymentMethod.class, options);
   }
 
@@ -191,7 +197,9 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/payment_methods/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/payment_methods/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, PaymentMethod.class, options);
   }
 
@@ -231,7 +239,8 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
     String url =
         String.format(
             "%s%s",
-            Stripe.getApiBase(), String.format("/v1/payment_methods/%s/attach", this.getId()));
+            Stripe.getApiBase(),
+            String.format("/v1/payment_methods/%s/attach", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, PaymentMethod.class, options);
   }
 
@@ -246,7 +255,8 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
     String url =
         String.format(
             "%s%s",
-            Stripe.getApiBase(), String.format("/v1/payment_methods/%s/attach", this.getId()));
+            Stripe.getApiBase(),
+            String.format("/v1/payment_methods/%s/attach", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, PaymentMethod.class, options);
   }
 
@@ -271,7 +281,8 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
     String url =
         String.format(
             "%s%s",
-            Stripe.getApiBase(), String.format("/v1/payment_methods/%s/detach", this.getId()));
+            Stripe.getApiBase(),
+            String.format("/v1/payment_methods/%s/detach", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, PaymentMethod.class, options);
   }
 
@@ -286,7 +297,8 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
     String url =
         String.format(
             "%s%s",
-            Stripe.getApiBase(), String.format("/v1/payment_methods/%s/detach", this.getId()));
+            Stripe.getApiBase(),
+            String.format("/v1/payment_methods/%s/detach", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, PaymentMethod.class, options);
   }
 

--- a/src/main/java/com/stripe/model/PaymentSourceCollection.java
+++ b/src/main/java/com/stripe/model/PaymentSourceCollection.java
@@ -51,7 +51,10 @@ public class PaymentSourceCollection extends StripeCollection<PaymentSource> {
   public PaymentSource retrieve(String id, Map<String, Object> params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("%s/%s", this.getUrl(), id));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("%s/%s", this.getUrl(), ApiResource.urlEncodeId(id)));
     return ApiResource.request(
         ApiResource.RequestMethod.GET, url, params, PaymentSource.class, options);
   }
@@ -61,7 +64,10 @@ public class PaymentSourceCollection extends StripeCollection<PaymentSource> {
       String id, PaymentSourceCollectionRetrieveParams params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("%s/%s", this.getUrl(), id));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("%s/%s", this.getUrl(), ApiResource.urlEncodeId(id)));
     return ApiResource.request(
         ApiResource.RequestMethod.GET, url, params, PaymentSource.class, options);
   }

--- a/src/main/java/com/stripe/model/Payout.java
+++ b/src/main/java/com/stripe/model/Payout.java
@@ -229,7 +229,9 @@ public class Payout extends ApiResource implements BalanceTransactionSource, Met
   public static Payout retrieve(String payout, Map<String, Object> params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/payouts/%s", payout));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(), String.format("/v1/payouts/%s", ApiResource.urlEncodeId(payout)));
     return request(ApiResource.RequestMethod.GET, url, params, Payout.class, options);
   }
 
@@ -241,7 +243,9 @@ public class Payout extends ApiResource implements BalanceTransactionSource, Met
   public static Payout retrieve(String payout, PayoutRetrieveParams params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/payouts/%s", payout));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(), String.format("/v1/payouts/%s", ApiResource.urlEncodeId(payout)));
     return request(ApiResource.RequestMethod.GET, url, params, Payout.class, options);
   }
 
@@ -369,7 +373,10 @@ public class Payout extends ApiResource implements BalanceTransactionSource, Met
   @Override
   public Payout update(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/payouts/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/payouts/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Payout.class, options);
   }
 
@@ -387,7 +394,10 @@ public class Payout extends ApiResource implements BalanceTransactionSource, Met
    */
   public Payout update(PayoutUpdateParams params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/payouts/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/payouts/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Payout.class, options);
   }
 
@@ -422,7 +432,9 @@ public class Payout extends ApiResource implements BalanceTransactionSource, Met
   public Payout cancel(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/payouts/%s/cancel", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/payouts/%s/cancel", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Payout.class, options);
   }
 
@@ -441,7 +453,9 @@ public class Payout extends ApiResource implements BalanceTransactionSource, Met
   public Payout cancel(PayoutCancelParams params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/payouts/%s/cancel", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/payouts/%s/cancel", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Payout.class, options);
   }
 }

--- a/src/main/java/com/stripe/model/Person.java
+++ b/src/main/java/com/stripe/model/Person.java
@@ -139,7 +139,10 @@ public class Person extends ApiResource implements HasId, MetadataStore<Person> 
           String.format(
               "%s%s",
               Stripe.getApiBase(),
-              String.format("/v1/accounts/%s/persons/%s", this.getAccount(), this.getId()));
+              String.format(
+                  "/v1/accounts/%s/persons/%s",
+                  ApiResource.urlEncodeId(this.getAccount()),
+                  ApiResource.urlEncodeId(this.getId())));
     } else {
       throw new InvalidRequestException(
           "Unable to construct url because [account] field(s) are all null",
@@ -165,7 +168,10 @@ public class Person extends ApiResource implements HasId, MetadataStore<Person> 
           String.format(
               "%s%s",
               Stripe.getApiBase(),
-              String.format("/v1/accounts/%s/persons/%s", this.getAccount(), this.getId()));
+              String.format(
+                  "/v1/accounts/%s/persons/%s",
+                  ApiResource.urlEncodeId(this.getAccount()),
+                  ApiResource.urlEncodeId(this.getId())));
     } else {
       throw new InvalidRequestException(
           "Unable to construct url because [account] field(s) are all null",
@@ -201,7 +207,10 @@ public class Person extends ApiResource implements HasId, MetadataStore<Person> 
           String.format(
               "%s%s",
               Stripe.getApiBase(),
-              String.format("/v1/accounts/%s/persons/%s", this.getAccount(), this.getId()));
+              String.format(
+                  "/v1/accounts/%s/persons/%s",
+                  ApiResource.urlEncodeId(this.getAccount()),
+                  ApiResource.urlEncodeId(this.getId())));
     } else {
       throw new InvalidRequestException(
           "Unable to construct url because [account] field(s) are all null",

--- a/src/main/java/com/stripe/model/PersonCollection.java
+++ b/src/main/java/com/stripe/model/PersonCollection.java
@@ -62,7 +62,10 @@ public class PersonCollection extends StripeCollection<Person> {
   public Person retrieve(String id, Map<String, Object> params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("%s/%s", this.getUrl(), id));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("%s/%s", this.getUrl(), ApiResource.urlEncodeId(id)));
     return ApiResource.request(ApiResource.RequestMethod.GET, url, params, Person.class, options);
   }
 
@@ -70,7 +73,10 @@ public class PersonCollection extends StripeCollection<Person> {
   public Person retrieve(String id, PersonCollectionRetrieveParams params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("%s/%s", this.getUrl(), id));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("%s/%s", this.getUrl(), ApiResource.urlEncodeId(id)));
     return ApiResource.request(ApiResource.RequestMethod.GET, url, params, Person.class, options);
   }
 

--- a/src/main/java/com/stripe/model/Plan.java
+++ b/src/main/java/com/stripe/model/Plan.java
@@ -241,7 +241,8 @@ public class Plan extends ApiResource implements HasId, MetadataStore<Plan> {
   /** Retrieves the plan with the given ID. */
   public static Plan retrieve(String plan, Map<String, Object> params, RequestOptions options)
       throws StripeException {
-    String url = String.format("%s%s", Stripe.getApiBase(), String.format("/v1/plans/%s", plan));
+    String url = String.format("%s%s", Stripe.getApiBase(), String.format("/v1/plans/%s",
+        urlEncodeId(plan)));
     return request(ApiResource.RequestMethod.GET, url, params, Plan.class, options);
   }
 

--- a/src/main/java/com/stripe/model/Plan.java
+++ b/src/main/java/com/stripe/model/Plan.java
@@ -241,15 +241,20 @@ public class Plan extends ApiResource implements HasId, MetadataStore<Plan> {
   /** Retrieves the plan with the given ID. */
   public static Plan retrieve(String plan, Map<String, Object> params, RequestOptions options)
       throws StripeException {
-    String url = String.format("%s%s", Stripe.getApiBase(), String.format("/v1/plans/%s",
-        urlEncodeId(plan)));
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(), String.format("/v1/plans/%s", ApiResource.urlEncodeId(plan)));
     return request(ApiResource.RequestMethod.GET, url, params, Plan.class, options);
   }
 
   /** Retrieves the plan with the given ID. */
   public static Plan retrieve(String plan, PlanRetrieveParams params, RequestOptions options)
       throws StripeException {
-    String url = String.format("%s%s", Stripe.getApiBase(), String.format("/v1/plans/%s", plan));
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(), String.format("/v1/plans/%s", ApiResource.urlEncodeId(plan)));
     return request(ApiResource.RequestMethod.GET, url, params, Plan.class, options);
   }
 
@@ -271,7 +276,10 @@ public class Plan extends ApiResource implements HasId, MetadataStore<Plan> {
   @Override
   public Plan update(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/plans/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/plans/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Plan.class, options);
   }
 
@@ -291,7 +299,10 @@ public class Plan extends ApiResource implements HasId, MetadataStore<Plan> {
    */
   public Plan update(PlanUpdateParams params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/plans/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/plans/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Plan.class, options);
   }
 
@@ -313,7 +324,10 @@ public class Plan extends ApiResource implements HasId, MetadataStore<Plan> {
   /** Deleting plans means new subscribers can’t be added. Existing subscribers aren’t affected. */
   public Plan delete(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/plans/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/plans/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.DELETE, url, params, Plan.class, options);
   }
 

--- a/src/main/java/com/stripe/model/Product.java
+++ b/src/main/java/com/stripe/model/Product.java
@@ -204,7 +204,10 @@ public class Product extends ApiResource implements HasId, MetadataStore<Product
    */
   public static Product retrieve(String id, Map<String, Object> params, RequestOptions options)
       throws StripeException {
-    String url = String.format("%s%s", Stripe.getApiBase(), String.format("/v1/products/%s", id));
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(), String.format("/v1/products/%s", ApiResource.urlEncodeId(id)));
     return request(ApiResource.RequestMethod.GET, url, params, Product.class, options);
   }
 
@@ -215,7 +218,10 @@ public class Product extends ApiResource implements HasId, MetadataStore<Product
    */
   public static Product retrieve(String id, ProductRetrieveParams params, RequestOptions options)
       throws StripeException {
-    String url = String.format("%s%s", Stripe.getApiBase(), String.format("/v1/products/%s", id));
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(), String.format("/v1/products/%s", ApiResource.urlEncodeId(id)));
     return request(ApiResource.RequestMethod.GET, url, params, Product.class, options);
   }
 
@@ -241,7 +247,10 @@ public class Product extends ApiResource implements HasId, MetadataStore<Product
   @Override
   public Product update(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/products/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/products/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Product.class, options);
   }
 
@@ -265,7 +274,10 @@ public class Product extends ApiResource implements HasId, MetadataStore<Product
    */
   public Product update(ProductUpdateParams params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/products/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/products/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Product.class, options);
   }
 
@@ -339,7 +351,10 @@ public class Product extends ApiResource implements HasId, MetadataStore<Product
    */
   public Product delete(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/products/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/products/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.DELETE, url, params, Product.class, options);
   }
 }

--- a/src/main/java/com/stripe/model/Recipient.java
+++ b/src/main/java/com/stripe/model/Recipient.java
@@ -250,7 +250,10 @@ public class Recipient extends ApiResource implements HasId, MetadataStore<Recip
    */
   public static Recipient retrieve(String id, Map<String, Object> params, RequestOptions options)
       throws StripeException {
-    String url = String.format("%s%s", Stripe.getApiBase(), String.format("/v1/recipients/%s", id));
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(), String.format("/v1/recipients/%s", ApiResource.urlEncodeId(id)));
     return request(ApiResource.RequestMethod.GET, url, params, Recipient.class, options);
   }
 
@@ -260,7 +263,10 @@ public class Recipient extends ApiResource implements HasId, MetadataStore<Recip
    */
   public static Recipient retrieve(
       String id, RecipientRetrieveParams params, RequestOptions options) throws StripeException {
-    String url = String.format("%s%s", Stripe.getApiBase(), String.format("/v1/recipients/%s", id));
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(), String.format("/v1/recipients/%s", ApiResource.urlEncodeId(id)));
     return request(ApiResource.RequestMethod.GET, url, params, Recipient.class, options);
   }
 
@@ -288,7 +294,9 @@ public class Recipient extends ApiResource implements HasId, MetadataStore<Recip
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/recipients/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/recipients/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Recipient.class, options);
   }
 
@@ -314,7 +322,9 @@ public class Recipient extends ApiResource implements HasId, MetadataStore<Recip
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/recipients/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/recipients/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Recipient.class, options);
   }
 
@@ -338,7 +348,9 @@ public class Recipient extends ApiResource implements HasId, MetadataStore<Recip
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/recipients/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/recipients/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.DELETE, url, params, Recipient.class, options);
   }
 }

--- a/src/main/java/com/stripe/model/Refund.java
+++ b/src/main/java/com/stripe/model/Refund.java
@@ -299,7 +299,9 @@ public class Refund extends ApiResource implements BalanceTransactionSource, Met
   public static Refund retrieve(String refund, Map<String, Object> params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/refunds/%s", refund));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(), String.format("/v1/refunds/%s", ApiResource.urlEncodeId(refund)));
     return request(ApiResource.RequestMethod.GET, url, params, Refund.class, options);
   }
 
@@ -307,7 +309,9 @@ public class Refund extends ApiResource implements BalanceTransactionSource, Met
   public static Refund retrieve(String refund, RefundRetrieveParams params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/refunds/%s", refund));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(), String.format("/v1/refunds/%s", ApiResource.urlEncodeId(refund)));
     return request(ApiResource.RequestMethod.GET, url, params, Refund.class, options);
   }
 
@@ -331,7 +335,10 @@ public class Refund extends ApiResource implements BalanceTransactionSource, Met
   @Override
   public Refund update(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/refunds/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/refunds/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Refund.class, options);
   }
 
@@ -353,7 +360,10 @@ public class Refund extends ApiResource implements BalanceTransactionSource, Met
    */
   public Refund update(RefundUpdateParams params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/refunds/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/refunds/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Refund.class, options);
   }
 }

--- a/src/main/java/com/stripe/model/RefundCollection.java
+++ b/src/main/java/com/stripe/model/RefundCollection.java
@@ -69,7 +69,10 @@ public class RefundCollection extends StripeCollection<Refund> {
   public Refund retrieve(String id, Map<String, Object> params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("%s/%s", this.getUrl(), id));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("%s/%s", this.getUrl(), ApiResource.urlEncodeId(id)));
     return ApiResource.request(ApiResource.RequestMethod.GET, url, params, Refund.class, options);
   }
 
@@ -77,7 +80,10 @@ public class RefundCollection extends StripeCollection<Refund> {
   public Refund retrieve(String id, RefundCollectionRetrieveParams params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("%s/%s", this.getUrl(), id));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("%s/%s", this.getUrl(), ApiResource.urlEncodeId(id)));
     return ApiResource.request(ApiResource.RequestMethod.GET, url, params, Refund.class, options);
   }
 }

--- a/src/main/java/com/stripe/model/Review.java
+++ b/src/main/java/com/stripe/model/Review.java
@@ -185,7 +185,9 @@ public class Review extends ApiResource implements HasId {
   public static Review retrieve(String review, Map<String, Object> params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/reviews/%s", review));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(), String.format("/v1/reviews/%s", ApiResource.urlEncodeId(review)));
     return request(ApiResource.RequestMethod.GET, url, params, Review.class, options);
   }
 
@@ -193,7 +195,9 @@ public class Review extends ApiResource implements HasId {
   public static Review retrieve(String review, ReviewRetrieveParams params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/reviews/%s", review));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(), String.format("/v1/reviews/%s", ApiResource.urlEncodeId(review)));
     return request(ApiResource.RequestMethod.GET, url, params, Review.class, options);
   }
 
@@ -216,7 +220,9 @@ public class Review extends ApiResource implements HasId {
   public Review approve(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/reviews/%s/approve", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/reviews/%s/approve", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Review.class, options);
   }
 
@@ -229,7 +235,9 @@ public class Review extends ApiResource implements HasId {
   public Review approve(ReviewApproveParams params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/reviews/%s/approve", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/reviews/%s/approve", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Review.class, options);
   }
 

--- a/src/main/java/com/stripe/model/Sku.java
+++ b/src/main/java/com/stripe/model/Sku.java
@@ -138,7 +138,9 @@ public class Sku extends ApiResource implements HasId, MetadataStore<Sku> {
    */
   public static Sku retrieve(String id, Map<String, Object> params, RequestOptions options)
       throws StripeException {
-    String url = String.format("%s%s", Stripe.getApiBase(), String.format("/v1/skus/%s", id));
+    String url =
+        String.format(
+            "%s%s", Stripe.getApiBase(), String.format("/v1/skus/%s", ApiResource.urlEncodeId(id)));
     return request(ApiResource.RequestMethod.GET, url, params, Sku.class, options);
   }
 
@@ -148,7 +150,9 @@ public class Sku extends ApiResource implements HasId, MetadataStore<Sku> {
    */
   public static Sku retrieve(String id, SkuRetrieveParams params, RequestOptions options)
       throws StripeException {
-    String url = String.format("%s%s", Stripe.getApiBase(), String.format("/v1/skus/%s", id));
+    String url =
+        String.format(
+            "%s%s", Stripe.getApiBase(), String.format("/v1/skus/%s", ApiResource.urlEncodeId(id)));
     return request(ApiResource.RequestMethod.GET, url, params, Sku.class, options);
   }
 
@@ -210,7 +214,10 @@ public class Sku extends ApiResource implements HasId, MetadataStore<Sku> {
   @Override
   public Sku update(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/skus/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/skus/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Sku.class, options);
   }
 
@@ -234,7 +241,10 @@ public class Sku extends ApiResource implements HasId, MetadataStore<Sku> {
    */
   public Sku update(SkuUpdateParams params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/skus/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/skus/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Sku.class, options);
   }
 
@@ -279,7 +289,10 @@ public class Sku extends ApiResource implements HasId, MetadataStore<Sku> {
   /** Delete a SKU. Deleting a SKU is only possible until it has been used in an order. */
   public Sku delete(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/skus/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/skus/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.DELETE, url, params, Sku.class, options);
   }
 

--- a/src/main/java/com/stripe/model/Source.java
+++ b/src/main/java/com/stripe/model/Source.java
@@ -197,7 +197,10 @@ public class Source extends ApiResource implements PaymentSource, MetadataStore<
           String.format(
               "%s%s",
               Stripe.getApiBase(),
-              String.format("/v1/customers/%s/sources/%s", this.getCustomer(), this.getId()));
+              String.format(
+                  "/v1/customers/%s/sources/%s",
+                  ApiResource.urlEncodeId(this.getCustomer()),
+                  ApiResource.urlEncodeId(this.getId())));
     } else {
       throw new InvalidRequestException(
           "Unable to construct url because [customer] field(s) are all null",
@@ -233,7 +236,9 @@ public class Source extends ApiResource implements PaymentSource, MetadataStore<
   public static Source retrieve(String source, Map<String, Object> params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/sources/%s", source));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(), String.format("/v1/sources/%s", ApiResource.urlEncodeId(source)));
     return request(ApiResource.RequestMethod.GET, url, params, Source.class, options);
   }
 
@@ -244,7 +249,9 @@ public class Source extends ApiResource implements PaymentSource, MetadataStore<
   public static Source retrieve(String source, SourceRetrieveParams params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/sources/%s", source));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(), String.format("/v1/sources/%s", ApiResource.urlEncodeId(source)));
     return request(ApiResource.RequestMethod.GET, url, params, Source.class, options);
   }
 
@@ -296,7 +303,10 @@ public class Source extends ApiResource implements PaymentSource, MetadataStore<
   @Override
   public Source update(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/sources/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/sources/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Source.class, options);
   }
 
@@ -322,7 +332,10 @@ public class Source extends ApiResource implements PaymentSource, MetadataStore<
    */
   public Source update(SourceUpdateParams params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/sources/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/sources/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Source.class, options);
   }
 
@@ -335,7 +348,9 @@ public class Source extends ApiResource implements PaymentSource, MetadataStore<
   public Source verify(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/sources/%s/verify", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/sources/%s/verify", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Source.class, options);
   }
 
@@ -348,7 +363,9 @@ public class Source extends ApiResource implements PaymentSource, MetadataStore<
   public Source verify(SourceVerifyParams params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/sources/%s/verify", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/sources/%s/verify", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Source.class, options);
   }
 
@@ -369,7 +386,9 @@ public class Source extends ApiResource implements PaymentSource, MetadataStore<
     String url =
         String.format(
             "%s%s",
-            Stripe.getApiBase(), String.format("/v1/sources/%s/source_transactions", this.getId()));
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/sources/%s/source_transactions", ApiResource.urlEncodeId(this.getId())));
     return requestCollection(url, params, SourceTransactionCollection.class, options);
   }
 
@@ -385,7 +404,9 @@ public class Source extends ApiResource implements PaymentSource, MetadataStore<
     String url =
         String.format(
             "%s%s",
-            Stripe.getApiBase(), String.format("/v1/sources/%s/source_transactions", this.getId()));
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/sources/%s/source_transactions", ApiResource.urlEncodeId(this.getId())));
     return requestCollection(url, params, SourceTransactionCollection.class, options);
   }
 

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -396,7 +396,9 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/subscriptions/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/subscriptions/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Subscription.class, options);
   }
 
@@ -420,7 +422,9 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/subscriptions/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/subscriptions/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Subscription.class, options);
   }
 
@@ -442,7 +446,8 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
     String url =
         String.format(
             "%s%s",
-            Stripe.getApiBase(), String.format("/v1/subscriptions/%s", subscriptionExposedId));
+            Stripe.getApiBase(),
+            String.format("/v1/subscriptions/%s", ApiResource.urlEncodeId(subscriptionExposedId)));
     return request(ApiResource.RequestMethod.GET, url, params, Subscription.class, options);
   }
 
@@ -453,7 +458,8 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
     String url =
         String.format(
             "%s%s",
-            Stripe.getApiBase(), String.format("/v1/subscriptions/%s", subscriptionExposedId));
+            Stripe.getApiBase(),
+            String.format("/v1/subscriptions/%s", ApiResource.urlEncodeId(subscriptionExposedId)));
     return request(ApiResource.RequestMethod.GET, url, params, Subscription.class, options);
   }
 
@@ -517,7 +523,9 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/subscriptions/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/subscriptions/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.DELETE, url, params, Subscription.class, options);
   }
 
@@ -561,7 +569,9 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/subscriptions/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/subscriptions/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.DELETE, url, params, Subscription.class, options);
   }
 
@@ -581,7 +591,8 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
     String url =
         String.format(
             "%s%s",
-            Stripe.getApiBase(), String.format("/v1/subscriptions/%s/discount", this.getId()));
+            Stripe.getApiBase(),
+            String.format("/v1/subscriptions/%s/discount", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.DELETE, url, params, Discount.class, options);
   }
 

--- a/src/main/java/com/stripe/model/SubscriptionItem.java
+++ b/src/main/java/com/stripe/model/SubscriptionItem.java
@@ -110,7 +110,9 @@ public class SubscriptionItem extends ApiResource
       String item, Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/subscription_items/%s", item));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/subscription_items/%s", ApiResource.urlEncodeId(item)));
     return request(ApiResource.RequestMethod.GET, url, params, SubscriptionItem.class, options);
   }
 
@@ -120,7 +122,9 @@ public class SubscriptionItem extends ApiResource
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/subscription_items/%s", item));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/subscription_items/%s", ApiResource.urlEncodeId(item)));
     return request(ApiResource.RequestMethod.GET, url, params, SubscriptionItem.class, options);
   }
 
@@ -161,7 +165,9 @@ public class SubscriptionItem extends ApiResource
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/subscription_items/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/subscription_items/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, SubscriptionItem.class, options);
   }
 
@@ -175,7 +181,9 @@ public class SubscriptionItem extends ApiResource
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/subscription_items/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/subscription_items/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, SubscriptionItem.class, options);
   }
 
@@ -211,7 +219,9 @@ public class SubscriptionItem extends ApiResource
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/subscription_items/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/subscription_items/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.DELETE, url, params, SubscriptionItem.class, options);
   }
 
@@ -231,7 +241,9 @@ public class SubscriptionItem extends ApiResource
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/subscription_items/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/subscription_items/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.DELETE, url, params, SubscriptionItem.class, options);
   }
 
@@ -280,7 +292,9 @@ public class SubscriptionItem extends ApiResource
         String.format(
             "%s%s",
             Stripe.getApiBase(),
-            String.format("/v1/subscription_items/%s/usage_record_summaries", this.getId()));
+            String.format(
+                "/v1/subscription_items/%s/usage_record_summaries",
+                ApiResource.urlEncodeId(this.getId())));
     return requestCollection(url, params, UsageRecordSummaryCollection.class, options);
   }
 
@@ -316,7 +330,9 @@ public class SubscriptionItem extends ApiResource
         String.format(
             "%s%s",
             Stripe.getApiBase(),
-            String.format("/v1/subscription_items/%s/usage_record_summaries", this.getId()));
+            String.format(
+                "/v1/subscription_items/%s/usage_record_summaries",
+                ApiResource.urlEncodeId(this.getId())));
     return requestCollection(url, params, UsageRecordSummaryCollection.class, options);
   }
 

--- a/src/main/java/com/stripe/model/SubscriptionSchedule.java
+++ b/src/main/java/com/stripe/model/SubscriptionSchedule.java
@@ -254,7 +254,9 @@ public class SubscriptionSchedule extends ApiResource
       String schedule, Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/subscription_schedules/%s", schedule));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/subscription_schedules/%s", ApiResource.urlEncodeId(schedule)));
     return request(ApiResource.RequestMethod.GET, url, params, SubscriptionSchedule.class, options);
   }
 
@@ -267,7 +269,9 @@ public class SubscriptionSchedule extends ApiResource
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/subscription_schedules/%s", schedule));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/subscription_schedules/%s", ApiResource.urlEncodeId(schedule)));
     return request(ApiResource.RequestMethod.GET, url, params, SubscriptionSchedule.class, options);
   }
 
@@ -284,7 +288,8 @@ public class SubscriptionSchedule extends ApiResource
     String url =
         String.format(
             "%s%s",
-            Stripe.getApiBase(), String.format("/v1/subscription_schedules/%s", this.getId()));
+            Stripe.getApiBase(),
+            String.format("/v1/subscription_schedules/%s", ApiResource.urlEncodeId(this.getId())));
     return request(
         ApiResource.RequestMethod.POST, url, params, SubscriptionSchedule.class, options);
   }
@@ -301,7 +306,8 @@ public class SubscriptionSchedule extends ApiResource
     String url =
         String.format(
             "%s%s",
-            Stripe.getApiBase(), String.format("/v1/subscription_schedules/%s", this.getId()));
+            Stripe.getApiBase(),
+            String.format("/v1/subscription_schedules/%s", ApiResource.urlEncodeId(this.getId())));
     return request(
         ApiResource.RequestMethod.POST, url, params, SubscriptionSchedule.class, options);
   }
@@ -344,7 +350,8 @@ public class SubscriptionSchedule extends ApiResource
         String.format(
             "%s%s",
             Stripe.getApiBase(),
-            String.format("/v1/subscription_schedules/%s/cancel", this.getId()));
+            String.format(
+                "/v1/subscription_schedules/%s/cancel", ApiResource.urlEncodeId(this.getId())));
     return request(
         ApiResource.RequestMethod.POST, url, params, SubscriptionSchedule.class, options);
   }
@@ -370,7 +377,8 @@ public class SubscriptionSchedule extends ApiResource
         String.format(
             "%s%s",
             Stripe.getApiBase(),
-            String.format("/v1/subscription_schedules/%s/cancel", this.getId()));
+            String.format(
+                "/v1/subscription_schedules/%s/cancel", ApiResource.urlEncodeId(this.getId())));
     return request(
         ApiResource.RequestMethod.POST, url, params, SubscriptionSchedule.class, options);
   }
@@ -421,7 +429,8 @@ public class SubscriptionSchedule extends ApiResource
         String.format(
             "%s%s",
             Stripe.getApiBase(),
-            String.format("/v1/subscription_schedules/%s/release", this.getId()));
+            String.format(
+                "/v1/subscription_schedules/%s/release", ApiResource.urlEncodeId(this.getId())));
     return request(
         ApiResource.RequestMethod.POST, url, params, SubscriptionSchedule.class, options);
   }
@@ -451,7 +460,8 @@ public class SubscriptionSchedule extends ApiResource
         String.format(
             "%s%s",
             Stripe.getApiBase(),
-            String.format("/v1/subscription_schedules/%s/release", this.getId()));
+            String.format(
+                "/v1/subscription_schedules/%s/release", ApiResource.urlEncodeId(this.getId())));
     return request(
         ApiResource.RequestMethod.POST, url, params, SubscriptionSchedule.class, options);
   }
@@ -474,7 +484,8 @@ public class SubscriptionSchedule extends ApiResource
         String.format(
             "%s%s",
             Stripe.getApiBase(),
-            String.format("/v1/subscription_schedules/%s/revisions", this.getId()));
+            String.format(
+                "/v1/subscription_schedules/%s/revisions", ApiResource.urlEncodeId(this.getId())));
     return requestCollection(url, params, SubscriptionScheduleRevisionCollection.class, options);
   }
 
@@ -491,7 +502,8 @@ public class SubscriptionSchedule extends ApiResource
         String.format(
             "%s%s",
             Stripe.getApiBase(),
-            String.format("/v1/subscription_schedules/%s/revisions", this.getId()));
+            String.format(
+                "/v1/subscription_schedules/%s/revisions", ApiResource.urlEncodeId(this.getId())));
     return requestCollection(url, params, SubscriptionScheduleRevisionCollection.class, options);
   }
 

--- a/src/main/java/com/stripe/model/SubscriptionScheduleRevisionCollection.java
+++ b/src/main/java/com/stripe/model/SubscriptionScheduleRevisionCollection.java
@@ -68,7 +68,10 @@ public class SubscriptionScheduleRevisionCollection
   public SubscriptionScheduleRevision retrieve(
       String id, Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("%s/%s", this.getUrl(), id));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("%s/%s", this.getUrl(), ApiResource.urlEncodeId(id)));
     return ApiResource.request(
         ApiResource.RequestMethod.GET, url, params, SubscriptionScheduleRevision.class, options);
   }
@@ -84,7 +87,10 @@ public class SubscriptionScheduleRevisionCollection
       RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("%s/%s", this.getUrl(), id));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("%s/%s", this.getUrl(), ApiResource.urlEncodeId(id)));
     return ApiResource.request(
         ApiResource.RequestMethod.GET, url, params, SubscriptionScheduleRevision.class, options);
   }

--- a/src/main/java/com/stripe/model/ThreeDSecure.java
+++ b/src/main/java/com/stripe/model/ThreeDSecure.java
@@ -92,7 +92,10 @@ public class ThreeDSecure extends ApiResource implements HasId {
       String threeDSecure, Map<String, Object> params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/3d_secure/%s", threeDSecure));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/3d_secure/%s", ApiResource.urlEncodeId(threeDSecure)));
     return request(ApiResource.RequestMethod.GET, url, params, ThreeDSecure.class, options);
   }
 
@@ -101,7 +104,10 @@ public class ThreeDSecure extends ApiResource implements HasId {
       String threeDSecure, ThreeDSecureRetrieveParams params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/3d_secure/%s", threeDSecure));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/3d_secure/%s", ApiResource.urlEncodeId(threeDSecure)));
     return request(ApiResource.RequestMethod.GET, url, params, ThreeDSecure.class, options);
   }
 

--- a/src/main/java/com/stripe/model/Token.java
+++ b/src/main/java/com/stripe/model/Token.java
@@ -76,14 +76,20 @@ public class Token extends ApiResource implements HasId {
   /** Retrieves the token with the given ID. */
   public static Token retrieve(String token, Map<String, Object> params, RequestOptions options)
       throws StripeException {
-    String url = String.format("%s%s", Stripe.getApiBase(), String.format("/v1/tokens/%s", token));
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(), String.format("/v1/tokens/%s", ApiResource.urlEncodeId(token)));
     return request(ApiResource.RequestMethod.GET, url, params, Token.class, options);
   }
 
   /** Retrieves the token with the given ID. */
   public static Token retrieve(String token, TokenRetrieveParams params, RequestOptions options)
       throws StripeException {
-    String url = String.format("%s%s", Stripe.getApiBase(), String.format("/v1/tokens/%s", token));
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(), String.format("/v1/tokens/%s", ApiResource.urlEncodeId(token)));
     return request(ApiResource.RequestMethod.GET, url, params, Token.class, options);
   }
 

--- a/src/main/java/com/stripe/model/Topup.java
+++ b/src/main/java/com/stripe/model/Topup.java
@@ -203,7 +203,10 @@ public class Topup extends ApiResource implements BalanceTransactionSource, Meta
    */
   public static Topup retrieve(String topup, Map<String, Object> params, RequestOptions options)
       throws StripeException {
-    String url = String.format("%s%s", Stripe.getApiBase(), String.format("/v1/topups/%s", topup));
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(), String.format("/v1/topups/%s", ApiResource.urlEncodeId(topup)));
     return request(ApiResource.RequestMethod.GET, url, params, Topup.class, options);
   }
 
@@ -214,7 +217,10 @@ public class Topup extends ApiResource implements BalanceTransactionSource, Meta
    */
   public static Topup retrieve(String topup, TopupRetrieveParams params, RequestOptions options)
       throws StripeException {
-    String url = String.format("%s%s", Stripe.getApiBase(), String.format("/v1/topups/%s", topup));
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(), String.format("/v1/topups/%s", ApiResource.urlEncodeId(topup)));
     return request(ApiResource.RequestMethod.GET, url, params, Topup.class, options);
   }
 
@@ -228,7 +234,10 @@ public class Topup extends ApiResource implements BalanceTransactionSource, Meta
   @Override
   public Topup update(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/topups/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/topups/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Topup.class, options);
   }
 
@@ -240,7 +249,10 @@ public class Topup extends ApiResource implements BalanceTransactionSource, Meta
   /** Updates the metadata of a top-up. Other top-up details are not editable by design. */
   public Topup update(TopupUpdateParams params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/topups/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/topups/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Topup.class, options);
   }
 
@@ -263,7 +275,9 @@ public class Topup extends ApiResource implements BalanceTransactionSource, Meta
   public Topup cancel(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/topups/%s/cancel", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/topups/%s/cancel", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Topup.class, options);
   }
 
@@ -276,7 +290,9 @@ public class Topup extends ApiResource implements BalanceTransactionSource, Meta
   public Topup cancel(TopupCancelParams params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/topups/%s/cancel", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/topups/%s/cancel", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Topup.class, options);
   }
 }

--- a/src/main/java/com/stripe/model/Transfer.java
+++ b/src/main/java/com/stripe/model/Transfer.java
@@ -301,7 +301,10 @@ public class Transfer extends ApiResource
   public static Transfer retrieve(
       String transfer, Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/transfers/%s", transfer));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/transfers/%s", ApiResource.urlEncodeId(transfer)));
     return request(ApiResource.RequestMethod.GET, url, params, Transfer.class, options);
   }
 
@@ -314,7 +317,10 @@ public class Transfer extends ApiResource
       String transfer, TransferRetrieveParams params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/transfers/%s", transfer));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/transfers/%s", ApiResource.urlEncodeId(transfer)));
     return request(ApiResource.RequestMethod.GET, url, params, Transfer.class, options);
   }
 
@@ -339,7 +345,10 @@ public class Transfer extends ApiResource
   public Transfer update(Map<String, Object> params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/transfers/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/transfers/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Transfer.class, options);
   }
 
@@ -362,7 +371,10 @@ public class Transfer extends ApiResource
   public Transfer update(TransferUpdateParams params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/transfers/%s", this.getId()));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/transfers/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Transfer.class, options);
   }
 }

--- a/src/main/java/com/stripe/model/TransferReversal.java
+++ b/src/main/java/com/stripe/model/TransferReversal.java
@@ -178,7 +178,10 @@ public class TransferReversal extends ApiResource
           String.format(
               "%s%s",
               Stripe.getApiBase(),
-              String.format("/v1/transfers/%s/reversals/%s", this.getTransfer(), this.getId()));
+              String.format(
+                  "/v1/transfers/%s/reversals/%s",
+                  ApiResource.urlEncodeId(this.getTransfer()),
+                  ApiResource.urlEncodeId(this.getId())));
     } else {
       throw new InvalidRequestException(
           "Unable to construct url because [transfer] field(s) are all null",
@@ -215,7 +218,10 @@ public class TransferReversal extends ApiResource
           String.format(
               "%s%s",
               Stripe.getApiBase(),
-              String.format("/v1/transfers/%s/reversals/%s", this.getTransfer(), this.getId()));
+              String.format(
+                  "/v1/transfers/%s/reversals/%s",
+                  ApiResource.urlEncodeId(this.getTransfer()),
+                  ApiResource.urlEncodeId(this.getId())));
     } else {
       throw new InvalidRequestException(
           "Unable to construct url because [transfer] field(s) are all null",

--- a/src/main/java/com/stripe/model/TransferReversalCollection.java
+++ b/src/main/java/com/stripe/model/TransferReversalCollection.java
@@ -144,7 +144,10 @@ public class TransferReversalCollection extends StripeCollection<TransferReversa
   public TransferReversal retrieve(String id, Map<String, Object> params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("%s/%s", this.getUrl(), id));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("%s/%s", this.getUrl(), ApiResource.urlEncodeId(id)));
     return ApiResource.request(
         ApiResource.RequestMethod.GET, url, params, TransferReversal.class, options);
   }
@@ -157,7 +160,10 @@ public class TransferReversalCollection extends StripeCollection<TransferReversa
       String id, TransferReversalCollectionRetrieveParams params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("%s/%s", this.getUrl(), id));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("%s/%s", this.getUrl(), ApiResource.urlEncodeId(id)));
     return ApiResource.request(
         ApiResource.RequestMethod.GET, url, params, TransferReversal.class, options);
   }

--- a/src/main/java/com/stripe/model/UsageRecord.java
+++ b/src/main/java/com/stripe/model/UsageRecord.java
@@ -74,7 +74,9 @@ public class UsageRecord extends ApiResource implements HasId {
         String.format(
             "%s%s",
             Stripe.getApiBase(),
-            String.format("/v1/subscription_items/%s/usage_records", subscriptionItem));
+            String.format(
+                "/v1/subscription_items/%s/usage_records",
+                ApiResource.urlEncodeId(subscriptionItem)));
     return request(ApiResource.RequestMethod.POST, url, params, UsageRecord.class, options);
   }
 
@@ -109,7 +111,9 @@ public class UsageRecord extends ApiResource implements HasId {
         String.format(
             "%s%s",
             Stripe.getApiBase(),
-            String.format("/v1/subscription_items/%s/usage_records", subscriptionItem));
+            String.format(
+                "/v1/subscription_items/%s/usage_records",
+                ApiResource.urlEncodeId(subscriptionItem)));
     return request(ApiResource.RequestMethod.POST, url, params, UsageRecord.class, options);
   }
 }

--- a/src/main/java/com/stripe/model/WebhookEndpoint.java
+++ b/src/main/java/com/stripe/model/WebhookEndpoint.java
@@ -117,7 +117,8 @@ public class WebhookEndpoint extends ApiResource implements HasId {
     String url =
         String.format(
             "%s%s",
-            Stripe.getApiBase(), String.format("/v1/webhook_endpoints/%s", webhookEndpoint));
+            Stripe.getApiBase(),
+            String.format("/v1/webhook_endpoints/%s", ApiResource.urlEncodeId(webhookEndpoint)));
     return request(ApiResource.RequestMethod.GET, url, params, WebhookEndpoint.class, options);
   }
 
@@ -128,7 +129,8 @@ public class WebhookEndpoint extends ApiResource implements HasId {
     String url =
         String.format(
             "%s%s",
-            Stripe.getApiBase(), String.format("/v1/webhook_endpoints/%s", webhookEndpoint));
+            Stripe.getApiBase(),
+            String.format("/v1/webhook_endpoints/%s", ApiResource.urlEncodeId(webhookEndpoint)));
     return request(ApiResource.RequestMethod.GET, url, params, WebhookEndpoint.class, options);
   }
 
@@ -204,7 +206,9 @@ public class WebhookEndpoint extends ApiResource implements HasId {
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/webhook_endpoints/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/webhook_endpoints/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, WebhookEndpoint.class, options);
   }
 
@@ -224,7 +228,9 @@ public class WebhookEndpoint extends ApiResource implements HasId {
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/webhook_endpoints/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/webhook_endpoints/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, WebhookEndpoint.class, options);
   }
 
@@ -264,7 +270,9 @@ public class WebhookEndpoint extends ApiResource implements HasId {
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/webhook_endpoints/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/webhook_endpoints/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.DELETE, url, params, WebhookEndpoint.class, options);
   }
 }

--- a/src/main/java/com/stripe/model/issuing/Authorization.java
+++ b/src/main/java/com/stripe/model/issuing/Authorization.java
@@ -224,7 +224,8 @@ public class Authorization extends ApiResource
     String url =
         String.format(
             "%s%s",
-            Stripe.getApiBase(), String.format("/v1/issuing/authorizations/%s", authorization));
+            Stripe.getApiBase(),
+            String.format("/v1/issuing/authorizations/%s", ApiResource.urlEncodeId(authorization)));
     return request(ApiResource.RequestMethod.GET, url, params, Authorization.class, options);
   }
 
@@ -235,7 +236,8 @@ public class Authorization extends ApiResource
     String url =
         String.format(
             "%s%s",
-            Stripe.getApiBase(), String.format("/v1/issuing/authorizations/%s", authorization));
+            Stripe.getApiBase(),
+            String.format("/v1/issuing/authorizations/%s", ApiResource.urlEncodeId(authorization)));
     return request(ApiResource.RequestMethod.GET, url, params, Authorization.class, options);
   }
 
@@ -258,7 +260,8 @@ public class Authorization extends ApiResource
     String url =
         String.format(
             "%s%s",
-            Stripe.getApiBase(), String.format("/v1/issuing/authorizations/%s", this.getId()));
+            Stripe.getApiBase(),
+            String.format("/v1/issuing/authorizations/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Authorization.class, options);
   }
 
@@ -279,7 +282,8 @@ public class Authorization extends ApiResource
     String url =
         String.format(
             "%s%s",
-            Stripe.getApiBase(), String.format("/v1/issuing/authorizations/%s", this.getId()));
+            Stripe.getApiBase(),
+            String.format("/v1/issuing/authorizations/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Authorization.class, options);
   }
 
@@ -305,7 +309,8 @@ public class Authorization extends ApiResource
         String.format(
             "%s%s",
             Stripe.getApiBase(),
-            String.format("/v1/issuing/authorizations/%s/approve", this.getId()));
+            String.format(
+                "/v1/issuing/authorizations/%s/approve", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Authorization.class, options);
   }
 
@@ -321,7 +326,8 @@ public class Authorization extends ApiResource
         String.format(
             "%s%s",
             Stripe.getApiBase(),
-            String.format("/v1/issuing/authorizations/%s/approve", this.getId()));
+            String.format(
+                "/v1/issuing/authorizations/%s/approve", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Authorization.class, options);
   }
 
@@ -347,7 +353,8 @@ public class Authorization extends ApiResource
         String.format(
             "%s%s",
             Stripe.getApiBase(),
-            String.format("/v1/issuing/authorizations/%s/decline", this.getId()));
+            String.format(
+                "/v1/issuing/authorizations/%s/decline", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Authorization.class, options);
   }
 
@@ -363,7 +370,8 @@ public class Authorization extends ApiResource
         String.format(
             "%s%s",
             Stripe.getApiBase(),
-            String.format("/v1/issuing/authorizations/%s/decline", this.getId()));
+            String.format(
+                "/v1/issuing/authorizations/%s/decline", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Authorization.class, options);
   }
 

--- a/src/main/java/com/stripe/model/issuing/Card.java
+++ b/src/main/java/com/stripe/model/issuing/Card.java
@@ -177,7 +177,10 @@ public class Card extends ApiResource implements HasId, MetadataStore<Card> {
   public static Card retrieve(String card, Map<String, Object> params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/issuing/cards/%s", card));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/issuing/cards/%s", ApiResource.urlEncodeId(card)));
     return request(ApiResource.RequestMethod.GET, url, params, Card.class, options);
   }
 
@@ -185,7 +188,10 @@ public class Card extends ApiResource implements HasId, MetadataStore<Card> {
   public static Card retrieve(String card, CardRetrieveParams params, RequestOptions options)
       throws StripeException {
     String url =
-        String.format("%s%s", Stripe.getApiBase(), String.format("/v1/issuing/cards/%s", card));
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/issuing/cards/%s", ApiResource.urlEncodeId(card)));
     return request(ApiResource.RequestMethod.GET, url, params, Card.class, options);
   }
 
@@ -206,7 +212,9 @@ public class Card extends ApiResource implements HasId, MetadataStore<Card> {
   public Card update(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/issuing/cards/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/issuing/cards/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Card.class, options);
   }
 
@@ -225,7 +233,9 @@ public class Card extends ApiResource implements HasId, MetadataStore<Card> {
   public Card update(CardUpdateParams params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/issuing/cards/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/issuing/cards/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Card.class, options);
   }
 
@@ -257,7 +267,8 @@ public class Card extends ApiResource implements HasId, MetadataStore<Card> {
     String url =
         String.format(
             "%s%s",
-            Stripe.getApiBase(), String.format("/v1/issuing/cards/%s/details", this.getId()));
+            Stripe.getApiBase(),
+            String.format("/v1/issuing/cards/%s/details", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.GET, url, params, CardDetails.class, options);
   }
 
@@ -280,7 +291,8 @@ public class Card extends ApiResource implements HasId, MetadataStore<Card> {
     String url =
         String.format(
             "%s%s",
-            Stripe.getApiBase(), String.format("/v1/issuing/cards/%s/details", this.getId()));
+            Stripe.getApiBase(),
+            String.format("/v1/issuing/cards/%s/details", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.GET, url, params, CardDetails.class, options);
   }
 

--- a/src/main/java/com/stripe/model/issuing/Cardholder.java
+++ b/src/main/java/com/stripe/model/issuing/Cardholder.java
@@ -160,7 +160,9 @@ public class Cardholder extends ApiResource implements HasId, MetadataStore<Card
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/issuing/cardholders/%s", cardholder));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/issuing/cardholders/%s", ApiResource.urlEncodeId(cardholder)));
     return request(ApiResource.RequestMethod.GET, url, params, Cardholder.class, options);
   }
 
@@ -170,7 +172,9 @@ public class Cardholder extends ApiResource implements HasId, MetadataStore<Card
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/issuing/cardholders/%s", cardholder));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/issuing/cardholders/%s", ApiResource.urlEncodeId(cardholder)));
     return request(ApiResource.RequestMethod.GET, url, params, Cardholder.class, options);
   }
 
@@ -192,7 +196,9 @@ public class Cardholder extends ApiResource implements HasId, MetadataStore<Card
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/issuing/cardholders/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/issuing/cardholders/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Cardholder.class, options);
   }
 
@@ -212,7 +218,9 @@ public class Cardholder extends ApiResource implements HasId, MetadataStore<Card
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/issuing/cardholders/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/issuing/cardholders/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Cardholder.class, options);
   }
 

--- a/src/main/java/com/stripe/model/issuing/Dispute.java
+++ b/src/main/java/com/stripe/model/issuing/Dispute.java
@@ -178,7 +178,9 @@ public class Dispute extends ApiResource implements HasId, MetadataStore<Dispute
   public Dispute update(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/issuing/disputes/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/issuing/disputes/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Dispute.class, options);
   }
 
@@ -197,7 +199,9 @@ public class Dispute extends ApiResource implements HasId, MetadataStore<Dispute
   public Dispute update(DisputeUpdateParams params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/issuing/disputes/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/issuing/disputes/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Dispute.class, options);
   }
 
@@ -216,7 +220,9 @@ public class Dispute extends ApiResource implements HasId, MetadataStore<Dispute
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/issuing/disputes/%s", dispute));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/issuing/disputes/%s", ApiResource.urlEncodeId(dispute)));
     return request(ApiResource.RequestMethod.GET, url, params, Dispute.class, options);
   }
 
@@ -225,7 +231,9 @@ public class Dispute extends ApiResource implements HasId, MetadataStore<Dispute
       String dispute, DisputeRetrieveParams params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/issuing/disputes/%s", dispute));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/issuing/disputes/%s", ApiResource.urlEncodeId(dispute)));
     return request(ApiResource.RequestMethod.GET, url, params, Dispute.class, options);
   }
 

--- a/src/main/java/com/stripe/model/issuing/Transaction.java
+++ b/src/main/java/com/stripe/model/issuing/Transaction.java
@@ -244,7 +244,9 @@ public class Transaction extends ApiResource
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/issuing/transactions/%s", transaction));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/issuing/transactions/%s", ApiResource.urlEncodeId(transaction)));
     return request(ApiResource.RequestMethod.GET, url, params, Transaction.class, options);
   }
 
@@ -254,7 +256,9 @@ public class Transaction extends ApiResource
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/issuing/transactions/%s", transaction));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/issuing/transactions/%s", ApiResource.urlEncodeId(transaction)));
     return request(ApiResource.RequestMethod.GET, url, params, Transaction.class, options);
   }
 
@@ -277,7 +281,8 @@ public class Transaction extends ApiResource
     String url =
         String.format(
             "%s%s",
-            Stripe.getApiBase(), String.format("/v1/issuing/transactions/%s", this.getId()));
+            Stripe.getApiBase(),
+            String.format("/v1/issuing/transactions/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Transaction.class, options);
   }
 
@@ -298,7 +303,8 @@ public class Transaction extends ApiResource
     String url =
         String.format(
             "%s%s",
-            Stripe.getApiBase(), String.format("/v1/issuing/transactions/%s", this.getId()));
+            Stripe.getApiBase(),
+            String.format("/v1/issuing/transactions/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Transaction.class, options);
   }
 }

--- a/src/main/java/com/stripe/model/radar/ValueList.java
+++ b/src/main/java/com/stripe/model/radar/ValueList.java
@@ -129,7 +129,9 @@ public class ValueList extends ApiResource implements HasId, MetadataStore<Value
       String valueList, Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/radar/value_lists/%s", valueList));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/radar/value_lists/%s", ApiResource.urlEncodeId(valueList)));
     return request(ApiResource.RequestMethod.GET, url, params, ValueList.class, options);
   }
 
@@ -139,7 +141,9 @@ public class ValueList extends ApiResource implements HasId, MetadataStore<Value
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/radar/value_lists/%s", valueList));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/radar/value_lists/%s", ApiResource.urlEncodeId(valueList)));
     return request(ApiResource.RequestMethod.GET, url, params, ValueList.class, options);
   }
 
@@ -185,7 +189,9 @@ public class ValueList extends ApiResource implements HasId, MetadataStore<Value
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/radar/value_lists/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/radar/value_lists/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, ValueList.class, options);
   }
 
@@ -205,7 +211,9 @@ public class ValueList extends ApiResource implements HasId, MetadataStore<Value
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/radar/value_lists/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/radar/value_lists/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, ValueList.class, options);
   }
 
@@ -241,7 +249,9 @@ public class ValueList extends ApiResource implements HasId, MetadataStore<Value
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/radar/value_lists/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/radar/value_lists/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.DELETE, url, params, ValueList.class, options);
   }
 }

--- a/src/main/java/com/stripe/model/radar/ValueListItem.java
+++ b/src/main/java/com/stripe/model/radar/ValueListItem.java
@@ -108,7 +108,9 @@ public class ValueListItem extends ApiResource implements HasId {
       String item, Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/radar/value_list_items/%s", item));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/radar/value_list_items/%s", ApiResource.urlEncodeId(item)));
     return request(ApiResource.RequestMethod.GET, url, params, ValueListItem.class, options);
   }
 
@@ -118,7 +120,9 @@ public class ValueListItem extends ApiResource implements HasId {
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/radar/value_list_items/%s", item));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/radar/value_list_items/%s", ApiResource.urlEncodeId(item)));
     return request(ApiResource.RequestMethod.GET, url, params, ValueListItem.class, options);
   }
 
@@ -179,7 +183,8 @@ public class ValueListItem extends ApiResource implements HasId {
     String url =
         String.format(
             "%s%s",
-            Stripe.getApiBase(), String.format("/v1/radar/value_list_items/%s", this.getId()));
+            Stripe.getApiBase(),
+            String.format("/v1/radar/value_list_items/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.DELETE, url, params, ValueListItem.class, options);
   }
 }

--- a/src/main/java/com/stripe/model/reporting/ReportRun.java
+++ b/src/main/java/com/stripe/model/reporting/ReportRun.java
@@ -104,7 +104,9 @@ public class ReportRun extends ApiResource implements HasId {
       String reportRun, Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/reporting/report_runs/%s", reportRun));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/reporting/report_runs/%s", ApiResource.urlEncodeId(reportRun)));
     return request(ApiResource.RequestMethod.GET, url, params, ReportRun.class, options);
   }
 
@@ -117,7 +119,9 @@ public class ReportRun extends ApiResource implements HasId {
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/reporting/report_runs/%s", reportRun));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/reporting/report_runs/%s", ApiResource.urlEncodeId(reportRun)));
     return request(ApiResource.RequestMethod.GET, url, params, ReportRun.class, options);
   }
 

--- a/src/main/java/com/stripe/model/reporting/ReportType.java
+++ b/src/main/java/com/stripe/model/reporting/ReportType.java
@@ -96,7 +96,8 @@ public class ReportType extends ApiResource implements HasId {
     String url =
         String.format(
             "%s%s",
-            Stripe.getApiBase(), String.format("/v1/reporting/report_types/%s", reportType));
+            Stripe.getApiBase(),
+            String.format("/v1/reporting/report_types/%s", ApiResource.urlEncodeId(reportType)));
     return request(ApiResource.RequestMethod.GET, url, params, ReportType.class, options);
   }
 
@@ -110,7 +111,8 @@ public class ReportType extends ApiResource implements HasId {
     String url =
         String.format(
             "%s%s",
-            Stripe.getApiBase(), String.format("/v1/reporting/report_types/%s", reportType));
+            Stripe.getApiBase(),
+            String.format("/v1/reporting/report_types/%s", ApiResource.urlEncodeId(reportType)));
     return request(ApiResource.RequestMethod.GET, url, params, ReportType.class, options);
   }
 

--- a/src/main/java/com/stripe/model/sigma/ScheduledQueryRun.java
+++ b/src/main/java/com/stripe/model/sigma/ScheduledQueryRun.java
@@ -116,7 +116,8 @@ public class ScheduledQueryRun extends ApiResource implements HasId {
         String.format(
             "%s%s",
             Stripe.getApiBase(),
-            String.format("/v1/sigma/scheduled_query_runs/%s", scheduledQueryRun));
+            String.format(
+                "/v1/sigma/scheduled_query_runs/%s", ApiResource.urlEncodeId(scheduledQueryRun)));
     return request(ApiResource.RequestMethod.GET, url, params, ScheduledQueryRun.class, options);
   }
 
@@ -128,7 +129,8 @@ public class ScheduledQueryRun extends ApiResource implements HasId {
         String.format(
             "%s%s",
             Stripe.getApiBase(),
-            String.format("/v1/sigma/scheduled_query_runs/%s", scheduledQueryRun));
+            String.format(
+                "/v1/sigma/scheduled_query_runs/%s", ApiResource.urlEncodeId(scheduledQueryRun)));
     return request(ApiResource.RequestMethod.GET, url, params, ScheduledQueryRun.class, options);
   }
 

--- a/src/main/java/com/stripe/model/terminal/Location.java
+++ b/src/main/java/com/stripe/model/terminal/Location.java
@@ -58,7 +58,9 @@ public class Location extends ApiResource implements HasId {
       String location, Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/terminal/locations/%s", location));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/terminal/locations/%s", ApiResource.urlEncodeId(location)));
     return request(ApiResource.RequestMethod.GET, url, params, Location.class, options);
   }
 
@@ -68,7 +70,9 @@ public class Location extends ApiResource implements HasId {
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/terminal/locations/%s", location));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/terminal/locations/%s", ApiResource.urlEncodeId(location)));
     return request(ApiResource.RequestMethod.GET, url, params, Location.class, options);
   }
 
@@ -112,7 +116,9 @@ public class Location extends ApiResource implements HasId {
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/terminal/locations/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/terminal/locations/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Location.class, options);
   }
 
@@ -132,7 +138,9 @@ public class Location extends ApiResource implements HasId {
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/terminal/locations/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/terminal/locations/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Location.class, options);
   }
 
@@ -180,7 +188,9 @@ public class Location extends ApiResource implements HasId {
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/terminal/locations/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/terminal/locations/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.DELETE, url, params, Location.class, options);
   }
 
@@ -194,7 +204,9 @@ public class Location extends ApiResource implements HasId {
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/terminal/locations/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/terminal/locations/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.DELETE, url, params, Location.class, options);
   }
 }

--- a/src/main/java/com/stripe/model/terminal/Reader.java
+++ b/src/main/java/com/stripe/model/terminal/Reader.java
@@ -78,7 +78,9 @@ public class Reader extends ApiResource implements HasId {
   public Reader update(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/terminal/readers/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/terminal/readers/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Reader.class, options);
   }
 
@@ -97,7 +99,9 @@ public class Reader extends ApiResource implements HasId {
   public Reader update(ReaderUpdateParams params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/terminal/readers/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/terminal/readers/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.POST, url, params, Reader.class, options);
   }
 
@@ -116,7 +120,9 @@ public class Reader extends ApiResource implements HasId {
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/terminal/readers/%s", reader));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/terminal/readers/%s", ApiResource.urlEncodeId(reader)));
     return request(ApiResource.RequestMethod.GET, url, params, Reader.class, options);
   }
 
@@ -125,7 +131,9 @@ public class Reader extends ApiResource implements HasId {
       throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/terminal/readers/%s", reader));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/terminal/readers/%s", ApiResource.urlEncodeId(reader)));
     return request(ApiResource.RequestMethod.GET, url, params, Reader.class, options);
   }
 
@@ -196,7 +204,9 @@ public class Reader extends ApiResource implements HasId {
   public Reader delete(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/terminal/readers/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/terminal/readers/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.DELETE, url, params, Reader.class, options);
   }
 
@@ -209,7 +219,9 @@ public class Reader extends ApiResource implements HasId {
   public Reader delete(ReaderDeleteParams params, RequestOptions options) throws StripeException {
     String url =
         String.format(
-            "%s%s", Stripe.getApiBase(), String.format("/v1/terminal/readers/%s", this.getId()));
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/terminal/readers/%s", ApiResource.urlEncodeId(this.getId())));
     return request(ApiResource.RequestMethod.DELETE, url, params, Reader.class, options);
   }
 }

--- a/src/main/java/com/stripe/net/ApiResource.java
+++ b/src/main/java/com/stripe/net/ApiResource.java
@@ -156,6 +156,20 @@ public abstract class ApiResource extends StripeObject {
     }
   }
 
+  /**
+   * URL-encode a string ID in url path formatting.
+   */
+  public static String urlEncodeId(String id) throws InvalidRequestException {
+    try {
+      return urlEncode(id);
+    } catch (UnsupportedEncodingException e) {
+      throw new InvalidRequestException(String.format(
+          "Unable to encode `%s` in the url to %s. "
+          + "Please contact support@stripe.com for assistance.", id, CHARSET),
+          null, null, null, 0, e);
+    }
+  }
+
   public static <T> T multipartRequest(ApiResource.RequestMethod method,
                      String url, Map<String, Object> params, Class<T> clazz,
                      RequestOptions options) throws StripeException {

--- a/src/main/java/com/stripe/param/ChargeUpdateParams.java
+++ b/src/main/java/com/stripe/param/ChargeUpdateParams.java
@@ -4,6 +4,7 @@ package com.stripe.param;
 
 import com.google.gson.annotations.SerializedName;
 import com.stripe.net.ApiRequestParams;
+import com.stripe.param.common.EmptyParam;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -233,9 +234,9 @@ public class ChargeUpdateParams extends ApiRequestParams {
 
   public static class FraudDetails {
     @SerializedName("user_report")
-    UserReport userReport;
+    ApiRequestParams.EnumParam userReport;
 
-    private FraudDetails(UserReport userReport) {
+    private FraudDetails(ApiRequestParams.EnumParam userReport) {
       this.userReport = userReport;
     }
 
@@ -244,7 +245,7 @@ public class ChargeUpdateParams extends ApiRequestParams {
     }
 
     public static class Builder {
-      private UserReport userReport;
+      private ApiRequestParams.EnumParam userReport;
 
       /** Finalize and obtain parameter instance from this builder. */
       public FraudDetails build() {
@@ -252,6 +253,11 @@ public class ChargeUpdateParams extends ApiRequestParams {
       }
 
       public Builder setUserReport(UserReport userReport) {
+        this.userReport = userReport;
+        return this;
+      }
+
+      public Builder setUserReport(EmptyParam userReport) {
         this.userReport = userReport;
         return this;
       }

--- a/src/main/java/com/stripe/param/CustomerCreateParams.java
+++ b/src/main/java/com/stripe/param/CustomerCreateParams.java
@@ -280,12 +280,17 @@ public class CustomerCreateParams extends ApiRequestParams {
     @SerializedName("custom_fields")
     Object customFields;
 
+    /** ID of the default payment method for the customer. */
+    @SerializedName("default_payment_method")
+    String defaultPaymentMethod;
+
     /** Default footer to be displayed on invoices for this customer. */
     @SerializedName("footer")
     String footer;
 
-    private InvoiceSettings(Object customFields, String footer) {
+    private InvoiceSettings(Object customFields, String defaultPaymentMethod, String footer) {
       this.customFields = customFields;
+      this.defaultPaymentMethod = defaultPaymentMethod;
       this.footer = footer;
     }
 
@@ -296,11 +301,13 @@ public class CustomerCreateParams extends ApiRequestParams {
     public static class Builder {
       private Object customFields;
 
+      private String defaultPaymentMethod;
+
       private String footer;
 
       /** Finalize and obtain parameter instance from this builder. */
       public InvoiceSettings build() {
-        return new InvoiceSettings(this.customFields, this.footer);
+        return new InvoiceSettings(this.customFields, this.defaultPaymentMethod, this.footer);
       }
 
       /** Default custom fields to be displayed on invoices for this customer. */
@@ -312,6 +319,12 @@ public class CustomerCreateParams extends ApiRequestParams {
       /** Default custom fields to be displayed on invoices for this customer. */
       public Builder setCustomFields(List<CustomField> customFields) {
         this.customFields = customFields;
+        return this;
+      }
+
+      /** ID of the default payment method for the customer. */
+      public Builder setDefaultPaymentMethod(String defaultPaymentMethod) {
+        this.defaultPaymentMethod = defaultPaymentMethod;
         return this;
       }
 

--- a/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
@@ -44,6 +44,21 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
   Boolean confirm;
 
   /**
+   * One of `automatic` (default) or `manual`.
+   *
+   * <p>When the confirmation method is `automatic`, a PaymentIntent can be confirmed using a
+   * publishable key. After `next_action`s are handled, no additional confirmation is required to
+   * complete the payment.
+   *
+   * <p>When the confirmation method is `manual`, all payment attempts must be made using a secret
+   * key. The PaymentIntent will return to the `requires_confirmation` state after handling
+   * `next_action`s, and requires your server to initiate each payment attempt with an explicit
+   * confirmation.
+   */
+  @SerializedName("confirmation_method")
+  ConfirmationMethod confirmationMethod;
+
+  /**
    * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in
    * lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
    */
@@ -145,6 +160,7 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       Long applicationFeeAmount,
       CaptureMethod captureMethod,
       Boolean confirm,
+      ConfirmationMethod confirmationMethod,
       String currency,
       String customer,
       String description,
@@ -165,6 +181,7 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     this.applicationFeeAmount = applicationFeeAmount;
     this.captureMethod = captureMethod;
     this.confirm = confirm;
+    this.confirmationMethod = confirmationMethod;
     this.currency = currency;
     this.customer = customer;
     this.description = description;
@@ -195,6 +212,8 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     private CaptureMethod captureMethod;
 
     private Boolean confirm;
+
+    private ConfirmationMethod confirmationMethod;
 
     private String currency;
 
@@ -235,6 +254,7 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
           this.applicationFeeAmount,
           this.captureMethod,
           this.confirm,
+          this.confirmationMethod,
           this.currency,
           this.customer,
           this.description,
@@ -290,6 +310,23 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
      */
     public Builder setConfirm(Boolean confirm) {
       this.confirm = confirm;
+      return this;
+    }
+
+    /**
+     * One of `automatic` (default) or `manual`.
+     *
+     * <p>When the confirmation method is `automatic`, a PaymentIntent can be confirmed using a
+     * publishable key. After `next_action`s are handled, no additional confirmation is required to
+     * complete the payment.
+     *
+     * <p>When the confirmation method is `manual`, all payment attempts must be made using a secret
+     * key. The PaymentIntent will return to the `requires_confirmation` state after handling
+     * `next_action`s, and requires your server to initiate each payment attempt with an explicit
+     * confirmation.
+     */
+    public Builder setConfirmationMethod(ConfirmationMethod confirmationMethod) {
+      this.confirmationMethod = confirmationMethod;
       return this;
     }
 
@@ -703,6 +740,21 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     private final String value;
 
     CaptureMethod(String value) {
+      this.value = value;
+    }
+  }
+
+  public enum ConfirmationMethod implements ApiRequestParams.EnumParam {
+    @SerializedName("automatic")
+    AUTOMATIC("automatic"),
+
+    @SerializedName("manual")
+    MANUAL("manual");
+
+    @Getter(onMethod = @__({@Override}))
+    private final String value;
+
+    ConfirmationMethod(String value) {
       this.value = value;
     }
   }

--- a/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
@@ -44,21 +44,6 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
   Boolean confirm;
 
   /**
-   * One of `automatic` (default) or `manual`.
-   *
-   * <p>When the confirmation method is `automatic`, a PaymentIntent can be confirmed using a
-   * publishable key. After `next_action`s are handled, no additional confirmation is required to
-   * complete the payment.
-   *
-   * <p>When the confirmation method is `manual`, all payment attempts must be made using a secret
-   * key. The PaymentIntent will return to the `requires_confirmation` state after handling
-   * `next_action`s, and requires your server to initiate each payment attempt with an explicit
-   * confirmation.
-   */
-  @SerializedName("confirmation_method")
-  ConfirmationMethod confirmationMethod;
-
-  /**
    * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in
    * lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
    */
@@ -160,7 +145,6 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       Long applicationFeeAmount,
       CaptureMethod captureMethod,
       Boolean confirm,
-      ConfirmationMethod confirmationMethod,
       String currency,
       String customer,
       String description,
@@ -181,7 +165,6 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     this.applicationFeeAmount = applicationFeeAmount;
     this.captureMethod = captureMethod;
     this.confirm = confirm;
-    this.confirmationMethod = confirmationMethod;
     this.currency = currency;
     this.customer = customer;
     this.description = description;
@@ -212,8 +195,6 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     private CaptureMethod captureMethod;
 
     private Boolean confirm;
-
-    private ConfirmationMethod confirmationMethod;
 
     private String currency;
 
@@ -254,7 +235,6 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
           this.applicationFeeAmount,
           this.captureMethod,
           this.confirm,
-          this.confirmationMethod,
           this.currency,
           this.customer,
           this.description,
@@ -310,23 +290,6 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
      */
     public Builder setConfirm(Boolean confirm) {
       this.confirm = confirm;
-      return this;
-    }
-
-    /**
-     * One of `automatic` (default) or `manual`.
-     *
-     * <p>When the confirmation method is `automatic`, a PaymentIntent can be confirmed using a
-     * publishable key. After `next_action`s are handled, no additional confirmation is required to
-     * complete the payment.
-     *
-     * <p>When the confirmation method is `manual`, all payment attempts must be made using a secret
-     * key. The PaymentIntent will return to the `requires_confirmation` state after handling
-     * `next_action`s, and requires your server to initiate each payment attempt with an explicit
-     * confirmation.
-     */
-    public Builder setConfirmationMethod(ConfirmationMethod confirmationMethod) {
-      this.confirmationMethod = confirmationMethod;
       return this;
     }
 
@@ -740,21 +703,6 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     private final String value;
 
     CaptureMethod(String value) {
-      this.value = value;
-    }
-  }
-
-  public enum ConfirmationMethod implements ApiRequestParams.EnumParam {
-    @SerializedName("automatic")
-    AUTOMATIC("automatic"),
-
-    @SerializedName("manual")
-    MANUAL("manual");
-
-    @Getter(onMethod = @__({@Override}))
-    private final String value;
-
-    ConfirmationMethod(String value) {
       this.value = value;
     }
   }

--- a/src/test/java/com/stripe/functional/PlanTest.java
+++ b/src/test/java/com/stripe/functional/PlanTest.java
@@ -59,6 +59,8 @@ public class PlanTest extends BaseStripeTest {
 
   @Test
   public void testRetrieveIdWithForwardSlash() throws StripeException {
+    // `stripe-mock` now has a different behavior from the actual APIs.
+    // It currently does not accept url-encoded values.
     InvalidRequestException exception =
         assertThrows(InvalidRequestException.class, () -> {
           Plan.retrieve("Pro plan $699/month");
@@ -66,6 +68,7 @@ public class PlanTest extends BaseStripeTest {
     assertThat(exception.getMessage(), CoreMatchers.containsString(
         "Unrecognized request URL (GET: /v1/plans/Pro+plan+$699/month)"));
 
+    // Still verifying that request is invoked with encoded url.
     verifyRequest(
         ApiResource.RequestMethod.GET,
         String.format("/v1/plans/%s", "Pro+plan+%24699%2Fmonth")

--- a/src/test/java/com/stripe/functional/PlanTest.java
+++ b/src/test/java/com/stripe/functional/PlanTest.java
@@ -1,9 +1,12 @@
 package com.stripe.functional;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.stripe.BaseStripeTest;
+import com.stripe.exception.InvalidRequestException;
 import com.stripe.exception.StripeException;
 import com.stripe.model.Plan;
 import com.stripe.model.PlanCollection;
@@ -12,6 +15,7 @@ import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 
 public class PlanTest extends BaseStripeTest {
@@ -50,6 +54,21 @@ public class PlanTest extends BaseStripeTest {
     verifyRequest(
         ApiResource.RequestMethod.GET,
         String.format("/v1/plans/%s", PLAN_ID)
+    );
+  }
+
+  @Test
+  public void testRetrieveIdWithForwardSlash() throws StripeException {
+    InvalidRequestException exception =
+        assertThrows(InvalidRequestException.class, () -> {
+          Plan.retrieve("Pro plan $699/month");
+        });
+    assertThat(exception.getMessage(), CoreMatchers.containsString(
+        "Unrecognized request URL (GET: /v1/plans/Pro+plan+$699/month)"));
+
+    verifyRequest(
+        ApiResource.RequestMethod.GET,
+        String.format("/v1/plans/%s", "Pro+plan+%24699%2Fmonth")
     );
   }
 

--- a/src/test/java/com/stripe/net/ApiResourceTest.java
+++ b/src/test/java/com/stripe/net/ApiResourceTest.java
@@ -1,6 +1,5 @@
 package com.stripe.net;
 
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.UnsupportedEncodingException;

--- a/src/test/java/com/stripe/net/ApiResourceTest.java
+++ b/src/test/java/com/stripe/net/ApiResourceTest.java
@@ -1,0 +1,17 @@
+package com.stripe.net;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.UnsupportedEncodingException;
+import org.junit.jupiter.api.Test;
+
+class ApiResourceTest {
+
+  @Test
+  public void testUrlEncodeId() throws UnsupportedEncodingException {
+    assertEquals("cus_123", ApiResource.urlEncode("cus_123"));
+    // legacy Ids allow customer-defined and can have arbitrary names
+    assertEquals("Plan+100%24%2Fmonth", ApiResource.urlEncode("Plan 100$/month"));
+  }
+}


### PR DESCRIPTION
r? @ob-stripe 
cc @brandur-stripe  @stripe/api-libraries 

- This PR url-encodes id in url path to address the issue https://github.com/stripe/stripe-java/issues/736
- Two things in this PR I would like to get feedback on, one is the implementation and the other is to confirm the expected behavior. Both are in the first commit. (The second is generated code)

i) Implementation exposes `urlEncodeId(String)` which is the same as our `urlEncode`, but it wraps the url encoding error with `InvalidRequestException` and returns error message specific about the ID. 

ii) it seems like stripe-mock has different behavior from our actual backend behavior. Although id is properly url-encoded, stripe-mock still rejects it.

For a string ID: `Pro plan $699/month` with url-encoded form `Pro+plan+%24699%2Fmonth`.
```
curl -i http://localhost:12111/v1/plans/Pro+plan+%24699%2Fmonth -H "Authorization: Bearer sk_test_123"
```
Stripe mock will give error: 404 with
```
{
  "error": {
    "message": "Unrecognized request URL (GET: /v1/plans/Pro+plan+$699/month).",
    "type": "invalid_request_error"
  }
}
```
But on test endpoint shows that our backend does read the id properly and is not confused by the encoded forward slash..
```
curl https://api.stripe.com/v1/plans/Pro+plan+%24699%2Fmonth \
  -u sk_test_4eC39HqLyjWDarjtT1zdp7dc:
```
gives:
```
{
  "error": {
    "code": "resource_missing",
    "doc_url": "https://stripe.com/docs/error-codes/resource-missing",
    "message": "No such plan: Pro plan $699/month",
    "param": "plan",
    "type": "invalid_request_error"
  }
}
```
