### PR TITLE
[generated] source: spec3.sdk.yaml@spec-dec5127 in master

### DIFF
--- a/src/main/java/com/stripe/model/PaymentIntent.java
+++ b/src/main/java/com/stripe/model/PaymentIntent.java
@@ -197,7 +197,9 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
 
   /**
    * Status of this PaymentIntent, one of `requires_payment_method`, `requires_confirmation`,
-   * `requires_action`, `processing`, `requires_capture`, `canceled`, or `succeeded`.
+   * `requires_action`, `processing`, `requires_capture`, `canceled`, or `succeeded`. You can read
+   * more about PaymentIntent statuses
+   * [here](https://stripe.com/docs/payments/payment-intents/usage#paymentintent-status-overview).
    */
   @SerializedName("status")
   String status;
@@ -345,24 +347,72 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
     this.source = new ExpandableField<PaymentSource>(expandableObject.getId(), expandableObject);
   }
 
-  /** Creates a PaymentIntent object. */
+  /**
+   * Creates a PaymentIntent object.
+   *
+   * <p>After the PaymentIntent is created, attach a payment method and <a
+   * href="/docs/api/payment_intents/confirm">confirm</a> to continue the payment. You can read more
+   * about the different payment flows available via the Payment Intents API <a
+   * href="/docs/payments/payment-intents">here</a>.
+   *
+   * <p>When <code>confirm=true</code> is used during creation, it is equivalent to creating and
+   * confirming the PaymentIntent in the same call. You may use any parameters available in the <a
+   * href="/docs/api/payment_intents/confirm">confirm API</a> when <code>confirm=true</code> is
+   * supplied.
+   */
   public static PaymentIntent create(Map<String, Object> params) throws StripeException {
     return create(params, (RequestOptions) null);
   }
 
-  /** Creates a PaymentIntent object. */
+  /**
+   * Creates a PaymentIntent object.
+   *
+   * <p>After the PaymentIntent is created, attach a payment method and <a
+   * href="/docs/api/payment_intents/confirm">confirm</a> to continue the payment. You can read more
+   * about the different payment flows available via the Payment Intents API <a
+   * href="/docs/payments/payment-intents">here</a>.
+   *
+   * <p>When <code>confirm=true</code> is used during creation, it is equivalent to creating and
+   * confirming the PaymentIntent in the same call. You may use any parameters available in the <a
+   * href="/docs/api/payment_intents/confirm">confirm API</a> when <code>confirm=true</code> is
+   * supplied.
+   */
   public static PaymentIntent create(Map<String, Object> params, RequestOptions options)
       throws StripeException {
     String url = String.format("%s%s", Stripe.getApiBase(), "/v1/payment_intents");
     return request(ApiResource.RequestMethod.POST, url, params, PaymentIntent.class, options);
   }
 
-  /** Creates a PaymentIntent object. */
+  /**
+   * Creates a PaymentIntent object.
+   *
+   * <p>After the PaymentIntent is created, attach a payment method and <a
+   * href="/docs/api/payment_intents/confirm">confirm</a> to continue the payment. You can read more
+   * about the different payment flows available via the Payment Intents API <a
+   * href="/docs/payments/payment-intents">here</a>.
+   *
+   * <p>When <code>confirm=true</code> is used during creation, it is equivalent to creating and
+   * confirming the PaymentIntent in the same call. You may use any parameters available in the <a
+   * href="/docs/api/payment_intents/confirm">confirm API</a> when <code>confirm=true</code> is
+   * supplied.
+   */
   public static PaymentIntent create(PaymentIntentCreateParams params) throws StripeException {
     return create(params, (RequestOptions) null);
   }
 
-  /** Creates a PaymentIntent object. */
+  /**
+   * Creates a PaymentIntent object.
+   *
+   * <p>After the PaymentIntent is created, attach a payment method and <a
+   * href="/docs/api/payment_intents/confirm">confirm</a> to continue the payment. You can read more
+   * about the different payment flows available via the Payment Intents API <a
+   * href="/docs/payments/payment-intents">here</a>.
+   *
+   * <p>When <code>confirm=true</code> is used during creation, it is equivalent to creating and
+   * confirming the PaymentIntent in the same call. You may use any parameters available in the <a
+   * href="/docs/api/payment_intents/confirm">confirm API</a> when <code>confirm=true</code> is
+   * supplied.
+   */
   public static PaymentIntent create(PaymentIntentCreateParams params, RequestOptions options)
       throws StripeException {
     String url = String.format("%s%s", Stripe.getApiBase(), "/v1/payment_intents");

--- a/src/main/java/com/stripe/model/PaymentMethod.java
+++ b/src/main/java/com/stripe/model/PaymentMethod.java
@@ -69,9 +69,8 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
   String object;
 
   /**
-   * The type of the PaymentMethod, one of `card` or `card_present`. An additional hash is included
-   * on the PaymentMethod with a name matching this value. It contains additional information
-   * specific to the PaymentMethod type.
+   * The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a name
+   * matching this value. It contains additional information specific to the PaymentMethod type.
    */
   @SerializedName("type")
   String type;

--- a/src/main/java/com/stripe/model/issuing/Card.java
+++ b/src/main/java/com/stripe/model/issuing/Card.java
@@ -6,6 +6,7 @@ import com.google.gson.annotations.SerializedName;
 import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
 import com.stripe.model.Address;
+import com.stripe.model.ExpandableField;
 import com.stripe.model.HasId;
 import com.stripe.model.MetadataStore;
 import com.stripe.model.StripeObject;
@@ -91,6 +92,16 @@ public class Card extends ApiResource implements HasId, MetadataStore<Card> {
   @SerializedName("object")
   String object;
 
+  /** The card this card replaces, if any. */
+  @SerializedName("replacement_for")
+  @Getter(lombok.AccessLevel.NONE)
+  @Setter(lombok.AccessLevel.NONE)
+  ExpandableField<Card> replacementFor;
+
+  /** Why the card that this card replaces (if any) needed to be replaced. */
+  @SerializedName("replacement_reason")
+  String replacementReason;
+
   /** Where and how the card will be shipped. */
   @SerializedName("shipping")
   Shipping shipping;
@@ -102,6 +113,24 @@ public class Card extends ApiResource implements HasId, MetadataStore<Card> {
   /** One of `virtual` or `physical`. */
   @SerializedName("type")
   String type;
+
+  /** Get id of expandable `replacementFor` object. */
+  public String getReplacementFor() {
+    return (this.replacementFor != null) ? this.replacementFor.getId() : null;
+  }
+
+  public void setReplacementFor(String id) {
+    this.replacementFor = ApiResource.setExpandableFieldId(id, this.replacementFor);
+  }
+
+  /** Get expanded `replacementFor`. */
+  public Card getReplacementForObject() {
+    return (this.replacementFor != null) ? this.replacementFor.getExpanded() : null;
+  }
+
+  public void setReplacementForObject(Card expandableObject) {
+    this.replacementFor = new ExpandableField<Card>(expandableObject.getId(), expandableObject);
+  }
 
   /**
    * Returns a list of Issuing <code>Card</code> objects. The objects are sorted in descending order

--- a/src/main/java/com/stripe/param/CustomerUpdateParams.java
+++ b/src/main/java/com/stripe/param/CustomerUpdateParams.java
@@ -108,7 +108,7 @@ public class CustomerUpdateParams extends ApiRequestParams {
    * charged for the first time. This will always overwrite any trials that might apply via a
    * subscribed plan. If set, trial_end will override the default trial period of the plan the
    * customer is being subscribed to. The special value `now` can be provided to end the customer's
-   * trial immediately.
+   * trial immediately. Can be at most two years from `billing_cycle_anchor`.
    */
   @SerializedName("trial_end")
   Object trialEnd;
@@ -422,7 +422,7 @@ public class CustomerUpdateParams extends ApiRequestParams {
      * charged for the first time. This will always overwrite any trials that might apply via a
      * subscribed plan. If set, trial_end will override the default trial period of the plan the
      * customer is being subscribed to. The special value `now` can be provided to end the
-     * customer's trial immediately.
+     * customer's trial immediately. Can be at most two years from `billing_cycle_anchor`.
      */
     public Builder setTrialEnd(TrialEnd trialEnd) {
       this.trialEnd = trialEnd;
@@ -434,7 +434,7 @@ public class CustomerUpdateParams extends ApiRequestParams {
      * charged for the first time. This will always overwrite any trials that might apply via a
      * subscribed plan. If set, trial_end will override the default trial period of the plan the
      * customer is being subscribed to. The special value `now` can be provided to end the
-     * customer's trial immediately.
+     * customer's trial immediately. Can be at most two years from `billing_cycle_anchor`.
      */
     public Builder setTrialEnd(Long trialEnd) {
       this.trialEnd = trialEnd;

--- a/src/main/java/com/stripe/param/PaymentIntentListParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentListParams.java
@@ -15,6 +15,10 @@ public class PaymentIntentListParams extends ApiRequestParams {
   @SerializedName("created")
   Object created;
 
+  /** Only return PaymentIntents for the customer specified by this customer ID. */
+  @SerializedName("customer")
+  String customer;
+
   /**
    * A cursor for use in pagination. `ending_before` is an object ID that defines your place in the
    * list. For instance, if you make a list request and receive 100 objects, starting with
@@ -45,8 +49,14 @@ public class PaymentIntentListParams extends ApiRequestParams {
   String startingAfter;
 
   private PaymentIntentListParams(
-      Object created, String endingBefore, List<String> expand, Long limit, String startingAfter) {
+      Object created,
+      String customer,
+      String endingBefore,
+      List<String> expand,
+      Long limit,
+      String startingAfter) {
     this.created = created;
+    this.customer = customer;
     this.endingBefore = endingBefore;
     this.expand = expand;
     this.limit = limit;
@@ -60,6 +70,8 @@ public class PaymentIntentListParams extends ApiRequestParams {
   public static class Builder {
     private Object created;
 
+    private String customer;
+
     private String endingBefore;
 
     private List<String> expand;
@@ -71,7 +83,12 @@ public class PaymentIntentListParams extends ApiRequestParams {
     /** Finalize and obtain parameter instance from this builder. */
     public PaymentIntentListParams build() {
       return new PaymentIntentListParams(
-          this.created, this.endingBefore, this.expand, this.limit, this.startingAfter);
+          this.created,
+          this.customer,
+          this.endingBefore,
+          this.expand,
+          this.limit,
+          this.startingAfter);
     }
 
     /**
@@ -89,6 +106,12 @@ public class PaymentIntentListParams extends ApiRequestParams {
      */
     public Builder setCreated(Long created) {
       this.created = created;
+      return this;
+    }
+
+    /** Only return PaymentIntents for the customer specified by this customer ID. */
+    public Builder setCustomer(String customer) {
+      this.customer = customer;
       return this;
     }
 

--- a/src/main/java/com/stripe/param/SubscriptionCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionCreateParams.java
@@ -160,7 +160,7 @@ public class SubscriptionCreateParams extends ApiRequestParams {
    * charged for the first time. This will always overwrite any trials that might apply via a
    * subscribed plan. If set, trial_end will override the default trial period of the plan the
    * customer is being subscribed to. The special value `now` can be provided to end the customer's
-   * trial immediately.
+   * trial immediately. Can be at most two years from `billing_cycle_anchor`.
    */
   @SerializedName("trial_end")
   Object trialEnd;
@@ -577,7 +577,7 @@ public class SubscriptionCreateParams extends ApiRequestParams {
      * charged for the first time. This will always overwrite any trials that might apply via a
      * subscribed plan. If set, trial_end will override the default trial period of the plan the
      * customer is being subscribed to. The special value `now` can be provided to end the
-     * customer's trial immediately.
+     * customer's trial immediately. Can be at most two years from `billing_cycle_anchor`.
      */
     public Builder setTrialEnd(TrialEnd trialEnd) {
       this.trialEnd = trialEnd;
@@ -589,7 +589,7 @@ public class SubscriptionCreateParams extends ApiRequestParams {
      * charged for the first time. This will always overwrite any trials that might apply via a
      * subscribed plan. If set, trial_end will override the default trial period of the plan the
      * customer is being subscribed to. The special value `now` can be provided to end the
-     * customer's trial immediately.
+     * customer's trial immediately. Can be at most two years from `billing_cycle_anchor`.
      */
     public Builder setTrialEnd(Long trialEnd) {
       this.trialEnd = trialEnd;

--- a/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
@@ -157,7 +157,7 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
    * charged for the first time. This will always overwrite any trials that might apply via a
    * subscribed plan. If set, trial_end will override the default trial period of the plan the
    * customer is being subscribed to. The special value `now` can be provided to end the customer's
-   * trial immediately.
+   * trial immediately. Can be at most two years from `billing_cycle_anchor`.
    */
   @SerializedName("trial_end")
   Object trialEnd;
@@ -571,7 +571,7 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
      * charged for the first time. This will always overwrite any trials that might apply via a
      * subscribed plan. If set, trial_end will override the default trial period of the plan the
      * customer is being subscribed to. The special value `now` can be provided to end the
-     * customer's trial immediately.
+     * customer's trial immediately. Can be at most two years from `billing_cycle_anchor`.
      */
     public Builder setTrialEnd(TrialEnd trialEnd) {
       this.trialEnd = trialEnd;
@@ -583,7 +583,7 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
      * charged for the first time. This will always overwrite any trials that might apply via a
      * subscribed plan. If set, trial_end will override the default trial period of the plan the
      * customer is being subscribed to. The special value `now` can be provided to end the
-     * customer's trial immediately.
+     * customer's trial immediately. Can be at most two years from `billing_cycle_anchor`.
      */
     public Builder setTrialEnd(Long trialEnd) {
       this.trialEnd = trialEnd;

--- a/src/main/java/com/stripe/param/issuing/CardCreateParams.java
+++ b/src/main/java/com/stripe/param/issuing/CardCreateParams.java
@@ -38,6 +38,14 @@ public class CardCreateParams extends ApiRequestParams {
   @SerializedName("metadata")
   Map<String, String> metadata;
 
+  /** The card this is meant to be a replacement for (if any). */
+  @SerializedName("replacement_for")
+  String replacementFor;
+
+  /** If `replacement_for` is specified, this should indicate why that card is being replaced. */
+  @SerializedName("replacement_reason")
+  ReplacementReason replacementReason;
+
   /**
    * The address where the card will be shipped. This will default to the cardholder's billing
    * address for physical cards.
@@ -62,6 +70,8 @@ public class CardCreateParams extends ApiRequestParams {
       String currency,
       List<String> expand,
       Map<String, String> metadata,
+      String replacementFor,
+      ReplacementReason replacementReason,
       Shipping shipping,
       Status status,
       Type type) {
@@ -70,6 +80,8 @@ public class CardCreateParams extends ApiRequestParams {
     this.currency = currency;
     this.expand = expand;
     this.metadata = metadata;
+    this.replacementFor = replacementFor;
+    this.replacementReason = replacementReason;
     this.shipping = shipping;
     this.status = status;
     this.type = type;
@@ -90,6 +102,10 @@ public class CardCreateParams extends ApiRequestParams {
 
     private Map<String, String> metadata;
 
+    private String replacementFor;
+
+    private ReplacementReason replacementReason;
+
     private Shipping shipping;
 
     private Status status;
@@ -104,6 +120,8 @@ public class CardCreateParams extends ApiRequestParams {
           this.currency,
           this.expand,
           this.metadata,
+          this.replacementFor,
+          this.replacementReason,
           this.shipping,
           this.status,
           this.type);
@@ -183,6 +201,18 @@ public class CardCreateParams extends ApiRequestParams {
         this.metadata = new HashMap<>();
       }
       this.metadata.putAll(map);
+      return this;
+    }
+
+    /** The card this is meant to be a replacement for (if any). */
+    public Builder setReplacementFor(String replacementFor) {
+      this.replacementFor = replacementFor;
+      return this;
+    }
+
+    /** If `replacement_for` is specified, this should indicate why that card is being replaced. */
+    public Builder setReplacementReason(ReplacementReason replacementReason) {
+      this.replacementReason = replacementReason;
       return this;
     }
 
@@ -3313,6 +3343,27 @@ public class CardCreateParams extends ApiRequestParams {
       Type(String value) {
         this.value = value;
       }
+    }
+  }
+
+  public enum ReplacementReason implements ApiRequestParams.EnumParam {
+    @SerializedName("damage")
+    DAMAGE("damage"),
+
+    @SerializedName("expiration")
+    EXPIRATION("expiration"),
+
+    @SerializedName("loss")
+    LOSS("loss"),
+
+    @SerializedName("theft")
+    THEFT("theft");
+
+    @Getter(onMethod_ = {@Override})
+    private final String value;
+
+    ReplacementReason(String value) {
+      this.value = value;
     }
   }
 


### PR DESCRIPTION
This adds support for `customer` on List PaymentIntents and `replacement_for` on Issuing Card.

r? @mickjermsurawong 
cc @stripe/api-libraries 