### PR TITLE
[generated] source: spec3.sdk.yaml@spec-265a626 in master

### DIFF
--- a/src/main/java/com/stripe/model/PaymentIntent.java
+++ b/src/main/java/com/stripe/model/PaymentIntent.java
@@ -202,6 +202,10 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
   @Setter(lombok.AccessLevel.NONE)
   ExpandableField<PaymentMethod> paymentMethod;
 
+  /** Payment-method-specific configuration for this PaymentIntent. */
+  @SerializedName("payment_method_options")
+  PaymentMethodOptions paymentMethodOptions;
+
   /** The list of payment method types (e.g. card) that this PaymentIntent is allowed to use. */
   @SerializedName("payment_method_types")
   List<String> paymentMethodTypes;
@@ -1058,6 +1062,28 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
     /** The URL you must redirect your customer to in order to authenticate the payment. */
     @SerializedName("url")
     String url;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class PaymentMethodOptions extends StripeObject {
+    @SerializedName("card")
+    Card card;
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class Card extends StripeObject {
+      /**
+       * We strongly recommend that you rely on our SCA engine to automatically prompt your
+       * customers for authentication based on risk level and other requirements. However, if you
+       * wish to request authentication based on logic from your own fraud engine, provide this
+       * option. Permitted values include: `automatic`, `any`, or `challenge_only`.
+       */
+      @SerializedName("request_three_d_secure")
+      String requestThreeDSecure;
+    }
   }
 
   @Getter

--- a/src/main/java/com/stripe/model/SetupIntent.java
+++ b/src/main/java/com/stripe/model/SetupIntent.java
@@ -112,6 +112,10 @@ public class SetupIntent extends ApiResource implements HasId, MetadataStore<Set
   @Setter(lombok.AccessLevel.NONE)
   ExpandableField<PaymentMethod> paymentMethod;
 
+  /** Payment-method-specific configuration for this SetupIntent. */
+  @SerializedName("payment_method_options")
+  PaymentMethodOptions paymentMethodOptions;
+
   /** The list of payment method types (e.g. card) that this SetupIntent is allowed to set up. */
   @SerializedName("payment_method_types")
   List<String> paymentMethodTypes;
@@ -604,5 +608,27 @@ public class SetupIntent extends ApiResource implements HasId, MetadataStore<Set
     /** The URL you must redirect your customer to in order to authenticate. */
     @SerializedName("url")
     String url;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class PaymentMethodOptions extends StripeObject {
+    @SerializedName("card")
+    Card card;
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class Card extends StripeObject {
+      /**
+       * We strongly recommend that you rely on our SCA engine to automatically prompt your
+       * customers for authentication based on risk level and other requirements. However, if you
+       * wish to request authentication based on logic from your own fraud engine, provide this
+       * option. Permitted values include: `automatic`, `any`, or `challenge_only`.
+       */
+      @SerializedName("request_three_d_secure")
+      String requestThreeDSecure;
+    }
   }
 }

--- a/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
@@ -41,6 +41,10 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
   @SerializedName("payment_method")
   String paymentMethod;
 
+  /** Payment-method-specific configuration for this PaymentIntent. */
+  @SerializedName("payment_method_options")
+  PaymentMethodOptions paymentMethodOptions;
+
   /** Email address that the receipt for the resulting payment will be sent to. */
   @SerializedName("receipt_email")
   String receiptEmail;
@@ -106,6 +110,7 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       Map<String, Object> extraParams,
       Object offSession,
       String paymentMethod,
+      PaymentMethodOptions paymentMethodOptions,
       String receiptEmail,
       String returnUrl,
       Boolean savePaymentMethod,
@@ -116,6 +121,7 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
     this.extraParams = extraParams;
     this.offSession = offSession;
     this.paymentMethod = paymentMethod;
+    this.paymentMethodOptions = paymentMethodOptions;
     this.receiptEmail = receiptEmail;
     this.returnUrl = returnUrl;
     this.savePaymentMethod = savePaymentMethod;
@@ -137,6 +143,8 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
 
     private String paymentMethod;
 
+    private PaymentMethodOptions paymentMethodOptions;
+
     private String receiptEmail;
 
     private String returnUrl;
@@ -156,6 +164,7 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
           this.extraParams,
           this.offSession,
           this.paymentMethod,
+          this.paymentMethodOptions,
           this.receiptEmail,
           this.returnUrl,
           this.savePaymentMethod,
@@ -247,6 +256,12 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       return this;
     }
 
+    /** Payment-method-specific configuration for this PaymentIntent. */
+    public Builder setPaymentMethodOptions(PaymentMethodOptions paymentMethodOptions) {
+      this.paymentMethodOptions = paymentMethodOptions;
+      return this;
+    }
+
     /** Email address that the receipt for the resulting payment will be sent to. */
     public Builder setReceiptEmail(String receiptEmail) {
       this.receiptEmail = receiptEmail;
@@ -323,6 +338,191 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
     public Builder setSource(String source) {
       this.source = source;
       return this;
+    }
+  }
+
+  public static class PaymentMethodOptions {
+    /** Configuration for any card payments attempted on this PaymentIntent. */
+    @SerializedName("card")
+    Card card;
+
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    private PaymentMethodOptions(Card card, Map<String, Object> extraParams) {
+      this.card = card;
+      this.extraParams = extraParams;
+    }
+
+    public static Builder builder() {
+      return new com.stripe.param.PaymentIntentConfirmParams.PaymentMethodOptions.Builder();
+    }
+
+    public static class Builder {
+      private Card card;
+
+      private Map<String, Object> extraParams;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public PaymentMethodOptions build() {
+        return new PaymentMethodOptions(this.card, this.extraParams);
+      }
+
+      /** Configuration for any card payments attempted on this PaymentIntent. */
+      public Builder setCard(Card card) {
+        this.card = card;
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * PaymentIntentConfirmParams.PaymentMethodOptions#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link PaymentIntentConfirmParams.PaymentMethodOptions#extraParams} for the field
+       * documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+    }
+
+    public static class Card {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /**
+       * When specified, this parameter indicates that a transaction will be marked as MOTO (Mail
+       * Order Telephone Order) and thus out of scope for SCA.
+       */
+      @SerializedName("moto")
+      Boolean moto;
+
+      /**
+       * We strongly recommend that you rely on our SCA engine to automatically prompt your
+       * customers for authentication based on risk level and other requirements. However, if you
+       * wish to request authentication based on logic from your own fraud engine, provide this
+       * option. Permitted values include: `automatic`, `any`, or `challenge_only`.
+       */
+      @SerializedName("request_three_d_secure")
+      RequestThreeDSecure requestThreeDSecure;
+
+      private Card(
+          Map<String, Object> extraParams, Boolean moto, RequestThreeDSecure requestThreeDSecure) {
+        this.extraParams = extraParams;
+        this.moto = moto;
+        this.requestThreeDSecure = requestThreeDSecure;
+      }
+
+      public static Builder builder() {
+        return new com.stripe.param.PaymentIntentConfirmParams.PaymentMethodOptions.Card.Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private Boolean moto;
+
+        private RequestThreeDSecure requestThreeDSecure;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Card build() {
+          return new Card(this.extraParams, this.moto, this.requestThreeDSecure);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentConfirmParams.PaymentMethodOptions.Card#extraParams} for the
+         * field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentConfirmParams.PaymentMethodOptions.Card#extraParams} for the
+         * field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /**
+         * When specified, this parameter indicates that a transaction will be marked as MOTO (Mail
+         * Order Telephone Order) and thus out of scope for SCA.
+         */
+        public Builder setMoto(Boolean moto) {
+          this.moto = moto;
+          return this;
+        }
+
+        /**
+         * We strongly recommend that you rely on our SCA engine to automatically prompt your
+         * customers for authentication based on risk level and other requirements. However, if you
+         * wish to request authentication based on logic from your own fraud engine, provide this
+         * option. Permitted values include: `automatic`, `any`, or `challenge_only`.
+         */
+        public Builder setRequestThreeDSecure(RequestThreeDSecure requestThreeDSecure) {
+          this.requestThreeDSecure = requestThreeDSecure;
+          return this;
+        }
+      }
+
+      public enum RequestThreeDSecure implements ApiRequestParams.EnumParam {
+        @SerializedName("any")
+        ANY("any"),
+
+        @SerializedName("automatic")
+        AUTOMATIC("automatic"),
+
+        @SerializedName("challenge_only")
+        CHALLENGE_ONLY("challenge_only");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        RequestThreeDSecure(String value) {
+          this.value = value;
+        }
+      }
     }
   }
 

--- a/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
@@ -135,6 +135,10 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
   @SerializedName("payment_method")
   String paymentMethod;
 
+  /** Payment-method-specific configuration for this PaymentIntent. */
+  @SerializedName("payment_method_options")
+  PaymentMethodOptions paymentMethodOptions;
+
   /**
    * The list of payment method types (e.g. card) that this PaymentIntent is allowed to use. If this
    * is not provided, defaults to ["card"].
@@ -240,6 +244,7 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       Object offSession,
       String onBehalfOf,
       String paymentMethod,
+      PaymentMethodOptions paymentMethodOptions,
       List<String> paymentMethodTypes,
       String receiptEmail,
       String returnUrl,
@@ -264,6 +269,7 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     this.offSession = offSession;
     this.onBehalfOf = onBehalfOf;
     this.paymentMethod = paymentMethod;
+    this.paymentMethodOptions = paymentMethodOptions;
     this.paymentMethodTypes = paymentMethodTypes;
     this.receiptEmail = receiptEmail;
     this.returnUrl = returnUrl;
@@ -309,6 +315,8 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
 
     private String paymentMethod;
 
+    private PaymentMethodOptions paymentMethodOptions;
+
     private List<String> paymentMethodTypes;
 
     private String receiptEmail;
@@ -346,6 +354,7 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
           this.offSession,
           this.onBehalfOf,
           this.paymentMethod,
+          this.paymentMethodOptions,
           this.paymentMethodTypes,
           this.receiptEmail,
           this.returnUrl,
@@ -573,6 +582,12 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       return this;
     }
 
+    /** Payment-method-specific configuration for this PaymentIntent. */
+    public Builder setPaymentMethodOptions(PaymentMethodOptions paymentMethodOptions) {
+      this.paymentMethodOptions = paymentMethodOptions;
+      return this;
+    }
+
     /**
      * Add an element to `paymentMethodTypes` list. A list is initialized for the first `add/addAll`
      * call, and subsequent calls adds additional elements to the original list. See {@link
@@ -699,6 +714,191 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     public Builder setTransferGroup(String transferGroup) {
       this.transferGroup = transferGroup;
       return this;
+    }
+  }
+
+  public static class PaymentMethodOptions {
+    /** Configuration for any card payments attempted on this PaymentIntent. */
+    @SerializedName("card")
+    Card card;
+
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    private PaymentMethodOptions(Card card, Map<String, Object> extraParams) {
+      this.card = card;
+      this.extraParams = extraParams;
+    }
+
+    public static Builder builder() {
+      return new com.stripe.param.PaymentIntentCreateParams.PaymentMethodOptions.Builder();
+    }
+
+    public static class Builder {
+      private Card card;
+
+      private Map<String, Object> extraParams;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public PaymentMethodOptions build() {
+        return new PaymentMethodOptions(this.card, this.extraParams);
+      }
+
+      /** Configuration for any card payments attempted on this PaymentIntent. */
+      public Builder setCard(Card card) {
+        this.card = card;
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * PaymentIntentCreateParams.PaymentMethodOptions#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link PaymentIntentCreateParams.PaymentMethodOptions#extraParams} for the field
+       * documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+    }
+
+    public static class Card {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /**
+       * When specified, this parameter indicates that a transaction will be marked as MOTO (Mail
+       * Order Telephone Order) and thus out of scope for SCA.
+       */
+      @SerializedName("moto")
+      Boolean moto;
+
+      /**
+       * We strongly recommend that you rely on our SCA engine to automatically prompt your
+       * customers for authentication based on risk level and other requirements. However, if you
+       * wish to request authentication based on logic from your own fraud engine, provide this
+       * option. Permitted values include: `automatic`, `any`, or `challenge_only`.
+       */
+      @SerializedName("request_three_d_secure")
+      RequestThreeDSecure requestThreeDSecure;
+
+      private Card(
+          Map<String, Object> extraParams, Boolean moto, RequestThreeDSecure requestThreeDSecure) {
+        this.extraParams = extraParams;
+        this.moto = moto;
+        this.requestThreeDSecure = requestThreeDSecure;
+      }
+
+      public static Builder builder() {
+        return new com.stripe.param.PaymentIntentCreateParams.PaymentMethodOptions.Card.Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private Boolean moto;
+
+        private RequestThreeDSecure requestThreeDSecure;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Card build() {
+          return new Card(this.extraParams, this.moto, this.requestThreeDSecure);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentCreateParams.PaymentMethodOptions.Card#extraParams} for the
+         * field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentCreateParams.PaymentMethodOptions.Card#extraParams} for the
+         * field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /**
+         * When specified, this parameter indicates that a transaction will be marked as MOTO (Mail
+         * Order Telephone Order) and thus out of scope for SCA.
+         */
+        public Builder setMoto(Boolean moto) {
+          this.moto = moto;
+          return this;
+        }
+
+        /**
+         * We strongly recommend that you rely on our SCA engine to automatically prompt your
+         * customers for authentication based on risk level and other requirements. However, if you
+         * wish to request authentication based on logic from your own fraud engine, provide this
+         * option. Permitted values include: `automatic`, `any`, or `challenge_only`.
+         */
+        public Builder setRequestThreeDSecure(RequestThreeDSecure requestThreeDSecure) {
+          this.requestThreeDSecure = requestThreeDSecure;
+          return this;
+        }
+      }
+
+      public enum RequestThreeDSecure implements ApiRequestParams.EnumParam {
+        @SerializedName("any")
+        ANY("any"),
+
+        @SerializedName("automatic")
+        AUTOMATIC("automatic"),
+
+        @SerializedName("challenge_only")
+        CHALLENGE_ONLY("challenge_only");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        RequestThreeDSecure(String value) {
+          this.value = value;
+        }
+      }
     }
   }
 

--- a/src/main/java/com/stripe/param/SetupIntentConfirmParams.java
+++ b/src/main/java/com/stripe/param/SetupIntentConfirmParams.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import lombok.Getter;
 
 public class SetupIntentConfirmParams extends ApiRequestParams {
   /** Specifies which fields in the response should be expanded. */
@@ -30,6 +31,10 @@ public class SetupIntentConfirmParams extends ApiRequestParams {
   @SerializedName("payment_method")
   String paymentMethod;
 
+  /** Payment-method-specific configuration for this SetupIntent. */
+  @SerializedName("payment_method_options")
+  PaymentMethodOptions paymentMethodOptions;
+
   /**
    * The URL to redirect your customer back to after they authenticate on the payment method's app
    * or site. If you'd prefer to redirect to a mobile application, you can alternatively supply an
@@ -43,10 +48,12 @@ public class SetupIntentConfirmParams extends ApiRequestParams {
       List<String> expand,
       Map<String, Object> extraParams,
       String paymentMethod,
+      PaymentMethodOptions paymentMethodOptions,
       String returnUrl) {
     this.expand = expand;
     this.extraParams = extraParams;
     this.paymentMethod = paymentMethod;
+    this.paymentMethodOptions = paymentMethodOptions;
     this.returnUrl = returnUrl;
   }
 
@@ -61,12 +68,18 @@ public class SetupIntentConfirmParams extends ApiRequestParams {
 
     private String paymentMethod;
 
+    private PaymentMethodOptions paymentMethodOptions;
+
     private String returnUrl;
 
     /** Finalize and obtain parameter instance from this builder. */
     public SetupIntentConfirmParams build() {
       return new SetupIntentConfirmParams(
-          this.expand, this.extraParams, this.paymentMethod, this.returnUrl);
+          this.expand,
+          this.extraParams,
+          this.paymentMethod,
+          this.paymentMethodOptions,
+          this.returnUrl);
     }
 
     /**
@@ -130,6 +143,12 @@ public class SetupIntentConfirmParams extends ApiRequestParams {
       return this;
     }
 
+    /** Payment-method-specific configuration for this SetupIntent. */
+    public Builder setPaymentMethodOptions(PaymentMethodOptions paymentMethodOptions) {
+      this.paymentMethodOptions = paymentMethodOptions;
+      return this;
+    }
+
     /**
      * The URL to redirect your customer back to after they authenticate on the payment method's app
      * or site. If you'd prefer to redirect to a mobile application, you can alternatively supply an
@@ -139,6 +158,191 @@ public class SetupIntentConfirmParams extends ApiRequestParams {
     public Builder setReturnUrl(String returnUrl) {
       this.returnUrl = returnUrl;
       return this;
+    }
+  }
+
+  public static class PaymentMethodOptions {
+    /** Configuration for any card setup attempted on this SetupIntent. */
+    @SerializedName("card")
+    Card card;
+
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    private PaymentMethodOptions(Card card, Map<String, Object> extraParams) {
+      this.card = card;
+      this.extraParams = extraParams;
+    }
+
+    public static Builder builder() {
+      return new com.stripe.param.SetupIntentConfirmParams.PaymentMethodOptions.Builder();
+    }
+
+    public static class Builder {
+      private Card card;
+
+      private Map<String, Object> extraParams;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public PaymentMethodOptions build() {
+        return new PaymentMethodOptions(this.card, this.extraParams);
+      }
+
+      /** Configuration for any card setup attempted on this SetupIntent. */
+      public Builder setCard(Card card) {
+        this.card = card;
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * SetupIntentConfirmParams.PaymentMethodOptions#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link SetupIntentConfirmParams.PaymentMethodOptions#extraParams} for the field
+       * documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+    }
+
+    public static class Card {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /**
+       * When specified, this parameter signals that a card has been collected as MOTO (Mail Order
+       * Telephone Order) and is thus out of scope for SCA.
+       */
+      @SerializedName("moto")
+      Boolean moto;
+
+      /**
+       * We strongly recommend that you rely on our SCA engine to automatically prompt your
+       * customers for authentication based on risk level and other requirements. However, if you
+       * wish to request authentication based on logic from your own fraud engine, provide this
+       * option. Permitted values include: `automatic`, `any`, or `challenge_only`.
+       */
+      @SerializedName("request_three_d_secure")
+      RequestThreeDSecure requestThreeDSecure;
+
+      private Card(
+          Map<String, Object> extraParams, Boolean moto, RequestThreeDSecure requestThreeDSecure) {
+        this.extraParams = extraParams;
+        this.moto = moto;
+        this.requestThreeDSecure = requestThreeDSecure;
+      }
+
+      public static Builder builder() {
+        return new com.stripe.param.SetupIntentConfirmParams.PaymentMethodOptions.Card.Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private Boolean moto;
+
+        private RequestThreeDSecure requestThreeDSecure;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Card build() {
+          return new Card(this.extraParams, this.moto, this.requestThreeDSecure);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link SetupIntentConfirmParams.PaymentMethodOptions.Card#extraParams} for the
+         * field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link SetupIntentConfirmParams.PaymentMethodOptions.Card#extraParams} for the
+         * field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /**
+         * When specified, this parameter signals that a card has been collected as MOTO (Mail Order
+         * Telephone Order) and is thus out of scope for SCA.
+         */
+        public Builder setMoto(Boolean moto) {
+          this.moto = moto;
+          return this;
+        }
+
+        /**
+         * We strongly recommend that you rely on our SCA engine to automatically prompt your
+         * customers for authentication based on risk level and other requirements. However, if you
+         * wish to request authentication based on logic from your own fraud engine, provide this
+         * option. Permitted values include: `automatic`, `any`, or `challenge_only`.
+         */
+        public Builder setRequestThreeDSecure(RequestThreeDSecure requestThreeDSecure) {
+          this.requestThreeDSecure = requestThreeDSecure;
+          return this;
+        }
+      }
+
+      public enum RequestThreeDSecure implements ApiRequestParams.EnumParam {
+        @SerializedName("any")
+        ANY("any"),
+
+        @SerializedName("automatic")
+        AUTOMATIC("automatic"),
+
+        @SerializedName("challenge_only")
+        CHALLENGE_ONLY("challenge_only");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        RequestThreeDSecure(String value) {
+          this.value = value;
+        }
+      }
     }
   }
 }

--- a/src/main/java/com/stripe/param/SetupIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/SetupIntentCreateParams.java
@@ -63,6 +63,10 @@ public class SetupIntentCreateParams extends ApiRequestParams {
   @SerializedName("payment_method")
   String paymentMethod;
 
+  /** Payment-method-specific configuration for this SetupIntent. */
+  @SerializedName("payment_method_options")
+  PaymentMethodOptions paymentMethodOptions;
+
   /**
    * The list of payment method types (e.g. card) that this SetupIntent is allowed to use. If this
    * is not provided, defaults to ["card"].
@@ -98,6 +102,7 @@ public class SetupIntentCreateParams extends ApiRequestParams {
       Map<String, String> metadata,
       String onBehalfOf,
       String paymentMethod,
+      PaymentMethodOptions paymentMethodOptions,
       List<String> paymentMethodTypes,
       String returnUrl,
       Object usage) {
@@ -109,6 +114,7 @@ public class SetupIntentCreateParams extends ApiRequestParams {
     this.metadata = metadata;
     this.onBehalfOf = onBehalfOf;
     this.paymentMethod = paymentMethod;
+    this.paymentMethodOptions = paymentMethodOptions;
     this.paymentMethodTypes = paymentMethodTypes;
     this.returnUrl = returnUrl;
     this.usage = usage;
@@ -135,6 +141,8 @@ public class SetupIntentCreateParams extends ApiRequestParams {
 
     private String paymentMethod;
 
+    private PaymentMethodOptions paymentMethodOptions;
+
     private List<String> paymentMethodTypes;
 
     private String returnUrl;
@@ -152,6 +160,7 @@ public class SetupIntentCreateParams extends ApiRequestParams {
           this.metadata,
           this.onBehalfOf,
           this.paymentMethod,
+          this.paymentMethodOptions,
           this.paymentMethodTypes,
           this.returnUrl,
           this.usage);
@@ -278,6 +287,12 @@ public class SetupIntentCreateParams extends ApiRequestParams {
       return this;
     }
 
+    /** Payment-method-specific configuration for this SetupIntent. */
+    public Builder setPaymentMethodOptions(PaymentMethodOptions paymentMethodOptions) {
+      this.paymentMethodOptions = paymentMethodOptions;
+      return this;
+    }
+
     /**
      * Add an element to `paymentMethodTypes` list. A list is initialized for the first `add/addAll`
      * call, and subsequent calls adds additional elements to the original list. See {@link
@@ -337,6 +352,191 @@ public class SetupIntentCreateParams extends ApiRequestParams {
     public Builder setUsage(String usage) {
       this.usage = usage;
       return this;
+    }
+  }
+
+  public static class PaymentMethodOptions {
+    /** Configuration for any card setup attempted on this SetupIntent. */
+    @SerializedName("card")
+    Card card;
+
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    private PaymentMethodOptions(Card card, Map<String, Object> extraParams) {
+      this.card = card;
+      this.extraParams = extraParams;
+    }
+
+    public static Builder builder() {
+      return new com.stripe.param.SetupIntentCreateParams.PaymentMethodOptions.Builder();
+    }
+
+    public static class Builder {
+      private Card card;
+
+      private Map<String, Object> extraParams;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public PaymentMethodOptions build() {
+        return new PaymentMethodOptions(this.card, this.extraParams);
+      }
+
+      /** Configuration for any card setup attempted on this SetupIntent. */
+      public Builder setCard(Card card) {
+        this.card = card;
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * SetupIntentCreateParams.PaymentMethodOptions#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link SetupIntentCreateParams.PaymentMethodOptions#extraParams} for the field
+       * documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+    }
+
+    public static class Card {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /**
+       * When specified, this parameter signals that a card has been collected as MOTO (Mail Order
+       * Telephone Order) and is thus out of scope for SCA.
+       */
+      @SerializedName("moto")
+      Boolean moto;
+
+      /**
+       * We strongly recommend that you rely on our SCA engine to automatically prompt your
+       * customers for authentication based on risk level and other requirements. However, if you
+       * wish to request authentication based on logic from your own fraud engine, provide this
+       * option. Permitted values include: `automatic`, `any`, or `challenge_only`.
+       */
+      @SerializedName("request_three_d_secure")
+      RequestThreeDSecure requestThreeDSecure;
+
+      private Card(
+          Map<String, Object> extraParams, Boolean moto, RequestThreeDSecure requestThreeDSecure) {
+        this.extraParams = extraParams;
+        this.moto = moto;
+        this.requestThreeDSecure = requestThreeDSecure;
+      }
+
+      public static Builder builder() {
+        return new com.stripe.param.SetupIntentCreateParams.PaymentMethodOptions.Card.Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private Boolean moto;
+
+        private RequestThreeDSecure requestThreeDSecure;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Card build() {
+          return new Card(this.extraParams, this.moto, this.requestThreeDSecure);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link SetupIntentCreateParams.PaymentMethodOptions.Card#extraParams} for the
+         * field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link SetupIntentCreateParams.PaymentMethodOptions.Card#extraParams} for the
+         * field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /**
+         * When specified, this parameter signals that a card has been collected as MOTO (Mail Order
+         * Telephone Order) and is thus out of scope for SCA.
+         */
+        public Builder setMoto(Boolean moto) {
+          this.moto = moto;
+          return this;
+        }
+
+        /**
+         * We strongly recommend that you rely on our SCA engine to automatically prompt your
+         * customers for authentication based on risk level and other requirements. However, if you
+         * wish to request authentication based on logic from your own fraud engine, provide this
+         * option. Permitted values include: `automatic`, `any`, or `challenge_only`.
+         */
+        public Builder setRequestThreeDSecure(RequestThreeDSecure requestThreeDSecure) {
+          this.requestThreeDSecure = requestThreeDSecure;
+          return this;
+        }
+      }
+
+      public enum RequestThreeDSecure implements ApiRequestParams.EnumParam {
+        @SerializedName("any")
+        ANY("any"),
+
+        @SerializedName("automatic")
+        AUTOMATIC("automatic"),
+
+        @SerializedName("challenge_only")
+        CHALLENGE_ONLY("challenge_only");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        RequestThreeDSecure(String value) {
+          this.value = value;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Add support for `payment_method_options` on `PaymentIntent` and `SetupIntent`

r? @ob-stripe 
cc @stripe/api-libraries 