### PR TITLE
Latest master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 env:
   global:
     # If changing this number, please also change it in `BaseStripeTest.java`.
-  - STRIPE_MOCK_VERSION=0.58.0
+  - STRIPE_MOCK_VERSION=0.63.0
 
 matrix:
   include:

--- a/src/main/java/com/stripe/model/Account.java
+++ b/src/main/java/com/stripe/model/Account.java
@@ -103,7 +103,7 @@ public class Account extends ApiResource implements PaymentSource, MetadataStore
   @SerializedName("requirements")
   Requirements requirements;
 
-  /** Account options for customizing how the account functions within Stripe. */
+  /** Options for customizing how the account functions within Stripe. */
   @SerializedName("settings")
   Settings settings;
 

--- a/src/main/java/com/stripe/model/BalanceTransaction.java
+++ b/src/main/java/com/stripe/model/BalanceTransaction.java
@@ -117,6 +117,9 @@ public class BalanceTransaction extends ApiResource implements HasId {
    * Returns a list of transactions that have contributed to the Stripe account balance (e.g.,
    * charges, transfers, and so forth). The transactions are returned in sorted order, with the most
    * recent transactions appearing first.
+   *
+   * <p>Note that this endpoint was previously called “Balance history” and used the path <code>
+   * /v1/balance/history</code>.
    */
   public static BalanceTransactionCollection list(Map<String, Object> params)
       throws StripeException {
@@ -127,10 +130,13 @@ public class BalanceTransaction extends ApiResource implements HasId {
    * Returns a list of transactions that have contributed to the Stripe account balance (e.g.,
    * charges, transfers, and so forth). The transactions are returned in sorted order, with the most
    * recent transactions appearing first.
+   *
+   * <p>Note that this endpoint was previously called “Balance history” and used the path <code>
+   * /v1/balance/history</code>.
    */
   public static BalanceTransactionCollection list(
       Map<String, Object> params, RequestOptions options) throws StripeException {
-    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/balance/history");
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/balance_transactions");
     return requestCollection(url, params, BalanceTransactionCollection.class, options);
   }
 
@@ -138,6 +144,9 @@ public class BalanceTransaction extends ApiResource implements HasId {
    * Returns a list of transactions that have contributed to the Stripe account balance (e.g.,
    * charges, transfers, and so forth). The transactions are returned in sorted order, with the most
    * recent transactions appearing first.
+   *
+   * <p>Note that this endpoint was previously called “Balance history” and used the path <code>
+   * /v1/balance/history</code>.
    */
   public static BalanceTransactionCollection list(BalanceTransactionListParams params)
       throws StripeException {
@@ -148,36 +157,55 @@ public class BalanceTransaction extends ApiResource implements HasId {
    * Returns a list of transactions that have contributed to the Stripe account balance (e.g.,
    * charges, transfers, and so forth). The transactions are returned in sorted order, with the most
    * recent transactions appearing first.
+   *
+   * <p>Note that this endpoint was previously called “Balance history” and used the path <code>
+   * /v1/balance/history</code>.
    */
   public static BalanceTransactionCollection list(
       BalanceTransactionListParams params, RequestOptions options) throws StripeException {
-    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/balance/history");
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/balance_transactions");
     return requestCollection(url, params, BalanceTransactionCollection.class, options);
   }
 
-  /** Retrieves the balance transaction with the given ID. */
+  /**
+   * Retrieves the balance transaction with the given ID.
+   *
+   * <p>Note that this endpoint previously used the path <code>/v1/balance/history/:id</code>.
+   */
   public static BalanceTransaction retrieve(String id) throws StripeException {
     return retrieve(id, (Map<String, Object>) null, (RequestOptions) null);
   }
 
-  /** Retrieves the balance transaction with the given ID. */
+  /**
+   * Retrieves the balance transaction with the given ID.
+   *
+   * <p>Note that this endpoint previously used the path <code>/v1/balance/history/:id</code>.
+   */
   public static BalanceTransaction retrieve(String id, RequestOptions options)
       throws StripeException {
     return retrieve(id, (Map<String, Object>) null, options);
   }
 
-  /** Retrieves the balance transaction with the given ID. */
+  /**
+   * Retrieves the balance transaction with the given ID.
+   *
+   * <p>Note that this endpoint previously used the path <code>/v1/balance/history/:id</code>.
+   */
   public static BalanceTransaction retrieve(
       String id, Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
         String.format(
             "%s%s",
             Stripe.getApiBase(),
-            String.format("/v1/balance/history/%s", ApiResource.urlEncodeId(id)));
+            String.format("/v1/balance_transactions/%s", ApiResource.urlEncodeId(id)));
     return request(ApiResource.RequestMethod.GET, url, params, BalanceTransaction.class, options);
   }
 
-  /** Retrieves the balance transaction with the given ID. */
+  /**
+   * Retrieves the balance transaction with the given ID.
+   *
+   * <p>Note that this endpoint previously used the path <code>/v1/balance/history/:id</code>.
+   */
   public static BalanceTransaction retrieve(
       String id, BalanceTransactionRetrieveParams params, RequestOptions options)
       throws StripeException {
@@ -185,7 +213,7 @@ public class BalanceTransaction extends ApiResource implements HasId {
         String.format(
             "%s%s",
             Stripe.getApiBase(),
-            String.format("/v1/balance/history/%s", ApiResource.urlEncodeId(id)));
+            String.format("/v1/balance_transactions/%s", ApiResource.urlEncodeId(id)));
     return request(ApiResource.RequestMethod.GET, url, params, BalanceTransaction.class, options);
   }
 

--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -270,11 +270,20 @@ public class Charge extends ApiResource implements BalanceTransactionSource, Met
   ExpandableField<Transfer> sourceTransfer;
 
   /**
-   * Extra information about a charge. This will appear on your customer's credit card statement. It
-   * must contain at least one letter.
+   * For card charges, use `statement_descriptor_suffix` instead. Otherwise, you can use this value
+   * as the complete description of a charge on your customers’ statements. Must contain at least
+   * one letter, maximum 22 characters.
    */
   @SerializedName("statement_descriptor")
   String statementDescriptor;
+
+  /**
+   * Provides information about the charge that customers see on their statements. Concatenated with
+   * the prefix (shortened descriptor) or statement descriptor that’s set on the account to form the
+   * complete statement descriptor. Maximum 22 characters for the concatenated descriptor.
+   */
+  @SerializedName("statement_descriptor_suffix")
+  String statementDescriptorSuffix;
 
   /** The status of the payment is either `succeeded`, `pending`, or `failed`. */
   @SerializedName("status")
@@ -1211,6 +1220,10 @@ public class Charge extends ApiResource implements BalanceTransactionSource, Met
       /** The last four digits of the card. */
       @SerializedName("last4")
       String last4;
+
+      /** True if this payment was marked as MOTO and out of scope for SCA. */
+      @SerializedName("moto")
+      Boolean moto;
 
       /** Populated if this transaction used 3D Secure authentication. */
       @SerializedName("three_d_secure")

--- a/src/main/java/com/stripe/model/CreditNote.java
+++ b/src/main/java/com/stripe/model/CreditNote.java
@@ -21,7 +21,9 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class CreditNote extends ApiResource implements HasId, MetadataStore<CreditNote> {
-  /** The integer amount in **%s** representing the total amount of the credit note. */
+  /**
+   * The integer amount in **%s** representing the total amount of the credit note, including tax.
+   */
   @SerializedName("amount")
   Long amount;
 

--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -381,8 +381,8 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
   Long subscriptionProrationDate;
 
   /**
-   * Total of all subscriptions, invoice items, and prorations on the invoice before any discount is
-   * applied.
+   * Total of all subscriptions, invoice items, and prorations on the invoice before any discount or
+   * tax is applied.
    */
   @SerializedName("subtotal")
   Long subtotal;
@@ -402,7 +402,7 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
   @SerializedName("threshold_reason")
   ThresholdReason thresholdReason;
 
-  /** Total after discount. */
+  /** Total after discounts and taxes. */
   @SerializedName("total")
   Long total;
 

--- a/src/main/java/com/stripe/model/PaymentIntent.java
+++ b/src/main/java/com/stripe/model/PaymentIntent.java
@@ -258,11 +258,19 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
   ExpandableField<PaymentSource> source;
 
   /**
-   * Extra information about a PaymentIntent. This will appear on your customer's statement when
-   * this PaymentIntent succeeds in creating a charge.
+   * For non-card charges, you can use this value as the complete description that appears on your
+   * customers’ statements. Must contain at least one letter, maximum 22 characters.
    */
   @SerializedName("statement_descriptor")
   String statementDescriptor;
+
+  /**
+   * Provides information about a card payment that customers see on their statements. Concatenated
+   * with the prefix (shortened descriptor) or statement descriptor that’s set on the account to
+   * form the complete statement descriptor. Maximum 22 characters for the concatenated descriptor.
+   */
+  @SerializedName("statement_descriptor_suffix")
+  String statementDescriptorSuffix;
 
   /**
    * Status of this PaymentIntent, one of `requires_payment_method`, `requires_confirmation`,

--- a/src/main/java/com/stripe/model/SourceTransaction.java
+++ b/src/main/java/com/stripe/model/SourceTransaction.java
@@ -36,6 +36,9 @@ public class SourceTransaction extends StripeObject implements HasId {
   @SerializedName("currency")
   String currency;
 
+  @SerializedName("gbp_credit_transfer")
+  GbpCreditTransferData gbpCreditTransfer;
+
   /** Unique identifier for the object. */
   @Getter(onMethod_ = {@Override})
   @SerializedName("id")
@@ -69,9 +72,6 @@ public class SourceTransaction extends StripeObject implements HasId {
   /** The type of source this transaction is attached to. */
   @SerializedName("type")
   String type;
-
-  @SerializedName("uk_credit_transfer")
-  UKCreditTransferData ukCreditTransfer;
 
   @Getter
   @Setter
@@ -122,6 +122,27 @@ public class SourceTransaction extends StripeObject implements HasId {
   @Getter
   @Setter
   @EqualsAndHashCode(callSuper = false)
+  public static class GbpCreditTransferData extends StripeObject {
+    /** Bank account fingerprint associated with the transfer. */
+    @SerializedName("fingerprint")
+    String fingerprint;
+
+    /** Last 4 digits of account number associated with the transfer. */
+    @SerializedName("last4")
+    String last4;
+
+    /** Sender name associated with the transfer. */
+    @SerializedName("sender_name")
+    String senderName;
+
+    /** Sort code associated with the transfer. */
+    @SerializedName("sort_code")
+    String sortCode;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
   public static class PaperCheckData extends StripeObject {
     /** String unix time for the available date. */
     @SerializedName("available_at")
@@ -147,26 +168,5 @@ public class SourceTransaction extends StripeObject implements HasId {
     /** Sender's name. */
     @SerializedName("sender_name")
     String senderName;
-  }
-
-  @Getter
-  @Setter
-  @EqualsAndHashCode(callSuper = false)
-  public static class UKCreditTransferData extends StripeObject {
-    /** Bank account fingerprint associated with the transfer. */
-    @SerializedName("fingerprint")
-    String fingerprint;
-
-    /** Last 4 digits of account number associated with the transfer. */
-    @SerializedName("last4")
-    String last4;
-
-    /** Sender name associated with the transfer. */
-    @SerializedName("sender_name")
-    String senderName;
-
-    /** Sort code associated with the transfer. */
-    @SerializedName("sort_code")
-    String sortCode;
   }
 }

--- a/src/main/java/com/stripe/param/ChargeCaptureParams.java
+++ b/src/main/java/com/stripe/param/ChargeCaptureParams.java
@@ -49,20 +49,20 @@ public class ChargeCaptureParams extends ApiRequestParams {
   String receiptEmail;
 
   /**
-   * An arbitrary string to be used as the dynamic portion of the full descriptor displayed on your
-   * customer's credit card statement. This value will be prefixed by your [account's statement
-   * descriptor](https://stripe.com/docs/charges#dynamic-statement-descriptor). As an example, if
-   * your account's statement descriptor is `RUNCLUB` and the item you're charging for is a race
-   * ticket, you may want to specify a `statement_descriptor` of `5K RACE`, so that the resulting
-   * full descriptor would be `RUNCLUB* 5K RACE`. The full descriptor may be up to *22 characters*.
-   * This value must contain at least one letter, may not include `"'` characters, and will appear
-   * on your customer's statement in capital letters. Non-ASCII characters are automatically
-   * stripped. Updating this value will overwrite the previous `statement_descriptor` of this
-   * charge. While most banks display this information consistently, some may display it incorrectly
-   * or not at all.
+   * For card charges, use `statement_descriptor_suffix` instead. Otherwise, you can use this value
+   * as the complete description of a charge on your customers’ statements. Must contain at least
+   * one letter, maximum 22 characters.
    */
   @SerializedName("statement_descriptor")
   String statementDescriptor;
+
+  /**
+   * Provides information about the charge that customers see on their statements. Concatenated with
+   * the prefix (shortened descriptor) or statement descriptor that’s set on the account to form the
+   * complete statement descriptor. Maximum 22 characters for the concatenated descriptor.
+   */
+  @SerializedName("statement_descriptor_suffix")
+  String statementDescriptorSuffix;
 
   /**
    * An optional dictionary including the account to automatically transfer to as part of a
@@ -89,6 +89,7 @@ public class ChargeCaptureParams extends ApiRequestParams {
       Map<String, Object> extraParams,
       String receiptEmail,
       String statementDescriptor,
+      String statementDescriptorSuffix,
       TransferData transferData,
       String transferGroup) {
     this.amount = amount;
@@ -98,6 +99,7 @@ public class ChargeCaptureParams extends ApiRequestParams {
     this.extraParams = extraParams;
     this.receiptEmail = receiptEmail;
     this.statementDescriptor = statementDescriptor;
+    this.statementDescriptorSuffix = statementDescriptorSuffix;
     this.transferData = transferData;
     this.transferGroup = transferGroup;
   }
@@ -121,6 +123,8 @@ public class ChargeCaptureParams extends ApiRequestParams {
 
     private String statementDescriptor;
 
+    private String statementDescriptorSuffix;
+
     private TransferData transferData;
 
     private String transferGroup;
@@ -135,6 +139,7 @@ public class ChargeCaptureParams extends ApiRequestParams {
           this.extraParams,
           this.receiptEmail,
           this.statementDescriptor,
+          this.statementDescriptorSuffix,
           this.transferData,
           this.transferGroup);
     }
@@ -226,20 +231,23 @@ public class ChargeCaptureParams extends ApiRequestParams {
     }
 
     /**
-     * An arbitrary string to be used as the dynamic portion of the full descriptor displayed on
-     * your customer's credit card statement. This value will be prefixed by your [account's
-     * statement descriptor](https://stripe.com/docs/charges#dynamic-statement-descriptor). As an
-     * example, if your account's statement descriptor is `RUNCLUB` and the item you're charging for
-     * is a race ticket, you may want to specify a `statement_descriptor` of `5K RACE`, so that the
-     * resulting full descriptor would be `RUNCLUB* 5K RACE`. The full descriptor may be up to *22
-     * characters*. This value must contain at least one letter, may not include `"'` characters,
-     * and will appear on your customer's statement in capital letters. Non-ASCII characters are
-     * automatically stripped. Updating this value will overwrite the previous
-     * `statement_descriptor` of this charge. While most banks display this information
-     * consistently, some may display it incorrectly or not at all.
+     * For card charges, use `statement_descriptor_suffix` instead. Otherwise, you can use this
+     * value as the complete description of a charge on your customers’ statements. Must contain at
+     * least one letter, maximum 22 characters.
      */
     public Builder setStatementDescriptor(String statementDescriptor) {
       this.statementDescriptor = statementDescriptor;
+      return this;
+    }
+
+    /**
+     * Provides information about the charge that customers see on their statements. Concatenated
+     * with the prefix (shortened descriptor) or statement descriptor that’s set on the account to
+     * form the complete statement descriptor. Maximum 22 characters for the concatenated
+     * descriptor.
+     */
+    public Builder setStatementDescriptorSuffix(String statementDescriptorSuffix) {
+      this.statementDescriptorSuffix = statementDescriptorSuffix;
       return this;
     }
 

--- a/src/main/java/com/stripe/param/ChargeCreateParams.java
+++ b/src/main/java/com/stripe/param/ChargeCreateParams.java
@@ -125,19 +125,20 @@ public class ChargeCreateParams extends ApiRequestParams {
   String source;
 
   /**
-   * An arbitrary string to be used as the dynamic portion of the full descriptor displayed on your
-   * customer's credit card statement. This value will be prefixed by your [account's statement
-   * descriptor](https://stripe.com/docs/charges#dynamic-statement-descriptor). As an example, if
-   * your account's statement descriptor is `RUNCLUB` and the item you're charging for is a race
-   * ticket, you may want to specify a `statement_descriptor` of `5K RACE`, so that the resulting
-   * full descriptor would be `RUNCLUB* 5K RACE`. The full descriptor may be up to *22 characters*.
-   * This value must contain at least one letter, may not include `"'` characters, and will appear
-   * on your customer's statement in capital letters. Non-ASCII characters are automatically
-   * stripped. While most banks display this information consistently, some may display it
-   * incorrectly or not at all.
+   * For card charges, use `statement_descriptor_suffix` instead. Otherwise, you can use this value
+   * as the complete description of a charge on your customers’ statements. Must contain at least
+   * one letter, maximum 22 characters.
    */
   @SerializedName("statement_descriptor")
   String statementDescriptor;
+
+  /**
+   * Provides information about the charge that customers see on their statements. Concatenated with
+   * the prefix (shortened descriptor) or statement descriptor that’s set on the account to form the
+   * complete statement descriptor. Maximum 22 characters for the concatenated descriptor.
+   */
+  @SerializedName("statement_descriptor_suffix")
+  String statementDescriptorSuffix;
 
   /**
    * An optional dictionary including the account to automatically transfer to as part of a
@@ -171,6 +172,7 @@ public class ChargeCreateParams extends ApiRequestParams {
       Shipping shipping,
       String source,
       String statementDescriptor,
+      String statementDescriptorSuffix,
       TransferData transferData,
       String transferGroup) {
     this.amount = amount;
@@ -189,6 +191,7 @@ public class ChargeCreateParams extends ApiRequestParams {
     this.shipping = shipping;
     this.source = source;
     this.statementDescriptor = statementDescriptor;
+    this.statementDescriptorSuffix = statementDescriptorSuffix;
     this.transferData = transferData;
     this.transferGroup = transferGroup;
   }
@@ -230,6 +233,8 @@ public class ChargeCreateParams extends ApiRequestParams {
 
     private String statementDescriptor;
 
+    private String statementDescriptorSuffix;
+
     private TransferData transferData;
 
     private String transferGroup;
@@ -253,6 +258,7 @@ public class ChargeCreateParams extends ApiRequestParams {
           this.shipping,
           this.source,
           this.statementDescriptor,
+          this.statementDescriptorSuffix,
           this.transferData,
           this.transferGroup);
     }
@@ -455,19 +461,23 @@ public class ChargeCreateParams extends ApiRequestParams {
     }
 
     /**
-     * An arbitrary string to be used as the dynamic portion of the full descriptor displayed on
-     * your customer's credit card statement. This value will be prefixed by your [account's
-     * statement descriptor](https://stripe.com/docs/charges#dynamic-statement-descriptor). As an
-     * example, if your account's statement descriptor is `RUNCLUB` and the item you're charging for
-     * is a race ticket, you may want to specify a `statement_descriptor` of `5K RACE`, so that the
-     * resulting full descriptor would be `RUNCLUB* 5K RACE`. The full descriptor may be up to *22
-     * characters*. This value must contain at least one letter, may not include `"'` characters,
-     * and will appear on your customer's statement in capital letters. Non-ASCII characters are
-     * automatically stripped. While most banks display this information consistently, some may
-     * display it incorrectly or not at all.
+     * For card charges, use `statement_descriptor_suffix` instead. Otherwise, you can use this
+     * value as the complete description of a charge on your customers’ statements. Must contain at
+     * least one letter, maximum 22 characters.
      */
     public Builder setStatementDescriptor(String statementDescriptor) {
       this.statementDescriptor = statementDescriptor;
+      return this;
+    }
+
+    /**
+     * Provides information about the charge that customers see on their statements. Concatenated
+     * with the prefix (shortened descriptor) or statement descriptor that’s set on the account to
+     * form the complete statement descriptor. Maximum 22 characters for the concatenated
+     * descriptor.
+     */
+    public Builder setStatementDescriptorSuffix(String statementDescriptorSuffix) {
+      this.statementDescriptorSuffix = statementDescriptorSuffix;
       return this;
     }
 

--- a/src/main/java/com/stripe/param/PaymentIntentCaptureParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentCaptureParams.java
@@ -41,11 +41,19 @@ public class PaymentIntentCaptureParams extends ApiRequestParams {
   Map<String, Object> extraParams;
 
   /**
-   * Extra information about a PaymentIntent. This will appear on your customer's statement when
-   * this PaymentIntent succeeds in creating a charge.
+   * For non-card charges, you can use this value as the complete description that appears on your
+   * customers’ statements. Must contain at least one letter, maximum 22 characters.
    */
   @SerializedName("statement_descriptor")
   String statementDescriptor;
+
+  /**
+   * Provides information about a card payment that customers see on their statements. Concatenated
+   * with the prefix (shortened descriptor) or statement descriptor that’s set on the account to
+   * form the complete statement descriptor. Maximum 22 characters for the concatenated descriptor.
+   */
+  @SerializedName("statement_descriptor_suffix")
+  String statementDescriptorSuffix;
 
   /**
    * The parameters used to automatically create a Transfer when the payment is captured. For more
@@ -61,12 +69,14 @@ public class PaymentIntentCaptureParams extends ApiRequestParams {
       List<String> expand,
       Map<String, Object> extraParams,
       String statementDescriptor,
+      String statementDescriptorSuffix,
       TransferData transferData) {
     this.amountToCapture = amountToCapture;
     this.applicationFeeAmount = applicationFeeAmount;
     this.expand = expand;
     this.extraParams = extraParams;
     this.statementDescriptor = statementDescriptor;
+    this.statementDescriptorSuffix = statementDescriptorSuffix;
     this.transferData = transferData;
   }
 
@@ -85,6 +95,8 @@ public class PaymentIntentCaptureParams extends ApiRequestParams {
 
     private String statementDescriptor;
 
+    private String statementDescriptorSuffix;
+
     private TransferData transferData;
 
     /** Finalize and obtain parameter instance from this builder. */
@@ -95,6 +107,7 @@ public class PaymentIntentCaptureParams extends ApiRequestParams {
           this.expand,
           this.extraParams,
           this.statementDescriptor,
+          this.statementDescriptorSuffix,
           this.transferData);
     }
 
@@ -172,11 +185,22 @@ public class PaymentIntentCaptureParams extends ApiRequestParams {
     }
 
     /**
-     * Extra information about a PaymentIntent. This will appear on your customer's statement when
-     * this PaymentIntent succeeds in creating a charge.
+     * For non-card charges, you can use this value as the complete description that appears on your
+     * customers’ statements. Must contain at least one letter, maximum 22 characters.
      */
     public Builder setStatementDescriptor(String statementDescriptor) {
       this.statementDescriptor = statementDescriptor;
+      return this;
+    }
+
+    /**
+     * Provides information about a card payment that customers see on their statements.
+     * Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set on the
+     * account to form the complete statement descriptor. Maximum 22 characters for the concatenated
+     * descriptor.
+     */
+    public Builder setStatementDescriptorSuffix(String statementDescriptorSuffix) {
+      this.statementDescriptorSuffix = statementDescriptorSuffix;
       return this;
     }
 

--- a/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
@@ -45,9 +45,10 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
   CaptureMethod captureMethod;
 
   /**
-   * Set to `true` to attempt to confirm this PaymentIntent immediately. This parameter defaults to
-   * `false`. If the payment method attached is a card, a return_url may be provided in case
-   * additional authentication is required.
+   * Set to `true` to attempt to [confirm](https://stripe.com/docs/api/payment_intents/confirm) this
+   * PaymentIntent immediately. This parameter defaults to `false`. When creating and confirming a
+   * PaymentIntent at the same time, parameters available in the
+   * [confirm](https://stripe.com/docs/api/payment_intents/confirm) API may also be provided.
    */
   @SerializedName("confirm")
   Boolean confirm;
@@ -115,7 +116,9 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
    * Set to `true` to indicate that the customer is not in your checkout flow during this payment
    * attempt, and therefore is unable to authenticate. This parameter is intended for scenarios
    * where you collect card details and [charge them
-   * later](https://stripe.com/docs/payments/cards/charging-saved-cards).
+   * later](https://stripe.com/docs/payments/cards/charging-saved-cards). This parameter can only be
+   * used with
+   * [`confirm=true`](https://stripe.com/docs/api/payment_intents/create#create_payment_intent-confirm).
    */
   @SerializedName("off_session")
   Object offSession;
@@ -153,7 +156,8 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
   /**
    * The URL to redirect your customer back to after they authenticate or cancel their payment on
    * the payment method's app or site. If you'd prefer to redirect to a mobile application, you can
-   * alternatively supply an application URI scheme. This param can only be used if `confirm=true`.
+   * alternatively supply an application URI scheme. This parameter can only be used with
+   * [`confirm=true`](https://stripe.com/docs/api/payment_intents/create#create_payment_intent-confirm).
    */
   @SerializedName("return_url")
   String returnUrl;
@@ -206,11 +210,19 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
   String source;
 
   /**
-   * Extra information about a PaymentIntent. This will appear on your customer's statement when
-   * this PaymentIntent succeeds in creating a charge.
+   * For non-card charges, you can use this value as the complete description that appears on your
+   * customers’ statements. Must contain at least one letter, maximum 22 characters.
    */
   @SerializedName("statement_descriptor")
   String statementDescriptor;
+
+  /**
+   * Provides information about a card payment that customers see on their statements. Concatenated
+   * with the prefix (shortened descriptor) or statement descriptor that’s set on the account to
+   * form the complete statement descriptor. Maximum 22 characters for the concatenated descriptor.
+   */
+  @SerializedName("statement_descriptor_suffix")
+  String statementDescriptorSuffix;
 
   /**
    * The parameters used to automatically create a Transfer when the payment succeeds. For more
@@ -253,6 +265,7 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       Shipping shipping,
       String source,
       String statementDescriptor,
+      String statementDescriptorSuffix,
       TransferData transferData,
       String transferGroup) {
     this.amount = amount;
@@ -278,6 +291,7 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     this.shipping = shipping;
     this.source = source;
     this.statementDescriptor = statementDescriptor;
+    this.statementDescriptorSuffix = statementDescriptorSuffix;
     this.transferData = transferData;
     this.transferGroup = transferGroup;
   }
@@ -333,6 +347,8 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
 
     private String statementDescriptor;
 
+    private String statementDescriptorSuffix;
+
     private TransferData transferData;
 
     private String transferGroup;
@@ -363,6 +379,7 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
           this.shipping,
           this.source,
           this.statementDescriptor,
+          this.statementDescriptorSuffix,
           this.transferData,
           this.transferGroup);
     }
@@ -407,9 +424,10 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     }
 
     /**
-     * Set to `true` to attempt to confirm this PaymentIntent immediately. This parameter defaults
-     * to `false`. If the payment method attached is a card, a return_url may be provided in case
-     * additional authentication is required.
+     * Set to `true` to attempt to [confirm](https://stripe.com/docs/api/payment_intents/confirm)
+     * this PaymentIntent immediately. This parameter defaults to `false`. When creating and
+     * confirming a PaymentIntent at the same time, parameters available in the
+     * [confirm](https://stripe.com/docs/api/payment_intents/confirm) API may also be provided.
      */
     public Builder setConfirm(Boolean confirm) {
       this.confirm = confirm;
@@ -545,7 +563,9 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
      * Set to `true` to indicate that the customer is not in your checkout flow during this payment
      * attempt, and therefore is unable to authenticate. This parameter is intended for scenarios
      * where you collect card details and [charge them
-     * later](https://stripe.com/docs/payments/cards/charging-saved-cards).
+     * later](https://stripe.com/docs/payments/cards/charging-saved-cards). This parameter can only
+     * be used with
+     * [`confirm=true`](https://stripe.com/docs/api/payment_intents/create#create_payment_intent-confirm).
      */
     public Builder setOffSession(OffSession offSession) {
       this.offSession = offSession;
@@ -556,7 +576,9 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
      * Set to `true` to indicate that the customer is not in your checkout flow during this payment
      * attempt, and therefore is unable to authenticate. This parameter is intended for scenarios
      * where you collect card details and [charge them
-     * later](https://stripe.com/docs/payments/cards/charging-saved-cards).
+     * later](https://stripe.com/docs/payments/cards/charging-saved-cards). This parameter can only
+     * be used with
+     * [`confirm=true`](https://stripe.com/docs/api/payment_intents/create#create_payment_intent-confirm).
      */
     public Builder setOffSession(Boolean offSession) {
       this.offSession = offSession;
@@ -623,8 +645,8 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     /**
      * The URL to redirect your customer back to after they authenticate or cancel their payment on
      * the payment method's app or site. If you'd prefer to redirect to a mobile application, you
-     * can alternatively supply an application URI scheme. This param can only be used if
-     * `confirm=true`.
+     * can alternatively supply an application URI scheme. This parameter can only be used with
+     * [`confirm=true`](https://stripe.com/docs/api/payment_intents/create#create_payment_intent-confirm).
      */
     public Builder setReturnUrl(String returnUrl) {
       this.returnUrl = returnUrl;
@@ -687,11 +709,22 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     }
 
     /**
-     * Extra information about a PaymentIntent. This will appear on your customer's statement when
-     * this PaymentIntent succeeds in creating a charge.
+     * For non-card charges, you can use this value as the complete description that appears on your
+     * customers’ statements. Must contain at least one letter, maximum 22 characters.
      */
     public Builder setStatementDescriptor(String statementDescriptor) {
       this.statementDescriptor = statementDescriptor;
+      return this;
+    }
+
+    /**
+     * Provides information about a card payment that customers see on their statements.
+     * Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set on the
+     * account to form the complete statement descriptor. Maximum 22 characters for the concatenated
+     * descriptor.
+     */
+    public Builder setStatementDescriptorSuffix(String statementDescriptorSuffix) {
+      this.statementDescriptorSuffix = statementDescriptorSuffix;
       return this;
     }
 

--- a/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
@@ -130,11 +130,19 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
   String source;
 
   /**
-   * Extra information about a PaymentIntent. This will appear on your customer's statement when
-   * this PaymentIntent succeeds in creating a charge.
+   * For non-card charges, you can use this value as the complete description that appears on your
+   * customers’ statements. Must contain at least one letter, maximum 22 characters.
    */
   @SerializedName("statement_descriptor")
   String statementDescriptor;
+
+  /**
+   * Provides information about a card payment that customers see on their statements. Concatenated
+   * with the prefix (shortened descriptor) or statement descriptor that’s set on the account to
+   * form the complete statement descriptor. Maximum 22 characters for the concatenated descriptor.
+   */
+  @SerializedName("statement_descriptor_suffix")
+  String statementDescriptorSuffix;
 
   /**
    * The parameters used to automatically create a Transfer when the payment succeeds. For more
@@ -170,6 +178,7 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       Object shipping,
       String source,
       String statementDescriptor,
+      String statementDescriptorSuffix,
       TransferData transferData,
       String transferGroup) {
     this.amount = amount;
@@ -188,6 +197,7 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     this.shipping = shipping;
     this.source = source;
     this.statementDescriptor = statementDescriptor;
+    this.statementDescriptorSuffix = statementDescriptorSuffix;
     this.transferData = transferData;
     this.transferGroup = transferGroup;
   }
@@ -229,6 +239,8 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
 
     private String statementDescriptor;
 
+    private String statementDescriptorSuffix;
+
     private TransferData transferData;
 
     private String transferGroup;
@@ -252,6 +264,7 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
           this.shipping,
           this.source,
           this.statementDescriptor,
+          this.statementDescriptorSuffix,
           this.transferData,
           this.transferGroup);
     }
@@ -520,11 +533,22 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     }
 
     /**
-     * Extra information about a PaymentIntent. This will appear on your customer's statement when
-     * this PaymentIntent succeeds in creating a charge.
+     * For non-card charges, you can use this value as the complete description that appears on your
+     * customers’ statements. Must contain at least one letter, maximum 22 characters.
      */
     public Builder setStatementDescriptor(String statementDescriptor) {
       this.statementDescriptor = statementDescriptor;
+      return this;
+    }
+
+    /**
+     * Provides information about a card payment that customers see on their statements.
+     * Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set on the
+     * account to form the complete statement descriptor. Maximum 22 characters for the concatenated
+     * descriptor.
+     */
+    public Builder setStatementDescriptorSuffix(String statementDescriptorSuffix) {
+      this.statementDescriptorSuffix = statementDescriptorSuffix;
       return this;
     }
 

--- a/src/main/java/com/stripe/param/SetupIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/SetupIntentCreateParams.java
@@ -74,6 +74,12 @@ public class SetupIntentCreateParams extends ApiRequestParams {
   @SerializedName("payment_method_types")
   List<String> paymentMethodTypes;
 
+  /**
+   * The URL to redirect your customer back to after they authenticate or cancel their payment on
+   * the payment method's app or site. If you'd prefer to redirect to a mobile application, you can
+   * alternatively supply an application URI scheme. This parameter can only be used with
+   * [`confirm=true`](https://stripe.com/docs/api/payment_intents/create#create_payment_intent-confirm).
+   */
   @SerializedName("return_url")
   String returnUrl;
 
@@ -313,6 +319,12 @@ public class SetupIntentCreateParams extends ApiRequestParams {
       return this;
     }
 
+    /**
+     * The URL to redirect your customer back to after they authenticate or cancel their payment on
+     * the payment method's app or site. If you'd prefer to redirect to a mobile application, you
+     * can alternatively supply an application URI scheme. This parameter can only be used with
+     * [`confirm=true`](https://stripe.com/docs/api/payment_intents/create#create_payment_intent-confirm).
+     */
     public Builder setReturnUrl(String returnUrl) {
       this.returnUrl = returnUrl;
       return this;

--- a/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
+++ b/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
@@ -4,6 +4,7 @@ package com.stripe.param.checkout;
 
 import com.google.gson.annotations.SerializedName;
 import com.stripe.net.ApiRequestParams;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -66,7 +67,7 @@ public class SessionCreateParams extends ApiRequestParams {
 
   /**
    * A list of items the customer is purchasing. Use this parameter for one-time payments or adding
-   * invoice line items to a subscription (used in conjunction with `subscription_data`.
+   * invoice line items to a subscription (used in conjunction with `subscription_data`).
    */
   @SerializedName("line_items")
   List<LineItem> lineItems;
@@ -1257,6 +1258,17 @@ public class SessionCreateParams extends ApiRequestParams {
 
   public static class SubscriptionData {
     /**
+     * A non-negative decimal between 0 and 100, with at most two decimal places. This represents
+     * the percentage of the subscription invoice subtotal that will be transferred to the
+     * application owner's Stripe account. To use an application fee percent, the request must be
+     * made on behalf of another account, using the `Stripe-Account` header or an OAuth key. For
+     * more information, see the application fees
+     * [documentation](https://stripe.com/docs/connect/subscriptions#collecting-fees-on-subscriptions).
+     */
+    @SerializedName("application_fee_percent")
+    BigDecimal applicationFeePercent;
+
+    /**
      * Map of extra parameters for custom features not available in this client library. The content
      * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
      * key/value pair is serialized as if the key is a root-level field (serialized) name in this
@@ -1294,11 +1306,13 @@ public class SessionCreateParams extends ApiRequestParams {
     Long trialPeriodDays;
 
     private SubscriptionData(
+        BigDecimal applicationFeePercent,
         Map<String, Object> extraParams,
         List<Item> items,
         Map<String, String> metadata,
         Long trialEnd,
         Long trialPeriodDays) {
+      this.applicationFeePercent = applicationFeePercent;
       this.extraParams = extraParams;
       this.items = items;
       this.metadata = metadata;
@@ -1311,6 +1325,8 @@ public class SessionCreateParams extends ApiRequestParams {
     }
 
     public static class Builder {
+      private BigDecimal applicationFeePercent;
+
       private Map<String, Object> extraParams;
 
       private List<Item> items;
@@ -1324,7 +1340,25 @@ public class SessionCreateParams extends ApiRequestParams {
       /** Finalize and obtain parameter instance from this builder. */
       public SubscriptionData build() {
         return new SubscriptionData(
-            this.extraParams, this.items, this.metadata, this.trialEnd, this.trialPeriodDays);
+            this.applicationFeePercent,
+            this.extraParams,
+            this.items,
+            this.metadata,
+            this.trialEnd,
+            this.trialPeriodDays);
+      }
+
+      /**
+       * A non-negative decimal between 0 and 100, with at most two decimal places. This represents
+       * the percentage of the subscription invoice subtotal that will be transferred to the
+       * application owner's Stripe account. To use an application fee percent, the request must be
+       * made on behalf of another account, using the `Stripe-Account` header or an OAuth key. For
+       * more information, see the application fees
+       * [documentation](https://stripe.com/docs/connect/subscriptions#collecting-fees-on-subscriptions).
+       */
+      public Builder setApplicationFeePercent(BigDecimal applicationFeePercent) {
+        this.applicationFeePercent = applicationFeePercent;
+        return this;
       }
 
       /**

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -32,7 +32,7 @@ import org.mockito.Mockito;
 
 public class BaseStripeTest {
   // If changing this number, please also change it in `.travis.yml`.
-  private static final String MOCK_MINIMUM_VERSION = "0.58.0";
+  private static final String MOCK_MINIMUM_VERSION = "0.63.0";
 
   private static String port;
 

--- a/src/test/java/com/stripe/functional/BalanceTransactionTest.java
+++ b/src/test/java/com/stripe/functional/BalanceTransactionTest.java
@@ -20,7 +20,7 @@ public class BalanceTransactionTest extends BaseStripeTest {
 
     assertNotNull(balanceTransaction);
     verifyRequest(
-        ApiResource.RequestMethod.GET, String.format("/v1/balance/history/%s", RESOURCE_ID));
+        ApiResource.RequestMethod.GET, String.format("/v1/balance_transactions/%s", RESOURCE_ID));
   }
 
   @Test
@@ -31,6 +31,6 @@ public class BalanceTransactionTest extends BaseStripeTest {
     final BalanceTransactionCollection balanceTransactions = BalanceTransaction.list(params);
 
     assertNotNull(balanceTransactions);
-    verifyRequest(ApiResource.RequestMethod.GET, String.format("/v1/balance/history"), params);
+    verifyRequest(ApiResource.RequestMethod.GET, String.format("/v1/balance_transactions"), params);
   }
 }

--- a/src/test/java/com/stripe/model/BalanceTransactionTest.java
+++ b/src/test/java/com/stripe/model/BalanceTransactionTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 public class BalanceTransactionTest extends BaseStripeTest {
   @Test
   public void testDeserialize() throws Exception {
-    final String data = getFixture("/v1/balance/history/txn_123");
+    final String data = getFixture("/v1/balance_transactions/txn_123");
     final BalanceTransaction resource = ApiResource.GSON.fromJson(data, BalanceTransaction.class);
     assertNotNull(resource);
     assertNotNull(resource.getId());


### PR DESCRIPTION
This adds a few things:
- support for `payment_method_details[card][moto]` on `Charge`
- support `statement_descriptor_suffix` on `Charge` and `PaymentIntent`
- support `subscription_data[application_fee_percent]` on Checkout `Session`
- (breaking) Rename `uk_credit_transfer` to `gbp_credit_transfer` on `Source`

r? @ob-stripe 
cc @stripe/api-libraries 