### PR TITLE
Enable request latency telemetry by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,15 @@ compile "com.stripe:stripe-java:10.1.0"
 You'll need to manually install the following JARs:
 
 * The Stripe JAR from https://github.com/stripe/stripe-java/releases/latest
-* [Google Gson](https://github.com/google/gson) from <https://repo1.maven.org/maven2/com/google/code/gson/gson/2.8.2/gson-2.8.2.jar>.
+* [Google Gson](https://github.com/google/gson) from <https://repo1.maven.org/maven2/com/google/code/gson/gson/2.8.5/gson-2.8.5.jar>.
 
-### [ProGuard](http://proguard.sourceforge.net/)
+### [ProGuard](https://www.guardsquare.com/en/products/proguard)
 
 If you're planning on using ProGuard, make sure that you exclude the Stripe bindings. You can do this by adding the following to your `proguard.cfg` file:
 
-    -keep class com.stripe.** { *; }
+```
+-keep class com.stripe.** { *; }
+```
 
 ## Documentation
 
@@ -86,7 +88,7 @@ For apps that need to use multiple keys during the lifetime of a process, like
 one that uses [Stripe Connect][connect], it's also possible to set a
 per-request key and/or account:
 
-``` java
+```java
 RequestOptions requestOptions = new RequestOptionsBuilder()
     .setApiKey("sk_test_...")
     .setStripeAccount("acct_...")
@@ -125,10 +127,23 @@ servers.
 If you're writing a plugin that uses the library, we'd appreciate it if you
 identified using `Stripe.setAppInfo()`:
 
-    Stripe.setAppInfo("MyAwesomePlugin", "1.2.34", "https://myawesomeplugin.info");
+```java
+Stripe.setAppInfo("MyAwesomePlugin", "1.2.34", "https://myawesomeplugin.info");
+```
 
 This information is passed along when the library makes calls to the Stripe
 API.
+
+### Request latency telemetry
+
+By default, the library sends request latency telemetry to Stripe. These
+numbers help Stripe improve the overall latency of its API for all users.
+
+You can disable this behavior if you prefer:
+
+```java
+Stripe.enableTelemetry = false;
+```
 
 ## Development
 
@@ -136,25 +151,33 @@ The test suite depends on [stripe-mock], so make sure to fetch and run it from a
 background terminal ([stripe-mock's README][stripe-mock] also contains
 instructions for installing via Homebrew and other methods):
 
-    go get -u github.com/stripe/stripe-mock
-    stripe-mock
+```sh
+go get -u github.com/stripe/stripe-mock
+stripe-mock
+```
 
 You must have Gradle installed. To run the tests:
 
-    ./gradlew test
+```sh
+./gradlew test
+```
 
 You can run particular tests by passing `--tests Class#method`. Make sure you use the fully qualified class name. For example:
 
-    ./gradlew test --tests com.stripe.model.AccountTest
-    ./gradlew test --tests com.stripe.functional.ChargeTest
-    ./gradlew test --tests com.stripe.functional.ChargeTest.testChargeCreate
+```sh
+./gradlew test --tests com.stripe.model.AccountTest
+./gradlew test --tests com.stripe.functional.ChargeTest
+./gradlew test --tests com.stripe.functional.ChargeTest.testChargeCreate
+```
 
 The library uses [Spotless][spotless] along with
 [google-java-format][google-java-format] for code formatting. Code must be
 formatted before PRs are submitted, otherwise CI will fail. Run the formatter
 with:
 
-    ./gradlew spotlessApply
+```sh
+./gradlew spotlessApply
+```
 
 The library uses [Project Lombok][lombok]. While it is not a requirement, you might want to install a [plugin][lombok-plugins] for your favorite IDE to facilitate development.
 

--- a/src/main/java/com/stripe/Stripe.java
+++ b/src/main/java/com/stripe/Stripe.java
@@ -17,7 +17,7 @@ public abstract class Stripe {
 
   public static volatile String apiKey;
   public static volatile String clientId;
-  public static volatile boolean enableTelemetry = false;
+  public static volatile boolean enableTelemetry = true;
   public static volatile String partnerId;
 
   // Note that URLConnection reserves the value of 0 to mean "infinite

--- a/src/test/java/com/stripe/functional/TelemetryTest.java
+++ b/src/test/java/com/stripe/functional/TelemetryTest.java
@@ -42,8 +42,12 @@ public class TelemetryTest extends BaseStripeTest {
     Stripe.enableTelemetry = true;
 
     Balance.retrieve();
-    RecordedRequest request1 = server.takeRequest();
-    assertNull(request1.getHeader("X-Stripe-Client-Telemetry"));
+    server.takeRequest();
+    // The first request may or may not include a `X-Stripe-Client-Telemetry` header depending on
+    // whether this test is the first to run or not. So we don't test the presence or absence of
+    // the header for the first request.
+    // Ideally we'd have a way of emptying the request metrics queue, but it's private and I don't
+    // want to make it public just for tests.
 
     Balance.retrieve();
     RecordedRequest request2 = server.takeRequest();


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe
cc @stripe/api-libraries

Cf. https://github.com/stripe/stripe-ruby/pull/800.