### PR TITLE
Move to API version 2019-08-14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 env:
   global:
     # If changing this number, please also change it in `BaseStripeTest.java`.
-  - STRIPE_MOCK_VERSION=0.63.0
+  - STRIPE_MOCK_VERSION=0.64.0
 
 matrix:
   include:

--- a/src/main/java/com/stripe/Stripe.java
+++ b/src/main/java/com/stripe/Stripe.java
@@ -9,7 +9,7 @@ public abstract class Stripe {
   public static final int DEFAULT_CONNECT_TIMEOUT = 30 * 1000;
   public static final int DEFAULT_READ_TIMEOUT = 80 * 1000;
 
-  public static final String API_VERSION = "2019-05-16";
+  public static final String API_VERSION = "2019-08-14";
   public static final String CONNECT_API_BASE = "https://connect.stripe.com";
   public static final String LIVE_API_BASE = "https://api.stripe.com";
   public static final String UPLOAD_API_BASE = "https://files.stripe.com";

--- a/src/main/java/com/stripe/model/Account.java
+++ b/src/main/java/com/stripe/model/Account.java
@@ -609,11 +609,11 @@ public class Account extends ApiResource implements PaymentSource, MetadataStore
     String legacyPayments;
 
     /**
-     * The status of the platform payments capability of the account, or whether your platform can
-     * process charges on behalf of the account.
+     * The status of the transfers capability of the account, or whether your platform can transfer
+     * funds to the account.
      */
-    @SerializedName("platform_payments")
-    String platformPayments;
+    @SerializedName("transfers")
+    String transfers;
   }
 
   @Getter

--- a/src/main/java/com/stripe/model/Person.java
+++ b/src/main/java/com/stripe/model/Person.java
@@ -187,10 +187,8 @@ public class Person extends ApiResource implements HasId, MetadataStore<Person> 
   /**
    * Deletes an existing person’s relationship to the account’s legal entity. Any person with a
    * relationship for an account can be deleted through the API, except if the person is the <code>
-   * account_opener</code>. If your integration is using the deprecated <code>controller</code> or
-   * <code>executive</code> parameter, you cannot delete the only verified <code>controller</code>
-   * (or <code>executive</code>), or the only <code>controller</code> (or <code>executive</code>) on
-   * file.
+   * account_opener</code>. If your integration is using the <code>executive</code> parameter, you
+   * cannot delete the only verified <code>executive</code> on file.
    */
   public Person delete() throws StripeException {
     return delete((Map<String, Object>) null, (RequestOptions) null);
@@ -199,10 +197,8 @@ public class Person extends ApiResource implements HasId, MetadataStore<Person> 
   /**
    * Deletes an existing person’s relationship to the account’s legal entity. Any person with a
    * relationship for an account can be deleted through the API, except if the person is the <code>
-   * account_opener</code>. If your integration is using the deprecated <code>controller</code> or
-   * <code>executive</code> parameter, you cannot delete the only verified <code>controller</code>
-   * (or <code>executive</code>), or the only <code>controller</code> (or <code>executive</code>) on
-   * file.
+   * account_opener</code>. If your integration is using the <code>executive</code> parameter, you
+   * cannot delete the only verified <code>executive</code> on file.
    */
   public Person delete(RequestOptions options) throws StripeException {
     return delete((Map<String, Object>) null, options);
@@ -211,10 +207,8 @@ public class Person extends ApiResource implements HasId, MetadataStore<Person> 
   /**
    * Deletes an existing person’s relationship to the account’s legal entity. Any person with a
    * relationship for an account can be deleted through the API, except if the person is the <code>
-   * account_opener</code>. If your integration is using the deprecated <code>controller</code> or
-   * <code>executive</code> parameter, you cannot delete the only verified <code>controller</code>
-   * (or <code>executive</code>), or the only <code>controller</code> (or <code>executive</code>) on
-   * file.
+   * account_opener</code>. If your integration is using the <code>executive</code> parameter, you
+   * cannot delete the only verified <code>executive</code> on file.
    */
   public Person delete(Map<String, Object> params) throws StripeException {
     return delete(params, (RequestOptions) null);
@@ -223,10 +217,8 @@ public class Person extends ApiResource implements HasId, MetadataStore<Person> 
   /**
    * Deletes an existing person’s relationship to the account’s legal entity. Any person with a
    * relationship for an account can be deleted through the API, except if the person is the <code>
-   * account_opener</code>. If your integration is using the deprecated <code>controller</code> or
-   * <code>executive</code> parameter, you cannot delete the only verified <code>controller</code>
-   * (or <code>executive</code>), or the only <code>controller</code> (or <code>executive</code>) on
-   * file.
+   * account_opener</code>. If your integration is using the <code>executive</code> parameter, you
+   * cannot delete the only verified <code>executive</code> on file.
    */
   public Person delete(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url;
@@ -322,6 +314,13 @@ public class Person extends ApiResource implements HasId, MetadataStore<Person> 
      */
     @SerializedName("director")
     Boolean director;
+
+    /**
+     * Whether the person has significant responsibility to control, manage, or direct the
+     * organization.
+     */
+    @SerializedName("executive")
+    Boolean executive;
 
     /** Whether the person is an owner of the account’s legal entity. */
     @SerializedName("owner")

--- a/src/main/java/com/stripe/param/AccountCreateParams.java
+++ b/src/main/java/com/stripe/param/AccountCreateParams.java
@@ -3486,8 +3486,8 @@ public class AccountCreateParams extends ApiRequestParams {
     @SerializedName("legacy_payments")
     LEGACY_PAYMENTS("legacy_payments"),
 
-    @SerializedName("platform_payments")
-    PLATFORM_PAYMENTS("platform_payments");
+    @SerializedName("transfers")
+    TRANSFERS("transfers");
 
     @Getter(onMethod_ = {@Override})
     private final String value;

--- a/src/main/java/com/stripe/param/AccountUpdateParams.java
+++ b/src/main/java/com/stripe/param/AccountUpdateParams.java
@@ -3442,8 +3442,8 @@ public class AccountUpdateParams extends ApiRequestParams {
     @SerializedName("legacy_payments")
     LEGACY_PAYMENTS("legacy_payments"),
 
-    @SerializedName("platform_payments")
-    PLATFORM_PAYMENTS("platform_payments");
+    @SerializedName("transfers")
+    TRANSFERS("transfers");
 
     @Getter(onMethod_ = {@Override})
     private final String value;

--- a/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
+++ b/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
@@ -457,7 +457,10 @@ public class WebhookEndpointCreateParams extends ApiRequestParams {
     VERSION_2019_03_14("2019-03-14"),
 
     @SerializedName("2019-05-16")
-    VERSION_2019_05_16("2019-05-16");
+    VERSION_2019_05_16("2019-05-16"),
+
+    @SerializedName("2019-08-14")
+    VERSION_2019_08_14("2019-08-14");
 
     @Getter(onMethod_ = {@Override})
     private final String value;

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -32,7 +32,7 @@ import org.mockito.Mockito;
 
 public class BaseStripeTest {
   // If changing this number, please also change it in `.travis.yml`.
-  private static final String MOCK_MINIMUM_VERSION = "0.63.0";
+  private static final String MOCK_MINIMUM_VERSION = "0.64.0";
 
   private static String port;
 


### PR DESCRIPTION
This introduces support for the latest API version [2019-08-14](https://stripe.com/docs/upgrades#2019-08-14)
* rename `platform_payments` to `transfer`
* introduce `executive` as a relationship on `Person`

r? @ob-stripe 
cc @stripe/api-libraries 

Can you also take releasing please?
