### PR TITLE
[non-gen service] EventService

### DIFF
--- a/src/main/java/com/stripe/net/ApiRequestParams.java
+++ b/src/main/java/com/stripe/net/ApiRequestParams.java
@@ -1,16 +1,5 @@
 package com.stripe.net;
 
-import com.google.gson.FieldNamingPolicy;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonObject;
-import com.google.gson.TypeAdapter;
-import com.google.gson.TypeAdapterFactory;
-import com.google.gson.reflect.TypeToken;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
-
-import java.io.IOException;
 import java.util.Map;
 
 /**
@@ -23,70 +12,34 @@ public abstract class ApiRequestParams {
   /**
    * Interface implemented by all enum parameter to get the actual string value that Stripe API
    * expects. Internally, it used in custom serialization
-   * {@link ApiRequestParams.HasEmptyEnumTypeAdapterFactory} converting empty string enum to null.
+   * {@link ApiRequestParamsConverter} converting empty string enum to
+   * null.
    */
   public interface EnumParam {
     String getValue();
   }
 
-  private static final Gson GSON = new GsonBuilder()
-      .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-      .registerTypeAdapterFactory(new HasEmptyEnumTypeAdapterFactory())
-      .create();
-
-  private static final UntypedMapDeserializer UNTYPED_MAP_DESERIALIZER =
-      new UntypedMapDeserializer();
-
-  private static class HasEmptyEnumTypeAdapterFactory implements TypeAdapterFactory {
-    @SuppressWarnings("unchecked")
-    @Override
-    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
-      if (!EnumParam.class.isAssignableFrom(type.getRawType())) {
-        return null;
-      }
-
-      TypeAdapter<EnumParam> paramEnum = new TypeAdapter<EnumParam>() {
-        @Override
-        public void write(JsonWriter out, EnumParam value) throws IOException {
-          if (value.getValue().equals("")) {
-            // need to restore serialize null setting
-            // not to affect other fields
-            boolean previousSetting = out.getSerializeNulls();
-            out.setSerializeNulls(true);
-            out.nullValue();
-            out.setSerializeNulls(previousSetting);
-          } else {
-            out.value(value.getValue());
-          }
-        }
-
-        @Override
-        public EnumParam read(JsonReader in) {
-          throw new UnsupportedOperationException(
-              "No deserialization is expected from this private type adapter for enum param.");
-        }
-      };
-      return (TypeAdapter<T>) paramEnum.nullSafe();
-    }
-  }
+  /**
+   * Param key for an `extraParams` map. Any param/sub-param specifying a field
+   * intended to support extra params from users should have the annotation
+   * {@code @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)}. Logic to handle this is in
+   * {@link ApiRequestParamsConverter}.
+   */
+  public static final String EXTRA_PARAMS_KEY = "_stripe_java_extra_param_key";
 
   /**
-   * Convenient method to convert this typed request params into an untyped map. This map is
-   * composed of {@code Map<String, Object>}, {@code List<Object>}, and basic Java data types.
-   * This allows you to test building the request params and verify compatibility with your
-   * prior integrations using the untyped params map
-   * {@link ApiResource#request(ApiResource.RequestMethod, String, Map, Class, RequestOptions)}.
-   *
-   * <p>The peculiarity of this conversion is that `EMPTY` {@link EnumParam} with raw
-   * value of empty string will be converted to null. This is compatible with the existing
-   * contract enforcing no empty string in the untyped map params.
-   *
-   * <p>Because of the translation from `EMPTY` enum to null, deserializing this map back to a
-   * request instance is lossy. The null value will not be converted back to the `EMPTY` enum.
+   * Converter mapping typed API request parameters into an untyped map.
+   */
+  private static final ApiRequestParamsConverter PARAMS_CONVERTER =
+      new ApiRequestParamsConverter();
+
+  /**
+   * Convert `this` api request params to an untyped map. The conversion is specific to api
+   * request params object. Please see documentation in
+   * {@link ApiRequestParamsConverter#convert(ApiRequestParams)}.
    */
   public Map<String, Object> toMap() {
-    JsonObject json = GSON.toJsonTree(this).getAsJsonObject();
-    return UNTYPED_MAP_DESERIALIZER.deserialize(json);
+    return PARAMS_CONVERTER.convert(this);
   }
 }
 

--- a/src/main/java/com/stripe/net/ApiRequestParamsConverter.java
+++ b/src/main/java/com/stripe/net/ApiRequestParamsConverter.java
@@ -1,0 +1,128 @@
+package com.stripe.net;
+
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import com.stripe.Stripe;
+
+import com.stripe.param.common.EmptyParam;
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Converter to map an api request object to an untyped map.
+ * It is not called a *Serializer because the outcome is not a JSON data.
+ * It is not called *UntypedMapDeserializer because it is not converting from JSON.
+ */
+class ApiRequestParamsConverter {
+  /**
+   * Strategy to flatten extra params in the API request parameters.
+   */
+  private static class ExtraParamsFlatteningStrategy implements UntypedMapDeserializer.Strategy {
+    @Override
+    public void deserializeAndTransform(Map<String, Object> outerMap,
+                                        Map.Entry<String, JsonElement> jsonEntry,
+                                        UntypedMapDeserializer untypedMapDeserializer) {
+      String key = jsonEntry.getKey();
+      JsonElement value = jsonEntry.getValue();
+      if (ApiRequestParams.EXTRA_PARAMS_KEY.equals(key)) {
+        if (!value.isJsonObject()) {
+          throw new IllegalStateException(String.format(
+              "Unexpected schema for extra params. JSON object is expected at key `%s`, but found"
+                  + " `%s`. This is likely a problem with this current library version `%s`. "
+                  + "Please contact support@stripe.com for assistance.",
+              ApiRequestParams.EXTRA_PARAMS_KEY, value, Stripe.VERSION));
+        }
+        // JSON value now corresponds to the extra params map, and is also deserialized as a map.
+        // Instead of putting this result map under the original key, flatten the map
+        // by adding all its key/value pairs to the outer map instead.
+        Map<String, Object> extraParamsMap =
+            untypedMapDeserializer.deserialize(value.getAsJsonObject());
+        outerMap.putAll(extraParamsMap);
+      } else {
+        // Normal deserialization where output map has the same structure as the given JSON content.
+        // The deserialized content is an untyped `Object` and added to the outer map at the
+        // original key.
+        outerMap.put(key, untypedMapDeserializer.deserializeJsonElement(value));
+      }
+    }
+  }
+
+  /**
+   * Type adapter to convert an empty enum to null value to comply with the lower-lever encoding
+   * logic for the API request parameters.
+   */
+  private static class HasEmptyEnumTypeAdapterFactory implements TypeAdapterFactory {
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+      if (!ApiRequestParams.EnumParam.class.isAssignableFrom(type.getRawType())) {
+        return null;
+      }
+
+      TypeAdapter<ApiRequestParams.EnumParam> paramEnum =
+          new TypeAdapter<ApiRequestParams.EnumParam>() {
+            @Override
+            public void write(JsonWriter out, ApiRequestParams.EnumParam value) throws IOException {
+              if (value.getValue().equals("")) {
+                // need to restore serialize null setting
+                // not to affect other fields
+                boolean previousSetting = out.getSerializeNulls();
+                out.setSerializeNulls(true);
+                out.nullValue();
+                out.setSerializeNulls(previousSetting);
+              } else {
+                out.value(value.getValue());
+              }
+            }
+
+            @Override
+            public ApiRequestParams.EnumParam read(JsonReader in) {
+              throw new UnsupportedOperationException(
+                  "No deserialization is expected from this private type adapter for enum param.");
+            }
+          };
+      return (TypeAdapter<T>) paramEnum.nullSafe();
+    }
+  }
+
+  private static final Gson GSON = new GsonBuilder()
+      .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+      .registerTypeAdapterFactory(new ApiRequestParamsConverter.HasEmptyEnumTypeAdapterFactory())
+      .create();
+
+  private static final UntypedMapDeserializer FLATTENING_EXTRA_PARAMS_DESERIALIZER =
+      new UntypedMapDeserializer(new ExtraParamsFlatteningStrategy());
+
+  /**
+   * Convert the given request params into an untyped map. This map is
+   * composed of {@code Map<String, Object>}, {@code List<Object>}, and basic Java data types.
+   * This allows you to test building the request params and verify compatibility with your
+   * prior integrations using the untyped params map
+   * {@link ApiResource#request(ApiResource.RequestMethod, String, Map, Class, RequestOptions)}.
+   *
+   * <p>There are two peculiarities in this conversion:
+   *
+   * <p>1) {@link EmptyParam#EMPTY}, containing a raw empty string value, is converted to null.
+   * This is because the form-encoding layer prohibits passing empty string as a param map value.
+   * It, however, allows a null value in the map (present key but null value).
+   * Because of the translation from `EMPTY` enum to null, deserializing this map back to a
+   * request instance is lossy. The null value will not be converted back to the `EMPTY` enum.
+   *
+   * <p>2) Parameter with serialized name {@link ApiRequestParams#EXTRA_PARAMS_KEY} will be
+   * flattened. This is to support passing new params that the current library has not
+   * yet supported.
+   */
+  Map<String, Object> convert(ApiRequestParams apiRequestParams) {
+    JsonObject jsonParams = GSON.toJsonTree(apiRequestParams).getAsJsonObject();
+    return FLATTENING_EXTRA_PARAMS_DESERIALIZER.deserialize(jsonParams);
+  }
+}

--- a/src/main/java/com/stripe/net/ApiService.java
+++ b/src/main/java/com/stripe/net/ApiService.java
@@ -1,0 +1,99 @@
+package com.stripe.net;
+
+import com.stripe.Stripe;
+import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
+import com.stripe.model.StripeCollectionInterface;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.MissingFormatArgumentException;
+import java.util.Optional;
+
+/**
+ * Super class to services that make API calls. The service sub-class takes in
+ * {@link ApiRequestParams} and returns {@link ApiResource} or
+ * {@link com.stripe.model.StripeCollection} similarly to the methods on the
+ * resource itself.
+ */
+public abstract class ApiService {
+  /**
+   * Helper class to handle input null params, so users can still conveniently pass null instead of
+   * invoking an empty builder.
+   */
+  private static class ApiServiceNullParams extends ApiRequestParams {
+  }
+
+  /**
+   * Build a resource url given the url format (containing `%s`) and url variables.
+   * The url variables will be UTF-8 encoded.
+   * @param urlFormat     standard string format to be used with {@link String#format}
+   * @param urlVariables  un-encoded url variables as arguments to the url format.
+   * @return url for the resource
+   */
+  protected String resourceUrl(String urlFormat, String... urlVariables)
+      throws InvalidRequestException {
+    List<String> urlVariableList = new ArrayList<>();
+    for (String variable : Arrays.asList(urlVariables)) {
+      urlVariableList.add(ApiResource.urlEncodeId(variable));
+    }
+
+    String format;
+    try {
+      format = String.format(urlFormat, urlVariableList.toArray());
+    } catch (MissingFormatArgumentException ex) {
+      throw new InvalidRequestException(String.format(
+          "Unable to create url with pattern `%s` with url variables `%s`. "
+              + "This is likely a problem with this current library version `%s`. "
+              + "Please contact support@stripe.com for assistance.",
+          urlFormat, urlVariableList, Stripe.VERSION),
+          null, null, null, 0, ex);
+    }
+
+    return String.format("%s%s", Stripe.getApiBase(), format);
+  }
+
+  /**
+   * Make an api request with a valid url like that from {@code resourceUrl}. This method is more
+   * general than its counterpart {@code requestCollection} to list collection classes.
+   * This implementation uses the same underlying method as that in resource class like
+   * {@code Charge.create(params, opts)}.
+   * @param method  http method
+   * @param url     valid url
+   * @param params  nullable request params; null value will be converted to empty params
+   * @param clazz   class to which JSON response is deserialized to
+   * @param options request options
+   * @return object of type clazz
+   * @throws StripeException exceptions containing error code and information helpful for debugging
+   *     and reporting to stripe support.
+   */
+  protected static <T> T request(ApiResource.RequestMethod method,
+                              String url, ApiRequestParams params, Class<T> clazz,
+                              RequestOptions options) throws StripeException {
+    return ApiResource.request(method, url, nullSafeParams(params), clazz, options);
+  }
+
+  /**
+   * Make an api request for collection classes with a valid url like that from {@code resourceUrl}.
+   * This implementation uses the same underlying method as that in resource class when obtaining
+   * object collection like {@code Charge.list(params)} to get {@code ChargeCollection}. Note
+   * that http method cannot be specified; the underlying implementation defaults to GET.
+   * @param url     a valid url
+   * @param params  nullable request params; null value will be converted to empty params
+   * @param clazz   stripe collection class to which JSON response is deserialized to
+   * @param options request options
+   * @return stripe collection object
+   * @throws StripeException exceptions containing error code and information helpful for debugging
+   *     and reporting to stripe support.
+   */
+  protected static <T extends StripeCollectionInterface<?>> T requestCollection(
+      String url, ApiRequestParams params, Class<T> clazz, RequestOptions options)
+      throws StripeException {
+    return ApiResource.requestCollection(url, nullSafeParams(params), clazz, options);
+  }
+
+  private static ApiRequestParams nullSafeParams(ApiRequestParams params) {
+    return Optional.ofNullable(params).orElse(new ApiServiceNullParams());
+  }
+}

--- a/src/main/java/com/stripe/net/UntypedMapDeserializer.java
+++ b/src/main/java/com/stripe/net/UntypedMapDeserializer.java
@@ -18,27 +18,94 @@ import java.util.Map;
  */
 public class UntypedMapDeserializer {
   /**
+   * Strategy to deserialize a JSON element, allowing for custom behavior between the deserialized
+   * element and its outer map.
+   * For example, for a full JSON:
+   * {
+   *   "foo": 1,
+   *   "foo_inner": { // outer context map
+   *     "bar": 1,
+   *     "zing": 2,   // given JSON element
+   *   },
+   * }
+   *
+   * <p>Given, a json entry of "zing": 2, the outer map corresponds to value for "foo_inner". A
+   * default strategy is to simply deserialize value and puts to the outer map at "zing" key.
+   *
+   * <p>Custom strategy allows, for example, renaming the key "zing", wrapping the deserialized
+   * value in another map/array, or flattening the value if the deserialized value is a map.
+   */
+  interface Strategy {
+    /**
+     * Define how the given JSON element should be deserialized, and how the deserialized content
+     * should be added to the given outer map.
+     * @param outerMap               the untyped map that the deserialized content can be added to.
+     * @param jsonEntry              original JSON entry with key and json element
+     * @param untypedMapDeserializer deserializer for the untyped map to transform the given json
+     *                               element
+     */
+    void deserializeAndTransform(Map<String, Object> outerMap,
+                                 Map.Entry<String, JsonElement> jsonEntry,
+                                 UntypedMapDeserializer untypedMapDeserializer
+    );
+  }
+
+  /**
+   * Strategy for this deserializer.
+   */
+  private Strategy strategy;
+
+  /**
+   * Default deserializer for the untyped map. The result untyped map has same object graph
+   * structure as that of the given JSON content.
+   */
+  public UntypedMapDeserializer() {
+    /**
+     * Default strategy where each JSON element gets deserialized and added with its original key.
+     */
+    this.strategy = new Strategy() {
+      @Override
+      public void deserializeAndTransform(Map<String, Object> outerMap,
+                                          Map.Entry<String, JsonElement> jsonEntry,
+                                          UntypedMapDeserializer untypedMapDeserializer) {
+        outerMap.put(
+            jsonEntry.getKey(),
+            untypedMapDeserializer.deserializeJsonElement(jsonEntry.getValue()));
+      }
+    };
+  }
+
+  /**
+   * Deserializer with a custom strategy.
+   * @param strategy definition of how JSON element should be deserialized and set in its outer map.
+   */
+  UntypedMapDeserializer(Strategy strategy) {
+    this.strategy = strategy;
+  }
+
+  /**
    * Deserialize JSON into untyped map.
    * {@code JsonArray} is represented as {@code List<Object>}.
    * {@code JsonObject} is represented as {@code Map<String, Object>}.
    * {@code JsonPrimitive} is represented as String, Number, or Boolean.
-   *
    * @param jsonObject  JSON to convert into untyped map
    * @return untyped map without dependency on JSON representation.
    */
   public Map<String, Object> deserialize(JsonObject jsonObject) {
     Map<String, Object> objMap = new HashMap<>();
     for (Map.Entry<String, JsonElement> entry : jsonObject.entrySet()) {
-      String key = entry.getKey();
-      JsonElement element = entry.getValue();
-      // JsonElement is super class of all JSON standard types:
-      // array, null, primitive, and object
-      objMap.put(key, deserializeJsonElement(element));
+      this.strategy.deserializeAndTransform(objMap, entry, this);
     }
     return objMap;
   }
 
-  private Object deserializeJsonElement(JsonElement element) {
+  /**
+   * Normalizes JSON element into an untyped Object as value to the untyped map.
+   * @param element JSON element to convert to java Object
+   * @return untyped object, one of {@code Map<String, Object>}, {@code String}, {@code Number},
+   * {@code Boolean}, or {@code List<Array>}.
+   */
+  Object deserializeJsonElement(JsonElement element) {
     if (element.isJsonNull()) {
       return null;
     } else if (element.isJsonObject()) {

--- a/src/main/java/com/stripe/param/EventListParams.java
+++ b/src/main/java/com/stripe/param/EventListParams.java
@@ -3,7 +3,9 @@ package com.stripe.param;
 import com.google.gson.annotations.SerializedName;
 import com.stripe.net.ApiRequestParams;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class EventListParams extends ApiRequestParams {
   @SerializedName("created")
@@ -28,6 +30,15 @@ public class EventListParams extends ApiRequestParams {
   /** Specifies which fields in the response should be expanded. */
   @SerializedName("expand")
   List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
 
   /**
    * A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
@@ -65,6 +76,7 @@ public class EventListParams extends ApiRequestParams {
       Boolean deliverySuccess,
       String endingBefore,
       List<String> expand,
+      Map<String, Object> extraParams,
       Long limit,
       String startingAfter,
       String type,
@@ -73,6 +85,7 @@ public class EventListParams extends ApiRequestParams {
     this.deliverySuccess = deliverySuccess;
     this.endingBefore = endingBefore;
     this.expand = expand;
+    this.extraParams = extraParams;
     this.limit = limit;
     this.startingAfter = startingAfter;
     this.type = type;
@@ -92,6 +105,8 @@ public class EventListParams extends ApiRequestParams {
 
     private List<String> expand;
 
+    private Map<String, Object> extraParams;
+
     private Long limit;
 
     private String startingAfter;
@@ -107,6 +122,7 @@ public class EventListParams extends ApiRequestParams {
           this.deliverySuccess,
           this.endingBefore,
           this.expand,
+          this.extraParams,
           this.limit,
           this.startingAfter,
           this.type,
@@ -170,6 +186,32 @@ public class EventListParams extends ApiRequestParams {
     }
 
     /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * EventListParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link EventListParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /**
      * A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
      * default is 10.
      */
@@ -226,6 +268,15 @@ public class EventListParams extends ApiRequestParams {
   }
 
   public static class Created {
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
     /** Minimum value to filter by (exclusive). */
     @SerializedName("gt")
     Long gt;
@@ -242,7 +293,8 @@ public class EventListParams extends ApiRequestParams {
     @SerializedName("lte")
     Long lte;
 
-    private Created(Long gt, Long gte, Long lt, Long lte) {
+    private Created(Map<String, Object> extraParams, Long gt, Long gte, Long lt, Long lte) {
+      this.extraParams = extraParams;
       this.gt = gt;
       this.gte = gte;
       this.lt = lt;
@@ -254,6 +306,8 @@ public class EventListParams extends ApiRequestParams {
     }
 
     public static class Builder {
+      private Map<String, Object> extraParams;
+
       private Long gt;
 
       private Long gte;
@@ -264,7 +318,33 @@ public class EventListParams extends ApiRequestParams {
 
       /** Finalize and obtain parameter instance from this builder. */
       public Created build() {
-        return new Created(this.gt, this.gte, this.lt, this.lte);
+        return new Created(this.extraParams, this.gt, this.gte, this.lt, this.lte);
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * EventListParams.Created#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link EventListParams.Created#extraParams} for the field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
       }
 
       /** Minimum value to filter by (exclusive). */

--- a/src/main/java/com/stripe/param/EventRetrieveParams.java
+++ b/src/main/java/com/stripe/param/EventRetrieveParams.java
@@ -1,0 +1,95 @@
+package com.stripe.param;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class EventRetrieveParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  private EventRetrieveParams(List<String> expand, Map<String, Object> extraParams) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+  }
+
+  public static Builder builder() {
+    return new com.stripe.param.EventRetrieveParams.Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public EventRetrieveParams build() {
+      return new EventRetrieveParams(this.expand, this.extraParams);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * EventRetrieveParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * EventRetrieveParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * EventRetrieveParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link EventRetrieveParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/stripe/service/EventService.java
+++ b/src/main/java/com/stripe/service/EventService.java
@@ -1,0 +1,52 @@
+package com.stripe.service;
+
+import com.stripe.exception.StripeException;
+import com.stripe.model.Event;
+import com.stripe.model.EventCollection;
+import com.stripe.net.ApiResource;
+import com.stripe.net.ApiService;
+import com.stripe.net.RequestOptions;
+import com.stripe.param.EventListParams;
+import com.stripe.param.EventRetrieveParams;
+
+public class EventService extends ApiService {
+  /**
+   * List events, going back up to 30 days. Each event data is rendered according to Stripe API
+   * version at its creation time, specified in <a href="/docs/api/events/object">event object</a>
+   * <code>api_version</code> attribute (not according to your current Stripe API version or <code>
+   * Stripe-Version</code> header).
+   */
+  public EventCollection list(EventListParams params) throws StripeException {
+    return list(params, (RequestOptions) null);
+  }
+
+  /**
+   * List events, going back up to 30 days. Each event data is rendered according to Stripe API
+   * version at its creation time, specified in <a href="/docs/api/events/object">event object</a>
+   * <code>api_version</code> attribute (not according to your current Stripe API version or <code>
+   * Stripe-Version</code> header).
+   */
+  public EventCollection list(EventListParams params, RequestOptions options)
+      throws StripeException {
+    String url = resourceUrl("/v1/events");
+    return requestCollection(url, params, EventCollection.class, options);
+  }
+
+  /**
+   * Retrieves the details of an event. Supply the unique identifier of the event, which you might
+   * have received in a webhook.
+   */
+  public Event retrieve(String id, EventRetrieveParams params) throws StripeException {
+    return retrieve(id, params, (RequestOptions) null);
+  }
+
+  /**
+   * Retrieves the details of an event. Supply the unique identifier of the event, which you might
+   * have received in a webhook.
+   */
+  public Event retrieve(String id, EventRetrieveParams params, RequestOptions options)
+      throws StripeException {
+    String url = resourceUrl("/v1/events/%s", id);
+    return request(ApiResource.RequestMethod.GET, url, params, Event.class, options);
+  }
+}

--- a/src/test/java/com/stripe/net/ApiRequestParamsConverterTest.java
+++ b/src/test/java/com/stripe/net/ApiRequestParamsConverterTest.java
@@ -1,0 +1,201 @@
+package com.stripe.net;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.gson.annotations.SerializedName;
+
+import com.stripe.param.common.EmptyParam;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+public class ApiRequestParamsConverterTest {
+  private ApiRequestParamsConverter converter = new ApiRequestParamsConverter();
+
+  // To test interactions between the flattening and empty enums
+  enum ParamCode implements ApiRequestParams.EnumParam {
+    ENUM_FOO("enum_foo"),
+    ENUM_BAR("enum_bar"),;
+
+    private final String value;
+
+    ParamCode(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public String getValue() {
+      return this.value;
+    }
+  }
+
+  private static class ModelHasExtraParams extends ApiRequestParams {
+    private String stringValue;
+    private EnumParam enumValue;
+
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    private Map<String, Object> extraParams;
+
+    public ModelHasExtraParams(EnumParam enumValue) {
+      this.stringValue = "foo";
+      this.enumValue = enumValue;
+      this.extraParams = new HashMap<>();
+      this.extraParams.put("hello", "world");
+    }
+
+    static Map<String, Object> expectedParams(String enumString) {
+      Map<String, Object> paramMap = new HashMap<>();
+      paramMap.put("string_value", "foo");
+      paramMap.put("enum_value", enumString);
+      // "hello" key is flattened to the same level as root-level params
+      // and the key for `extraParams` is dropped
+      paramMap.put("hello", "world");
+      return paramMap;
+    }
+  }
+
+  private static class RootModelHasNestedExtraParams extends ApiRequestParams {
+    private String rootStringValue;
+    private EnumParam rootEnumValue;
+    private ModelHasExtraParams subParamFoo;
+
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    private Map<String, String> extraParams;
+
+    public RootModelHasNestedExtraParams(EnumParam rootEnumValue,
+                                         ModelHasExtraParams subParamFoo) {
+      this.rootStringValue = "bar";
+      this.rootEnumValue = rootEnumValue;
+      this.subParamFoo = subParamFoo;
+      this.extraParams = new HashMap<>();
+      this.extraParams.put("bar_hello", "bar_world");
+    }
+
+    static Map<String, Object> expectedParams(String enumString) {
+      Map<String, Object> rootLevelParams = new HashMap<>();
+      rootLevelParams.put("root_string_value", "bar");
+      rootLevelParams.put("root_enum_value", enumString);
+      // similar to the `ModelHasExtraParams` test model,
+      // "bar_hello" key is flattened to the same level as root-level params
+      rootLevelParams.put("bar_hello", "bar_world");
+      return rootLevelParams;
+    }
+  }
+
+  private static class ModelHasListExtraParams extends ApiRequestParams {
+    List<ModelHasExtraParams> paramFooList;
+  }
+
+  private static class ModelHasExtraParamsWithWrongSerializedName extends ApiRequestParams {
+    @SerializedName("extra_params")
+    private Map<String, String> extraParams;
+  }
+
+  private static class IllegalModelHasWrongExtraParamsType extends ApiRequestParams {
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    String extraParams;
+  }
+
+  @Test
+  public void testHasExtraParams() {
+    ModelHasExtraParams params = new ModelHasExtraParams(ParamCode.ENUM_FOO);
+
+    assertEquals(
+        ModelHasExtraParams.expectedParams("enum_foo"),
+        toMap(params));
+  }
+
+  @Test
+  public void testHasExtraParamsWithFormEncodedKeys() {
+    ModelHasExtraParams params = new ModelHasExtraParams(ParamCode.ENUM_FOO);
+    params.extraParams.put("root_param[foo][string]", "value_foo");
+    params.extraParams.put("root_param[bar][integer]", "123");
+
+    Map<String, Object> expected = ModelHasExtraParams.expectedParams("enum_foo");
+    assertNotEquals(expected, toMap(params));
+
+    expected.put("root_param[foo][string]", "value_foo");
+    expected.put("root_param[bar][integer]", "123");
+    assertEquals(expected, toMap(params));
+  }
+
+  @Test
+  public void testHasNestedExtraParams() {
+    ModelHasExtraParams fooParams = new ModelHasExtraParams(ParamCode.ENUM_FOO);
+    RootModelHasNestedExtraParams barParams = new RootModelHasNestedExtraParams(
+        ParamCode.ENUM_BAR, fooParams);
+
+    Map<String, Object> expected = RootModelHasNestedExtraParams
+        .expectedParams("enum_bar");
+    expected.put("sub_param_foo", ModelHasExtraParams.expectedParams("enum_foo"));
+
+    assertEquals(expected, toMap(barParams));
+  }
+
+  @Test
+  public void testHasNestedExtraParamsWithEmpty() {
+    ModelHasExtraParams fooParams = new ModelHasExtraParams(EmptyParam.EMPTY);
+
+    RootModelHasNestedExtraParams barParams = new RootModelHasNestedExtraParams(
+        EmptyParam.EMPTY, fooParams);
+
+    Map<String, Object> expected = RootModelHasNestedExtraParams.expectedParams(null);
+    expected.put("sub_param_foo", ModelHasExtraParams.expectedParams(null));
+
+    assertEquals(expected, toMap(barParams));
+  }
+
+  @Test
+  public void testHasListExtraParams() {
+    ModelHasListExtraParams params = new ModelHasListExtraParams();
+    params.paramFooList = Arrays.asList(
+        new ModelHasExtraParams(ParamCode.ENUM_FOO),
+        new ModelHasExtraParams(ParamCode.ENUM_BAR)
+    );
+
+    Map<String, Object> expected = new HashMap<>();
+    expected.put("param_foo_list",
+        Arrays.asList(
+            ModelHasExtraParams.expectedParams("enum_foo"),
+            ModelHasExtraParams.expectedParams("enum_bar")
+        ));
+    assertEquals(expected, toMap(params));
+  }
+
+  @Test
+  public void testHasExtraParamsWithWrongSerializedName() {
+    ModelHasExtraParamsWithWrongSerializedName params =
+        new ModelHasExtraParamsWithWrongSerializedName();
+    params.extraParams = new HashMap<>();
+    params.extraParams.put("foo", "bar");
+
+    Map<String, Object> untypedParams = toMap(params);
+    assertEquals(1, untypedParams.size());
+    assertTrue(untypedParams.containsKey("extra_params"));
+    Map<String, Object> subParams = (Map<String, Object>)untypedParams.get("extra_params");
+    assertEquals(1, subParams.size());
+    assertEquals("bar", subParams.get("foo"));
+  }
+
+  @Test
+  public void testIllegalExtraParamsType() {
+    IllegalModelHasWrongExtraParamsType params = new IllegalModelHasWrongExtraParamsType();
+    params.extraParams = "should have been a map";
+
+    IllegalStateException exception = assertThrows(IllegalStateException.class, () -> {
+      toMap(params);
+    });
+    assertTrue(exception.getMessage().contains("Unexpected schema for extra params"));
+  }
+
+  private Map<String, Object> toMap(ApiRequestParams params) {
+    return converter.convert(params);
+  }
+}

--- a/src/test/java/com/stripe/net/ApiServiceTest.java
+++ b/src/test/java/com/stripe/net/ApiServiceTest.java
@@ -1,0 +1,222 @@
+package com.stripe.net;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.stripe.Stripe;
+import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
+import com.stripe.model.HasId;
+import com.stripe.model.StripeCollection;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.Mockito;
+
+class ApiServiceTest {
+  private static final String FOO_ID = "foo_123";
+  private static final String BAR_ID = "bar_123";
+
+  private static class Foo extends ApiResource implements HasId {
+    @Override
+    public String getId() {
+      return FOO_ID;
+    }
+  }
+
+  private static class FooCollection extends StripeCollection<Foo> {
+  }
+
+  private static class FooParams extends ApiRequestParams {
+  }
+
+  private static class FooOnBarParams extends ApiRequestParams {
+  }
+
+  private static class FooService extends ApiService {
+    String createUrl = "/v1/foos";
+    String customOperationUrl = "/v1/foos/%s/custom_operation";
+    String deleteUrl = "/v1/foos/%s";
+    String listUrl = "/v1/foos";
+    String retrieveUrl = "/v1/foos/%s";
+    String updateUrl = "/v1/foos/%s";
+    String updateOnBarUrl = "/v1/bars/%s/foos/%s";
+
+    public Foo create(FooParams params, RequestOptions options)
+        throws StripeException {
+      String url = resourceUrl(this.createUrl);
+      return request(ApiResource.RequestMethod.POST, url, params, Foo.class, options);
+    }
+
+    public Foo customOperation(String foo, FooParams params, RequestOptions options)
+        throws StripeException {
+      String url = resourceUrl(this.customOperationUrl, foo);
+      return request(ApiResource.RequestMethod.POST, url, params, Foo.class, options);
+    }
+
+    public Foo delete(String foo, FooParams params, RequestOptions options)
+        throws StripeException {
+      String url = resourceUrl(this.deleteUrl, foo);
+      return request(ApiResource.RequestMethod.DELETE, url, params, Foo.class, options);
+    }
+
+    public FooCollection list(FooParams params, RequestOptions options)
+        throws StripeException {
+      String url = resourceUrl(this.listUrl);
+      return requestCollection(url, params, FooCollection.class, options);
+    }
+
+    public Foo retrieve(String foo, FooParams params, RequestOptions options)
+        throws StripeException {
+      String url = resourceUrl(this.retrieveUrl, foo);
+      return request(ApiResource.RequestMethod.GET, url, params, Foo.class, options);
+    }
+
+    public Foo update(String foo, FooParams params, RequestOptions options)
+        throws StripeException {
+      String url = resourceUrl(this.updateUrl, foo);
+      return request(ApiResource.RequestMethod.POST, url, params, Foo.class, options);
+    }
+
+    public Foo update(String bar, String foo, FooOnBarParams params, RequestOptions options)
+        throws StripeException {
+      String url = resourceUrl(this.updateOnBarUrl, bar, foo);
+      return request(ApiResource.RequestMethod.POST, url, params, Foo.class, options);
+    }
+
+    public Foo updateWithInvalidFormatting(String foo, FooParams params, RequestOptions options)
+        throws StripeException {
+      String url = resourceUrl("/v1/foos/%s/bars/%s", foo);
+      return request(ApiResource.RequestMethod.POST, url, params, Foo.class, options);
+    }
+  }
+
+  @AfterAll
+  public static void restoreNetwork() {
+    ApiResource.setStripeResponseGetter(new LiveStripeResponseGetter());
+  }
+
+  private LiveStripeResponseGetter networkMock;
+  private FooService fooService;
+
+  /**
+   * This service test does not rely on stripe-mock, and intended verifications
+   * are at the invocation of the {@code LiveStripeResponseGetter} not the deep-layer
+   * of API request stacks. Therefore, it uses `mock` of the response getter instead of
+   * spy which still does actual invocation in {@link com.stripe.BaseStripeTest}.
+   */
+  @BeforeEach
+  public void setUpNetworkMock() {
+    fooService = new FooService();
+    networkMock = Mockito.mock(LiveStripeResponseGetter.class);
+    ApiResource.setStripeResponseGetter(networkMock);
+  }
+
+  @Test
+  public void testCreate() throws StripeException {
+    fooService.create(new FooParams(), RequestOptions.getDefault());
+
+    verifyRequest(ApiResource.RequestMethod.POST,
+        "/v1/foos", Foo.class);
+  }
+
+  @Test
+  public void testCustomOperation() throws StripeException {
+    fooService.customOperation(FOO_ID, new FooParams(), RequestOptions.getDefault());
+
+    verifyRequest(ApiResource.RequestMethod.POST,
+        String.format("/v1/foos/%s/custom_operation", FOO_ID), Foo.class);
+  }
+
+  @Test
+  public void testDelete() throws StripeException {
+    fooService.delete(FOO_ID, new FooParams(), RequestOptions.getDefault());
+
+    verifyRequest(ApiResource.RequestMethod.DELETE,
+        String.format("/v1/foos/%s", FOO_ID),
+        Foo.class
+    );
+  }
+
+  @Test
+  public void testDeleteWithNullParams() throws StripeException {
+    fooService.delete(FOO_ID, null, RequestOptions.getDefault());
+
+    verifyRequest(ApiResource.RequestMethod.DELETE,
+        String.format("/v1/foos/%s", FOO_ID),
+        Foo.class
+    );
+  }
+
+  @Test
+  public void testList() throws StripeException {
+    fooService.list(new FooParams(), RequestOptions.getDefault());
+
+    verifyRequest(ApiResource.RequestMethod.GET,
+        "/v1/foos",
+        FooCollection.class);
+  }
+
+  @Test
+  public void testRetrieve() throws StripeException {
+    fooService.retrieve(FOO_ID, new FooParams(), RequestOptions.getDefault());
+
+    verifyRequest(ApiResource.RequestMethod.GET,
+        String.format("/v1/foos/%s", FOO_ID),
+        Foo.class
+    );
+  }
+
+  @Test
+  public void testUpdate() throws StripeException {
+    fooService.update(FOO_ID, new FooParams(), RequestOptions.getDefault());
+
+    verifyRequest(ApiResource.RequestMethod.POST,
+        String.format("/v1/foos/%s", FOO_ID), Foo.class);
+  }
+
+  @Test
+  public void testUpdateOnParent() throws StripeException {
+    fooService.update(BAR_ID, FOO_ID, new FooOnBarParams(), RequestOptions.getDefault());
+
+    verifyRequest(ApiResource.RequestMethod.POST,
+        String.format("/v1/bars/%s/foos/%s", BAR_ID, FOO_ID),
+        Foo.class);
+  }
+
+  @Test
+  public void testUpdateThrowingUrlFormatting() {
+    assertThrows(InvalidRequestException.class, () -> {
+      fooService.updateWithInvalidFormatting(FOO_ID, new FooParams(), RequestOptions.getDefault());
+    });
+  }
+
+  @Test
+  public void testUpdateEnsureEncodedVariable() throws StripeException {
+    fooService.update("Plan 100$/month",
+        "Plan 200$/month",
+        new FooOnBarParams(), RequestOptions.getDefault());
+
+    verifyRequest(ApiResource.RequestMethod.POST,
+        String.format("/v1/bars/%s/foos/%s",
+            "Plan+100%24%2Fmonth",
+            "Plan+200%24%2Fmonth"),
+        Foo.class);
+  }
+
+  private void verifyRequest(ApiResource.RequestMethod method,
+                             String path,
+                             Class<?> clazz) throws StripeException {
+    Mockito.verify(networkMock).request(
+        Mockito.eq(method),
+        Mockito.eq(String.format("%s%s", Stripe.getApiBase(), path)),
+        Mockito.any(Map.class),
+        Mockito.eq(clazz),
+        Mockito.eq(ApiResource.RequestType.NORMAL),
+        Mockito.any(RequestOptions.class)
+    );
+  }
+}

--- a/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
+++ b/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
@@ -116,6 +116,27 @@ public class LiveStripeResponseGetterTest {
   }
 
   @Test
+  public void testCreateQueryWithFormEncodedKeys() throws StripeException,
+      UnsupportedEncodingException {
+    /* Use LinkedHashMap because it preserves iteration order */
+    final Map<String, Object> params = new LinkedHashMap<>();
+
+    // Params with form-encoded keys can happen through "extraParams". Instead of passing a
+    // string key and `Object` value, users can also specify key as form-encoded path to the
+    // extra param value.
+    // This "extraParams" behavior is supported by other typed libraries, but not
+    // intended in `stripe-java`. However, by the virtue of supporting arbitrary string key in
+    // extra param map, this behavior is implicitly supported.
+    params.put("nested[0][A]", "A-1");
+    params.put("nested[0][B]", "B-1");
+    params.put("nested[1][A]", "A-2");
+    params.put("nested[1][B]", "B-2");
+
+    assertEquals("nested[0][A]=A-1&nested[0][B]=B-1&nested[1][A]=A-2&nested[1][B]=B-2",
+        LiveStripeResponseGetter.createQuery(params));
+  }
+
+  @Test
   public void testCreateQueryWithEmptyList() throws StripeException, UnsupportedEncodingException {
     final Map<String, Object> params = new HashMap<>();
     params.put("a", new ArrayList<String>());

--- a/src/test/java/com/stripe/service/EventServiceTest.java
+++ b/src/test/java/com/stripe/service/EventServiceTest.java
@@ -1,0 +1,51 @@
+package com.stripe.service;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.google.common.collect.ImmutableMap;
+
+import com.stripe.BaseStripeTest;
+import com.stripe.exception.StripeException;
+import com.stripe.model.Event;
+import com.stripe.model.EventCollection;
+import com.stripe.net.ApiResource;
+import com.stripe.param.EventListParams;
+
+import org.junit.jupiter.api.Test;
+
+public class EventServiceTest extends BaseStripeTest {
+  public static final String EVENT_ID = "evt_123";
+
+  private EventService service = new EventService();
+
+  @Test
+  public void testRetrieve() throws StripeException {
+    final Event event = service.retrieve(EVENT_ID, null);
+
+    assertNotNull(event);
+    verifyRequest(
+        ApiResource.RequestMethod.GET,
+        String.format("/v1/events/%s", EVENT_ID)
+    );
+  }
+
+  @Test
+  public void testList() throws StripeException {
+    EventListParams params = EventListParams.builder()
+        .setLimit(1L)
+        .setType("charge.succeeded")
+        .build();
+
+    final EventCollection resources = service.list(params);
+
+    assertNotNull(resources);
+    verifyRequest(
+        ApiResource.RequestMethod.GET,
+        String.format("/v1/events"),
+        ImmutableMap.of(
+            "limit", 1L,
+            "type", "charge.succeeded"
+        )
+    );
+  }
+}


### PR DESCRIPTION
- This PR implements service for Event which is non-gen.
- The first commit is changes in params: now contains extraParams map required in the service approach.
- The second is the service and its test. Unlike other file, and ephemeral key, event service doesn't have custom logic at the API methods.

This PR is similar to #758 and #759 for `FileService`, and `EphemeralKeyService`
r? @ob-stripe 
@stripe/api-libraries 