### PR TITLE
Stop testing OracleJDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,12 @@ before_install:
 
 env:
   global:
-  - STRIPE_MOCK_VERSION=0.57.0
+    # If changing this number, please also change it in `BaseStripeTest.java`.
+  - STRIPE_MOCK_VERSION=0.58.0
 
 matrix:
   include:
-    - jdk: oraclejdk8
     - jdk: openjdk8
-    - jdk: oraclejdk9
     - jdk: openjdk9
     - jdk: openjdk10
     - jdk: openjdk11
@@ -38,7 +37,7 @@ notifications:
 script:
   - ./gradlew --version
   - ./gradlew clean
-  - if [ "$TRAVIS_JDK_VERSION" == "oraclejdk9" ]; then ./gradlew check; fi
+  - if [ "$TRAVIS_JDK_VERSION" == "openjdk8" ]; then ./gradlew check; fi
   - ./gradlew -Djdk.tls.client.protocols="TLSv1.2" cobertura coveralls
 
 before_cache:

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -32,7 +32,7 @@ import org.mockito.Mockito;
 
 public class BaseStripeTest {
   // If changing this number, please also change it in `.travis.yml`.
-  private static final String MOCK_MINIMUM_VERSION = "0.57.0";
+  private static final String MOCK_MINIMUM_VERSION = "0.58.0";
 
   private static String port;
 


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe 
cc @stripe/api-libraries 

It looks like Travis no longer supports Oracle JDK 8 or 9 (the former fails with `Expected feature release number in range of 9 to 14, but got: 8`, the latter fails with a download error).

I'm not sure if this is transient or not, but I think we can safely stop testing Oracle JDK. AFAIK the only technical differences between the two are some very specific components (like OpenJDK Font Renderer and Oracle JDK Flight Recorder), but stripe-java doesn't use those at all.
