### PR TITLE
[generated] source: spec3.sdk.yaml@spec-6886e55 in master

### DIFF
--- a/src/main/java/com/stripe/param/PaymentIntentCaptureParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentCaptureParams.java
@@ -41,6 +41,13 @@ public class PaymentIntentCaptureParams extends ApiRequestParams {
   Map<String, Object> extraParams;
 
   /**
+   * Extra information about a PaymentIntent. This will appear on your customer's statement when
+   * this PaymentIntent succeeds in creating a charge.
+   */
+  @SerializedName("statement_descriptor")
+  String statementDescriptor;
+
+  /**
    * The parameters used to automatically create a Transfer when the payment is captured. For more
    * information, see the PaymentIntents [use case for connected
    * accounts](https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts).
@@ -53,11 +60,13 @@ public class PaymentIntentCaptureParams extends ApiRequestParams {
       Long applicationFeeAmount,
       List<String> expand,
       Map<String, Object> extraParams,
+      String statementDescriptor,
       TransferData transferData) {
     this.amountToCapture = amountToCapture;
     this.applicationFeeAmount = applicationFeeAmount;
     this.expand = expand;
     this.extraParams = extraParams;
+    this.statementDescriptor = statementDescriptor;
     this.transferData = transferData;
   }
 
@@ -74,6 +83,8 @@ public class PaymentIntentCaptureParams extends ApiRequestParams {
 
     private Map<String, Object> extraParams;
 
+    private String statementDescriptor;
+
     private TransferData transferData;
 
     /** Finalize and obtain parameter instance from this builder. */
@@ -83,6 +94,7 @@ public class PaymentIntentCaptureParams extends ApiRequestParams {
           this.applicationFeeAmount,
           this.expand,
           this.extraParams,
+          this.statementDescriptor,
           this.transferData);
     }
 
@@ -156,6 +168,15 @@ public class PaymentIntentCaptureParams extends ApiRequestParams {
         this.extraParams = new HashMap<>();
       }
       this.extraParams.putAll(map);
+      return this;
+    }
+
+    /**
+     * Extra information about a PaymentIntent. This will appear on your customer's statement when
+     * this PaymentIntent succeeds in creating a charge.
+     */
+    public Builder setStatementDescriptor(String statementDescriptor) {
+      this.statementDescriptor = statementDescriptor;
       return this;
     }
 

--- a/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
@@ -83,15 +83,16 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
    * <p>Stripe uses `setup_future_usage` to dynamically optimize your payment flow and comply with
    * regional legislation and network rules. For example, if your customer is impacted by
    * [SCA](https://stripe.com/docs/strong-customer-authentication), using `off_session` will ensure
-   * that they are authenticated while processing this PaymentIntent. You will then be able to make
-   * later [off-session](https://stripe.com/docs/payments/payment-intents/off-session) payments for
-   * this customer.
+   * that they are authenticated while processing this PaymentIntent. You will then be able to
+   * collect [off-session
+   * payments](https://stripe.com/docs/payments/cards/charging-saved-cards#off-session-payments-with-saved-cards)
+   * for this customer.
    *
    * <p>If `setup_future_usage` is already set and you are performing a request using a publishable
    * key, you may only update the value from `on_session` to `off_session`.
    */
   @SerializedName("setup_future_usage")
-  SetupFutureUsage setupFutureUsage;
+  ApiRequestParams.EnumParam setupFutureUsage;
 
   /** Shipping information for this PaymentIntent. */
   @SerializedName("shipping")
@@ -114,7 +115,7 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       String receiptEmail,
       String returnUrl,
       Boolean savePaymentMethod,
-      SetupFutureUsage setupFutureUsage,
+      ApiRequestParams.EnumParam setupFutureUsage,
       Object shipping,
       String source) {
     this.expand = expand;
@@ -151,7 +152,7 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
 
     private Boolean savePaymentMethod;
 
-    private SetupFutureUsage setupFutureUsage;
+    private ApiRequestParams.EnumParam setupFutureUsage;
 
     private Object shipping;
 
@@ -307,13 +308,41 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
      * regional legislation and network rules. For example, if your customer is impacted by
      * [SCA](https://stripe.com/docs/strong-customer-authentication), using `off_session` will
      * ensure that they are authenticated while processing this PaymentIntent. You will then be able
-     * to make later [off-session](https://stripe.com/docs/payments/payment-intents/off-session)
-     * payments for this customer.
+     * to collect [off-session
+     * payments](https://stripe.com/docs/payments/cards/charging-saved-cards#off-session-payments-with-saved-cards)
+     * for this customer.
      *
      * <p>If `setup_future_usage` is already set and you are performing a request using a
      * publishable key, you may only update the value from `on_session` to `off_session`.
      */
     public Builder setSetupFutureUsage(SetupFutureUsage setupFutureUsage) {
+      this.setupFutureUsage = setupFutureUsage;
+      return this;
+    }
+
+    /**
+     * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+     *
+     * <p>If present, the payment method used with this PaymentIntent can be
+     * [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer, even after the
+     * transaction completes.
+     *
+     * <p>Use `on_session` if you intend to only reuse the payment method when your customer is
+     * present in your checkout flow. Use `off_session` if your customer may or may not be in your
+     * checkout flow.
+     *
+     * <p>Stripe uses `setup_future_usage` to dynamically optimize your payment flow and comply with
+     * regional legislation and network rules. For example, if your customer is impacted by
+     * [SCA](https://stripe.com/docs/strong-customer-authentication), using `off_session` will
+     * ensure that they are authenticated while processing this PaymentIntent. You will then be able
+     * to collect [off-session
+     * payments](https://stripe.com/docs/payments/cards/charging-saved-cards#off-session-payments-with-saved-cards)
+     * for this customer.
+     *
+     * <p>If `setup_future_usage` is already set and you are performing a request using a
+     * publishable key, you may only update the value from `on_session` to `off_session`.
+     */
+    public Builder setSetupFutureUsage(EmptyParam setupFutureUsage) {
       this.setupFutureUsage = setupFutureUsage;
       return this;
     }

--- a/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
@@ -106,15 +106,16 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
    * <p>Stripe uses `setup_future_usage` to dynamically optimize your payment flow and comply with
    * regional legislation and network rules. For example, if your customer is impacted by
    * [SCA](https://stripe.com/docs/strong-customer-authentication), using `off_session` will ensure
-   * that they are authenticated while processing this PaymentIntent. You will then be able to make
-   * later [off-session](https://stripe.com/docs/payments/payment-intents/off-session) payments for
-   * this customer.
+   * that they are authenticated while processing this PaymentIntent. You will then be able to
+   * collect [off-session
+   * payments](https://stripe.com/docs/payments/cards/charging-saved-cards#off-session-payments-with-saved-cards)
+   * for this customer.
    *
    * <p>If `setup_future_usage` is already set and you are performing a request using a publishable
    * key, you may only update the value from `on_session` to `off_session`.
    */
   @SerializedName("setup_future_usage")
-  SetupFutureUsage setupFutureUsage;
+  ApiRequestParams.EnumParam setupFutureUsage;
 
   /** Shipping information for this PaymentIntent. */
   @SerializedName("shipping")
@@ -165,7 +166,7 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       List<String> paymentMethodTypes,
       String receiptEmail,
       Boolean savePaymentMethod,
-      SetupFutureUsage setupFutureUsage,
+      ApiRequestParams.EnumParam setupFutureUsage,
       Object shipping,
       String source,
       String statementDescriptor,
@@ -220,7 +221,7 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
 
     private Boolean savePaymentMethod;
 
-    private SetupFutureUsage setupFutureUsage;
+    private ApiRequestParams.EnumParam setupFutureUsage;
 
     private Object shipping;
 
@@ -457,13 +458,41 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
      * regional legislation and network rules. For example, if your customer is impacted by
      * [SCA](https://stripe.com/docs/strong-customer-authentication), using `off_session` will
      * ensure that they are authenticated while processing this PaymentIntent. You will then be able
-     * to make later [off-session](https://stripe.com/docs/payments/payment-intents/off-session)
-     * payments for this customer.
+     * to collect [off-session
+     * payments](https://stripe.com/docs/payments/cards/charging-saved-cards#off-session-payments-with-saved-cards)
+     * for this customer.
      *
      * <p>If `setup_future_usage` is already set and you are performing a request using a
      * publishable key, you may only update the value from `on_session` to `off_session`.
      */
     public Builder setSetupFutureUsage(SetupFutureUsage setupFutureUsage) {
+      this.setupFutureUsage = setupFutureUsage;
+      return this;
+    }
+
+    /**
+     * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+     *
+     * <p>If present, the payment method used with this PaymentIntent can be
+     * [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer, even after the
+     * transaction completes.
+     *
+     * <p>Use `on_session` if you intend to only reuse the payment method when your customer is
+     * present in your checkout flow. Use `off_session` if your customer may or may not be in your
+     * checkout flow.
+     *
+     * <p>Stripe uses `setup_future_usage` to dynamically optimize your payment flow and comply with
+     * regional legislation and network rules. For example, if your customer is impacted by
+     * [SCA](https://stripe.com/docs/strong-customer-authentication), using `off_session` will
+     * ensure that they are authenticated while processing this PaymentIntent. You will then be able
+     * to collect [off-session
+     * payments](https://stripe.com/docs/payments/cards/charging-saved-cards#off-session-payments-with-saved-cards)
+     * for this customer.
+     *
+     * <p>If `setup_future_usage` is already set and you are performing a request using a
+     * publishable key, you may only update the value from `on_session` to `off_session`.
+     */
+    public Builder setSetupFutureUsage(EmptyParam setupFutureUsage) {
       this.setupFutureUsage = setupFutureUsage;
       return this;
     }


### PR DESCRIPTION
* Add support for `statement_descriptor` for `PaymentIntent` capture
* Add support for unsetting `setup_future_usage` on `PaymentIntent`

r? @ob-stripe 
cc @stripe/api-libraries 