### PR TITLE
Clean up ErrorProne warnings

### DIFF
--- a/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
+++ b/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
@@ -29,7 +29,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -124,6 +123,7 @@ public class LiveStripeResponseGetterTest {
         LiveStripeResponseGetter.createQuery(params));
   }
 
+  @SuppressWarnings("ModifiedButNotUsed")
   @Test
   public void testCreateQueryWithCollection() throws UnsupportedEncodingException,
       InvalidRequestException {
@@ -143,13 +143,13 @@ public class LiveStripeResponseGetterTest {
     nestedLinkedHashSet.add("B");
     nestedLinkedHashSet.add("C");
 
-    final List<String> linkedList = new LinkedList<>();
-    linkedList.add("A");
-    linkedList.add("B");
-    linkedList.add("C");
+    final List<String> nestedList = new ArrayList<>();
+    nestedList.add("A");
+    nestedList.add("B");
+    nestedList.add("C");
 
     List<Collection<String>> collections = Arrays.asList(nestedTreeSet, nestedDequeue,
-        nestedLinkedHashSet);
+        nestedLinkedHashSet, nestedList);
 
     for (Collection<String> collection : collections) {
       final Map<String, Object> params = new LinkedHashMap<>();


### PR DESCRIPTION
Small clean ups on error prone warning for the new test that was added in https://github.com/stripe/stripe-java/pull/756
1) Suppress warning to collection that we never accessed directly (but tested the encoding)
```
/home/travis/build/stripe/stripe-java/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java:146: warning: 
[ModifiedButNotUsed] A collection or proto builder was created, but its values were never accessed.
    final List<String> linkedList = new LinkedList<>();
                                    ^
    (see https://errorprone.info/bugpattern/ModifiedButNotUsed)
  Did you mean to remove this line?
```
2) Removed usage of old linked list
```
/home/travis/build/stripe/stripe-java/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java:146: warning: [JdkObsolete] It is very rare for LinkedList to out-perform ArrayList or ArrayDeque. 
Avoid it unless you're willing to invest a lot of time into benchmarking. Caveat: LinkedList supports null elements, but ArrayDeque does not.
    final List<String> linkedList = new LinkedList<>();
                                    ^
    (see https://errorprone.info/bugpattern/JdkObsolete)
  Did you mean 'final List<String> linkedList = new ArrayList<>();'?
2 warnings
```
r? @ob-stripe 
cc @stripe/api-libraries 