### PR TITLE
Make headers access case insensitive

### DIFF
--- a/src/main/java/com/stripe/net/StripeHeaders.java
+++ b/src/main/java/com/stripe/net/StripeHeaders.java
@@ -1,14 +1,34 @@
 package com.stripe.net;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class StripeHeaders {
 
-  Map<String, List<String>> headers;
+  Map<String, List<String>> headers = new HashMap<String, List<String>>();
 
+  /**
+   * Constructs a collection of headers from the given map.
+   */
   public StripeHeaders(Map<String, List<String>> headers) {
-    this.headers = headers;
+    // Downcase all header names so that we can easily and efficiently perform
+    // case-insensitive lookups.
+    //
+    // This is a general convenience feature, but is particularly important for
+    // HTTP/2 where header names are downcased and looking up something like
+    // `Request-Id` would not otherwise work.
+    for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+      String key = entry.getKey() != null ? entry.getKey().toLowerCase() : null;
+      if (this.headers.containsKey(key)) {
+        throw new IllegalArgumentException(String.format(
+        "Header map contained key `%s` multiple times with varying casing",
+        entry.getKey()
+      ));
+      }
+
+      this.headers.put(key, entry.getValue());
+    }
   }
 
   /**
@@ -26,7 +46,7 @@ public class StripeHeaders {
   }
 
   public List<String> values(String name) {
-    return headers == null ? null : headers.get(name);
+    return headers == null ? null : headers.get(name.toLowerCase());
   }
 
 }

--- a/src/test/java/com/stripe/net/StripeHeadersTest.java
+++ b/src/test/java/com/stripe/net/StripeHeadersTest.java
@@ -1,10 +1,12 @@
 package com.stripe.net;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.stripe.BaseStripeTest;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,10 +32,28 @@ public class StripeHeadersTest extends BaseStripeTest {
   }
 
   @Test
+  public void testDuplicatedKeyError() {
+    assertThrows(IllegalArgumentException.class, () -> {
+      final Map<String, List<String>> headerMap = new HashMap<>();
+      headerMap.put("Request-Id", Arrays.asList("req_123"));
+      headerMap.put("request-id", Arrays.asList("req_123"));
+
+      new StripeHeaders(headerMap);
+    });
+  }
+
+  @Test
   public void testGet() {
     final StripeHeaders headers = new StripeHeaders(generateHeaderMap());
     assertEquals("req_12345", headers.get("Request-Id"));
     assertEquals("FirstValue", headers.get("Multi-Val"));
+  }
+
+  @Test
+  public void testGetCaseInsensitive() {
+    final StripeHeaders headers = new StripeHeaders(generateHeaderMap());
+    assertEquals("req_12345", headers.get("request-id"));
+    assertEquals("FirstValue", headers.get("multi-val"));
   }
 
   @Test


### PR DESCRIPTION
Makes access to header names case insensitive so that we can easily
support HTTP/2 where the convention is to have downcased header names.
This allows us to access something like `Request-Id` regardless of the
backend protocol that's in use.

~~@ob-stripe The one sketchy thing I did here was using Java 8 streams
(because the code looks so good!). We're technically on Java 8+ so this
might be fine, but curious to hear if you have any thoughts on it.
Thanks!~~

r? @ob-stripe
cc @stripe/api-libraries