### PR TITLE
Support extra parameters in typed params

### DIFF
--- a/src/main/java/com/stripe/net/ApiRequestParams.java
+++ b/src/main/java/com/stripe/net/ApiRequestParams.java
@@ -1,16 +1,5 @@
 package com.stripe.net;
 
-import com.google.gson.FieldNamingPolicy;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonObject;
-import com.google.gson.TypeAdapter;
-import com.google.gson.TypeAdapterFactory;
-import com.google.gson.reflect.TypeToken;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
-
-import java.io.IOException;
 import java.util.Map;
 
 /**
@@ -23,70 +12,34 @@ public abstract class ApiRequestParams {
   /**
    * Interface implemented by all enum parameter to get the actual string value that Stripe API
    * expects. Internally, it used in custom serialization
-   * {@link ApiRequestParams.HasEmptyEnumTypeAdapterFactory} converting empty string enum to null.
+   * {@link ApiRequestParamsConverter} converting empty string enum to
+   * null.
    */
   public interface EnumParam {
     String getValue();
   }
 
-  private static final Gson GSON = new GsonBuilder()
-      .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-      .registerTypeAdapterFactory(new HasEmptyEnumTypeAdapterFactory())
-      .create();
-
-  private static final UntypedMapDeserializer UNTYPED_MAP_DESERIALIZER =
-      new UntypedMapDeserializer();
-
-  private static class HasEmptyEnumTypeAdapterFactory implements TypeAdapterFactory {
-    @SuppressWarnings("unchecked")
-    @Override
-    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
-      if (!EnumParam.class.isAssignableFrom(type.getRawType())) {
-        return null;
-      }
-
-      TypeAdapter<EnumParam> paramEnum = new TypeAdapter<EnumParam>() {
-        @Override
-        public void write(JsonWriter out, EnumParam value) throws IOException {
-          if (value.getValue().equals("")) {
-            // need to restore serialize null setting
-            // not to affect other fields
-            boolean previousSetting = out.getSerializeNulls();
-            out.setSerializeNulls(true);
-            out.nullValue();
-            out.setSerializeNulls(previousSetting);
-          } else {
-            out.value(value.getValue());
-          }
-        }
-
-        @Override
-        public EnumParam read(JsonReader in) {
-          throw new UnsupportedOperationException(
-              "No deserialization is expected from this private type adapter for enum param.");
-        }
-      };
-      return (TypeAdapter<T>) paramEnum.nullSafe();
-    }
-  }
+  /**
+   * Param key for an `extraParams` map. Any param/sub-param specifying a field
+   * intended to support extra params from users should have the annotation
+   * {@code @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)}. Logic to handle this is in
+   * {@link ApiRequestParamsConverter}.
+   */
+  public static final String EXTRA_PARAMS_KEY = "_stripe_java_extra_param_key";
 
   /**
-   * Convenient method to convert this typed request params into an untyped map. This map is
-   * composed of {@code Map<String, Object>}, {@code List<Object>}, and basic Java data types.
-   * This allows you to test building the request params and verify compatibility with your
-   * prior integrations using the untyped params map
-   * {@link ApiResource#request(ApiResource.RequestMethod, String, Map, Class, RequestOptions)}.
-   *
-   * <p>The peculiarity of this conversion is that `EMPTY` {@link EnumParam} with raw
-   * value of empty string will be converted to null. This is compatible with the existing
-   * contract enforcing no empty string in the untyped map params.
-   *
-   * <p>Because of the translation from `EMPTY` enum to null, deserializing this map back to a
-   * request instance is lossy. The null value will not be converted back to the `EMPTY` enum.
+   * Converter mapping typed API request parameters into an untyped map.
+   */
+  private static final ApiRequestParamsConverter PARAMS_CONVERTER =
+      new ApiRequestParamsConverter();
+
+  /**
+   * Convert `this` api request params to an untyped map. The conversion is specific to api
+   * request params object. Please see documentation in
+   * {@link ApiRequestParamsConverter#convert(ApiRequestParams)}.
    */
   public Map<String, Object> toMap() {
-    JsonObject json = GSON.toJsonTree(this).getAsJsonObject();
-    return UNTYPED_MAP_DESERIALIZER.deserialize(json);
+    return PARAMS_CONVERTER.convert(this);
   }
 }
 

--- a/src/main/java/com/stripe/net/ApiRequestParamsConverter.java
+++ b/src/main/java/com/stripe/net/ApiRequestParamsConverter.java
@@ -1,0 +1,125 @@
+package com.stripe.net;
+
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import com.stripe.Stripe;
+
+import com.stripe.param.common.EmptyParam;
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Converter to map an api request object to an untyped map.
+ * It is not called a *Serializer because the outcome is not a JSON data.
+ * It is not called *UntypedMapDeserializer because it is not converting from JSON.
+ */
+class ApiRequestParamsConverter {
+  /**
+   * Strategy to flatten extra params in the API request parameters.
+   */
+  private static class ExtraParamsFlatteningStrategy implements UntypedMapDeserializer.Strategy {
+    @Override
+    public void deserializeAndTransform(Map<String, Object> outerMap,
+                                        Map.Entry<String, JsonElement> jsonEntry,
+                                        UntypedMapDeserializer untypedMapDeserializer) {
+      String key = jsonEntry.getKey();
+      JsonElement value = jsonEntry.getValue();
+      if (ApiRequestParams.EXTRA_PARAMS_KEY.equals(key)) {
+        if (!value.isJsonObject()) {
+          throw new IllegalStateException(String.format(
+              "Unexpected schema for extra params. JSON object is expected at key `%s`, but found"
+                  + " `%s`. This is likely a problem with this current library version `%s`. "
+                  + "Please contact support@stripe.com for assistance.",
+              ApiRequestParams.EXTRA_PARAMS_KEY, value, Stripe.VERSION));
+        }
+        // `key` value indicating extra params is dropped, and instead the extra params are
+        // flattened and set at this outer map instead.
+        Map<String, Object> extraParamsMap =
+            untypedMapDeserializer.deserialize(value.getAsJsonObject());
+        outerMap.putAll(extraParamsMap);
+      } else {
+        // normal deserialization where output map has the same structure as given JSON content.
+        outerMap.put(key, untypedMapDeserializer.deserializeJsonElement(value));
+      }
+    }
+  }
+
+  /**
+   * Type adapter to convert an empty enum to null value to comply with the lower-lever encoding
+   * logic for the API request parameters.
+   */
+  private static class HasEmptyEnumTypeAdapterFactory implements TypeAdapterFactory {
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+      if (!ApiRequestParams.EnumParam.class.isAssignableFrom(type.getRawType())) {
+        return null;
+      }
+
+      TypeAdapter<ApiRequestParams.EnumParam> paramEnum =
+          new TypeAdapter<ApiRequestParams.EnumParam>() {
+            @Override
+            public void write(JsonWriter out, ApiRequestParams.EnumParam value) throws IOException {
+              if (value.getValue().equals("")) {
+                // need to restore serialize null setting
+                // not to affect other fields
+                boolean previousSetting = out.getSerializeNulls();
+                out.setSerializeNulls(true);
+                out.nullValue();
+                out.setSerializeNulls(previousSetting);
+              } else {
+                out.value(value.getValue());
+              }
+            }
+
+            @Override
+            public ApiRequestParams.EnumParam read(JsonReader in) {
+              throw new UnsupportedOperationException(
+                  "No deserialization is expected from this private type adapter for enum param.");
+            }
+          };
+      return (TypeAdapter<T>) paramEnum.nullSafe();
+    }
+  }
+
+  private static final Gson GSON = new GsonBuilder()
+      .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+      .registerTypeAdapterFactory(new ApiRequestParamsConverter.HasEmptyEnumTypeAdapterFactory())
+      .create();
+
+  private static final UntypedMapDeserializer FLATTENING_EXTRA_PARAMS_DESERIALIZER =
+      new UntypedMapDeserializer(new ExtraParamsFlatteningStrategy());
+
+  /**
+   * Convert the given request params into an untyped map. This map is
+   * composed of {@code Map<String, Object>}, {@code List<Object>}, and basic Java data types.
+   * This allows you to test building the request params and verify compatibility with your
+   * prior integrations using the untyped params map
+   * {@link ApiResource#request(ApiResource.RequestMethod, String, Map, Class, RequestOptions)}.
+   *
+   * <p>There are two peculiarities in this conversion:
+   *
+   * <p>1) {@link EmptyParam#EMPTY}, containing a raw empty string value, is converted to null.
+   * This is because the form-encoding layer prohibits passing empty string as a param map value.
+   * It, however, allows a null value in the map (present key but null value).
+   * Because of the translation from `EMPTY` enum to null, deserializing this map back to a
+   * request instance is lossy. The null value will not be converted back to the `EMPTY` enum.
+   *
+   * <p>2) Parameter with serialized name {@link ApiRequestParams#EXTRA_PARAMS_KEY} will be
+   * flattened. This is to support passing beta or new params that the current library has not
+   * yet supported.
+   */
+  Map<String, Object> convert(ApiRequestParams apiRequestParams) {
+    JsonObject jsonParams = GSON.toJsonTree(apiRequestParams).getAsJsonObject();
+    return FLATTENING_EXTRA_PARAMS_DESERIALIZER.deserialize(jsonParams);
+  }
+}

--- a/src/main/java/com/stripe/net/ApiRequestParamsConverter.java
+++ b/src/main/java/com/stripe/net/ApiRequestParamsConverter.java
@@ -41,13 +41,16 @@ class ApiRequestParamsConverter {
                   + "Please contact support@stripe.com for assistance.",
               ApiRequestParams.EXTRA_PARAMS_KEY, value, Stripe.VERSION));
         }
-        // `key` value indicating extra params is dropped, and instead the extra params are
-        // flattened and set at this outer map instead.
+        // JSON value now corresponds to the extra params map, and is also deserialized as a map.
+        // Instead of putting this result map under the original key, flatten the map
+        // by adding all its key/value pairs to the outer map instead.
         Map<String, Object> extraParamsMap =
             untypedMapDeserializer.deserialize(value.getAsJsonObject());
         outerMap.putAll(extraParamsMap);
       } else {
-        // normal deserialization where output map has the same structure as given JSON content.
+        // Normal deserialization where output map has the same structure as the given JSON content.
+        // The deserialized content is an untyped `Object` and added to the outer map at the
+        // original key.
         outerMap.put(key, untypedMapDeserializer.deserializeJsonElement(value));
       }
     }
@@ -115,7 +118,7 @@ class ApiRequestParamsConverter {
    * request instance is lossy. The null value will not be converted back to the `EMPTY` enum.
    *
    * <p>2) Parameter with serialized name {@link ApiRequestParams#EXTRA_PARAMS_KEY} will be
-   * flattened. This is to support passing beta or new params that the current library has not
+   * flattened. This is to support passing new params that the current library has not
    * yet supported.
    */
   Map<String, Object> convert(ApiRequestParams apiRequestParams) {

--- a/src/main/java/com/stripe/net/UntypedMapDeserializer.java
+++ b/src/main/java/com/stripe/net/UntypedMapDeserializer.java
@@ -30,10 +30,10 @@ public class UntypedMapDeserializer {
    * }
    *
    * <p>Given, a json entry of "zing": 2, the outer map corresponds to value for "foo_inner". A
-   * default strategy is to simply deserialize value and adds to given map at "zing" key.
+   * default strategy is to simply deserialize value and puts to the outer map at "zing" key.
    *
-   * <p>Custom strategy allows, for example, renaming the key "zing", wraps the deserialized
-   * value in another map/array, or flatten the value if the deserialized value is a map.
+   * <p>Custom strategy allows, for example, renaming the key "zing", wrapping the deserialized
+   * value in another map/array, or flattening the value if the deserialized value is a map.
    */
   interface Strategy {
     /**

--- a/src/test/java/com/stripe/net/ApiRequestParamsConverterTest.java
+++ b/src/test/java/com/stripe/net/ApiRequestParamsConverterTest.java
@@ -1,0 +1,201 @@
+package com.stripe.net;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.gson.annotations.SerializedName;
+
+import com.stripe.param.common.EmptyParam;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+public class ApiRequestParamsConverterTest {
+  private ApiRequestParamsConverter converter = new ApiRequestParamsConverter();
+
+  // To test interactions between the flattening and empty enums
+  enum ParamCode implements ApiRequestParams.EnumParam {
+    ENUM_FOO("enum_foo"),
+    ENUM_BAR("enum_bar"),;
+
+    private final String value;
+
+    ParamCode(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String getValue() {
+      return this.value;
+    }
+  }
+
+  private static class ModelHasExtraParams extends ApiRequestParams {
+    private String stringValue;
+    private EnumParam enumValue;
+
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    private Map<String, Object> extraParams;
+
+    public ModelHasExtraParams(EnumParam enumValue) {
+      this.stringValue = "foo";
+      this.enumValue = enumValue;
+      this.extraParams = new HashMap<>();
+      this.extraParams.put("hello", "world");
+    }
+
+    static Map<String, Object> expectedParams(String enumString) {
+      Map<String, Object> paramMap = new HashMap<>();
+      paramMap.put("string_value", "foo");
+      paramMap.put("enum_value", enumString);
+      // "hello" key is flattened to the same level as root-level params
+      // and the key for `extraParams` is dropped
+      paramMap.put("hello", "world");
+      return paramMap;
+    }
+  }
+
+  private static class RootModelHasNestedExtraParams extends ApiRequestParams {
+    private String rootStringValue;
+    private EnumParam rootEnumValue;
+    private ModelHasExtraParams subParamFoo;
+
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    private Map<String, String> extraParams;
+
+    public RootModelHasNestedExtraParams(EnumParam rootEnumValue,
+                                         ModelHasExtraParams subParamFoo) {
+      this.rootStringValue = "bar";
+      this.rootEnumValue = rootEnumValue;
+      this.subParamFoo = subParamFoo;
+      this.extraParams = new HashMap<>();
+      this.extraParams.put("bar_hello", "bar_world");
+    }
+
+    static Map<String, Object> expectedParams(String enumString) {
+      Map<String, Object> rootLevelParams = new HashMap<>();
+      rootLevelParams.put("root_string_value", "bar");
+      rootLevelParams.put("root_enum_value", enumString);
+      // similar to the `ModelHasExtraParams` test model,
+      // "bar_hello" key is flattened to the same level as root-level params
+      rootLevelParams.put("bar_hello", "bar_world");
+      return rootLevelParams;
+    }
+  }
+
+  private static class ModelHasListExtraParams extends ApiRequestParams {
+    List<ModelHasExtraParams> paramFooList;
+  }
+
+  private static class ModelHasExtraParamsWithWrongSerializedName extends ApiRequestParams {
+    @SerializedName("extra_params")
+    private Map<String, String> extraParams;
+  }
+
+  private static class IllegalModelHasWrongExtraParamsType extends ApiRequestParams {
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    String extraParams;
+  }
+
+  @Test
+  public void testHasExtraParams() {
+    ModelHasExtraParams params = new ModelHasExtraParams(ParamCode.ENUM_FOO);
+
+    assertEquals(
+        ModelHasExtraParams.expectedParams("enum_foo"),
+        toMap(params));
+  }
+
+  @Test
+  public void testHasExtraParamsWithFormEncodedKeys() {
+    ModelHasExtraParams params = new ModelHasExtraParams(ParamCode.ENUM_FOO);
+    params.extraParams.put("root_param[foo][string]", "value_foo");
+    params.extraParams.put("root_param[bar][integer]", "123");
+
+    Map<String, Object> expected = ModelHasExtraParams.expectedParams("enum_foo");
+    assertNotEquals(expected, toMap(params));
+
+    expected.put("root_param[foo][string]", "value_foo");
+    expected.put("root_param[bar][integer]", "123");
+    assertEquals(expected, toMap(params));
+  }
+
+  @Test
+  public void testHasNestedExtraParams() {
+    ModelHasExtraParams fooParams = new ModelHasExtraParams(ParamCode.ENUM_FOO);
+    RootModelHasNestedExtraParams barParams = new RootModelHasNestedExtraParams(
+        ParamCode.ENUM_BAR, fooParams);
+
+    Map<String, Object> expected = RootModelHasNestedExtraParams
+        .expectedParams("enum_bar");
+    expected.put("sub_param_foo", ModelHasExtraParams.expectedParams("enum_foo"));
+
+    assertEquals(expected, toMap(barParams));
+  }
+
+  @Test
+  public void testHasNestedExtraParamsWithEmpty() {
+    ModelHasExtraParams fooParams = new ModelHasExtraParams(EmptyParam.EMPTY);
+
+    RootModelHasNestedExtraParams barParams = new RootModelHasNestedExtraParams(
+        EmptyParam.EMPTY, fooParams);
+
+    Map<String, Object> expected = RootModelHasNestedExtraParams.expectedParams(null);
+    expected.put("sub_param_foo", ModelHasExtraParams.expectedParams(null));
+
+    assertEquals(expected, toMap(barParams));
+  }
+
+  @Test
+  public void testHasListExtraParams() {
+    ModelHasListExtraParams params = new ModelHasListExtraParams();
+    params.paramFooList = Arrays.asList(
+        new ModelHasExtraParams(ParamCode.ENUM_FOO),
+        new ModelHasExtraParams(ParamCode.ENUM_BAR)
+    );
+
+    Map<String, Object> expected = new HashMap<>();
+    expected.put("param_foo_list",
+        Arrays.asList(
+            ModelHasExtraParams.expectedParams("enum_foo"),
+            ModelHasExtraParams.expectedParams("enum_bar")
+        ));
+    assertEquals(expected, toMap(params));
+  }
+
+  @Test
+  public void testHasExtraParamsWithWrongSerializedName() {
+    ModelHasExtraParamsWithWrongSerializedName params =
+        new ModelHasExtraParamsWithWrongSerializedName();
+    params.extraParams = new HashMap<>();
+    params.extraParams.put("foo", "bar");
+
+    Map<String, Object> untypedParams = toMap(params);
+    assertEquals(1, untypedParams.size());
+    assertTrue(untypedParams.containsKey("extra_params"));
+    Map<String, Object> subParams = (Map<String, Object>)untypedParams.get("extra_params");
+    assertEquals(1, subParams.size());
+    assertEquals("bar", subParams.get("foo"));
+  }
+
+  @Test
+  public void testIllegalExtraParamsType() {
+    IllegalModelHasWrongExtraParamsType params = new IllegalModelHasWrongExtraParamsType();
+    params.extraParams = "should have been a map";
+
+    IllegalStateException exception = assertThrows(IllegalStateException.class, () -> {
+      toMap(params);
+    });
+    assertTrue(exception.getMessage().contains("Unexpected schema for extra params"));
+  }
+
+  private Map<String, Object> toMap(ApiRequestParams params) {
+    return converter.convert(params);
+  }
+}

--- a/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
+++ b/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
@@ -116,6 +116,24 @@ public class LiveStripeResponseGetterTest {
   }
 
   @Test
+  public void testCreateQueryWithFormEncodedKeys() throws StripeException,
+      UnsupportedEncodingException {
+    /* Use LinkedHashMap because it preserves iteration order */
+    final Map<String, Object> params = new LinkedHashMap<>();
+
+    // params with form-encoded keys at creating query can happen through "extraParams"
+    // we now support only map of string key/value, so specifying nested params relies on form
+    // encoding.
+    params.put("nested[0][A]", "A-1");
+    params.put("nested[0][B]", "B-1");
+    params.put("nested[1][A]", "A-2");
+    params.put("nested[1][B]", "B-2");
+
+    assertEquals("nested[0][A]=A-1&nested[0][B]=B-1&nested[1][A]=A-2&nested[1][B]=B-2",
+        LiveStripeResponseGetter.createQuery(params));
+  }
+
+  @Test
   public void testCreateQueryWithEmptyList() throws StripeException, UnsupportedEncodingException {
     final Map<String, Object> params = new HashMap<>();
     params.put("a", new ArrayList<String>());

--- a/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
+++ b/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
@@ -121,9 +121,12 @@ public class LiveStripeResponseGetterTest {
     /* Use LinkedHashMap because it preserves iteration order */
     final Map<String, Object> params = new LinkedHashMap<>();
 
-    // params with form-encoded keys at creating query can happen through "extraParams"
-    // we now support only map of string key/value, so specifying nested params relies on form
-    // encoding.
+    // Params with form-encoded keys can happen through "extraParams". Instead of passing a
+    // string key and `Object` value, users can also specify key as form-encoded path to the
+    // extra param value.
+    // This "extraParams" behavior is supported by other typed libraries, but not
+    // intended in `stripe-java`. However, by the virtue of supporting arbitrary string key in
+    // extra param map, this behavior is implicitly supported.
     params.put("nested[0][A]", "A-1");
     params.put("nested[0][B]", "B-1");
     params.put("nested[1][A]", "A-2");


### PR DESCRIPTION
- This PR implements serialization logic for the "extra params"--to flatten the extra params to its outer object.
- There are two parts to this PR. 
  - First, modify the current `UntypedMapDeserializer` that converts JSON to untyped map to take a custom `Strategy`.
  - Second, implement the flattening logic.

- Params object will have the field `extraParams` generated, but what's needed is the `ApiRequestParams.EXTRA_PARAMS_KEY` serialized name as this solution works by flattening JSON to the the untyped map for form-encoding.
```
public class SkuCreateParams extends ApiRequestParams {
  // ...
  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
  Map<String, Object> extraParams;
  // ...
}
```

- Alternative solution considered here is implementing this a GSON level itself https://github.com/stripe/stripe-java/pull/751/files. The sketch of solution is
  - Define interface `HasExtraParams` so that we can define type adapter to this specific type
  - Each param/sub param to implements this
  - Declare the `extraParam` map as `transient` so that it won't get serialized and we don't need to know the "magic" param key to remove it from JSON
  - Custom type adapter to flatten the JSON. 
    - This proves more involved than I wished it to be. The problem is writing out the value immediately closes the JSON such that we cannot smuggle in the extra params. 
    - To handle that, it needs a distinct writer to first get hold of the main JSON param object, add the extra params, and decode the JSON object back to the writer syntax (beginObject, endObject...)

- I prefer this approach because it 
  - introduces less code, and we can reason more easily without GSON.
  - more efficient than GSON solution (at least the one I had) which requires decode/encode for every sub-params

- Motivation here is that, in the service methods, we want to get rid of all untyped params, but we need support to add arbitrary sub-hash for beta feature. The api of this extra params look like https://github.com/stripe/stripe-java/pull/753
Where all param builder supports
```
public Builder putExtraParam(String key, Object value);
public Builder putAllExtraParam(Map<String, Object> map);
```
```
    SkuCreateParams.Inventory inventory = SkuCreateParams.Inventory.builder()
        .putExtraParam("type", "bucket")
        .build();
    // Map<String, Object> inventory  would work too

    Map<String, String> additionalAttributes = new HashMap<>();
    additionalAttributes.put("attr2", "val2");

    SkuCreateParams typedParams = SkuCreateParams.builder()
        .putExtraParam("active", true)
        .putExtraParam("price", 499L)
        .putExtraParam("currency", "usd")
        .putExtraParam("inventory", inventory)
        // allow both put/putAll
        .putAllExtraParam(ImmutableMap.of(
            "product", "prod_123",
            "image", "http://example.com/foo.png"
        ))
        .build();
```
    
r? @brandur-stripe @ob-stripe 
cc @stripe/api-libraries 

