### PR TITLE
[generated] source: spec3.sdk.yaml@spec-a38dabc in master

### DIFF
--- a/src/main/java/com/stripe/model/Account.java
+++ b/src/main/java/com/stripe/model/Account.java
@@ -76,7 +76,7 @@ public class Account extends ApiResource implements PaymentSource, MetadataStore
   ExternalAccountCollection externalAccounts;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -87,7 +87,7 @@ public class Account extends ApiResource implements PaymentSource, MetadataStore
    * Set of key-value pairs that you can attach to an object. This can be useful for storing
    * additional information about the object in a structured format.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 

--- a/src/main/java/com/stripe/model/AlipayAccount.java
+++ b/src/main/java/com/stripe/model/AlipayAccount.java
@@ -34,7 +34,7 @@ public class AlipayAccount extends StripeObject implements PaymentSource {
   String fingerprint;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 

--- a/src/main/java/com/stripe/model/ApplePayDomain.java
+++ b/src/main/java/com/stripe/model/ApplePayDomain.java
@@ -31,7 +31,7 @@ public class ApplePayDomain extends ApiResource implements HasId {
   String domainName;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 

--- a/src/main/java/com/stripe/model/Application.java
+++ b/src/main/java/com/stripe/model/Application.java
@@ -12,7 +12,7 @@ import lombok.Setter;
 @EqualsAndHashCode(callSuper = false)
 public class Application extends StripeObject implements HasId {
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 

--- a/src/main/java/com/stripe/model/ApplicationFee.java
+++ b/src/main/java/com/stripe/model/ApplicationFee.java
@@ -68,7 +68,7 @@ public class ApplicationFee extends ApiResource implements BalanceTransactionSou
   String currency;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 

--- a/src/main/java/com/stripe/model/BalanceTransaction.java
+++ b/src/main/java/com/stripe/model/BalanceTransaction.java
@@ -55,7 +55,7 @@ public class BalanceTransaction extends ApiResource implements HasId {
   List<Fee> feeDetails;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 

--- a/src/main/java/com/stripe/model/BalanceTransactionSourceTypeAdapterFactory.java
+++ b/src/main/java/com/stripe/model/BalanceTransactionSourceTypeAdapterFactory.java
@@ -69,31 +69,31 @@ public class BalanceTransactionSourceTypeAdapterFactory implements TypeAdapterFa
             JsonObject object = jsonElementAdapter.read(in).getAsJsonObject();
             BalanceTransactionSource objectResult;
             String objectType = object.getAsJsonPrimitive(discriminator).getAsString();
-            if (objectType.equals("application_fee")) {
+            if ("application_fee".equals(objectType)) {
               objectResult = applicationFeeAdapter.fromJsonTree(object);
-            } else if (objectType.equals("charge")) {
+            } else if ("charge".equals(objectType)) {
               objectResult = chargeAdapter.fromJsonTree(object);
-            } else if (objectType.equals("connect_collection_transfer")) {
+            } else if ("connect_collection_transfer".equals(objectType)) {
               objectResult = connectCollectionTransferAdapter.fromJsonTree(object);
-            } else if (objectType.equals("dispute")) {
+            } else if ("dispute".equals(objectType)) {
               objectResult = disputeAdapter.fromJsonTree(object);
-            } else if (objectType.equals("fee_refund")) {
+            } else if ("fee_refund".equals(objectType)) {
               objectResult = feeRefundAdapter.fromJsonTree(object);
-            } else if (objectType.equals("issuing.authorization")) {
+            } else if ("issuing.authorization".equals(objectType)) {
               objectResult = authorizationAdapter.fromJsonTree(object);
-            } else if (objectType.equals("issuing.transaction")) {
+            } else if ("issuing.transaction".equals(objectType)) {
               objectResult = transactionAdapter.fromJsonTree(object);
-            } else if (objectType.equals("payout")) {
+            } else if ("payout".equals(objectType)) {
               objectResult = payoutAdapter.fromJsonTree(object);
-            } else if (objectType.equals("refund")) {
+            } else if ("refund".equals(objectType)) {
               objectResult = refundAdapter.fromJsonTree(object);
-            } else if (objectType.equals("reserve_transaction")) {
+            } else if ("reserve_transaction".equals(objectType)) {
               objectResult = reserveTransactionAdapter.fromJsonTree(object);
-            } else if (objectType.equals("topup")) {
+            } else if ("topup".equals(objectType)) {
               objectResult = topupAdapter.fromJsonTree(object);
-            } else if (objectType.equals("transfer")) {
+            } else if ("transfer".equals(objectType)) {
               objectResult = transferAdapter.fromJsonTree(object);
-            } else if (objectType.equals("transfer_reversal")) {
+            } else if ("transfer_reversal".equals(objectType)) {
               objectResult = transferReversalAdapter.fromJsonTree(object);
             } else {
               String id = object.getAsJsonPrimitive("id").getAsString();

--- a/src/main/java/com/stripe/model/BankAccount.java
+++ b/src/main/java/com/stripe/model/BankAccount.java
@@ -70,7 +70,7 @@ public class BankAccount extends ApiResource
   String fingerprint;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -81,7 +81,7 @@ public class BankAccount extends ApiResource
    * Set of key-value pairs that you can attach to an object. This can be useful for storing
    * additional information about the object in a structured format.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 

--- a/src/main/java/com/stripe/model/BitcoinReceiver.java
+++ b/src/main/java/com/stripe/model/BitcoinReceiver.java
@@ -82,7 +82,7 @@ public class BitcoinReceiver extends ApiResource implements PaymentSource {
   Boolean filled;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 

--- a/src/main/java/com/stripe/model/BitcoinTransaction.java
+++ b/src/main/java/com/stripe/model/BitcoinTransaction.java
@@ -31,7 +31,7 @@ public class BitcoinTransaction extends StripeObject implements HasId {
   String currency;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 

--- a/src/main/java/com/stripe/model/Card.java
+++ b/src/main/java/com/stripe/model/Card.java
@@ -149,7 +149,7 @@ public class Card extends ApiResource
   String funding;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -175,7 +175,7 @@ public class Card extends ApiResource
    * Set of key-value pairs that you can attach to an object. This can be useful for storing
    * additional information about the object in a structured format.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 

--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -140,7 +140,7 @@ public class Charge extends ApiResource implements BalanceTransactionSource, Met
   FraudDetails fraudDetails;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -164,7 +164,7 @@ public class Charge extends ApiResource implements BalanceTransactionSource, Met
    * Set of key-value pairs that you can attach to an object. This can be useful for storing
    * additional information about the object in a structured format.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 

--- a/src/main/java/com/stripe/model/ConnectCollectionTransfer.java
+++ b/src/main/java/com/stripe/model/ConnectCollectionTransfer.java
@@ -30,7 +30,7 @@ public class ConnectCollectionTransfer extends StripeObject implements BalanceTr
   ExpandableField<Account> destination;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 

--- a/src/main/java/com/stripe/model/CountrySpec.java
+++ b/src/main/java/com/stripe/model/CountrySpec.java
@@ -26,7 +26,7 @@ public class CountrySpec extends ApiResource implements HasId {
   String defaultCurrency;
 
   /** Unique identifier for the object. Represented as the ISO country code for this country. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 

--- a/src/main/java/com/stripe/model/Coupon.java
+++ b/src/main/java/com/stripe/model/Coupon.java
@@ -58,7 +58,7 @@ public class Coupon extends ApiResource implements HasId, MetadataStore<Coupon> 
   Long durationInMonths;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -80,7 +80,7 @@ public class Coupon extends ApiResource implements HasId, MetadataStore<Coupon> 
    * Set of key-value pairs that you can attach to an object. This can be useful for storing
    * additional information about the object in a structured format.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 

--- a/src/main/java/com/stripe/model/CreditNote.java
+++ b/src/main/java/com/stripe/model/CreditNote.java
@@ -43,7 +43,7 @@ public class CreditNote extends ApiResource implements HasId, MetadataStore<Cred
   ExpandableField<Customer> customer;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -68,7 +68,7 @@ public class CreditNote extends ApiResource implements HasId, MetadataStore<Cred
    * Set of key-value pairs that you can attach to an object. This can be useful for storing
    * additional information about the object in a structured format.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 

--- a/src/main/java/com/stripe/model/Customer.java
+++ b/src/main/java/com/stripe/model/Customer.java
@@ -78,7 +78,7 @@ public class Customer extends ApiResource implements HasId, MetadataStore<Custom
   String email;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -100,7 +100,7 @@ public class Customer extends ApiResource implements HasId, MetadataStore<Custom
    * Set of key-value pairs that you can attach to an object. This can be useful for storing
    * additional information about the object in a structured format.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 

--- a/src/main/java/com/stripe/model/Dispute.java
+++ b/src/main/java/com/stripe/model/Dispute.java
@@ -60,7 +60,7 @@ public class Dispute extends ApiResource
   EvidenceDetails evidenceDetails;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -83,7 +83,7 @@ public class Dispute extends ApiResource
    * Set of key-value pairs that you can attach to an object. This can be useful for storing
    * additional information about the object in a structured format.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 

--- a/src/main/java/com/stripe/model/ExchangeRate.java
+++ b/src/main/java/com/stripe/model/ExchangeRate.java
@@ -23,7 +23,7 @@ public class ExchangeRate extends ApiResource implements HasId {
    * Unique identifier for the object. Represented as the three-letter [ISO currency
    * code](https://www.iso.org/iso-4217-currency-codes.html) in lowercase.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 

--- a/src/main/java/com/stripe/model/ExternalAccountTypeAdapterFactory.java
+++ b/src/main/java/com/stripe/model/ExternalAccountTypeAdapterFactory.java
@@ -47,9 +47,9 @@ public class ExternalAccountTypeAdapterFactory implements TypeAdapterFactory {
             JsonObject object = jsonElementAdapter.read(in).getAsJsonObject();
             ExternalAccount objectResult;
             String objectType = object.getAsJsonPrimitive(discriminator).getAsString();
-            if (objectType.equals("bank_account")) {
+            if ("bank_account".equals(objectType)) {
               objectResult = bankAccountAdapter.fromJsonTree(object);
-            } else if (objectType.equals("card")) {
+            } else if ("card".equals(objectType)) {
               objectResult = cardAdapter.fromJsonTree(object);
             } else {
               String id = object.getAsJsonPrimitive("id").getAsString();

--- a/src/main/java/com/stripe/model/FeeRefund.java
+++ b/src/main/java/com/stripe/model/FeeRefund.java
@@ -47,7 +47,7 @@ public class FeeRefund extends ApiResource
   ExpandableField<ApplicationFee> fee;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -55,7 +55,7 @@ public class FeeRefund extends ApiResource
    * Set of key-value pairs that you can attach to an object. This can be useful for storing
    * additional information about the object in a structured format.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 

--- a/src/main/java/com/stripe/model/FileLink.java
+++ b/src/main/java/com/stripe/model/FileLink.java
@@ -39,7 +39,7 @@ public class FileLink extends ApiResource implements HasId, MetadataStore<FileLi
   ExpandableField<File> file;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -54,7 +54,7 @@ public class FileLink extends ApiResource implements HasId, MetadataStore<FileLi
    * Set of key-value pairs that you can attach to an object. This can be useful for storing
    * additional information about the object in a structured format.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 

--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -253,7 +253,7 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
   String hostedInvoiceUrl;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -282,7 +282,7 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
    * Set of key-value pairs that you can attach to an object. This can be useful for storing
    * additional information about the object in a structured format.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 

--- a/src/main/java/com/stripe/model/InvoiceItem.java
+++ b/src/main/java/com/stripe/model/InvoiceItem.java
@@ -57,7 +57,7 @@ public class InvoiceItem extends ApiResource implements HasId, MetadataStore<Inv
   Boolean discountable;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -78,7 +78,7 @@ public class InvoiceItem extends ApiResource implements HasId, MetadataStore<Inv
    * Set of key-value pairs that you can attach to an object. This can be useful for storing
    * additional information about the object in a structured format.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 

--- a/src/main/java/com/stripe/model/InvoiceLineItem.java
+++ b/src/main/java/com/stripe/model/InvoiceLineItem.java
@@ -33,7 +33,7 @@ public class InvoiceLineItem extends StripeObject implements HasId {
   Boolean discountable;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 

--- a/src/main/java/com/stripe/model/IssuerFraudRecord.java
+++ b/src/main/java/com/stripe/model/IssuerFraudRecord.java
@@ -52,7 +52,7 @@ public class IssuerFraudRecord extends ApiResource implements HasId {
   Boolean hasLiabilityShift;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 

--- a/src/main/java/com/stripe/model/Order.java
+++ b/src/main/java/com/stripe/model/Order.java
@@ -74,7 +74,7 @@ public class Order extends ApiResource implements HasId, MetadataStore<Order> {
   String externalCouponCode;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -93,7 +93,7 @@ public class Order extends ApiResource implements HasId, MetadataStore<Order> {
    * Set of key-value pairs that you can attach to an object. This can be useful for storing
    * additional information about the object in a structured format.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 
@@ -467,7 +467,7 @@ public class Order extends ApiResource implements HasId, MetadataStore<Order> {
     String description;
 
     /** Unique identifier for the object. */
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     @SerializedName("id")
     String id;
 

--- a/src/main/java/com/stripe/model/OrderReturn.java
+++ b/src/main/java/com/stripe/model/OrderReturn.java
@@ -39,7 +39,7 @@ public class OrderReturn extends ApiResource implements HasId {
   String currency;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 

--- a/src/main/java/com/stripe/model/PaymentIntent.java
+++ b/src/main/java/com/stripe/model/PaymentIntent.java
@@ -107,7 +107,7 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
   String description;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -133,7 +133,7 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
    * additional information about the object in a structured format. For more information, see the
    * [documentation](https://stripe.com/docs/payments/payment-intents/creating-payment-intents#storing-information-in-metadata).
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 

--- a/src/main/java/com/stripe/model/PaymentMethod.java
+++ b/src/main/java/com/stripe/model/PaymentMethod.java
@@ -45,7 +45,7 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
   ExpandableField<Customer> customer;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -60,7 +60,7 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
    * Set of key-value pairs that you can attach to an object. This can be useful for storing
    * additional information about the object in a structured format.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 

--- a/src/main/java/com/stripe/model/PaymentSourceTypeAdapterFactory.java
+++ b/src/main/java/com/stripe/model/PaymentSourceTypeAdapterFactory.java
@@ -52,17 +52,17 @@ public class PaymentSourceTypeAdapterFactory implements TypeAdapterFactory {
             JsonObject object = jsonElementAdapter.read(in).getAsJsonObject();
             PaymentSource objectResult;
             String objectType = object.getAsJsonPrimitive(discriminator).getAsString();
-            if (objectType.equals("account")) {
+            if ("account".equals(objectType)) {
               objectResult = accountAdapter.fromJsonTree(object);
-            } else if (objectType.equals("alipay_account")) {
+            } else if ("alipay_account".equals(objectType)) {
               objectResult = alipayAccountAdapter.fromJsonTree(object);
-            } else if (objectType.equals("bank_account")) {
+            } else if ("bank_account".equals(objectType)) {
               objectResult = bankAccountAdapter.fromJsonTree(object);
-            } else if (objectType.equals("bitcoin_receiver")) {
+            } else if ("bitcoin_receiver".equals(objectType)) {
               objectResult = bitcoinReceiverAdapter.fromJsonTree(object);
-            } else if (objectType.equals("card")) {
+            } else if ("card".equals(objectType)) {
               objectResult = cardAdapter.fromJsonTree(object);
-            } else if (objectType.equals("source")) {
+            } else if ("source".equals(objectType)) {
               objectResult = sourceAdapter.fromJsonTree(object);
             } else {
               String id = object.getAsJsonPrimitive("id").getAsString();

--- a/src/main/java/com/stripe/model/Payout.java
+++ b/src/main/java/com/stripe/model/Payout.java
@@ -91,7 +91,7 @@ public class Payout extends ApiResource implements BalanceTransactionSource, Met
   String failureMessage;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -106,7 +106,7 @@ public class Payout extends ApiResource implements BalanceTransactionSource, Met
    * Set of key-value pairs that you can attach to an object. This can be useful for storing
    * additional information about the object in a structured format.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 

--- a/src/main/java/com/stripe/model/Person.java
+++ b/src/main/java/com/stripe/model/Person.java
@@ -67,7 +67,7 @@ public class Person extends ApiResource implements HasId, MetadataStore<Person> 
   String gender;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -95,7 +95,7 @@ public class Person extends ApiResource implements HasId, MetadataStore<Person> 
    * Set of key-value pairs that you can attach to an object. This can be useful for storing
    * additional information about the object in a structured format.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 

--- a/src/main/java/com/stripe/model/Plan.java
+++ b/src/main/java/com/stripe/model/Plan.java
@@ -65,7 +65,7 @@ public class Plan extends ApiResource implements HasId, MetadataStore<Plan> {
   Boolean deleted;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -94,7 +94,7 @@ public class Plan extends ApiResource implements HasId, MetadataStore<Plan> {
    * Set of key-value pairs that you can attach to an object. This can be useful for storing
    * additional information about the object in a structured format.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 

--- a/src/main/java/com/stripe/model/Product.java
+++ b/src/main/java/com/stripe/model/Product.java
@@ -62,7 +62,7 @@ public class Product extends ApiResource implements HasId, MetadataStore<Product
   String description;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -84,7 +84,7 @@ public class Product extends ApiResource implements HasId, MetadataStore<Product
    * Set of key-value pairs that you can attach to an object. This can be useful for storing
    * additional information about the object in a structured format.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 

--- a/src/main/java/com/stripe/model/Recipient.java
+++ b/src/main/java/com/stripe/model/Recipient.java
@@ -49,7 +49,7 @@ public class Recipient extends ApiResource implements HasId, MetadataStore<Recip
   String email;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -64,7 +64,7 @@ public class Recipient extends ApiResource implements HasId, MetadataStore<Recip
    * Set of key-value pairs that you can attach to an object. This can be useful for storing
    * additional information about the object in a structured format.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 

--- a/src/main/java/com/stripe/model/Refund.java
+++ b/src/main/java/com/stripe/model/Refund.java
@@ -71,7 +71,7 @@ public class Refund extends ApiResource implements BalanceTransactionSource, Met
   String failureReason;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -79,7 +79,7 @@ public class Refund extends ApiResource implements BalanceTransactionSource, Met
    * Set of key-value pairs that you can attach to an object. This can be useful for storing
    * additional information about the object in a structured format.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 

--- a/src/main/java/com/stripe/model/ReserveTransaction.java
+++ b/src/main/java/com/stripe/model/ReserveTransaction.java
@@ -26,7 +26,7 @@ public class ReserveTransaction extends StripeObject implements BalanceTransacti
   String description;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 

--- a/src/main/java/com/stripe/model/Review.java
+++ b/src/main/java/com/stripe/model/Review.java
@@ -42,7 +42,7 @@ public class Review extends ApiResource implements HasId {
   Long created;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 

--- a/src/main/java/com/stripe/model/Sku.java
+++ b/src/main/java/com/stripe/model/Sku.java
@@ -48,7 +48,7 @@ public class Sku extends ApiResource implements HasId, MetadataStore<Sku> {
   Boolean deleted;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -70,7 +70,7 @@ public class Sku extends ApiResource implements HasId, MetadataStore<Sku> {
    * Set of key-value pairs that you can attach to an object. This can be useful for storing
    * additional information about the object in a structured format.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 

--- a/src/main/java/com/stripe/model/Source.java
+++ b/src/main/java/com/stripe/model/Source.java
@@ -89,7 +89,7 @@ public class Source extends ApiResource implements PaymentSource, MetadataStore<
   Giropay giropay;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -107,7 +107,7 @@ public class Source extends ApiResource implements PaymentSource, MetadataStore<
    * Set of key-value pairs that you can attach to an object. This can be useful for storing
    * additional information about the object in a structured format.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 

--- a/src/main/java/com/stripe/model/SourceMandateNotification.java
+++ b/src/main/java/com/stripe/model/SourceMandateNotification.java
@@ -28,7 +28,7 @@ public class SourceMandateNotification extends StripeObject implements HasId {
   Long created;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 

--- a/src/main/java/com/stripe/model/SourceTransaction.java
+++ b/src/main/java/com/stripe/model/SourceTransaction.java
@@ -37,7 +37,7 @@ public class SourceTransaction extends StripeObject implements HasId {
   String currency;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -143,7 +143,7 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
   Long endedAt;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -168,7 +168,7 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
    * Set of key-value pairs that you can attach to an object. This can be useful for storing
    * additional information about the object in a structured format.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 

--- a/src/main/java/com/stripe/model/SubscriptionItem.java
+++ b/src/main/java/com/stripe/model/SubscriptionItem.java
@@ -40,7 +40,7 @@ public class SubscriptionItem extends ApiResource
   Boolean deleted;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -48,7 +48,7 @@ public class SubscriptionItem extends ApiResource
    * Set of key-value pairs that you can attach to an object. This can be useful for storing
    * additional information about the object in a structured format.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 

--- a/src/main/java/com/stripe/model/SubscriptionSchedule.java
+++ b/src/main/java/com/stripe/model/SubscriptionSchedule.java
@@ -73,7 +73,7 @@ public class SubscriptionSchedule extends ApiResource
   ExpandableField<Customer> customer;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -92,7 +92,7 @@ public class SubscriptionSchedule extends ApiResource
    * Set of key-value pairs that you can attach to an object. This can be useful for storing
    * additional information about the object in a structured format.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 

--- a/src/main/java/com/stripe/model/SubscriptionScheduleRevision.java
+++ b/src/main/java/com/stripe/model/SubscriptionScheduleRevision.java
@@ -18,7 +18,7 @@ public class SubscriptionScheduleRevision extends StripeObject implements HasId 
   Long created;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 

--- a/src/main/java/com/stripe/model/TaxId.java
+++ b/src/main/java/com/stripe/model/TaxId.java
@@ -36,7 +36,7 @@ public class TaxId extends ApiResource implements HasId {
   Boolean deleted;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 

--- a/src/main/java/com/stripe/model/TaxRate.java
+++ b/src/main/java/com/stripe/model/TaxRate.java
@@ -47,7 +47,7 @@ public class TaxRate extends ApiResource implements HasId, MetadataStore<TaxRate
   String displayName;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -70,7 +70,7 @@ public class TaxRate extends ApiResource implements HasId, MetadataStore<TaxRate
    * Set of key-value pairs that you can attach to an object. This can be useful for storing
    * additional information about the object in a structured format.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 

--- a/src/main/java/com/stripe/model/ThreeDSecure.java
+++ b/src/main/java/com/stripe/model/ThreeDSecure.java
@@ -43,7 +43,7 @@ public class ThreeDSecure extends ApiResource implements HasId {
   String currency;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 

--- a/src/main/java/com/stripe/model/Token.java
+++ b/src/main/java/com/stripe/model/Token.java
@@ -40,7 +40,7 @@ public class Token extends ApiResource implements HasId {
   String email;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 

--- a/src/main/java/com/stripe/model/Topup.java
+++ b/src/main/java/com/stripe/model/Topup.java
@@ -68,7 +68,7 @@ public class Topup extends ApiResource implements BalanceTransactionSource, Meta
   String failureMessage;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -83,7 +83,7 @@ public class Topup extends ApiResource implements BalanceTransactionSource, Meta
    * Set of key-value pairs that you can attach to an object. This can be useful for storing
    * additional information about the object in a structured format.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 

--- a/src/main/java/com/stripe/model/Transfer.java
+++ b/src/main/java/com/stripe/model/Transfer.java
@@ -69,7 +69,7 @@ public class Transfer extends ApiResource
   ExpandableField<Charge> destinationPayment;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -84,7 +84,7 @@ public class Transfer extends ApiResource
    * A set of key-value pairs that you can attach to a transfer object. It can be useful for storing
    * additional information about the transfer in a structured format.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 

--- a/src/main/java/com/stripe/model/TransferReversal.java
+++ b/src/main/java/com/stripe/model/TransferReversal.java
@@ -47,7 +47,7 @@ public class TransferReversal extends ApiResource
   ExpandableField<Refund> destinationPaymentRefund;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -55,7 +55,7 @@ public class TransferReversal extends ApiResource
    * Set of key-value pairs that you can attach to an object. This can be useful for storing
    * additional information about the object in a structured format.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 

--- a/src/main/java/com/stripe/model/UsageRecord.java
+++ b/src/main/java/com/stripe/model/UsageRecord.java
@@ -18,7 +18,7 @@ import lombok.Setter;
 @EqualsAndHashCode(callSuper = false)
 public class UsageRecord extends ApiResource implements HasId {
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 

--- a/src/main/java/com/stripe/model/UsageRecordSummary.java
+++ b/src/main/java/com/stripe/model/UsageRecordSummary.java
@@ -12,7 +12,7 @@ import lombok.Setter;
 @EqualsAndHashCode(callSuper = false)
 public class UsageRecordSummary extends StripeObject implements HasId {
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 

--- a/src/main/java/com/stripe/model/WebhookEndpoint.java
+++ b/src/main/java/com/stripe/model/WebhookEndpoint.java
@@ -44,7 +44,7 @@ public class WebhookEndpoint extends ApiResource implements HasId {
   List<String> enabledEvents;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 

--- a/src/main/java/com/stripe/model/checkout/Session.java
+++ b/src/main/java/com/stripe/model/checkout/Session.java
@@ -70,7 +70,7 @@ public class Session extends ApiResource implements HasId {
   List<DisplayItem> displayItems;
 
   /** Unique identifier for the object. Used to pass to `redirectToCheckout` in Stripe.js. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 

--- a/src/main/java/com/stripe/model/issuing/Authorization.java
+++ b/src/main/java/com/stripe/model/issuing/Authorization.java
@@ -88,7 +88,7 @@ public class Authorization extends ApiResource
   String heldCurrency;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -109,7 +109,7 @@ public class Authorization extends ApiResource
    * Set of key-value pairs that you can attach to an object. This can be useful for storing
    * additional information about the object in a structured format.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 

--- a/src/main/java/com/stripe/model/issuing/Card.java
+++ b/src/main/java/com/stripe/model/issuing/Card.java
@@ -60,7 +60,7 @@ public class Card extends ApiResource implements HasId, MetadataStore<Card> {
   Long expYear;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -79,7 +79,7 @@ public class Card extends ApiResource implements HasId, MetadataStore<Card> {
    * Set of key-value pairs that you can attach to an object. This can be useful for storing
    * additional information about the object in a structured format.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 

--- a/src/main/java/com/stripe/model/issuing/Cardholder.java
+++ b/src/main/java/com/stripe/model/issuing/Cardholder.java
@@ -40,7 +40,7 @@ public class Cardholder extends ApiResource implements HasId, MetadataStore<Card
   String email;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -59,7 +59,7 @@ public class Cardholder extends ApiResource implements HasId, MetadataStore<Card
    * Set of key-value pairs that you can attach to an object. This can be useful for storing
    * additional information about the object in a structured format.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 

--- a/src/main/java/com/stripe/model/issuing/Dispute.java
+++ b/src/main/java/com/stripe/model/issuing/Dispute.java
@@ -50,7 +50,7 @@ public class Dispute extends ApiResource implements HasId, MetadataStore<Dispute
   Evidence evidence;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -66,7 +66,7 @@ public class Dispute extends ApiResource implements HasId, MetadataStore<Dispute
    * additional information about the object in a structured format. Individual keys can be unset by
    * posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 

--- a/src/main/java/com/stripe/model/issuing/Transaction.java
+++ b/src/main/java/com/stripe/model/issuing/Transaction.java
@@ -67,7 +67,7 @@ public class Transaction extends ApiResource
   ExpandableField<Dispute> dispute;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -85,7 +85,7 @@ public class Transaction extends ApiResource
    * Set of key-value pairs that you can attach to an object. This can be useful for storing
    * additional information about the object in a structured format.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 

--- a/src/main/java/com/stripe/model/radar/Rule.java
+++ b/src/main/java/com/stripe/model/radar/Rule.java
@@ -22,7 +22,7 @@ public class Rule extends StripeObject implements HasId {
   Boolean deleted;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 

--- a/src/main/java/com/stripe/model/radar/ValueList.java
+++ b/src/main/java/com/stripe/model/radar/ValueList.java
@@ -39,7 +39,7 @@ public class ValueList extends ApiResource implements HasId, MetadataStore<Value
   Boolean deleted;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -65,7 +65,7 @@ public class ValueList extends ApiResource implements HasId, MetadataStore<Value
    * Set of key-value pairs that you can attach to an object. This can be useful for storing
    * additional information about the object in a structured format.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("metadata")
   Map<String, String> metadata;
 

--- a/src/main/java/com/stripe/model/radar/ValueListItem.java
+++ b/src/main/java/com/stripe/model/radar/ValueListItem.java
@@ -33,7 +33,7 @@ public class ValueListItem extends ApiResource implements HasId {
   Boolean deleted;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 

--- a/src/main/java/com/stripe/model/reporting/ReportRun.java
+++ b/src/main/java/com/stripe/model/reporting/ReportRun.java
@@ -35,7 +35,7 @@ public class ReportRun extends ApiResource implements HasId {
   String error;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 

--- a/src/main/java/com/stripe/model/reporting/ReportType.java
+++ b/src/main/java/com/stripe/model/reporting/ReportType.java
@@ -46,7 +46,7 @@ public class ReportType extends ApiResource implements HasId {
    * Type](https://stripe.com/docs/reporting/statements/api#available-report-types), such as
    * `balance.summary.1`.
    */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 

--- a/src/main/java/com/stripe/model/sigma/ScheduledQueryRun.java
+++ b/src/main/java/com/stripe/model/sigma/ScheduledQueryRun.java
@@ -37,7 +37,7 @@ public class ScheduledQueryRun extends ApiResource implements HasId {
   File file;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 

--- a/src/main/java/com/stripe/model/terminal/Location.java
+++ b/src/main/java/com/stripe/model/terminal/Location.java
@@ -35,7 +35,7 @@ public class Location extends ApiResource implements HasId {
   String displayName;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 

--- a/src/main/java/com/stripe/model/terminal/Reader.java
+++ b/src/main/java/com/stripe/model/terminal/Reader.java
@@ -35,7 +35,7 @@ public class Reader extends ApiResource implements HasId {
   String deviceType;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 

--- a/src/main/java/com/stripe/param/AccountCreateParams.java
+++ b/src/main/java/com/stripe/param/AccountCreateParams.java
@@ -2406,7 +2406,7 @@ public class AccountCreateParams extends ApiRequestParams {
           @SerializedName("minimum")
           MINIMUM("minimum");
 
-          @Getter(onMethod = @__({@Override}))
+          @Getter(onMethod_ = {@Override})
           private final String value;
 
           DelayDays(String value) {
@@ -2427,7 +2427,7 @@ public class AccountCreateParams extends ApiRequestParams {
           @SerializedName("weekly")
           WEEKLY("weekly");
 
-          @Getter(onMethod = @__({@Override}))
+          @Getter(onMethod_ = {@Override})
           private final String value;
 
           Interval(String value) {
@@ -2457,7 +2457,7 @@ public class AccountCreateParams extends ApiRequestParams {
           @SerializedName("wednesday")
           WEDNESDAY("wednesday");
 
-          @Getter(onMethod = @__({@Override}))
+          @Getter(onMethod_ = {@Override})
           private final String value;
 
           WeeklyAnchor(String value) {
@@ -2550,7 +2550,7 @@ public class AccountCreateParams extends ApiRequestParams {
     @SerializedName("platform_payments")
     PLATFORM_PAYMENTS("platform_payments");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     RequestedCapability(String value) {
@@ -2568,7 +2568,7 @@ public class AccountCreateParams extends ApiRequestParams {
     @SerializedName("standard")
     STANDARD("standard");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Type(String value) {

--- a/src/main/java/com/stripe/param/AccountLinkCreateParams.java
+++ b/src/main/java/com/stripe/param/AccountLinkCreateParams.java
@@ -147,7 +147,7 @@ public class AccountLinkCreateParams extends ApiRequestParams {
     @SerializedName("eventually_due")
     EVENTUALLY_DUE("eventually_due");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Collect(String value) {

--- a/src/main/java/com/stripe/param/AccountUpdateParams.java
+++ b/src/main/java/com/stripe/param/AccountUpdateParams.java
@@ -2362,7 +2362,7 @@ public class AccountUpdateParams extends ApiRequestParams {
           @SerializedName("minimum")
           MINIMUM("minimum");
 
-          @Getter(onMethod = @__({@Override}))
+          @Getter(onMethod_ = {@Override})
           private final String value;
 
           DelayDays(String value) {
@@ -2383,7 +2383,7 @@ public class AccountUpdateParams extends ApiRequestParams {
           @SerializedName("weekly")
           WEEKLY("weekly");
 
-          @Getter(onMethod = @__({@Override}))
+          @Getter(onMethod_ = {@Override})
           private final String value;
 
           Interval(String value) {
@@ -2413,7 +2413,7 @@ public class AccountUpdateParams extends ApiRequestParams {
           @SerializedName("wednesday")
           WEDNESDAY("wednesday");
 
-          @Getter(onMethod = @__({@Override}))
+          @Getter(onMethod_ = {@Override})
           private final String value;
 
           WeeklyAnchor(String value) {
@@ -2506,7 +2506,7 @@ public class AccountUpdateParams extends ApiRequestParams {
     @SerializedName("platform_payments")
     PLATFORM_PAYMENTS("platform_payments");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     RequestedCapability(String value) {

--- a/src/main/java/com/stripe/param/BankAccountUpdateOnAccountParams.java
+++ b/src/main/java/com/stripe/param/BankAccountUpdateOnAccountParams.java
@@ -153,7 +153,7 @@ public class BankAccountUpdateOnAccountParams extends ApiRequestParams {
     @SerializedName("individual")
     INDIVIDUAL("individual");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     AccountHolderType(String value) {

--- a/src/main/java/com/stripe/param/BankAccountUpdateOnCustomerParams.java
+++ b/src/main/java/com/stripe/param/BankAccountUpdateOnCustomerParams.java
@@ -128,7 +128,7 @@ public class BankAccountUpdateOnCustomerParams extends ApiRequestParams {
     @SerializedName("individual")
     INDIVIDUAL("individual");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     AccountHolderType(String value) {

--- a/src/main/java/com/stripe/param/ChargeUpdateParams.java
+++ b/src/main/java/com/stripe/param/ChargeUpdateParams.java
@@ -270,7 +270,7 @@ public class ChargeUpdateParams extends ApiRequestParams {
       @SerializedName("safe")
       SAFE("safe");
 
-      @Getter(onMethod = @__({@Override}))
+      @Getter(onMethod_ = {@Override})
       private final String value;
 
       UserReport(String value) {

--- a/src/main/java/com/stripe/param/CouponCreateParams.java
+++ b/src/main/java/com/stripe/param/CouponCreateParams.java
@@ -302,7 +302,7 @@ public class CouponCreateParams extends ApiRequestParams {
     @SerializedName("repeating")
     REPEATING("repeating");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Duration(String value) {

--- a/src/main/java/com/stripe/param/CreditNoteCreateParams.java
+++ b/src/main/java/com/stripe/param/CreditNoteCreateParams.java
@@ -235,7 +235,7 @@ public class CreditNoteCreateParams extends ApiRequestParams {
     @SerializedName("product_unsatisfactory")
     PRODUCT_UNSATISFACTORY("product_unsatisfactory");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Reason(String value) {

--- a/src/main/java/com/stripe/param/CustomerCreateParams.java
+++ b/src/main/java/com/stripe/param/CustomerCreateParams.java
@@ -809,7 +809,7 @@ public class CustomerCreateParams extends ApiRequestParams {
       @SerializedName("nz_gst")
       NZ_GST("nz_gst");
 
-      @Getter(onMethod = @__({@Override}))
+      @Getter(onMethod_ = {@Override})
       private final String value;
 
       Type(String value) {
@@ -863,7 +863,7 @@ public class CustomerCreateParams extends ApiRequestParams {
       @SerializedName("vat")
       VAT("vat");
 
-      @Getter(onMethod = @__({@Override}))
+      @Getter(onMethod_ = {@Override})
       private final String value;
 
       Type(String value) {
@@ -882,7 +882,7 @@ public class CustomerCreateParams extends ApiRequestParams {
     @SerializedName("reverse")
     REVERSE("reverse");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     TaxExempt(String value) {

--- a/src/main/java/com/stripe/param/CustomerUpdateParams.java
+++ b/src/main/java/com/stripe/param/CustomerUpdateParams.java
@@ -818,7 +818,7 @@ public class CustomerUpdateParams extends ApiRequestParams {
       @SerializedName("vat")
       VAT("vat");
 
-      @Getter(onMethod = @__({@Override}))
+      @Getter(onMethod_ = {@Override})
       private final String value;
 
       Type(String value) {
@@ -837,7 +837,7 @@ public class CustomerUpdateParams extends ApiRequestParams {
     @SerializedName("reverse")
     REVERSE("reverse");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     TaxExempt(String value) {
@@ -849,7 +849,7 @@ public class CustomerUpdateParams extends ApiRequestParams {
     @SerializedName("now")
     NOW("now");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     TrialEnd(String value) {

--- a/src/main/java/com/stripe/param/ExternalAccountUpdateParams.java
+++ b/src/main/java/com/stripe/param/ExternalAccountUpdateParams.java
@@ -288,7 +288,7 @@ public class ExternalAccountUpdateParams extends ApiRequestParams {
     @SerializedName("individual")
     INDIVIDUAL("individual");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     AccountHolderType(String value) {

--- a/src/main/java/com/stripe/param/FileLinkUpdateParams.java
+++ b/src/main/java/com/stripe/param/FileLinkUpdateParams.java
@@ -137,7 +137,7 @@ public class FileLinkUpdateParams extends ApiRequestParams {
     @SerializedName("now")
     NOW("now");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     ExpiresAt(String value) {

--- a/src/main/java/com/stripe/param/InvoiceCreateParams.java
+++ b/src/main/java/com/stripe/param/InvoiceCreateParams.java
@@ -527,7 +527,7 @@ public class InvoiceCreateParams extends ApiRequestParams {
     @SerializedName("send_invoice")
     SEND_INVOICE("send_invoice");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Billing(String value) {

--- a/src/main/java/com/stripe/param/InvoiceListParams.java
+++ b/src/main/java/com/stripe/param/InvoiceListParams.java
@@ -357,7 +357,7 @@ public class InvoiceListParams extends ApiRequestParams {
     @SerializedName("send_invoice")
     SEND_INVOICE("send_invoice");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Billing(String value) {

--- a/src/main/java/com/stripe/param/InvoiceUpcomingParams.java
+++ b/src/main/java/com/stripe/param/InvoiceUpcomingParams.java
@@ -916,7 +916,7 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
     @SerializedName("unchanged")
     UNCHANGED("unchanged");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     SubscriptionBillingCycleAnchor(String value) {
@@ -928,7 +928,7 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
     @SerializedName("now")
     NOW("now");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     SubscriptionTrialEnd(String value) {

--- a/src/main/java/com/stripe/param/OrderCreateParams.java
+++ b/src/main/java/com/stripe/param/OrderCreateParams.java
@@ -343,7 +343,7 @@ public class OrderCreateParams extends ApiRequestParams {
       @SerializedName("tax")
       TAX("tax");
 
-      @Getter(onMethod = @__({@Override}))
+      @Getter(onMethod_ = {@Override})
       private final String value;
 
       Type(String value) {

--- a/src/main/java/com/stripe/param/OrderReturnOrderParams.java
+++ b/src/main/java/com/stripe/param/OrderReturnOrderParams.java
@@ -169,7 +169,7 @@ public class OrderReturnOrderParams extends ApiRequestParams {
       @SerializedName("tax")
       TAX("tax");
 
-      @Getter(onMethod = @__({@Override}))
+      @Getter(onMethod_ = {@Override})
       private final String value;
 
       Type(String value) {

--- a/src/main/java/com/stripe/param/OrderUpdateParams.java
+++ b/src/main/java/com/stripe/param/OrderUpdateParams.java
@@ -238,7 +238,7 @@ public class OrderUpdateParams extends ApiRequestParams {
     @SerializedName("returned")
     RETURNED("returned");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Status(String value) {

--- a/src/main/java/com/stripe/param/PaymentIntentCancelParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentCancelParams.java
@@ -88,7 +88,7 @@ public class PaymentIntentCancelParams extends ApiRequestParams {
     @SerializedName("requested_by_customer")
     REQUESTED_BY_CUSTOMER("requested_by_customer");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     CancellationReason(String value) {

--- a/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
@@ -736,7 +736,7 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     @SerializedName("manual")
     MANUAL("manual");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     CaptureMethod(String value) {
@@ -751,7 +751,7 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     @SerializedName("manual")
     MANUAL("manual");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     ConfirmationMethod(String value) {

--- a/src/main/java/com/stripe/param/PaymentMethodCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentMethodCreateParams.java
@@ -477,7 +477,7 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
     @SerializedName("card_present")
     CARD_PRESENT("card_present");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Type(String value) {

--- a/src/main/java/com/stripe/param/PaymentMethodListParams.java
+++ b/src/main/java/com/stripe/param/PaymentMethodListParams.java
@@ -161,7 +161,7 @@ public class PaymentMethodListParams extends ApiRequestParams {
     @SerializedName("card_present")
     CARD_PRESENT("card_present");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Type(String value) {

--- a/src/main/java/com/stripe/param/PayoutCreateParams.java
+++ b/src/main/java/com/stripe/param/PayoutCreateParams.java
@@ -246,7 +246,7 @@ public class PayoutCreateParams extends ApiRequestParams {
     @SerializedName("standard")
     STANDARD("standard");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Method(String value) {
@@ -261,7 +261,7 @@ public class PayoutCreateParams extends ApiRequestParams {
     @SerializedName("card")
     CARD("card");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     SourceType(String value) {

--- a/src/main/java/com/stripe/param/PlanCreateParams.java
+++ b/src/main/java/com/stripe/param/PlanCreateParams.java
@@ -613,7 +613,7 @@ public class PlanCreateParams extends ApiRequestParams {
       @SerializedName("inf")
       INF("inf");
 
-      @Getter(onMethod = @__({@Override}))
+      @Getter(onMethod_ = {@Override})
       private final String value;
 
       UpTo(String value) {
@@ -670,7 +670,7 @@ public class PlanCreateParams extends ApiRequestParams {
       @SerializedName("up")
       UP("up");
 
-      @Getter(onMethod = @__({@Override}))
+      @Getter(onMethod_ = {@Override})
       private final String value;
 
       Round(String value) {
@@ -692,7 +692,7 @@ public class PlanCreateParams extends ApiRequestParams {
     @SerializedName("sum")
     SUM("sum");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     AggregateUsage(String value) {
@@ -707,7 +707,7 @@ public class PlanCreateParams extends ApiRequestParams {
     @SerializedName("tiered")
     TIERED("tiered");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     BillingScheme(String value) {
@@ -728,7 +728,7 @@ public class PlanCreateParams extends ApiRequestParams {
     @SerializedName("year")
     YEAR("year");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Interval(String value) {
@@ -743,7 +743,7 @@ public class PlanCreateParams extends ApiRequestParams {
     @SerializedName("volume")
     VOLUME("volume");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     TiersMode(String value) {
@@ -758,7 +758,7 @@ public class PlanCreateParams extends ApiRequestParams {
     @SerializedName("metered")
     METERED("metered");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     UsageType(String value) {

--- a/src/main/java/com/stripe/param/ProductCreateParams.java
+++ b/src/main/java/com/stripe/param/ProductCreateParams.java
@@ -515,7 +515,7 @@ public class ProductCreateParams extends ApiRequestParams {
     @SerializedName("service")
     SERVICE("service");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Type(String value) {

--- a/src/main/java/com/stripe/param/ProductListParams.java
+++ b/src/main/java/com/stripe/param/ProductListParams.java
@@ -326,7 +326,7 @@ public class ProductListParams extends ApiRequestParams {
     @SerializedName("service")
     SERVICE("service");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Type(String value) {

--- a/src/main/java/com/stripe/param/RecipientListParams.java
+++ b/src/main/java/com/stripe/param/RecipientListParams.java
@@ -250,7 +250,7 @@ public class RecipientListParams extends ApiRequestParams {
     @SerializedName("individual")
     INDIVIDUAL("individual");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Type(String value) {

--- a/src/main/java/com/stripe/param/RefundCreateParams.java
+++ b/src/main/java/com/stripe/param/RefundCreateParams.java
@@ -169,7 +169,7 @@ public class RefundCreateParams extends ApiRequestParams {
     @SerializedName("requested_by_customer")
     REQUESTED_BY_CUSTOMER("requested_by_customer");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Reason(String value) {

--- a/src/main/java/com/stripe/param/SkuCreateParams.java
+++ b/src/main/java/com/stripe/param/SkuCreateParams.java
@@ -358,7 +358,7 @@ public class SkuCreateParams extends ApiRequestParams {
       @SerializedName("infinite")
       INFINITE("infinite");
 
-      @Getter(onMethod = @__({@Override}))
+      @Getter(onMethod_ = {@Override})
       private final String value;
 
       Type(String value) {
@@ -376,7 +376,7 @@ public class SkuCreateParams extends ApiRequestParams {
       @SerializedName("out_of_stock")
       OUT_OF_STOCK("out_of_stock");
 
-      @Getter(onMethod = @__({@Override}))
+      @Getter(onMethod_ = {@Override})
       private final String value;
 
       Value(String value) {

--- a/src/main/java/com/stripe/param/SkuUpdateParams.java
+++ b/src/main/java/com/stripe/param/SkuUpdateParams.java
@@ -350,7 +350,7 @@ public class SkuUpdateParams extends ApiRequestParams {
       @SerializedName("infinite")
       INFINITE("infinite");
 
-      @Getter(onMethod = @__({@Override}))
+      @Getter(onMethod_ = {@Override})
       private final String value;
 
       Type(String value) {
@@ -368,7 +368,7 @@ public class SkuUpdateParams extends ApiRequestParams {
       @SerializedName("out_of_stock")
       OUT_OF_STOCK("out_of_stock");
 
-      @Getter(onMethod = @__({@Override}))
+      @Getter(onMethod_ = {@Override})
       private final String value;
 
       Value(String value) {

--- a/src/main/java/com/stripe/param/SourceCreateParams.java
+++ b/src/main/java/com/stripe/param/SourceCreateParams.java
@@ -547,7 +547,7 @@ public class SourceCreateParams extends ApiRequestParams {
       @SerializedName("none")
       NONE("none");
 
-      @Getter(onMethod = @__({@Override}))
+      @Getter(onMethod_ = {@Override})
       private final String value;
 
       RefundAttributesMethod(String value) {
@@ -604,7 +604,7 @@ public class SourceCreateParams extends ApiRequestParams {
     @SerializedName("redirect")
     REDIRECT("redirect");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Flow(String value) {
@@ -619,7 +619,7 @@ public class SourceCreateParams extends ApiRequestParams {
     @SerializedName("single_use")
     SINGLE_USE("single_use");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Usage(String value) {

--- a/src/main/java/com/stripe/param/SubscriptionCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionCreateParams.java
@@ -871,7 +871,7 @@ public class SubscriptionCreateParams extends ApiRequestParams {
     @SerializedName("send_invoice")
     SEND_INVOICE("send_invoice");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Billing(String value) {
@@ -883,7 +883,7 @@ public class SubscriptionCreateParams extends ApiRequestParams {
     @SerializedName("now")
     NOW("now");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     TrialEnd(String value) {

--- a/src/main/java/com/stripe/param/SubscriptionListParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionListParams.java
@@ -470,7 +470,7 @@ public class SubscriptionListParams extends ApiRequestParams {
     @SerializedName("send_invoice")
     SEND_INVOICE("send_invoice");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Billing(String value) {
@@ -506,7 +506,7 @@ public class SubscriptionListParams extends ApiRequestParams {
     @SerializedName("unpaid")
     UNPAID("unpaid");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Status(String value) {

--- a/src/main/java/com/stripe/param/SubscriptionScheduleCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionScheduleCreateParams.java
@@ -833,7 +833,7 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
       @SerializedName("year")
       YEAR("year");
 
-      @Getter(onMethod = @__({@Override}))
+      @Getter(onMethod_ = {@Override})
       private final String value;
 
       Interval(String value) {
@@ -849,7 +849,7 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
     @SerializedName("send_invoice")
     SEND_INVOICE("send_invoice");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Billing(String value) {
@@ -867,7 +867,7 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
     @SerializedName("renew")
     RENEW("renew");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     RenewalBehavior(String value) {
@@ -879,7 +879,7 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
     @SerializedName("now")
     NOW("now");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     StartDate(String value) {

--- a/src/main/java/com/stripe/param/SubscriptionScheduleUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionScheduleUpdateParams.java
@@ -776,7 +776,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
       @SerializedName("now")
       NOW("now");
 
-      @Getter(onMethod = @__({@Override}))
+      @Getter(onMethod_ = {@Override})
       private final String value;
 
       EndDate(String value) {
@@ -788,7 +788,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
       @SerializedName("now")
       NOW("now");
 
-      @Getter(onMethod = @__({@Override}))
+      @Getter(onMethod_ = {@Override})
       private final String value;
 
       StartDate(String value) {
@@ -800,7 +800,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
       @SerializedName("now")
       NOW("now");
 
-      @Getter(onMethod = @__({@Override}))
+      @Getter(onMethod_ = {@Override})
       private final String value;
 
       TrialEnd(String value) {
@@ -869,7 +869,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
       @SerializedName("year")
       YEAR("year");
 
-      @Getter(onMethod = @__({@Override}))
+      @Getter(onMethod_ = {@Override})
       private final String value;
 
       Interval(String value) {
@@ -885,7 +885,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
     @SerializedName("send_invoice")
     SEND_INVOICE("send_invoice");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Billing(String value) {
@@ -903,7 +903,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
     @SerializedName("renew")
     RENEW("renew");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     RenewalBehavior(String value) {

--- a/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
@@ -911,7 +911,7 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
     @SerializedName("send_invoice")
     SEND_INVOICE("send_invoice");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Billing(String value) {
@@ -926,7 +926,7 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
     @SerializedName("unchanged")
     UNCHANGED("unchanged");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     BillingCycleAnchor(String value) {
@@ -938,7 +938,7 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
     @SerializedName("now")
     NOW("now");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     TrialEnd(String value) {

--- a/src/main/java/com/stripe/param/TaxIdCollectionCreateParams.java
+++ b/src/main/java/com/stripe/param/TaxIdCollectionCreateParams.java
@@ -92,7 +92,7 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
     @SerializedName("nz_gst")
     NZ_GST("nz_gst");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Type(String value) {

--- a/src/main/java/com/stripe/param/TokenCreateParams.java
+++ b/src/main/java/com/stripe/param/TokenCreateParams.java
@@ -265,7 +265,7 @@ public class TokenCreateParams extends ApiRequestParams {
       @SerializedName("individual")
       INDIVIDUAL("individual");
 
-      @Getter(onMethod = @__({@Override}))
+      @Getter(onMethod_ = {@Override})
       private final String value;
 
       AccountHolderType(String value) {

--- a/src/main/java/com/stripe/param/TopupListParams.java
+++ b/src/main/java/com/stripe/param/TopupListParams.java
@@ -350,7 +350,7 @@ public class TopupListParams extends ApiRequestParams {
     @SerializedName("succeeded")
     SUCCEEDED("succeeded");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Status(String value) {

--- a/src/main/java/com/stripe/param/TransferCreateParams.java
+++ b/src/main/java/com/stripe/param/TransferCreateParams.java
@@ -243,7 +243,7 @@ public class TransferCreateParams extends ApiRequestParams {
     @SerializedName("card")
     CARD("card");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     SourceType(String value) {

--- a/src/main/java/com/stripe/param/UsageRecordCreateOnSubscriptionItemParams.java
+++ b/src/main/java/com/stripe/param/UsageRecordCreateOnSubscriptionItemParams.java
@@ -122,7 +122,7 @@ public class UsageRecordCreateOnSubscriptionItemParams extends ApiRequestParams 
     @SerializedName("set")
     SET("set");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Action(String value) {

--- a/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
+++ b/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
@@ -410,7 +410,7 @@ public class WebhookEndpointCreateParams extends ApiRequestParams {
     @SerializedName("2019-03-14")
     VERSION_2019_03_14("2019-03-14");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     ApiVersion(String value) {
@@ -818,7 +818,7 @@ public class WebhookEndpointCreateParams extends ApiRequestParams {
     @SerializedName("transfer.updated")
     TRANSFER__UPDATED("transfer.updated");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     EnabledEvent(String value) {

--- a/src/main/java/com/stripe/param/WebhookEndpointUpdateParams.java
+++ b/src/main/java/com/stripe/param/WebhookEndpointUpdateParams.java
@@ -519,7 +519,7 @@ public class WebhookEndpointUpdateParams extends ApiRequestParams {
     @SerializedName("transfer.updated")
     TRANSFER__UPDATED("transfer.updated");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     EnabledEvent(String value) {

--- a/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
+++ b/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
@@ -888,7 +888,7 @@ public class SessionCreateParams extends ApiRequestParams {
       @SerializedName("manual")
       MANUAL("manual");
 
-      @Getter(onMethod = @__({@Override}))
+      @Getter(onMethod_ = {@Override})
       private final String value;
 
       CaptureMethod(String value) {
@@ -1073,7 +1073,7 @@ public class SessionCreateParams extends ApiRequestParams {
     @SerializedName("required")
     REQUIRED("required");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     BillingAddressCollection(String value) {
@@ -1127,7 +1127,7 @@ public class SessionCreateParams extends ApiRequestParams {
     @SerializedName("zh")
     ZH("zh");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Locale(String value) {
@@ -1139,7 +1139,7 @@ public class SessionCreateParams extends ApiRequestParams {
     @SerializedName("card")
     CARD("card");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     PaymentMethodType(String value) {

--- a/src/main/java/com/stripe/param/issuing/AuthorizationListParams.java
+++ b/src/main/java/com/stripe/param/issuing/AuthorizationListParams.java
@@ -273,7 +273,7 @@ public class AuthorizationListParams extends ApiRequestParams {
     @SerializedName("reversed")
     REVERSED("reversed");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Status(String value) {

--- a/src/main/java/com/stripe/param/issuing/CardCreateParams.java
+++ b/src/main/java/com/stripe/param/issuing/CardCreateParams.java
@@ -1341,7 +1341,7 @@ public class CardCreateParams extends ApiRequestParams {
         @SerializedName("wrecking_and_salvage_yards")
         WRECKING_AND_SALVAGE_YARDS("wrecking_and_salvage_yards");
 
-        @Getter(onMethod = @__({@Override}))
+        @Getter(onMethod_ = {@Override})
         private final String value;
 
         Category(String value) {
@@ -1368,7 +1368,7 @@ public class CardCreateParams extends ApiRequestParams {
         @SerializedName("yearly")
         YEARLY("yearly");
 
-        @Getter(onMethod = @__({@Override}))
+        @Getter(onMethod_ = {@Override})
         private final String value;
 
         Interval(String value) {
@@ -2250,7 +2250,7 @@ public class CardCreateParams extends ApiRequestParams {
       @SerializedName("wrecking_and_salvage_yards")
       WRECKING_AND_SALVAGE_YARDS("wrecking_and_salvage_yards");
 
-      @Getter(onMethod = @__({@Override}))
+      @Getter(onMethod_ = {@Override})
       private final String value;
 
       AllowedCategory(String value) {
@@ -3131,7 +3131,7 @@ public class CardCreateParams extends ApiRequestParams {
       @SerializedName("wrecking_and_salvage_yards")
       WRECKING_AND_SALVAGE_YARDS("wrecking_and_salvage_yards");
 
-      @Getter(onMethod = @__({@Override}))
+      @Getter(onMethod_ = {@Override})
       private final String value;
 
       BlockedCategory(String value) {
@@ -3301,7 +3301,7 @@ public class CardCreateParams extends ApiRequestParams {
       @SerializedName("individual")
       INDIVIDUAL("individual");
 
-      @Getter(onMethod = @__({@Override}))
+      @Getter(onMethod_ = {@Override})
       private final String value;
 
       Type(String value) {
@@ -3317,7 +3317,7 @@ public class CardCreateParams extends ApiRequestParams {
     @SerializedName("inactive")
     INACTIVE("inactive");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Status(String value) {
@@ -3332,7 +3332,7 @@ public class CardCreateParams extends ApiRequestParams {
     @SerializedName("virtual")
     VIRTUAL("virtual");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Type(String value) {

--- a/src/main/java/com/stripe/param/issuing/CardListParams.java
+++ b/src/main/java/com/stripe/param/issuing/CardListParams.java
@@ -360,7 +360,7 @@ public class CardListParams extends ApiRequestParams {
     @SerializedName("stolen")
     STOLEN("stolen");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Status(String value) {
@@ -375,7 +375,7 @@ public class CardListParams extends ApiRequestParams {
     @SerializedName("virtual")
     VIRTUAL("virtual");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Type(String value) {

--- a/src/main/java/com/stripe/param/issuing/CardUpdateParams.java
+++ b/src/main/java/com/stripe/param/issuing/CardUpdateParams.java
@@ -1285,7 +1285,7 @@ public class CardUpdateParams extends ApiRequestParams {
         @SerializedName("wrecking_and_salvage_yards")
         WRECKING_AND_SALVAGE_YARDS("wrecking_and_salvage_yards");
 
-        @Getter(onMethod = @__({@Override}))
+        @Getter(onMethod_ = {@Override})
         private final String value;
 
         Category(String value) {
@@ -1312,7 +1312,7 @@ public class CardUpdateParams extends ApiRequestParams {
         @SerializedName("yearly")
         YEARLY("yearly");
 
-        @Getter(onMethod = @__({@Override}))
+        @Getter(onMethod_ = {@Override})
         private final String value;
 
         Interval(String value) {
@@ -2194,7 +2194,7 @@ public class CardUpdateParams extends ApiRequestParams {
       @SerializedName("wrecking_and_salvage_yards")
       WRECKING_AND_SALVAGE_YARDS("wrecking_and_salvage_yards");
 
-      @Getter(onMethod = @__({@Override}))
+      @Getter(onMethod_ = {@Override})
       private final String value;
 
       AllowedCategory(String value) {
@@ -3075,7 +3075,7 @@ public class CardUpdateParams extends ApiRequestParams {
       @SerializedName("wrecking_and_salvage_yards")
       WRECKING_AND_SALVAGE_YARDS("wrecking_and_salvage_yards");
 
-      @Getter(onMethod = @__({@Override}))
+      @Getter(onMethod_ = {@Override})
       private final String value;
 
       BlockedCategory(String value) {
@@ -3100,7 +3100,7 @@ public class CardUpdateParams extends ApiRequestParams {
     @SerializedName("stolen")
     STOLEN("stolen");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Status(String value) {

--- a/src/main/java/com/stripe/param/issuing/CardholderCreateParams.java
+++ b/src/main/java/com/stripe/param/issuing/CardholderCreateParams.java
@@ -1318,7 +1318,7 @@ public class CardholderCreateParams extends ApiRequestParams {
         @SerializedName("wrecking_and_salvage_yards")
         WRECKING_AND_SALVAGE_YARDS("wrecking_and_salvage_yards");
 
-        @Getter(onMethod = @__({@Override}))
+        @Getter(onMethod_ = {@Override})
         private final String value;
 
         Category(String value) {
@@ -1345,7 +1345,7 @@ public class CardholderCreateParams extends ApiRequestParams {
         @SerializedName("yearly")
         YEARLY("yearly");
 
-        @Getter(onMethod = @__({@Override}))
+        @Getter(onMethod_ = {@Override})
         private final String value;
 
         Interval(String value) {
@@ -2227,7 +2227,7 @@ public class CardholderCreateParams extends ApiRequestParams {
       @SerializedName("wrecking_and_salvage_yards")
       WRECKING_AND_SALVAGE_YARDS("wrecking_and_salvage_yards");
 
-      @Getter(onMethod = @__({@Override}))
+      @Getter(onMethod_ = {@Override})
       private final String value;
 
       AllowedCategory(String value) {
@@ -3108,7 +3108,7 @@ public class CardholderCreateParams extends ApiRequestParams {
       @SerializedName("wrecking_and_salvage_yards")
       WRECKING_AND_SALVAGE_YARDS("wrecking_and_salvage_yards");
 
-      @Getter(onMethod = @__({@Override}))
+      @Getter(onMethod_ = {@Override})
       private final String value;
 
       BlockedCategory(String value) {
@@ -3251,7 +3251,7 @@ public class CardholderCreateParams extends ApiRequestParams {
     @SerializedName("inactive")
     INACTIVE("inactive");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Status(String value) {
@@ -3266,7 +3266,7 @@ public class CardholderCreateParams extends ApiRequestParams {
     @SerializedName("individual")
     INDIVIDUAL("individual");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Type(String value) {

--- a/src/main/java/com/stripe/param/issuing/CardholderListParams.java
+++ b/src/main/java/com/stripe/param/issuing/CardholderListParams.java
@@ -310,7 +310,7 @@ public class CardholderListParams extends ApiRequestParams {
     @SerializedName("inactive")
     INACTIVE("inactive");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Status(String value) {
@@ -325,7 +325,7 @@ public class CardholderListParams extends ApiRequestParams {
     @SerializedName("individual")
     INDIVIDUAL("individual");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Type(String value) {

--- a/src/main/java/com/stripe/param/issuing/CardholderUpdateParams.java
+++ b/src/main/java/com/stripe/param/issuing/CardholderUpdateParams.java
@@ -1287,7 +1287,7 @@ public class CardholderUpdateParams extends ApiRequestParams {
         @SerializedName("wrecking_and_salvage_yards")
         WRECKING_AND_SALVAGE_YARDS("wrecking_and_salvage_yards");
 
-        @Getter(onMethod = @__({@Override}))
+        @Getter(onMethod_ = {@Override})
         private final String value;
 
         Category(String value) {
@@ -1314,7 +1314,7 @@ public class CardholderUpdateParams extends ApiRequestParams {
         @SerializedName("yearly")
         YEARLY("yearly");
 
-        @Getter(onMethod = @__({@Override}))
+        @Getter(onMethod_ = {@Override})
         private final String value;
 
         Interval(String value) {
@@ -2196,7 +2196,7 @@ public class CardholderUpdateParams extends ApiRequestParams {
       @SerializedName("wrecking_and_salvage_yards")
       WRECKING_AND_SALVAGE_YARDS("wrecking_and_salvage_yards");
 
-      @Getter(onMethod = @__({@Override}))
+      @Getter(onMethod_ = {@Override})
       private final String value;
 
       AllowedCategory(String value) {
@@ -3077,7 +3077,7 @@ public class CardholderUpdateParams extends ApiRequestParams {
       @SerializedName("wrecking_and_salvage_yards")
       WRECKING_AND_SALVAGE_YARDS("wrecking_and_salvage_yards");
 
-      @Getter(onMethod = @__({@Override}))
+      @Getter(onMethod_ = {@Override})
       private final String value;
 
       BlockedCategory(String value) {
@@ -3220,7 +3220,7 @@ public class CardholderUpdateParams extends ApiRequestParams {
     @SerializedName("inactive")
     INACTIVE("inactive");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Status(String value) {

--- a/src/main/java/com/stripe/param/issuing/DisputeCreateParams.java
+++ b/src/main/java/com/stripe/param/issuing/DisputeCreateParams.java
@@ -326,7 +326,7 @@ public class DisputeCreateParams extends ApiRequestParams {
     @SerializedName("other")
     OTHER("other");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Reason(String value) {

--- a/src/main/java/com/stripe/param/radar/ValueListCreateParams.java
+++ b/src/main/java/com/stripe/param/radar/ValueListCreateParams.java
@@ -170,7 +170,7 @@ public class ValueListCreateParams extends ApiRequestParams {
     @SerializedName("string")
     STRING("string");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     ItemType(String value) {

--- a/src/main/java/com/stripe/param/reporting/ReportRunCreateParams.java
+++ b/src/main/java/com/stripe/param/reporting/ReportRunCreateParams.java
@@ -333,7 +333,7 @@ public class ReportRunCreateParams extends ApiRequestParams {
       @SerializedName("transfer_reversal")
       TRANSFER_REVERSAL("transfer_reversal");
 
-      @Getter(onMethod = @__({@Override}))
+      @Getter(onMethod_ = {@Override})
       private final String value;
 
       ReportingCategory(String value) {


### PR DESCRIPTION
- Use new annotation @Getter(onMethod_ = {@Override}) instead of @Getter(onMethod = @__({@Override}))
- Null-safe equality check in discriminator for interface deserializer

r? @ob-stripe 
cc @stripe/api-libraries 