### PR TITLE
Add `getRawJsonObject()` accessor

### DIFF
--- a/src/main/java/com/stripe/model/StripeObject.java
+++ b/src/main/java/com/stripe/model/StripeObject.java
@@ -3,6 +3,8 @@ package com.stripe.model;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import com.stripe.net.ApiResource;
 import com.stripe.net.StripeResponse;
 import java.lang.reflect.Field;
 
@@ -34,11 +36,34 @@ public abstract class StripeObject {
     this.lastResponse = response;
   }
 
+  /**
+   * Returns the raw JsonObject exposed by the Gson library. This can be used to access properties
+   * that are not directly exposed by Stripe's Java library.
+   *
+   * <p>Note: You should always prefer using the standard property accessors whenever possible.
+   * Because this method exposes Gson's underlying API, it is not considered fully stable. Stripe's
+   * Java library might move off Gson in the future and this method would be removed or change
+   * significantly.
+   *
+   * @return The raw JsonObject.
+   */
+  public JsonObject getRawJsonObject() {
+    // Lazily initialize this the first time the getter is called.
+    if (this.rawJsonObject == null) {
+      this.rawJsonObject =
+          ApiResource.GSON.fromJson(this.getLastResponse().body(), JsonObject.class);
+    }
+
+    return this.rawJsonObject;
+  }
+
   public String toJson() {
     return PRETTY_PRINT_GSON.toJson(this);
   }
 
   private transient StripeResponse lastResponse;
+
+  private transient JsonObject rawJsonObject;
 
   private Object getIdString() {
     try {

--- a/src/test/java/com/stripe/functional/StripeObjectTest.java
+++ b/src/test/java/com/stripe/functional/StripeObjectTest.java
@@ -1,0 +1,46 @@
+package com.stripe.functional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.stripe.BaseStripeTest;
+import com.stripe.exception.StripeException;
+import com.stripe.model.Subscription;
+import org.junit.jupiter.api.Test;
+
+public class StripeObjectTest extends BaseStripeTest {
+  @Test
+  public void testGetRawJsonObject() throws StripeException {
+    final Subscription subscription = Subscription.retrieve("sub_123");
+
+    // Access `id`, a string element
+    assertEquals(
+        subscription.getId(),
+        subscription.getRawJsonObject().getAsJsonPrimitive("id").getAsString());
+
+    // Access `created`, a number element
+    assertEquals(
+        subscription.getCreated(),
+        subscription.getRawJsonObject().getAsJsonPrimitive("created").getAsLong());
+
+    // Access `plan[id]`, a nested string element
+    assertEquals(
+        subscription.getPlan().getId(),
+        subscription
+            .getRawJsonObject()
+            .getAsJsonObject("plan")
+            .getAsJsonPrimitive("id")
+            .getAsString());
+
+    // Access `items[data][0][id]`, a deeply nested string element
+    assertEquals(
+        subscription.getItems().getData().get(0).getId(),
+        subscription
+            .getRawJsonObject()
+            .getAsJsonObject("items")
+            .getAsJsonArray("data")
+            .get(0)
+            .getAsJsonObject()
+            .getAsJsonPrimitive("id")
+            .getAsString());
+  }
+}


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Adds a `getRawJsonObject()` accessor to `StripeObject` that returns a raw Gson `JsonObject`. Since this forces us to deserialize the JSON response a second time, the backing field is lazily initialized the first time the method is called.
