### PR TITLE
Set default timeouts in RequestOptionsBuilder

### DIFF
--- a/src/main/java/com/stripe/Stripe.java
+++ b/src/main/java/com/stripe/Stripe.java
@@ -6,8 +6,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 public abstract class Stripe {
-  private static final int DEFAULT_CONNECT_TIMEOUT = 30 * 1000;
-  private static final int DEFAULT_READ_TIMEOUT = 80 * 1000;
+  public static final int DEFAULT_CONNECT_TIMEOUT = 30 * 1000;
+  public static final int DEFAULT_READ_TIMEOUT = 80 * 1000;
 
   public static final String API_VERSION = "2019-05-16";
   public static final String CONNECT_API_BASE = "https://connect.stripe.com";

--- a/src/main/java/com/stripe/net/RequestOptions.java
+++ b/src/main/java/com/stripe/net/RequestOptions.java
@@ -104,12 +104,14 @@ public class RequestOptions {
     private int readTimeout;
 
     /**
-     * Constructs a request options builder with the global parameters (API key, client ID and API
-     * version) as default values.
+     * Constructs a request options builder with the global parameters (API key and client ID) as
+     * default values.
      */
     public RequestOptionsBuilder() {
       this.apiKey = Stripe.apiKey;
       this.clientId = Stripe.clientId;
+      this.connectTimeout = Stripe.DEFAULT_CONNECT_TIMEOUT;
+      this.readTimeout = Stripe.DEFAULT_READ_TIMEOUT;
     }
 
     public String getApiKey() {

--- a/src/test/java/com/stripe/net/RequestOptionsTest.java
+++ b/src/test/java/com/stripe/net/RequestOptionsTest.java
@@ -3,6 +3,7 @@ package com.stripe.net;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import com.stripe.Stripe;
 import org.junit.jupiter.api.Test;
 
 public class RequestOptionsTest {
@@ -30,8 +31,8 @@ public class RequestOptionsTest {
     assertNull(optsRebuilt.getClientId());
     assertNull(optsRebuilt.getIdempotencyKey());
     assertNull(optsRebuilt.getStripeVersionOverride());
-    assertEquals(0, optsRebuilt.getReadTimeout());
-    assertEquals(0, optsRebuilt.getConnectTimeout());
+    assertEquals(Stripe.DEFAULT_CONNECT_TIMEOUT, optsRebuilt.getConnectTimeout());
+    assertEquals(Stripe.DEFAULT_READ_TIMEOUT, optsRebuilt.getReadTimeout());
   }
 
   @Test
@@ -73,5 +74,13 @@ public class RequestOptionsTest {
 
     assertEquals(opts1, opts2);
     assertEquals(opts1.hashCode(), opts2.hashCode());
+  }
+
+  @Test
+  public void testTimeoutDefaultValues() {
+    RequestOptions opts = RequestOptions.builder().build();
+
+    assertEquals(Stripe.DEFAULT_CONNECT_TIMEOUT, opts.getConnectTimeout());
+    assertEquals(Stripe.DEFAULT_READ_TIMEOUT, opts.getReadTimeout());
   }
 }


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Use the default values for the connect and read timeouts in `RequestOptionsBuilder`. Previously they defaulted to 0, i.e. no timeout.

Fixes #817.
