### PR TITLE
[generated] source: spec3.sdk.yaml@spec-a15e00e in master

### DIFF
--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -959,6 +959,9 @@ public class Charge extends ApiResource implements BalanceTransactionSource, Met
     @SerializedName("alipay")
     Alipay alipay;
 
+    @SerializedName("au_becs_debit")
+    AuBecsDebit auBecsDebit;
+
     @SerializedName("bancontact")
     Bancontact bancontact;
 
@@ -1095,6 +1098,26 @@ public class Charge extends ApiResource implements BalanceTransactionSource, Met
     @Setter
     @EqualsAndHashCode(callSuper = false)
     public static class Alipay extends StripeObject {}
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class AuBecsDebit extends StripeObject {
+      /** Bank-State-Branch number of the bank account. */
+      @SerializedName("bsb_number")
+      String bsbNumber;
+
+      /**
+       * Uniquely identifies this particular bank account. You can use this attribute to check
+       * whether two bank accounts are the same.
+       */
+      @SerializedName("fingerprint")
+      String fingerprint;
+
+      /** Last four digits of the bank account number. */
+      @SerializedName("last4")
+      String last4;
+    }
 
     @Getter
     @Setter

--- a/src/main/java/com/stripe/model/Customer.java
+++ b/src/main/java/com/stripe/model/Customer.java
@@ -416,7 +416,7 @@ public class Customer extends ApiResource implements HasId, MetadataStore<Custom
   }
 
   /**
-   * Retrieves the list of transactions that updated the customer’s <a
+   * Returns a list of transactions that updated the customer’s <a
    * href="/docs/api/customers/object#customer_object-balance"><code>balance</code></a>.
    */
   public CustomerBalanceTransactionCollection balanceTransactions() throws StripeException {
@@ -424,7 +424,7 @@ public class Customer extends ApiResource implements HasId, MetadataStore<Custom
   }
 
   /**
-   * Retrieves the list of transactions that updated the customer’s <a
+   * Returns a list of transactions that updated the customer’s <a
    * href="/docs/api/customers/object#customer_object-balance"><code>balance</code></a>.
    */
   public CustomerBalanceTransactionCollection balanceTransactions(Map<String, Object> params)
@@ -433,7 +433,7 @@ public class Customer extends ApiResource implements HasId, MetadataStore<Custom
   }
 
   /**
-   * Retrieves the list of transactions that updated the customer’s <a
+   * Returns a list of transactions that updated the customer’s <a
    * href="/docs/api/customers/object#customer_object-balance"><code>balance</code></a>.
    */
   public CustomerBalanceTransactionCollection balanceTransactions(
@@ -448,7 +448,7 @@ public class Customer extends ApiResource implements HasId, MetadataStore<Custom
   }
 
   /**
-   * Retrieves the list of transactions that updated the customer’s <a
+   * Returns a list of transactions that updated the customer’s <a
    * href="/docs/api/customers/object#customer_object-balance"><code>balance</code></a>.
    */
   public CustomerBalanceTransactionCollection balanceTransactions(
@@ -457,7 +457,7 @@ public class Customer extends ApiResource implements HasId, MetadataStore<Custom
   }
 
   /**
-   * Retrieves the list of transactions that updated the customer’s <a
+   * Returns a list of transactions that updated the customer’s <a
    * href="/docs/api/customers/object#customer_object-balance"><code>balance</code></a>.
    */
   public CustomerBalanceTransactionCollection balanceTransactions(

--- a/src/main/java/com/stripe/model/CustomerBalanceTransactionCollection.java
+++ b/src/main/java/com/stripe/model/CustomerBalanceTransactionCollection.java
@@ -62,7 +62,7 @@ public class CustomerBalanceTransactionCollection
   }
 
   /**
-   * Retrieves the list of transactions that updated the customer’s <a
+   * Returns a list of transactions that updated the customer’s <a
    * href="/docs/api/customers/object#customer_object-balance"><code>balance</code></a>.
    */
   public CustomerBalanceTransactionCollection list(Map<String, Object> params)
@@ -71,7 +71,7 @@ public class CustomerBalanceTransactionCollection
   }
 
   /**
-   * Retrieves the list of transactions that updated the customer’s <a
+   * Returns a list of transactions that updated the customer’s <a
    * href="/docs/api/customers/object#customer_object-balance"><code>balance</code></a>.
    */
   public CustomerBalanceTransactionCollection list(
@@ -82,7 +82,7 @@ public class CustomerBalanceTransactionCollection
   }
 
   /**
-   * Retrieves the list of transactions that updated the customer’s <a
+   * Returns a list of transactions that updated the customer’s <a
    * href="/docs/api/customers/object#customer_object-balance"><code>balance</code></a>.
    */
   public CustomerBalanceTransactionCollection list(
@@ -91,7 +91,7 @@ public class CustomerBalanceTransactionCollection
   }
 
   /**
-   * Retrieves the list of transactions that updated the customer’s <a
+   * Returns a list of transactions that updated the customer’s <a
    * href="/docs/api/customers/object#customer_object-balance"><code>balance</code></a>.
    */
   public CustomerBalanceTransactionCollection list(

--- a/src/main/java/com/stripe/model/Source.java
+++ b/src/main/java/com/stripe/model/Source.java
@@ -44,6 +44,9 @@ public class Source extends ApiResource implements PaymentSource, MetadataStore<
   @SerializedName("amount")
   Long amount;
 
+  @SerializedName("au_becs_debit")
+  AuBecsDebit auBecsDebit;
+
   @SerializedName("bancontact")
   Bancontact bancontact;
 
@@ -521,6 +524,20 @@ public class Source extends ApiResource implements PaymentSource, MetadataStore<
 
     @SerializedName("statement_descriptor")
     String statementDescriptor;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class AuBecsDebit extends StripeObject {
+    @SerializedName("bsb_number")
+    String bsbNumber;
+
+    @SerializedName("fingerprint")
+    String fingerprint;
+
+    @SerializedName("last4")
+    String last4;
   }
 
   @Getter

--- a/src/main/java/com/stripe/model/issuing/Card.java
+++ b/src/main/java/com/stripe/model/issuing/Card.java
@@ -92,6 +92,10 @@ public class Card extends ApiResource implements HasId, MetadataStore<Card> {
   @SerializedName("object")
   String object;
 
+  /** Metadata about the PIN on the card. */
+  @SerializedName("pin")
+  Pin pin;
+
   /** The card this card replaces, if any. */
   @SerializedName("replacement_for")
   @Getter(lombok.AccessLevel.NONE)
@@ -377,6 +381,15 @@ public class Card extends ApiResource implements HasId, MetadataStore<Card> {
     /** Currency for the amounts within spending_limits. Locked to the currency of the card. */
     @SerializedName("spending_limits_currency")
     String spendingLimitsCurrency;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class Pin extends StripeObject {
+    /** The status of the pin. One of `blocked` or `active`. */
+    @SerializedName("status")
+    String status;
   }
 
   @Getter

--- a/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
@@ -455,7 +455,8 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
 
       /**
        * When specified, this parameter indicates that a transaction will be marked as MOTO (Mail
-       * Order Telephone Order) and thus out of scope for SCA.
+       * Order Telephone Order) and thus out of scope for SCA. This parameter can only be provided
+       * during confirmation.
        */
       @SerializedName("moto")
       Boolean moto;
@@ -526,7 +527,8 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
 
         /**
          * When specified, this parameter indicates that a transaction will be marked as MOTO (Mail
-         * Order Telephone Order) and thus out of scope for SCA.
+         * Order Telephone Order) and thus out of scope for SCA. This parameter can only be provided
+         * during confirmation.
          */
         public Builder setMoto(Boolean moto) {
           this.moto = moto;

--- a/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
@@ -829,7 +829,8 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
 
       /**
        * When specified, this parameter indicates that a transaction will be marked as MOTO (Mail
-       * Order Telephone Order) and thus out of scope for SCA.
+       * Order Telephone Order) and thus out of scope for SCA. This parameter can only be provided
+       * during confirmation.
        */
       @SerializedName("moto")
       Boolean moto;
@@ -900,7 +901,8 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
 
         /**
          * When specified, this parameter indicates that a transaction will be marked as MOTO (Mail
-         * Order Telephone Order) and thus out of scope for SCA.
+         * Order Telephone Order) and thus out of scope for SCA. This parameter can only be provided
+         * during confirmation.
          */
         public Builder setMoto(Boolean moto) {
           this.moto = moto;

--- a/src/main/java/com/stripe/param/SetupIntentConfirmParams.java
+++ b/src/main/java/com/stripe/param/SetupIntentConfirmParams.java
@@ -240,7 +240,8 @@ public class SetupIntentConfirmParams extends ApiRequestParams {
 
       /**
        * When specified, this parameter signals that a card has been collected as MOTO (Mail Order
-       * Telephone Order) and is thus out of scope for SCA.
+       * Telephone Order) and thus out of scope for SCA. This parameter can only be provided during
+       * confirmation.
        */
       @SerializedName("moto")
       Boolean moto;
@@ -311,7 +312,8 @@ public class SetupIntentConfirmParams extends ApiRequestParams {
 
         /**
          * When specified, this parameter signals that a card has been collected as MOTO (Mail Order
-         * Telephone Order) and is thus out of scope for SCA.
+         * Telephone Order) and thus out of scope for SCA. This parameter can only be provided
+         * during confirmation.
          */
         public Builder setMoto(Boolean moto) {
           this.moto = moto;

--- a/src/main/java/com/stripe/param/SetupIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/SetupIntentCreateParams.java
@@ -434,7 +434,8 @@ public class SetupIntentCreateParams extends ApiRequestParams {
 
       /**
        * When specified, this parameter signals that a card has been collected as MOTO (Mail Order
-       * Telephone Order) and is thus out of scope for SCA.
+       * Telephone Order) and thus out of scope for SCA. This parameter can only be provided during
+       * confirmation.
        */
       @SerializedName("moto")
       Boolean moto;
@@ -505,7 +506,8 @@ public class SetupIntentCreateParams extends ApiRequestParams {
 
         /**
          * When specified, this parameter signals that a card has been collected as MOTO (Mail Order
-         * Telephone Order) and is thus out of scope for SCA.
+         * Telephone Order) and thus out of scope for SCA. This parameter can only be provided
+         * during confirmation.
          */
         public Builder setMoto(Boolean moto) {
           this.moto = moto;

--- a/src/main/java/com/stripe/param/SourceCreateParams.java
+++ b/src/main/java/com/stripe/param/SourceCreateParams.java
@@ -4,6 +4,7 @@ package com.stripe.param;
 
 import com.google.gson.annotations.SerializedName;
 import com.stripe.net.ApiRequestParams;
+import com.stripe.param.common.EmptyParam;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -51,6 +52,13 @@ public class SourceCreateParams extends ApiRequestParams {
    */
   @SerializedName("flow")
   Flow flow;
+
+  /**
+   * Information about a mandate possibility attached to a source object (generally for bank debits)
+   * as well as its acceptance status.
+   */
+  @SerializedName("mandate")
+  Mandate mandate;
 
   /**
    * A set of key-value pairs that you can attach to a source object. It can be useful for storing
@@ -125,6 +133,7 @@ public class SourceCreateParams extends ApiRequestParams {
       List<String> expand,
       Map<String, Object> extraParams,
       Flow flow,
+      Mandate mandate,
       Map<String, String> metadata,
       String originalSource,
       Owner owner,
@@ -141,6 +150,7 @@ public class SourceCreateParams extends ApiRequestParams {
     this.expand = expand;
     this.extraParams = extraParams;
     this.flow = flow;
+    this.mandate = mandate;
     this.metadata = metadata;
     this.originalSource = originalSource;
     this.owner = owner;
@@ -169,6 +179,8 @@ public class SourceCreateParams extends ApiRequestParams {
     private Map<String, Object> extraParams;
 
     private Flow flow;
+
+    private Mandate mandate;
 
     private Map<String, String> metadata;
 
@@ -199,6 +211,7 @@ public class SourceCreateParams extends ApiRequestParams {
           this.expand,
           this.extraParams,
           this.flow,
+          this.mandate,
           this.metadata,
           this.originalSource,
           this.owner,
@@ -296,6 +309,15 @@ public class SourceCreateParams extends ApiRequestParams {
      */
     public Builder setFlow(Flow flow) {
       this.flow = flow;
+      return this;
+    }
+
+    /**
+     * Information about a mandate possibility attached to a source object (generally for bank
+     * debits) as well as its acceptance status.
+     */
+    public Builder setMandate(Mandate mandate) {
+      this.mandate = mandate;
       return this;
     }
 
@@ -400,6 +422,616 @@ public class SourceCreateParams extends ApiRequestParams {
     public Builder setUsage(Usage usage) {
       this.usage = usage;
       return this;
+    }
+  }
+
+  public static class Mandate {
+    /**
+     * The parameters required to notify Stripe of a mandate acceptance or refusal by the customer.
+     */
+    @SerializedName("acceptance")
+    Acceptance acceptance;
+
+    /** The amount specified by the mandate. (Leave null for a mandate covering all amounts) */
+    @SerializedName("amount")
+    Object amount;
+
+    /** The currency specified by the mandate. (Must match `currency` of the source) */
+    @SerializedName("currency")
+    String currency;
+
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /**
+     * The interval of debits permitted by the mandate. Either `one_time` (just permitting a single
+     * debit), `scheduled` (with debits on an agreed schedule or for clearly-defined events), or
+     * `variable`(for debits with any frequency)
+     */
+    @SerializedName("interval")
+    Interval interval;
+
+    /**
+     * The method Stripe should use to notify the customer of upcoming debit instructions and/or
+     * mandate confirmation as required by the underlying debit network. Either `email` (an email is
+     * sent directly to the customer), `manual` (a `source.mandate_notification` event is sent to
+     * your webhooks endpoint and you should handle the notification) or `none` (the underlying
+     * debit network does not require any notification).
+     */
+    @SerializedName("notification_method")
+    NotificationMethod notificationMethod;
+
+    private Mandate(
+        Acceptance acceptance,
+        Object amount,
+        String currency,
+        Map<String, Object> extraParams,
+        Interval interval,
+        NotificationMethod notificationMethod) {
+      this.acceptance = acceptance;
+      this.amount = amount;
+      this.currency = currency;
+      this.extraParams = extraParams;
+      this.interval = interval;
+      this.notificationMethod = notificationMethod;
+    }
+
+    public static Builder builder() {
+      return new com.stripe.param.SourceCreateParams.Mandate.Builder();
+    }
+
+    public static class Builder {
+      private Acceptance acceptance;
+
+      private Object amount;
+
+      private String currency;
+
+      private Map<String, Object> extraParams;
+
+      private Interval interval;
+
+      private NotificationMethod notificationMethod;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public Mandate build() {
+        return new Mandate(
+            this.acceptance,
+            this.amount,
+            this.currency,
+            this.extraParams,
+            this.interval,
+            this.notificationMethod);
+      }
+
+      /**
+       * The parameters required to notify Stripe of a mandate acceptance or refusal by the
+       * customer.
+       */
+      public Builder setAcceptance(Acceptance acceptance) {
+        this.acceptance = acceptance;
+        return this;
+      }
+
+      /** The amount specified by the mandate. (Leave null for a mandate covering all amounts) */
+      public Builder setAmount(EmptyParam amount) {
+        this.amount = amount;
+        return this;
+      }
+
+      /** The amount specified by the mandate. (Leave null for a mandate covering all amounts) */
+      public Builder setAmount(Long amount) {
+        this.amount = amount;
+        return this;
+      }
+
+      /** The currency specified by the mandate. (Must match `currency` of the source) */
+      public Builder setCurrency(String currency) {
+        this.currency = currency;
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * SourceCreateParams.Mandate#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link SourceCreateParams.Mandate#extraParams} for the field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /**
+       * The interval of debits permitted by the mandate. Either `one_time` (just permitting a
+       * single debit), `scheduled` (with debits on an agreed schedule or for clearly-defined
+       * events), or `variable`(for debits with any frequency)
+       */
+      public Builder setInterval(Interval interval) {
+        this.interval = interval;
+        return this;
+      }
+
+      /**
+       * The method Stripe should use to notify the customer of upcoming debit instructions and/or
+       * mandate confirmation as required by the underlying debit network. Either `email` (an email
+       * is sent directly to the customer), `manual` (a `source.mandate_notification` event is sent
+       * to your webhooks endpoint and you should handle the notification) or `none` (the underlying
+       * debit network does not require any notification).
+       */
+      public Builder setNotificationMethod(NotificationMethod notificationMethod) {
+        this.notificationMethod = notificationMethod;
+        return this;
+      }
+    }
+
+    public static class Acceptance {
+      /** The unix timestamp the mandate was accepted or refused at by the customer. */
+      @SerializedName("date")
+      Long date;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** The IP address from which the mandate was accepted or refused by the customer. */
+      @SerializedName("ip")
+      String ip;
+
+      /**
+       * The parameters required to store a mandate accepted offline. Should only be set if
+       * `mandate[type]` is `offline`
+       */
+      @SerializedName("offline")
+      Offline offline;
+
+      /**
+       * The parameters required to store a mandate accepted online. Should only be set if
+       * `mandate[type]` is `online`
+       */
+      @SerializedName("online")
+      Online online;
+
+      /**
+       * The status of the mandate acceptance. Either `accepted` (the mandate was accepted) or
+       * `refused` (the mandate was refused).
+       */
+      @SerializedName("status")
+      Status status;
+
+      /**
+       * The type of acceptance information included with the mandate. Either `online` or `offline`
+       */
+      @SerializedName("type")
+      Type type;
+
+      /**
+       * The user agent of the browser from which the mandate was accepted or refused by the
+       * customer.
+       */
+      @SerializedName("user_agent")
+      String userAgent;
+
+      private Acceptance(
+          Long date,
+          Map<String, Object> extraParams,
+          String ip,
+          Offline offline,
+          Online online,
+          Status status,
+          Type type,
+          String userAgent) {
+        this.date = date;
+        this.extraParams = extraParams;
+        this.ip = ip;
+        this.offline = offline;
+        this.online = online;
+        this.status = status;
+        this.type = type;
+        this.userAgent = userAgent;
+      }
+
+      public static Builder builder() {
+        return new com.stripe.param.SourceCreateParams.Mandate.Acceptance.Builder();
+      }
+
+      public static class Builder {
+        private Long date;
+
+        private Map<String, Object> extraParams;
+
+        private String ip;
+
+        private Offline offline;
+
+        private Online online;
+
+        private Status status;
+
+        private Type type;
+
+        private String userAgent;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Acceptance build() {
+          return new Acceptance(
+              this.date,
+              this.extraParams,
+              this.ip,
+              this.offline,
+              this.online,
+              this.status,
+              this.type,
+              this.userAgent);
+        }
+
+        /** The unix timestamp the mandate was accepted or refused at by the customer. */
+        public Builder setDate(Long date) {
+          this.date = date;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link SourceCreateParams.Mandate.Acceptance#extraParams} for the field
+         * documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link SourceCreateParams.Mandate.Acceptance#extraParams} for the field
+         * documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** The IP address from which the mandate was accepted or refused by the customer. */
+        public Builder setIp(String ip) {
+          this.ip = ip;
+          return this;
+        }
+
+        /**
+         * The parameters required to store a mandate accepted offline. Should only be set if
+         * `mandate[type]` is `offline`
+         */
+        public Builder setOffline(Offline offline) {
+          this.offline = offline;
+          return this;
+        }
+
+        /**
+         * The parameters required to store a mandate accepted online. Should only be set if
+         * `mandate[type]` is `online`
+         */
+        public Builder setOnline(Online online) {
+          this.online = online;
+          return this;
+        }
+
+        /**
+         * The status of the mandate acceptance. Either `accepted` (the mandate was accepted) or
+         * `refused` (the mandate was refused).
+         */
+        public Builder setStatus(Status status) {
+          this.status = status;
+          return this;
+        }
+
+        /**
+         * The type of acceptance information included with the mandate. Either `online` or
+         * `offline`
+         */
+        public Builder setType(Type type) {
+          this.type = type;
+          return this;
+        }
+
+        /**
+         * The user agent of the browser from which the mandate was accepted or refused by the
+         * customer.
+         */
+        public Builder setUserAgent(String userAgent) {
+          this.userAgent = userAgent;
+          return this;
+        }
+      }
+
+      public static class Offline {
+        /**
+         * An email to contact you with if a copy of the mandate is requested, required if `type` is
+         * `offline`.
+         */
+        @SerializedName("contact_email")
+        String contactEmail;
+
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        private Offline(String contactEmail, Map<String, Object> extraParams) {
+          this.contactEmail = contactEmail;
+          this.extraParams = extraParams;
+        }
+
+        public static Builder builder() {
+          return new com.stripe.param.SourceCreateParams.Mandate.Acceptance.Offline.Builder();
+        }
+
+        public static class Builder {
+          private String contactEmail;
+
+          private Map<String, Object> extraParams;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public Offline build() {
+            return new Offline(this.contactEmail, this.extraParams);
+          }
+
+          /**
+           * An email to contact you with if a copy of the mandate is requested, required if `type`
+           * is `offline`.
+           */
+          public Builder setContactEmail(String contactEmail) {
+            this.contactEmail = contactEmail;
+            return this;
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link SourceCreateParams.Mandate.Acceptance.Offline#extraParams} for the
+           * field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link SourceCreateParams.Mandate.Acceptance.Offline#extraParams} for the
+           * field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+        }
+      }
+
+      public static class Online {
+        /** The unix timestamp the mandate was accepted or refused at by the customer. */
+        @SerializedName("date")
+        Long date;
+
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /** The IP address from which the mandate was accepted or refused by the customer. */
+        @SerializedName("ip")
+        String ip;
+
+        /**
+         * The user agent of the browser from which the mandate was accepted or refused by the
+         * customer.
+         */
+        @SerializedName("user_agent")
+        String userAgent;
+
+        private Online(Long date, Map<String, Object> extraParams, String ip, String userAgent) {
+          this.date = date;
+          this.extraParams = extraParams;
+          this.ip = ip;
+          this.userAgent = userAgent;
+        }
+
+        public static Builder builder() {
+          return new com.stripe.param.SourceCreateParams.Mandate.Acceptance.Online.Builder();
+        }
+
+        public static class Builder {
+          private Long date;
+
+          private Map<String, Object> extraParams;
+
+          private String ip;
+
+          private String userAgent;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public Online build() {
+            return new Online(this.date, this.extraParams, this.ip, this.userAgent);
+          }
+
+          /** The unix timestamp the mandate was accepted or refused at by the customer. */
+          public Builder setDate(Long date) {
+            this.date = date;
+            return this;
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link SourceCreateParams.Mandate.Acceptance.Online#extraParams} for the field
+           * documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link SourceCreateParams.Mandate.Acceptance.Online#extraParams} for the field
+           * documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /** The IP address from which the mandate was accepted or refused by the customer. */
+          public Builder setIp(String ip) {
+            this.ip = ip;
+            return this;
+          }
+
+          /**
+           * The user agent of the browser from which the mandate was accepted or refused by the
+           * customer.
+           */
+          public Builder setUserAgent(String userAgent) {
+            this.userAgent = userAgent;
+            return this;
+          }
+        }
+      }
+
+      public enum Status implements ApiRequestParams.EnumParam {
+        @SerializedName("accepted")
+        ACCEPTED("accepted"),
+
+        @SerializedName("pending")
+        PENDING("pending"),
+
+        @SerializedName("refused")
+        REFUSED("refused"),
+
+        @SerializedName("revoked")
+        REVOKED("revoked");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        Status(String value) {
+          this.value = value;
+        }
+      }
+
+      public enum Type implements ApiRequestParams.EnumParam {
+        @SerializedName("offline")
+        OFFLINE("offline"),
+
+        @SerializedName("online")
+        ONLINE("online");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        Type(String value) {
+          this.value = value;
+        }
+      }
+    }
+
+    public enum Interval implements ApiRequestParams.EnumParam {
+      @SerializedName("one_time")
+      ONE_TIME("one_time"),
+
+      @SerializedName("scheduled")
+      SCHEDULED("scheduled"),
+
+      @SerializedName("variable")
+      VARIABLE("variable");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      Interval(String value) {
+        this.value = value;
+      }
+    }
+
+    public enum NotificationMethod implements ApiRequestParams.EnumParam {
+      @SerializedName("deprecated_none")
+      DEPRECATED_NONE("deprecated_none"),
+
+      @SerializedName("email")
+      EMAIL("email"),
+
+      @SerializedName("manual")
+      MANUAL("manual"),
+
+      @SerializedName("none")
+      NONE("none"),
+
+      @SerializedName("stripe_email")
+      STRIPE_EMAIL("stripe_email");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      NotificationMethod(String value) {
+        this.value = value;
+      }
     }
   }
 

--- a/src/main/java/com/stripe/param/SourceUpdateParams.java
+++ b/src/main/java/com/stripe/param/SourceUpdateParams.java
@@ -4,6 +4,7 @@ package com.stripe.param;
 
 import com.google.gson.annotations.SerializedName;
 import com.stripe.net.ApiRequestParams;
+import com.stripe.param.common.EmptyParam;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -11,6 +12,10 @@ import java.util.Map;
 import lombok.Getter;
 
 public class SourceUpdateParams extends ApiRequestParams {
+  /** Amount associated with the source. */
+  @SerializedName("amount")
+  Long amount;
+
   /** Specifies which fields in the response should be expanded. */
   @SerializedName("expand")
   List<String> expand;
@@ -23,6 +28,13 @@ public class SourceUpdateParams extends ApiRequestParams {
    */
   @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
   Map<String, Object> extraParams;
+
+  /**
+   * Information about a mandate possibility attached to a source object (generally for bank debits)
+   * as well as its acceptance status.
+   */
+  @SerializedName("mandate")
+  Mandate mandate;
 
   /**
    * A set of key-value pairs that you can attach to a source object. It can be useful for storing
@@ -46,13 +58,17 @@ public class SourceUpdateParams extends ApiRequestParams {
   SourceOrder sourceOrder;
 
   private SourceUpdateParams(
+      Long amount,
       List<String> expand,
       Map<String, Object> extraParams,
+      Mandate mandate,
       Map<String, String> metadata,
       Owner owner,
       SourceOrder sourceOrder) {
+    this.amount = amount;
     this.expand = expand;
     this.extraParams = extraParams;
+    this.mandate = mandate;
     this.metadata = metadata;
     this.owner = owner;
     this.sourceOrder = sourceOrder;
@@ -63,9 +79,13 @@ public class SourceUpdateParams extends ApiRequestParams {
   }
 
   public static class Builder {
+    private Long amount;
+
     private List<String> expand;
 
     private Map<String, Object> extraParams;
+
+    private Mandate mandate;
 
     private Map<String, String> metadata;
 
@@ -76,7 +96,19 @@ public class SourceUpdateParams extends ApiRequestParams {
     /** Finalize and obtain parameter instance from this builder. */
     public SourceUpdateParams build() {
       return new SourceUpdateParams(
-          this.expand, this.extraParams, this.metadata, this.owner, this.sourceOrder);
+          this.amount,
+          this.expand,
+          this.extraParams,
+          this.mandate,
+          this.metadata,
+          this.owner,
+          this.sourceOrder);
+    }
+
+    /** Amount associated with the source. */
+    public Builder setAmount(Long amount) {
+      this.amount = amount;
+      return this;
     }
 
     /**
@@ -132,6 +164,15 @@ public class SourceUpdateParams extends ApiRequestParams {
     }
 
     /**
+     * Information about a mandate possibility attached to a source object (generally for bank
+     * debits) as well as its acceptance status.
+     */
+    public Builder setMandate(Mandate mandate) {
+      this.mandate = mandate;
+      return this;
+    }
+
+    /**
      * Add a key/value pair to `metadata` map. A map is initialized for the first `put/putAll` call,
      * and subsequent calls add additional key/value pairs to the original map. See {@link
      * SourceUpdateParams#metadata} for the field documentation.
@@ -173,6 +214,616 @@ public class SourceUpdateParams extends ApiRequestParams {
     public Builder setSourceOrder(SourceOrder sourceOrder) {
       this.sourceOrder = sourceOrder;
       return this;
+    }
+  }
+
+  public static class Mandate {
+    /**
+     * The parameters required to notify Stripe of a mandate acceptance or refusal by the customer.
+     */
+    @SerializedName("acceptance")
+    Acceptance acceptance;
+
+    /** The amount specified by the mandate. (Leave null for a mandate covering all amounts) */
+    @SerializedName("amount")
+    Object amount;
+
+    /** The currency specified by the mandate. (Must match `currency` of the source) */
+    @SerializedName("currency")
+    String currency;
+
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /**
+     * The interval of debits permitted by the mandate. Either `one_time` (just permitting a single
+     * debit), `scheduled` (with debits on an agreed schedule or for clearly-defined events), or
+     * `variable`(for debits with any frequency)
+     */
+    @SerializedName("interval")
+    Interval interval;
+
+    /**
+     * The method Stripe should use to notify the customer of upcoming debit instructions and/or
+     * mandate confirmation as required by the underlying debit network. Either `email` (an email is
+     * sent directly to the customer), `manual` (a `source.mandate_notification` event is sent to
+     * your webhooks endpoint and you should handle the notification) or `none` (the underlying
+     * debit network does not require any notification).
+     */
+    @SerializedName("notification_method")
+    NotificationMethod notificationMethod;
+
+    private Mandate(
+        Acceptance acceptance,
+        Object amount,
+        String currency,
+        Map<String, Object> extraParams,
+        Interval interval,
+        NotificationMethod notificationMethod) {
+      this.acceptance = acceptance;
+      this.amount = amount;
+      this.currency = currency;
+      this.extraParams = extraParams;
+      this.interval = interval;
+      this.notificationMethod = notificationMethod;
+    }
+
+    public static Builder builder() {
+      return new com.stripe.param.SourceUpdateParams.Mandate.Builder();
+    }
+
+    public static class Builder {
+      private Acceptance acceptance;
+
+      private Object amount;
+
+      private String currency;
+
+      private Map<String, Object> extraParams;
+
+      private Interval interval;
+
+      private NotificationMethod notificationMethod;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public Mandate build() {
+        return new Mandate(
+            this.acceptance,
+            this.amount,
+            this.currency,
+            this.extraParams,
+            this.interval,
+            this.notificationMethod);
+      }
+
+      /**
+       * The parameters required to notify Stripe of a mandate acceptance or refusal by the
+       * customer.
+       */
+      public Builder setAcceptance(Acceptance acceptance) {
+        this.acceptance = acceptance;
+        return this;
+      }
+
+      /** The amount specified by the mandate. (Leave null for a mandate covering all amounts) */
+      public Builder setAmount(EmptyParam amount) {
+        this.amount = amount;
+        return this;
+      }
+
+      /** The amount specified by the mandate. (Leave null for a mandate covering all amounts) */
+      public Builder setAmount(Long amount) {
+        this.amount = amount;
+        return this;
+      }
+
+      /** The currency specified by the mandate. (Must match `currency` of the source) */
+      public Builder setCurrency(String currency) {
+        this.currency = currency;
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * SourceUpdateParams.Mandate#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link SourceUpdateParams.Mandate#extraParams} for the field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /**
+       * The interval of debits permitted by the mandate. Either `one_time` (just permitting a
+       * single debit), `scheduled` (with debits on an agreed schedule or for clearly-defined
+       * events), or `variable`(for debits with any frequency)
+       */
+      public Builder setInterval(Interval interval) {
+        this.interval = interval;
+        return this;
+      }
+
+      /**
+       * The method Stripe should use to notify the customer of upcoming debit instructions and/or
+       * mandate confirmation as required by the underlying debit network. Either `email` (an email
+       * is sent directly to the customer), `manual` (a `source.mandate_notification` event is sent
+       * to your webhooks endpoint and you should handle the notification) or `none` (the underlying
+       * debit network does not require any notification).
+       */
+      public Builder setNotificationMethod(NotificationMethod notificationMethod) {
+        this.notificationMethod = notificationMethod;
+        return this;
+      }
+    }
+
+    public static class Acceptance {
+      /** The unix timestamp the mandate was accepted or refused at by the customer. */
+      @SerializedName("date")
+      Long date;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** The IP address from which the mandate was accepted or refused by the customer. */
+      @SerializedName("ip")
+      String ip;
+
+      /**
+       * The parameters required to store a mandate accepted offline. Should only be set if
+       * `mandate[type]` is `offline`
+       */
+      @SerializedName("offline")
+      Offline offline;
+
+      /**
+       * The parameters required to store a mandate accepted online. Should only be set if
+       * `mandate[type]` is `online`
+       */
+      @SerializedName("online")
+      Online online;
+
+      /**
+       * The status of the mandate acceptance. Either `accepted` (the mandate was accepted) or
+       * `refused` (the mandate was refused).
+       */
+      @SerializedName("status")
+      Status status;
+
+      /**
+       * The type of acceptance information included with the mandate. Either `online` or `offline`
+       */
+      @SerializedName("type")
+      Type type;
+
+      /**
+       * The user agent of the browser from which the mandate was accepted or refused by the
+       * customer.
+       */
+      @SerializedName("user_agent")
+      String userAgent;
+
+      private Acceptance(
+          Long date,
+          Map<String, Object> extraParams,
+          String ip,
+          Offline offline,
+          Online online,
+          Status status,
+          Type type,
+          String userAgent) {
+        this.date = date;
+        this.extraParams = extraParams;
+        this.ip = ip;
+        this.offline = offline;
+        this.online = online;
+        this.status = status;
+        this.type = type;
+        this.userAgent = userAgent;
+      }
+
+      public static Builder builder() {
+        return new com.stripe.param.SourceUpdateParams.Mandate.Acceptance.Builder();
+      }
+
+      public static class Builder {
+        private Long date;
+
+        private Map<String, Object> extraParams;
+
+        private String ip;
+
+        private Offline offline;
+
+        private Online online;
+
+        private Status status;
+
+        private Type type;
+
+        private String userAgent;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Acceptance build() {
+          return new Acceptance(
+              this.date,
+              this.extraParams,
+              this.ip,
+              this.offline,
+              this.online,
+              this.status,
+              this.type,
+              this.userAgent);
+        }
+
+        /** The unix timestamp the mandate was accepted or refused at by the customer. */
+        public Builder setDate(Long date) {
+          this.date = date;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link SourceUpdateParams.Mandate.Acceptance#extraParams} for the field
+         * documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link SourceUpdateParams.Mandate.Acceptance#extraParams} for the field
+         * documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** The IP address from which the mandate was accepted or refused by the customer. */
+        public Builder setIp(String ip) {
+          this.ip = ip;
+          return this;
+        }
+
+        /**
+         * The parameters required to store a mandate accepted offline. Should only be set if
+         * `mandate[type]` is `offline`
+         */
+        public Builder setOffline(Offline offline) {
+          this.offline = offline;
+          return this;
+        }
+
+        /**
+         * The parameters required to store a mandate accepted online. Should only be set if
+         * `mandate[type]` is `online`
+         */
+        public Builder setOnline(Online online) {
+          this.online = online;
+          return this;
+        }
+
+        /**
+         * The status of the mandate acceptance. Either `accepted` (the mandate was accepted) or
+         * `refused` (the mandate was refused).
+         */
+        public Builder setStatus(Status status) {
+          this.status = status;
+          return this;
+        }
+
+        /**
+         * The type of acceptance information included with the mandate. Either `online` or
+         * `offline`
+         */
+        public Builder setType(Type type) {
+          this.type = type;
+          return this;
+        }
+
+        /**
+         * The user agent of the browser from which the mandate was accepted or refused by the
+         * customer.
+         */
+        public Builder setUserAgent(String userAgent) {
+          this.userAgent = userAgent;
+          return this;
+        }
+      }
+
+      public static class Offline {
+        /**
+         * An email to contact you with if a copy of the mandate is requested, required if `type` is
+         * `offline`.
+         */
+        @SerializedName("contact_email")
+        String contactEmail;
+
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        private Offline(String contactEmail, Map<String, Object> extraParams) {
+          this.contactEmail = contactEmail;
+          this.extraParams = extraParams;
+        }
+
+        public static Builder builder() {
+          return new com.stripe.param.SourceUpdateParams.Mandate.Acceptance.Offline.Builder();
+        }
+
+        public static class Builder {
+          private String contactEmail;
+
+          private Map<String, Object> extraParams;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public Offline build() {
+            return new Offline(this.contactEmail, this.extraParams);
+          }
+
+          /**
+           * An email to contact you with if a copy of the mandate is requested, required if `type`
+           * is `offline`.
+           */
+          public Builder setContactEmail(String contactEmail) {
+            this.contactEmail = contactEmail;
+            return this;
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link SourceUpdateParams.Mandate.Acceptance.Offline#extraParams} for the
+           * field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link SourceUpdateParams.Mandate.Acceptance.Offline#extraParams} for the
+           * field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+        }
+      }
+
+      public static class Online {
+        /** The unix timestamp the mandate was accepted or refused at by the customer. */
+        @SerializedName("date")
+        Long date;
+
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /** The IP address from which the mandate was accepted or refused by the customer. */
+        @SerializedName("ip")
+        String ip;
+
+        /**
+         * The user agent of the browser from which the mandate was accepted or refused by the
+         * customer.
+         */
+        @SerializedName("user_agent")
+        String userAgent;
+
+        private Online(Long date, Map<String, Object> extraParams, String ip, String userAgent) {
+          this.date = date;
+          this.extraParams = extraParams;
+          this.ip = ip;
+          this.userAgent = userAgent;
+        }
+
+        public static Builder builder() {
+          return new com.stripe.param.SourceUpdateParams.Mandate.Acceptance.Online.Builder();
+        }
+
+        public static class Builder {
+          private Long date;
+
+          private Map<String, Object> extraParams;
+
+          private String ip;
+
+          private String userAgent;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public Online build() {
+            return new Online(this.date, this.extraParams, this.ip, this.userAgent);
+          }
+
+          /** The unix timestamp the mandate was accepted or refused at by the customer. */
+          public Builder setDate(Long date) {
+            this.date = date;
+            return this;
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link SourceUpdateParams.Mandate.Acceptance.Online#extraParams} for the field
+           * documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link SourceUpdateParams.Mandate.Acceptance.Online#extraParams} for the field
+           * documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /** The IP address from which the mandate was accepted or refused by the customer. */
+          public Builder setIp(String ip) {
+            this.ip = ip;
+            return this;
+          }
+
+          /**
+           * The user agent of the browser from which the mandate was accepted or refused by the
+           * customer.
+           */
+          public Builder setUserAgent(String userAgent) {
+            this.userAgent = userAgent;
+            return this;
+          }
+        }
+      }
+
+      public enum Status implements ApiRequestParams.EnumParam {
+        @SerializedName("accepted")
+        ACCEPTED("accepted"),
+
+        @SerializedName("pending")
+        PENDING("pending"),
+
+        @SerializedName("refused")
+        REFUSED("refused"),
+
+        @SerializedName("revoked")
+        REVOKED("revoked");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        Status(String value) {
+          this.value = value;
+        }
+      }
+
+      public enum Type implements ApiRequestParams.EnumParam {
+        @SerializedName("offline")
+        OFFLINE("offline"),
+
+        @SerializedName("online")
+        ONLINE("online");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        Type(String value) {
+          this.value = value;
+        }
+      }
+    }
+
+    public enum Interval implements ApiRequestParams.EnumParam {
+      @SerializedName("one_time")
+      ONE_TIME("one_time"),
+
+      @SerializedName("scheduled")
+      SCHEDULED("scheduled"),
+
+      @SerializedName("variable")
+      VARIABLE("variable");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      Interval(String value) {
+        this.value = value;
+      }
+    }
+
+    public enum NotificationMethod implements ApiRequestParams.EnumParam {
+      @SerializedName("deprecated_none")
+      DEPRECATED_NONE("deprecated_none"),
+
+      @SerializedName("email")
+      EMAIL("email"),
+
+      @SerializedName("manual")
+      MANUAL("manual"),
+
+      @SerializedName("none")
+      NONE("none"),
+
+      @SerializedName("stripe_email")
+      STRIPE_EMAIL("stripe_email");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      NotificationMethod(String value) {
+        this.value = value;
+      }
     }
   }
 

--- a/src/main/java/com/stripe/param/issuing/CardCreateParams.java
+++ b/src/main/java/com/stripe/param/issuing/CardCreateParams.java
@@ -886,6 +886,9 @@ public class CardCreateParams extends ApiRequestParams {
         @SerializedName("detective_agencies")
         DETECTIVE_AGENCIES("detective_agencies"),
 
+        @SerializedName("digital_goods_applications")
+        DIGITAL_GOODS_APPLICATIONS("digital_goods_applications"),
+
         @SerializedName("direct_marketing_catalog_merchant")
         DIRECT_MARKETING_CATALOG_MERCHANT("direct_marketing_catalog_merchant"),
 
@@ -1795,6 +1798,9 @@ public class CardCreateParams extends ApiRequestParams {
       @SerializedName("detective_agencies")
       DETECTIVE_AGENCIES("detective_agencies"),
 
+      @SerializedName("digital_goods_applications")
+      DIGITAL_GOODS_APPLICATIONS("digital_goods_applications"),
+
       @SerializedName("direct_marketing_catalog_merchant")
       DIRECT_MARKETING_CATALOG_MERCHANT("direct_marketing_catalog_merchant"),
 
@@ -2675,6 +2681,9 @@ public class CardCreateParams extends ApiRequestParams {
 
       @SerializedName("detective_agencies")
       DETECTIVE_AGENCIES("detective_agencies"),
+
+      @SerializedName("digital_goods_applications")
+      DIGITAL_GOODS_APPLICATIONS("digital_goods_applications"),
 
       @SerializedName("direct_marketing_catalog_merchant")
       DIRECT_MARKETING_CATALOG_MERCHANT("direct_marketing_catalog_merchant"),

--- a/src/main/java/com/stripe/param/issuing/CardUpdateParams.java
+++ b/src/main/java/com/stripe/param/issuing/CardUpdateParams.java
@@ -804,6 +804,9 @@ public class CardUpdateParams extends ApiRequestParams {
         @SerializedName("detective_agencies")
         DETECTIVE_AGENCIES("detective_agencies"),
 
+        @SerializedName("digital_goods_applications")
+        DIGITAL_GOODS_APPLICATIONS("digital_goods_applications"),
+
         @SerializedName("direct_marketing_catalog_merchant")
         DIRECT_MARKETING_CATALOG_MERCHANT("direct_marketing_catalog_merchant"),
 
@@ -1713,6 +1716,9 @@ public class CardUpdateParams extends ApiRequestParams {
       @SerializedName("detective_agencies")
       DETECTIVE_AGENCIES("detective_agencies"),
 
+      @SerializedName("digital_goods_applications")
+      DIGITAL_GOODS_APPLICATIONS("digital_goods_applications"),
+
       @SerializedName("direct_marketing_catalog_merchant")
       DIRECT_MARKETING_CATALOG_MERCHANT("direct_marketing_catalog_merchant"),
 
@@ -2593,6 +2599,9 @@ public class CardUpdateParams extends ApiRequestParams {
 
       @SerializedName("detective_agencies")
       DETECTIVE_AGENCIES("detective_agencies"),
+
+      @SerializedName("digital_goods_applications")
+      DIGITAL_GOODS_APPLICATIONS("digital_goods_applications"),
 
       @SerializedName("direct_marketing_catalog_merchant")
       DIRECT_MARKETING_CATALOG_MERCHANT("direct_marketing_catalog_merchant"),

--- a/src/main/java/com/stripe/param/issuing/CardholderCreateParams.java
+++ b/src/main/java/com/stripe/param/issuing/CardholderCreateParams.java
@@ -851,6 +851,9 @@ public class CardholderCreateParams extends ApiRequestParams {
         @SerializedName("detective_agencies")
         DETECTIVE_AGENCIES("detective_agencies"),
 
+        @SerializedName("digital_goods_applications")
+        DIGITAL_GOODS_APPLICATIONS("digital_goods_applications"),
+
         @SerializedName("direct_marketing_catalog_merchant")
         DIRECT_MARKETING_CATALOG_MERCHANT("direct_marketing_catalog_merchant"),
 
@@ -1760,6 +1763,9 @@ public class CardholderCreateParams extends ApiRequestParams {
       @SerializedName("detective_agencies")
       DETECTIVE_AGENCIES("detective_agencies"),
 
+      @SerializedName("digital_goods_applications")
+      DIGITAL_GOODS_APPLICATIONS("digital_goods_applications"),
+
       @SerializedName("direct_marketing_catalog_merchant")
       DIRECT_MARKETING_CATALOG_MERCHANT("direct_marketing_catalog_merchant"),
 
@@ -2640,6 +2646,9 @@ public class CardholderCreateParams extends ApiRequestParams {
 
       @SerializedName("detective_agencies")
       DETECTIVE_AGENCIES("detective_agencies"),
+
+      @SerializedName("digital_goods_applications")
+      DIGITAL_GOODS_APPLICATIONS("digital_goods_applications"),
 
       @SerializedName("direct_marketing_catalog_merchant")
       DIRECT_MARKETING_CATALOG_MERCHANT("direct_marketing_catalog_merchant"),

--- a/src/main/java/com/stripe/param/issuing/CardholderUpdateParams.java
+++ b/src/main/java/com/stripe/param/issuing/CardholderUpdateParams.java
@@ -820,6 +820,9 @@ public class CardholderUpdateParams extends ApiRequestParams {
         @SerializedName("detective_agencies")
         DETECTIVE_AGENCIES("detective_agencies"),
 
+        @SerializedName("digital_goods_applications")
+        DIGITAL_GOODS_APPLICATIONS("digital_goods_applications"),
+
         @SerializedName("direct_marketing_catalog_merchant")
         DIRECT_MARKETING_CATALOG_MERCHANT("direct_marketing_catalog_merchant"),
 
@@ -1729,6 +1732,9 @@ public class CardholderUpdateParams extends ApiRequestParams {
       @SerializedName("detective_agencies")
       DETECTIVE_AGENCIES("detective_agencies"),
 
+      @SerializedName("digital_goods_applications")
+      DIGITAL_GOODS_APPLICATIONS("digital_goods_applications"),
+
       @SerializedName("direct_marketing_catalog_merchant")
       DIRECT_MARKETING_CATALOG_MERCHANT("direct_marketing_catalog_merchant"),
 
@@ -2609,6 +2615,9 @@ public class CardholderUpdateParams extends ApiRequestParams {
 
       @SerializedName("detective_agencies")
       DETECTIVE_AGENCIES("detective_agencies"),
+
+      @SerializedName("digital_goods_applications")
+      DIGITAL_GOODS_APPLICATIONS("digital_goods_applications"),
 
       @SerializedName("direct_marketing_catalog_merchant")
       DIRECT_MARKETING_CATALOG_MERCHANT("direct_marketing_catalog_merchant"),


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries @shengwei-stripe 

- Add support for `au_becs_debit` sources
- Add support for `mandate` parameter in source creation and update requests
- Add support for `amount` in source update requests
- Add support for `pin` attribute on `issuing.card` objects
- Add support for `digital_goods_applications` category for Issuing