### PR TITLE
Base api service to be subclassed by autogen

### DIFF
--- a/src/main/java/com/stripe/net/ApiService.java
+++ b/src/main/java/com/stripe/net/ApiService.java
@@ -1,0 +1,72 @@
+package com.stripe.net;
+
+import com.stripe.Stripe;
+import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
+import com.stripe.model.StripeCollectionInterface;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.MissingFormatArgumentException;
+import java.util.Optional;
+
+/**
+ * Super class to services that make API calls. The service sub-class takes in
+ * {@link ApiRequestParams} and returns {@link ApiResource} or
+ * {@link com.stripe.model.StripeCollection} similarly to the methods on the
+ * resource itself.
+ */
+public abstract class ApiService {
+  /**
+   * Helper class to handle input null params, so users can still conveniently pass null instead of
+   * invoking an empty builder.
+   */
+  private static class ApiServiceNullParams extends ApiRequestParams {
+  }
+
+  /**
+   * Build a resource url given the url format (containing `%s`) and url variables.
+   * The url variables will be UTF-8 encoded.
+   * @param urlFormat     standard string format to be used with {@link String#format}
+   * @param urlVariables  un-encoded url variables as arguments to the url format.
+   * @return url for the resource
+   */
+  protected String resourceUrl(String urlFormat, String... urlVariables)
+      throws InvalidRequestException {
+    List<String> urlVariableList = new ArrayList<>();
+    for (String variable : Arrays.asList(urlVariables)) {
+      urlVariableList.add(ApiResource.urlEncodeId(variable));
+    }
+
+    String format;
+    try {
+      format = String.format(urlFormat, urlVariableList.toArray());
+    } catch (MissingFormatArgumentException ex) {
+      throw new InvalidRequestException(String.format(
+          "Unable to create url with pattern `%s` with url variables `%s`. "
+              + "This is likely a problem with this current library version `%s`. "
+              + "Please contact support@stripe.com for assistance.",
+          urlFormat, urlVariableList, Stripe.VERSION),
+          null, null, null, 0, ex);
+    }
+
+    return String.format("%s%s", Stripe.getApiBase(), format);
+  }
+
+  protected static <T> T request(ApiResource.RequestMethod method,
+                              String url, ApiRequestParams params, Class<T> clazz,
+                              RequestOptions options) throws StripeException {
+    return ApiResource.request(method, url, nullSafeParams(params), clazz, options);
+  }
+
+  protected static <T extends StripeCollectionInterface<?>> T requestCollection(
+      String url, ApiRequestParams params, Class<T> clazz, RequestOptions options)
+      throws StripeException {
+    return ApiResource.requestCollection(url, nullSafeParams(params), clazz, options);
+  }
+
+  private static ApiRequestParams nullSafeParams(ApiRequestParams params) {
+    return Optional.ofNullable(params).orElse(new ApiServiceNullParams());
+  }
+}

--- a/src/main/java/com/stripe/net/ApiService.java
+++ b/src/main/java/com/stripe/net/ApiService.java
@@ -54,12 +54,39 @@ public abstract class ApiService {
     return String.format("%s%s", Stripe.getApiBase(), format);
   }
 
+  /**
+   * Make an api request with a valid url like that from {@code resourceUrl}. This method is more
+   * general than its counterpart {@code requestCollection} to list collection classes.
+   * This implementation uses the same underlying method as that in resource class like
+   * {@code Charge.create(params, opts)}.
+   * @param method  http method
+   * @param url     valid url
+   * @param params  nullable request params; null value will be converted to empty params
+   * @param clazz   class to which JSON response is deserialized to
+   * @param options request options
+   * @return object of type clazz
+   * @throws StripeException exceptions containing error code and information helpful for debugging
+   *     and reporting to stripe support.
+   */
   protected static <T> T request(ApiResource.RequestMethod method,
                               String url, ApiRequestParams params, Class<T> clazz,
                               RequestOptions options) throws StripeException {
     return ApiResource.request(method, url, nullSafeParams(params), clazz, options);
   }
 
+  /**
+   * Make an api request for collection classes with a valid url like that from {@code resourceUrl}.
+   * This implementation uses the same underlying method as that in resource class when obtaining
+   * object collection like {@code Charge.list(params)} to get {@code ChargeCollection}. Note
+   * that http method cannot be specified; the underlying implementation defaults to GET.
+   * @param url     a valid url
+   * @param params  nullable request params; null value will be converted to empty params
+   * @param clazz   stripe collection class to which JSON response is deserialized to
+   * @param options request options
+   * @return stripe collection object
+   * @throws StripeException exceptions containing error code and information helpful for debugging
+   *     and reporting to stripe support.
+   */
   protected static <T extends StripeCollectionInterface<?>> T requestCollection(
       String url, ApiRequestParams params, Class<T> clazz, RequestOptions options)
       throws StripeException {

--- a/src/test/java/com/stripe/net/ApiServiceTest.java
+++ b/src/test/java/com/stripe/net/ApiServiceTest.java
@@ -30,7 +30,6 @@ class ApiServiceTest {
   private static class FooCollection extends StripeCollection<Foo> {
   }
 
-
   private static class FooParams extends ApiRequestParams {
   }
 

--- a/src/test/java/com/stripe/net/ApiServiceTest.java
+++ b/src/test/java/com/stripe/net/ApiServiceTest.java
@@ -1,0 +1,176 @@
+package com.stripe.net;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.stripe.Stripe;
+import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
+import com.stripe.model.HasId;
+import com.stripe.model.StripeCollection;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.Mockito;
+
+class ApiServiceTest {
+  private static final String FOO_ID = "foo_123";
+  private static final String BAR_ID = "bar_123";
+
+  private static class Foo extends ApiResource implements HasId {
+    @Override
+    public String getId() {
+      return FOO_ID;
+    }
+  }
+
+  private static class FooCollection extends StripeCollection<Foo> {
+  }
+
+
+  private static class FooParams extends ApiRequestParams {
+  }
+
+  private static class FooOnBarParams extends ApiRequestParams {
+  }
+
+  private static class FooService extends ApiService {
+    String updateUrl = "/v1/foos/%s";
+    String updateOnBarUrl = "/v1/bars/%s/foos/%s";
+    String deleteUrl = "/v1/foos/%s";
+    String listUrl = "/v1/foos";
+
+    public Foo update(String foo, FooParams params, RequestOptions options)
+        throws StripeException {
+      String url = resourceUrl(this.updateUrl, foo);
+      return request(ApiResource.RequestMethod.POST, url, params, Foo.class, options);
+    }
+
+    public Foo update(String bar, String foo, FooOnBarParams params, RequestOptions options)
+        throws StripeException {
+      String url = resourceUrl(this.updateOnBarUrl, bar, foo);
+      return request(ApiResource.RequestMethod.POST, url, params, Foo.class, options);
+    }
+
+    public Foo delete(String foo, FooParams params, RequestOptions options)
+        throws StripeException {
+      String url = resourceUrl(this.deleteUrl, foo);
+      return request(ApiResource.RequestMethod.DELETE, url, params, Foo.class, options);
+    }
+
+    public FooCollection list(FooParams params, RequestOptions options)
+        throws StripeException {
+      String url = resourceUrl(this.listUrl);
+      return requestCollection(url, params, FooCollection.class, options);
+    }
+
+    public Foo updateWithInvalidFormatting(String foo, FooParams params, RequestOptions options)
+        throws StripeException {
+      String url = resourceUrl("/v1/foos/%s/bars/%s", foo);
+      return request(ApiResource.RequestMethod.POST, url, params, Foo.class, options);
+    }
+  }
+
+  @AfterAll
+  public static void restoreNetWork() {
+    ApiResource.setStripeResponseGetter(new LiveStripeResponseGetter());
+  }
+
+  private LiveStripeResponseGetter networkMock;
+  private FooService fooService;
+
+  /**
+   * This service test does not rely on stripe-mock, and intended verifications
+   * are at the invocation of the {@code LiveStripeResponseGetter} not the deep-layer
+   * of API request stacks. Therefore, it uses `mock` of the response getter instead of
+   * spy which still does actual invocation in {@link com.stripe.BaseStripeTest}.
+   */
+  @BeforeEach
+  public void setUpNetworkMock() {
+    fooService = new FooService();
+    networkMock = Mockito.mock(LiveStripeResponseGetter.class);
+    ApiResource.setStripeResponseGetter(networkMock);
+  }
+
+  @Test
+  public void testRequestUpdate() throws StripeException {
+    fooService.update(FOO_ID, new FooParams(), RequestOptions.getDefault());
+
+    verifyRequest(ApiResource.RequestMethod.POST,
+        String.format("/v1/foos/%s", FOO_ID), Foo.class);
+  }
+
+  @Test
+  public void testRequestUpdateOnParent() throws StripeException {
+    fooService.update(BAR_ID, FOO_ID, new FooOnBarParams(), RequestOptions.getDefault());
+
+    verifyRequest(ApiResource.RequestMethod.POST,
+        String.format("/v1/bars/%s/foos/%s", BAR_ID, FOO_ID),
+        Foo.class);
+  }
+
+  @Test
+  public void testRequestCollection() throws StripeException {
+    fooService.list(new FooParams(), RequestOptions.getDefault());
+
+    verifyRequest(ApiResource.RequestMethod.GET,
+        "/v1/foos",
+        FooCollection.class);
+  }
+
+  @Test
+  public void testRequestDelete() throws StripeException {
+    fooService.delete(FOO_ID, new FooParams(), RequestOptions.getDefault());
+
+    verifyRequest(ApiResource.RequestMethod.DELETE,
+        String.format("/v1/foos/%s", FOO_ID),
+        Foo.class
+    );
+  }
+
+  @Test
+  public void testRequestDeleteWithNullParams() throws StripeException {
+    fooService.delete(FOO_ID, null, RequestOptions.getDefault());
+
+    verifyRequest(ApiResource.RequestMethod.DELETE,
+        String.format("/v1/foos/%s", FOO_ID),
+        Foo.class
+    );
+  }
+
+  @Test
+  public void testRequestThrowingUrlFormatting() {
+    assertThrows(InvalidRequestException.class, () -> {
+      fooService.updateWithInvalidFormatting(FOO_ID, new FooParams(), RequestOptions.getDefault());
+    });
+  }
+
+  @Test
+  public void testRequestUrlVariableEncoded() throws StripeException {
+    fooService.update("Plan 100$/month",
+        "Plan 200$/month",
+        new FooOnBarParams(), RequestOptions.getDefault());
+
+    verifyRequest(ApiResource.RequestMethod.POST,
+        String.format("/v1/bars/%s/foos/%s",
+            "Plan+100%24%2Fmonth",
+            "Plan+200%24%2Fmonth"),
+        Foo.class);
+  }
+
+  private void verifyRequest(ApiResource.RequestMethod method,
+                             String path,
+                             Class<?> clazz) throws StripeException {
+    Mockito.verify(networkMock).request(
+        Mockito.eq(method),
+        Mockito.eq(String.format("%s%s", Stripe.getApiBase(), path)),
+        Mockito.any(Map.class),
+        Mockito.eq(clazz),
+        Mockito.eq(ApiResource.RequestType.NORMAL),
+        Mockito.any(RequestOptions.class)
+    );
+  }
+}


### PR DESCRIPTION
This PR implements base api-service to be subclassed by the autogenerated services.
This is thin layer of abstraction to the existing `ApiResource.request` methods. 
Now it does only a few things.
- url variable encoding
- nullsafe ApiRequestParam

Example of this usage is in PR https://github.com/stripe/stripe-java/pull/743
eg. [`PaymentIntentService.java`](https://github.com/stripe/stripe-java/pull/743/files#diff-7e3d9d207a4be27423928689b2d0a611)

r? @brandur-stripe 
cc @ob-stripe 
cc @stripe/api-libraries 
