### PR TITLE
Check null on URL id encoding

### DIFF
--- a/src/main/java/com/stripe/net/ApiResource.java
+++ b/src/main/java/com/stripe/net/ApiResource.java
@@ -160,6 +160,14 @@ public abstract class ApiResource extends StripeObject {
    * URL-encode a string ID in url path formatting.
    */
   public static String urlEncodeId(String id) throws InvalidRequestException {
+    if (id == null) {
+      throw new InvalidRequestException(
+          "Invalid null ID found for url path formatting. This can be because your string ID "
+              + "argument to the API method is null, or the ID field in your stripe object "
+              + "instance is null. Please contact support@stripe.com on the latter case. ",
+          null, null, null, 0, null);
+    }
+
     try {
       return urlEncode(id);
     } catch (UnsupportedEncodingException e) {

--- a/src/test/java/com/stripe/net/ApiResourceTest.java
+++ b/src/test/java/com/stripe/net/ApiResourceTest.java
@@ -1,16 +1,27 @@
 package com.stripe.net;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.stripe.exception.InvalidRequestException;
 
 import java.io.UnsupportedEncodingException;
+
 import org.junit.jupiter.api.Test;
 
 class ApiResourceTest {
 
   @Test
-  public void testUrlEncodeId() throws UnsupportedEncodingException {
+  public void testUrlEncode() throws UnsupportedEncodingException {
     assertEquals("cus_123", ApiResource.urlEncode("cus_123"));
     // legacy Ids allow customer-defined and can have arbitrary names
     assertEquals("Plan+100%24%2Fmonth", ApiResource.urlEncode("Plan 100$/month"));
+  }
+
+  @Test
+  public void testUrlEncodeIdThrowingOnNull() {
+    assertThrows(InvalidRequestException.class, () -> {
+      ApiResource.urlEncodeId(null);
+    });
   }
 }


### PR DESCRIPTION
- Adds null-check on id encoding for url path. This is to simplify the generated code (using prettier poet) that omits this check.
- Currently, this check is already caught in nested resource that access instance field for parent id
https://github.com/stripe/stripe-java/blob/344910fd331262b20406d17e258a235be0872973/src/main/java/com/stripe/model/Source.java#L195-L215
- The new check will allow the generated code to just construct the url instead of the explicit check for all methods.
- This is a "breaking change" because this check now covers string method argument like id in `retrieve` method, or instance id on non-nested resource like basic `update` or `delete`. Although I'm inclined to see this as a fix and make patch bump.

- With this change, generated code with prettier poet passes all the existing tests. It currently fails on 
https://github.com/stripe/stripe-java/blob/344910fd331262b20406d17e258a235be0872973/src/test/java/com/stripe/functional/SourceTest.java#L125-L133
r? @rattrayalex-stripe @ob-stripe 
cc @stripe/api-libraries 