### PR TITLE
Validate extra params conflict

### DIFF
--- a/src/main/java/com/stripe/net/ApiService.java
+++ b/src/main/java/com/stripe/net/ApiService.java
@@ -1,0 +1,99 @@
+package com.stripe.net;
+
+import com.stripe.Stripe;
+import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
+import com.stripe.model.StripeCollectionInterface;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.MissingFormatArgumentException;
+import java.util.Optional;
+
+/**
+ * Super class to services that make API calls. The service sub-class takes in
+ * {@link ApiRequestParams} and returns {@link ApiResource} or
+ * {@link com.stripe.model.StripeCollection} similarly to the methods on the
+ * resource itself.
+ */
+public abstract class ApiService {
+  /**
+   * Helper class to handle input null params, so users can still conveniently pass null instead of
+   * invoking an empty builder.
+   */
+  private static class ApiServiceNullParams extends ApiRequestParams {
+  }
+
+  /**
+   * Build a resource url given the url format (containing `%s`) and url variables.
+   * The url variables will be UTF-8 encoded.
+   * @param urlFormat     standard string format to be used with {@link String#format}
+   * @param urlVariables  un-encoded url variables as arguments to the url format.
+   * @return url for the resource
+   */
+  protected String resourceUrl(String urlFormat, String... urlVariables)
+      throws InvalidRequestException {
+    List<String> urlVariableList = new ArrayList<>();
+    for (String variable : Arrays.asList(urlVariables)) {
+      urlVariableList.add(ApiResource.urlEncodeId(variable));
+    }
+
+    String format;
+    try {
+      format = String.format(urlFormat, urlVariableList.toArray());
+    } catch (MissingFormatArgumentException ex) {
+      throw new InvalidRequestException(String.format(
+          "Unable to create url with pattern `%s` with url variables `%s`. "
+              + "This is likely a problem with this current library version `%s`. "
+              + "Please contact support@stripe.com for assistance.",
+          urlFormat, urlVariableList, Stripe.VERSION),
+          null, null, null, 0, ex);
+    }
+
+    return String.format("%s%s", Stripe.getApiBase(), format);
+  }
+
+  /**
+   * Make an api request with a valid url like that from {@code resourceUrl}. This method is more
+   * general than its counterpart {@code requestCollection} to list collection classes.
+   * This implementation uses the same underlying method as that in resource class like
+   * {@code Charge.create(params, opts)}.
+   * @param method  http method
+   * @param url     valid url
+   * @param params  nullable request params; null value will be converted to empty params
+   * @param clazz   class to which JSON response is deserialized to
+   * @param options request options
+   * @return object of type clazz
+   * @throws StripeException exceptions containing error code and information helpful for debugging
+   *     and reporting to stripe support.
+   */
+  protected static <T> T request(ApiResource.RequestMethod method,
+                              String url, ApiRequestParams params, Class<T> clazz,
+                              RequestOptions options) throws StripeException {
+    return ApiResource.request(method, url, nullSafeParams(params), clazz, options);
+  }
+
+  /**
+   * Make an api request for collection classes with a valid url like that from {@code resourceUrl}.
+   * This implementation uses the same underlying method as that in resource class when obtaining
+   * object collection like {@code Charge.list(params)} to get {@code ChargeCollection}. Note
+   * that http method cannot be specified; the underlying implementation defaults to GET.
+   * @param url     a valid url
+   * @param params  nullable request params; null value will be converted to empty params
+   * @param clazz   stripe collection class to which JSON response is deserialized to
+   * @param options request options
+   * @return stripe collection object
+   * @throws StripeException exceptions containing error code and information helpful for debugging
+   *     and reporting to stripe support.
+   */
+  protected static <T extends StripeCollectionInterface<?>> T requestCollection(
+      String url, ApiRequestParams params, Class<T> clazz, RequestOptions options)
+      throws StripeException {
+    return ApiResource.requestCollection(url, nullSafeParams(params), clazz, options);
+  }
+
+  private static ApiRequestParams nullSafeParams(ApiRequestParams params) {
+    return Optional.ofNullable(params).orElse(new ApiServiceNullParams());
+  }
+}

--- a/src/test/java/com/stripe/net/ApiRequestParamsConverterTest.java
+++ b/src/test/java/com/stripe/net/ApiRequestParamsConverterTest.java
@@ -195,6 +195,21 @@ public class ApiRequestParamsConverterTest {
     assertTrue(exception.getMessage().contains("Unexpected schema for extra params"));
   }
 
+  @Test
+  public void testIllegalConflictingExtraParams() {
+    ModelHasExtraParams fooParams = new ModelHasExtraParams(ParamCode.ENUM_FOO);
+    // `string_value` will find two param values: one from the original param, the other from the
+    // flattened extra param map.
+    assertTrue(fooParams.toMap().containsKey("string_value"));
+    fooParams.extraParams.put("string_value", "my conflicting param value");
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+      toMap(fooParams);
+    });
+    assertTrue(exception.getMessage().contains(
+        "Found param key `string_value` with values `foo` and `my conflicting param value`."));
+  }
+
   private Map<String, Object> toMap(ApiRequestParams params) {
     return converter.convert(params);
   }

--- a/src/test/java/com/stripe/net/ApiServiceTest.java
+++ b/src/test/java/com/stripe/net/ApiServiceTest.java
@@ -1,0 +1,222 @@
+package com.stripe.net;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.stripe.Stripe;
+import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
+import com.stripe.model.HasId;
+import com.stripe.model.StripeCollection;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.Mockito;
+
+class ApiServiceTest {
+  private static final String FOO_ID = "foo_123";
+  private static final String BAR_ID = "bar_123";
+
+  private static class Foo extends ApiResource implements HasId {
+    @Override
+    public String getId() {
+      return FOO_ID;
+    }
+  }
+
+  private static class FooCollection extends StripeCollection<Foo> {
+  }
+
+  private static class FooParams extends ApiRequestParams {
+  }
+
+  private static class FooOnBarParams extends ApiRequestParams {
+  }
+
+  private static class FooService extends ApiService {
+    String createUrl = "/v1/foos";
+    String customOperationUrl = "/v1/foos/%s/custom_operation";
+    String deleteUrl = "/v1/foos/%s";
+    String listUrl = "/v1/foos";
+    String retrieveUrl = "/v1/foos/%s";
+    String updateUrl = "/v1/foos/%s";
+    String updateOnBarUrl = "/v1/bars/%s/foos/%s";
+
+    public Foo create(FooParams params, RequestOptions options)
+        throws StripeException {
+      String url = resourceUrl(this.createUrl);
+      return request(ApiResource.RequestMethod.POST, url, params, Foo.class, options);
+    }
+
+    public Foo customOperation(String foo, FooParams params, RequestOptions options)
+        throws StripeException {
+      String url = resourceUrl(this.customOperationUrl, foo);
+      return request(ApiResource.RequestMethod.POST, url, params, Foo.class, options);
+    }
+
+    public Foo delete(String foo, FooParams params, RequestOptions options)
+        throws StripeException {
+      String url = resourceUrl(this.deleteUrl, foo);
+      return request(ApiResource.RequestMethod.DELETE, url, params, Foo.class, options);
+    }
+
+    public FooCollection list(FooParams params, RequestOptions options)
+        throws StripeException {
+      String url = resourceUrl(this.listUrl);
+      return requestCollection(url, params, FooCollection.class, options);
+    }
+
+    public Foo retrieve(String foo, FooParams params, RequestOptions options)
+        throws StripeException {
+      String url = resourceUrl(this.retrieveUrl, foo);
+      return request(ApiResource.RequestMethod.GET, url, params, Foo.class, options);
+    }
+
+    public Foo update(String foo, FooParams params, RequestOptions options)
+        throws StripeException {
+      String url = resourceUrl(this.updateUrl, foo);
+      return request(ApiResource.RequestMethod.POST, url, params, Foo.class, options);
+    }
+
+    public Foo update(String bar, String foo, FooOnBarParams params, RequestOptions options)
+        throws StripeException {
+      String url = resourceUrl(this.updateOnBarUrl, bar, foo);
+      return request(ApiResource.RequestMethod.POST, url, params, Foo.class, options);
+    }
+
+    public Foo updateWithInvalidFormatting(String foo, FooParams params, RequestOptions options)
+        throws StripeException {
+      String url = resourceUrl("/v1/foos/%s/bars/%s", foo);
+      return request(ApiResource.RequestMethod.POST, url, params, Foo.class, options);
+    }
+  }
+
+  @AfterAll
+  public static void restoreNetwork() {
+    ApiResource.setStripeResponseGetter(new LiveStripeResponseGetter());
+  }
+
+  private LiveStripeResponseGetter networkMock;
+  private FooService fooService;
+
+  /**
+   * This service test does not rely on stripe-mock, and intended verifications
+   * are at the invocation of the {@code LiveStripeResponseGetter} not the deep-layer
+   * of API request stacks. Therefore, it uses `mock` of the response getter instead of
+   * spy which still does actual invocation in {@link com.stripe.BaseStripeTest}.
+   */
+  @BeforeEach
+  public void setUpNetworkMock() {
+    fooService = new FooService();
+    networkMock = Mockito.mock(LiveStripeResponseGetter.class);
+    ApiResource.setStripeResponseGetter(networkMock);
+  }
+
+  @Test
+  public void testCreate() throws StripeException {
+    fooService.create(new FooParams(), RequestOptions.getDefault());
+
+    verifyRequest(ApiResource.RequestMethod.POST,
+        "/v1/foos", Foo.class);
+  }
+
+  @Test
+  public void testCustomOperation() throws StripeException {
+    fooService.customOperation(FOO_ID, new FooParams(), RequestOptions.getDefault());
+
+    verifyRequest(ApiResource.RequestMethod.POST,
+        String.format("/v1/foos/%s/custom_operation", FOO_ID), Foo.class);
+  }
+
+  @Test
+  public void testDelete() throws StripeException {
+    fooService.delete(FOO_ID, new FooParams(), RequestOptions.getDefault());
+
+    verifyRequest(ApiResource.RequestMethod.DELETE,
+        String.format("/v1/foos/%s", FOO_ID),
+        Foo.class
+    );
+  }
+
+  @Test
+  public void testDeleteWithNullParams() throws StripeException {
+    fooService.delete(FOO_ID, null, RequestOptions.getDefault());
+
+    verifyRequest(ApiResource.RequestMethod.DELETE,
+        String.format("/v1/foos/%s", FOO_ID),
+        Foo.class
+    );
+  }
+
+  @Test
+  public void testList() throws StripeException {
+    fooService.list(new FooParams(), RequestOptions.getDefault());
+
+    verifyRequest(ApiResource.RequestMethod.GET,
+        "/v1/foos",
+        FooCollection.class);
+  }
+
+  @Test
+  public void testRetrieve() throws StripeException {
+    fooService.retrieve(FOO_ID, new FooParams(), RequestOptions.getDefault());
+
+    verifyRequest(ApiResource.RequestMethod.GET,
+        String.format("/v1/foos/%s", FOO_ID),
+        Foo.class
+    );
+  }
+
+  @Test
+  public void testUpdate() throws StripeException {
+    fooService.update(FOO_ID, new FooParams(), RequestOptions.getDefault());
+
+    verifyRequest(ApiResource.RequestMethod.POST,
+        String.format("/v1/foos/%s", FOO_ID), Foo.class);
+  }
+
+  @Test
+  public void testUpdateOnParent() throws StripeException {
+    fooService.update(BAR_ID, FOO_ID, new FooOnBarParams(), RequestOptions.getDefault());
+
+    verifyRequest(ApiResource.RequestMethod.POST,
+        String.format("/v1/bars/%s/foos/%s", BAR_ID, FOO_ID),
+        Foo.class);
+  }
+
+  @Test
+  public void testUpdateThrowingUrlFormatting() {
+    assertThrows(InvalidRequestException.class, () -> {
+      fooService.updateWithInvalidFormatting(FOO_ID, new FooParams(), RequestOptions.getDefault());
+    });
+  }
+
+  @Test
+  public void testUpdateEnsureEncodedVariable() throws StripeException {
+    fooService.update("Plan 100$/month",
+        "Plan 200$/month",
+        new FooOnBarParams(), RequestOptions.getDefault());
+
+    verifyRequest(ApiResource.RequestMethod.POST,
+        String.format("/v1/bars/%s/foos/%s",
+            "Plan+100%24%2Fmonth",
+            "Plan+200%24%2Fmonth"),
+        Foo.class);
+  }
+
+  private void verifyRequest(ApiResource.RequestMethod method,
+                             String path,
+                             Class<?> clazz) throws StripeException {
+    Mockito.verify(networkMock).request(
+        Mockito.eq(method),
+        Mockito.eq(String.format("%s%s", Stripe.getApiBase(), path)),
+        Mockito.any(Map.class),
+        Mockito.eq(clazz),
+        Mockito.eq(ApiResource.RequestType.NORMAL),
+        Mockito.any(RequestOptions.class)
+    );
+  }
+}


### PR DESCRIPTION
- This PR adds validation on passing extra params that conflict with the existing typed params.
- Passing conflicting params may likely be a problem if users think that the extra params that now support object value (instead of only string value) will get automatically merged with the typed params.
- Motivation here is also that we want to release adding extra params independently of the service method changes. 

Now the following pattern will get validation error.
```
// pseudo class schema
FooParams {
  Address {
    Billing {
      line_1: String
      // extra params to support.
      line_3: String
    }
  }
}

// extra params which will conflict with existing params from root-level
Map<String, Object> myLine3Map = ImmutableMap.of(
  "billing", ImmutableMap.of(
    "line_3", "my extra param line3"
  )
);

// will get error here
FooParams fooParams = FooParams.builder()
	.setAddress(myTypedAddressParams())
        .putExtraParams("address", myLine3Map).build();
```
The error message is:
```
Found multiple param values for the same param key. 
This can happen because you passed additional parameters via 
`putExtraParam` that conflict with the existing params. 
Found param key `address` with values `<conflicting value1>` and `<conflicting value2>`. 
If you wish to pass additional params for nested parameters, 
you should add extra params at the nested params themselves, 
not from the top-level param.
```

r? @ob-stripe 
cc @remi-stripe  @stripe/api-libraries  