### PR TITLE
Pin library to API version 2019-05-16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
 
 env:
   global:
-  - STRIPE_MOCK_VERSION=0.52.0
+  - STRIPE_MOCK_VERSION=0.57.0
 
 matrix:
   include:

--- a/src/main/java/com/stripe/Stripe.java
+++ b/src/main/java/com/stripe/Stripe.java
@@ -10,7 +10,7 @@ public abstract class Stripe {
   private static final int DEFAULT_CONNECT_TIMEOUT = 30 * 1000;
   private static final int DEFAULT_READ_TIMEOUT = 80 * 1000;
 
-  public static final String API_VERSION = "2019-03-14";
+  public static final String API_VERSION = "2019-05-16";
   public static final String CONNECT_API_BASE = "https://connect.stripe.com";
   public static final String LIVE_API_BASE = "https://api.stripe.com";
   public static final String UPLOAD_API_BASE = "https://files.stripe.com";

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -37,7 +37,7 @@ import org.mockito.Mockito;
 
 public class BaseStripeTest {
   // If changing this number, please also change it in `.travis.yml`.
-  private static final String MOCK_MINIMUM_VERSION = "0.49.0";
+  private static final String MOCK_MINIMUM_VERSION = "0.57.0";
 
   private static String port;
 

--- a/src/test/java/com/stripe/functional/PaymentIntentTest.java
+++ b/src/test/java/com/stripe/functional/PaymentIntentTest.java
@@ -10,7 +10,6 @@ import com.stripe.model.Application;
 import com.stripe.model.Customer;
 import com.stripe.model.PaymentIntent;
 import com.stripe.model.PaymentIntentCollection;
-import com.stripe.model.PaymentSource;
 import com.stripe.model.Review;
 import com.stripe.net.ApiResource;
 
@@ -74,7 +73,7 @@ public class PaymentIntentTest extends BaseStripeTest {
         .addExpand("application")
         .addExpand("customer")
         .addExpand("on_behalf_of")
-        .addAllExpand(Arrays.asList("review", "source", "transfer_data.destination"))
+        .addAllExpand(Arrays.asList("review", "transfer_data.destination"))
         .build();
 
     final PaymentIntent resource = PaymentIntent.retrieve(PAYMENT_INTENT_ID, typedParams,
@@ -99,10 +98,6 @@ public class PaymentIntentTest extends BaseStripeTest {
     assertNotNull(review);
     assertNotNull(review.getId());
     assertEquals(resource.getReview(), review.getId());
-    final PaymentSource source = resource.getSourceObject();
-    assertNotNull(source);
-    assertNotNull(source.getId());
-    assertEquals(resource.getSource(), source.getId());
 
     final Account transferDestination = resource.getTransferData().getDestinationObject();
     assertNotNull(transferDestination);

--- a/src/test/java/com/stripe/model/PaymentIntentTest.java
+++ b/src/test/java/com/stripe/model/PaymentIntentTest.java
@@ -51,10 +51,10 @@ public class PaymentIntentTest extends BaseStripeTest {
     final String[] expansions = {
       "application",
       "customer",
+      "invoice",
       "on_behalf_of",
       "payment_method",
       "review",
-      "source",
       "transfer_data.destination",
     };
 
@@ -72,6 +72,10 @@ public class PaymentIntentTest extends BaseStripeTest {
     assertNotNull(customer);
     assertNotNull(customer.getId());
     assertEquals(resource.getCustomer(), customer.getId());
+    final Invoice invoice = resource.getInvoiceObject();
+    assertNotNull(invoice);
+    assertNotNull(invoice.getId());
+    assertEquals(resource.getInvoice(), invoice.getId());
     final Account account = resource.getOnBehalfOfObject();
     assertNotNull(account);
     assertNotNull(account.getId());
@@ -84,10 +88,6 @@ public class PaymentIntentTest extends BaseStripeTest {
     assertNotNull(review);
     assertNotNull(review.getId());
     assertEquals(resource.getReview(), review.getId());
-    final PaymentSource source = resource.getSourceObject();
-    assertNotNull(source);
-    assertNotNull(source.getId());
-    assertEquals(resource.getSource(), source.getId());
 
     final Account transferDestination = resource.getTransferData().getDestinationObject();
     assertNotNull(transferDestination);


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Tagging this as a breaking API change because it's an API version change and needs to be released as a new major version, but note that there no actual API changes: this API version includes a single behavior change. Cf. https://stripe.com/docs/upgrades#2019-05-16