### PR TITLE
[generated] source: spec3.sdk.yaml@spec-eee72d4 in master

### DIFF
--- a/src/main/java/com/stripe/model/Account.java
+++ b/src/main/java/com/stripe/model/Account.java
@@ -643,7 +643,7 @@ public class Account extends ApiResource implements PaymentSource, MetadataStore
     @SerializedName("name")
     String name;
 
-    /** The Kana variation of the company's legal name Japan only). */
+    /** The Kana variation of the company's legal name (Japan only). */
     @SerializedName("name_kana")
     String nameKana;
 

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -209,6 +209,12 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
   @SerializedName("quantity")
   Long quantity;
 
+  /** The schedule attached to the subscription. */
+  @SerializedName("schedule")
+  @Getter(lombok.AccessLevel.NONE)
+  @Setter(lombok.AccessLevel.NONE)
+  ExpandableField<SubscriptionSchedule> schedule;
+
   /**
    * Date of the last substantial change to this subscription. For example, a change to the items
    * array, or a change of status, will reset this timestamp.
@@ -364,6 +370,25 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
   public void setPendingSetupIntentObject(SetupIntent expandableObject) {
     this.pendingSetupIntent =
         new ExpandableField<SetupIntent>(expandableObject.getId(), expandableObject);
+  }
+
+  /** Get id of expandable `schedule` object. */
+  public String getSchedule() {
+    return (this.schedule != null) ? this.schedule.getId() : null;
+  }
+
+  public void setSchedule(String id) {
+    this.schedule = ApiResource.setExpandableFieldId(id, this.schedule);
+  }
+
+  /** Get expanded `schedule`. */
+  public SubscriptionSchedule getScheduleObject() {
+    return (this.schedule != null) ? this.schedule.getExpanded() : null;
+  }
+
+  public void setScheduleObject(SubscriptionSchedule expandableObject) {
+    this.schedule =
+        new ExpandableField<SubscriptionSchedule>(expandableObject.getId(), expandableObject);
   }
 
   /**

--- a/src/main/java/com/stripe/model/SubscriptionSchedule.java
+++ b/src/main/java/com/stripe/model/SubscriptionSchedule.java
@@ -561,11 +561,37 @@ public class SubscriptionSchedule extends ApiResource
     @SerializedName("application_fee_percent")
     BigDecimal applicationFeePercent;
 
+    /**
+     * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
+     * billing period.
+     */
+    @SerializedName("billing_thresholds")
+    Subscription.BillingThresholds billingThresholds;
+
+    /**
+     * Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will
+     * attempt to pay the underlying subscription at the end of each billing cycle using the default
+     * source attached to the customer. When sending an invoice, Stripe will email your customer an
+     * invoice with payment instructions.
+     */
+    @SerializedName("collection_method")
+    String collectionMethod;
+
     /** ID of the coupon to use during this phase of the subscription schedule. */
     @SerializedName("coupon")
     @Getter(lombok.AccessLevel.NONE)
     @Setter(lombok.AccessLevel.NONE)
     ExpandableField<Coupon> coupon;
+
+    /**
+     * ID of the default payment method for the subscription schedule. It must belong to the
+     * customer associated with the subscription schedule. If not set, invoices will use the default
+     * payment method in the customer's invoice settings.
+     */
+    @SerializedName("default_payment_method")
+    @Getter(lombok.AccessLevel.NONE)
+    @Setter(lombok.AccessLevel.NONE)
+    ExpandableField<PaymentMethod> defaultPaymentMethod;
 
     @SerializedName("default_tax_rates")
     List<TaxRate> defaultTaxRates;
@@ -573,6 +599,10 @@ public class SubscriptionSchedule extends ApiResource
     /** The end of this phase of the subscription schedule. */
     @SerializedName("end_date")
     Long endDate;
+
+    /** The subscription schedule's default invoice settings. */
+    @SerializedName("invoice_settings")
+    InvoiceSettings invoiceSettings;
 
     /** Plans to subscribe during this phase of the subscription schedule. */
     @SerializedName("plans")
@@ -609,6 +639,25 @@ public class SubscriptionSchedule extends ApiResource
 
     public void setCouponObject(Coupon expandableObject) {
       this.coupon = new ExpandableField<Coupon>(expandableObject.getId(), expandableObject);
+    }
+
+    /** Get id of expandable `defaultPaymentMethod` object. */
+    public String getDefaultPaymentMethod() {
+      return (this.defaultPaymentMethod != null) ? this.defaultPaymentMethod.getId() : null;
+    }
+
+    public void setDefaultPaymentMethod(String id) {
+      this.defaultPaymentMethod = ApiResource.setExpandableFieldId(id, this.defaultPaymentMethod);
+    }
+
+    /** Get expanded `defaultPaymentMethod`. */
+    public PaymentMethod getDefaultPaymentMethodObject() {
+      return (this.defaultPaymentMethod != null) ? this.defaultPaymentMethod.getExpanded() : null;
+    }
+
+    public void setDefaultPaymentMethodObject(PaymentMethod expandableObject) {
+      this.defaultPaymentMethod =
+          new ExpandableField<PaymentMethod>(expandableObject.getId(), expandableObject);
     }
   }
 

--- a/src/main/java/com/stripe/model/checkout/Session.java
+++ b/src/main/java/com/stripe/model/checkout/Session.java
@@ -10,6 +10,7 @@ import com.stripe.model.ExpandableField;
 import com.stripe.model.HasId;
 import com.stripe.model.PaymentIntent;
 import com.stripe.model.Plan;
+import com.stripe.model.SetupIntent;
 import com.stripe.model.Sku;
 import com.stripe.model.StripeObject;
 import com.stripe.model.Subscription;
@@ -88,6 +89,10 @@ public class Session extends ApiResource implements HasId {
   @SerializedName("locale")
   String locale;
 
+  /** The mode of the Checkout Session. */
+  @SerializedName("mode")
+  String mode;
+
   /** String representing the object's type. Objects of the same type share the same value. */
   @SerializedName("object")
   String object;
@@ -103,6 +108,12 @@ public class Session extends ApiResource implements HasId {
    */
   @SerializedName("payment_method_types")
   List<String> paymentMethodTypes;
+
+  /** The ID of the SetupIntent if mode was set to `setup`. */
+  @SerializedName("setup_intent")
+  @Getter(lombok.AccessLevel.NONE)
+  @Setter(lombok.AccessLevel.NONE)
+  ExpandableField<SetupIntent> setupIntent;
 
   /**
    * Describes the type of transaction being performed by Checkout in order to customize relevant
@@ -161,6 +172,24 @@ public class Session extends ApiResource implements HasId {
   public void setPaymentIntentObject(PaymentIntent expandableObject) {
     this.paymentIntent =
         new ExpandableField<PaymentIntent>(expandableObject.getId(), expandableObject);
+  }
+
+  /** Get id of expandable `setupIntent` object. */
+  public String getSetupIntent() {
+    return (this.setupIntent != null) ? this.setupIntent.getId() : null;
+  }
+
+  public void setSetupIntent(String id) {
+    this.setupIntent = ApiResource.setExpandableFieldId(id, this.setupIntent);
+  }
+
+  /** Get expanded `setupIntent`. */
+  public SetupIntent getSetupIntentObject() {
+    return (this.setupIntent != null) ? this.setupIntent.getExpanded() : null;
+  }
+
+  public void setSetupIntentObject(SetupIntent expandableObject) {
+    this.setupIntent = new ExpandableField<SetupIntent>(expandableObject.getId(), expandableObject);
   }
 
   /** Get id of expandable `subscription` object. */

--- a/src/main/java/com/stripe/param/InvoiceUpcomingParams.java
+++ b/src/main/java/com/stripe/param/InvoiceUpcomingParams.java
@@ -45,6 +45,13 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
   List<InvoiceItem> invoiceItems;
 
   /**
+   * The identifier of the unstarted schedule whose upcoming invoice you'd like to retrieve. Cannot
+   * be used with subscription or subscription fields.
+   */
+  @SerializedName("schedule")
+  String schedule;
+
+  /**
    * The identifier of the subscription for which you'd like to retrieve the upcoming invoice. If
    * not provided, but a `subscription_items` is provided, you will preview creating a subscription
    * with those items. If neither `subscription` nor `subscription_items` is provided, you will
@@ -62,6 +69,13 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
    */
   @SerializedName("subscription_billing_cycle_anchor")
   Object subscriptionBillingCycleAnchor;
+
+  /**
+   * Boolean indicating when the subscription should be scheduled to cancel. Will prorate if within
+   * the current period if `prorate=true`
+   */
+  @SerializedName("subscription_cancel_at")
+  Object subscriptionCancelAt;
 
   /**
    * Boolean indicating whether this subscription should cancel at the end of the current period.
@@ -137,8 +151,10 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
       List<String> expand,
       Map<String, Object> extraParams,
       List<InvoiceItem> invoiceItems,
+      String schedule,
       String subscription,
       Object subscriptionBillingCycleAnchor,
+      Object subscriptionCancelAt,
       Boolean subscriptionCancelAtPeriodEnd,
       Boolean subscriptionCancelNow,
       Object subscriptionDefaultTaxRates,
@@ -154,8 +170,10 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
     this.expand = expand;
     this.extraParams = extraParams;
     this.invoiceItems = invoiceItems;
+    this.schedule = schedule;
     this.subscription = subscription;
     this.subscriptionBillingCycleAnchor = subscriptionBillingCycleAnchor;
+    this.subscriptionCancelAt = subscriptionCancelAt;
     this.subscriptionCancelAtPeriodEnd = subscriptionCancelAtPeriodEnd;
     this.subscriptionCancelNow = subscriptionCancelNow;
     this.subscriptionDefaultTaxRates = subscriptionDefaultTaxRates;
@@ -183,9 +201,13 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
 
     private List<InvoiceItem> invoiceItems;
 
+    private String schedule;
+
     private String subscription;
 
     private Object subscriptionBillingCycleAnchor;
+
+    private Object subscriptionCancelAt;
 
     private Boolean subscriptionCancelAtPeriodEnd;
 
@@ -215,8 +237,10 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
           this.expand,
           this.extraParams,
           this.invoiceItems,
+          this.schedule,
           this.subscription,
           this.subscriptionBillingCycleAnchor,
+          this.subscriptionCancelAt,
           this.subscriptionCancelAtPeriodEnd,
           this.subscriptionCancelNow,
           this.subscriptionDefaultTaxRates,
@@ -326,6 +350,15 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
     }
 
     /**
+     * The identifier of the unstarted schedule whose upcoming invoice you'd like to retrieve.
+     * Cannot be used with subscription or subscription fields.
+     */
+    public Builder setSchedule(String schedule) {
+      this.schedule = schedule;
+      return this;
+    }
+
+    /**
      * The identifier of the subscription for which you'd like to retrieve the upcoming invoice. If
      * not provided, but a `subscription_items` is provided, you will preview creating a
      * subscription with those items. If neither `subscription` nor `subscription_items` is
@@ -359,6 +392,24 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
      */
     public Builder setSubscriptionBillingCycleAnchor(Long subscriptionBillingCycleAnchor) {
       this.subscriptionBillingCycleAnchor = subscriptionBillingCycleAnchor;
+      return this;
+    }
+
+    /**
+     * Boolean indicating when the subscription should be scheduled to cancel. Will prorate if
+     * within the current period if `prorate=true`
+     */
+    public Builder setSubscriptionCancelAt(EmptyParam subscriptionCancelAt) {
+      this.subscriptionCancelAt = subscriptionCancelAt;
+      return this;
+    }
+
+    /**
+     * Boolean indicating when the subscription should be scheduled to cancel. Will prorate if
+     * within the current period if `prorate=true`
+     */
+    public Builder setSubscriptionCancelAt(Long subscriptionCancelAt) {
+      this.subscriptionCancelAt = subscriptionCancelAt;
       return this;
     }
 

--- a/src/main/java/com/stripe/param/SubscriptionScheduleCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionScheduleCreateParams.java
@@ -594,9 +594,33 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
     @SerializedName("application_fee_percent")
     BigDecimal applicationFeePercent;
 
+    /**
+     * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
+     * billing period. Pass an empty string to remove previously-defined thresholds.
+     */
+    @SerializedName("billing_thresholds")
+    Object billingThresholds;
+
+    /**
+     * Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will
+     * attempt to pay the underlying subscription at the end of each billing cycle using the default
+     * source attached to the customer. When sending an invoice, Stripe will email your customer an
+     * invoice with payment instructions. Defaults to `charge_automatically` on creation.
+     */
+    @SerializedName("collection_method")
+    CollectionMethod collectionMethod;
+
     /** The identifier of the coupon to apply to this phase of the subscription schedule. */
     @SerializedName("coupon")
     String coupon;
+
+    /**
+     * ID of the default payment method for the subscription schedule. It must belong to the
+     * customer associated with the subscription schedule. If not set, invoices will use the default
+     * payment method in the customer's invoice settings.
+     */
+    @SerializedName("default_payment_method")
+    String defaultPaymentMethod;
 
     /**
      * The tax rates that will apply to any phase that does not have `tax_rates` set. Invoices
@@ -620,6 +644,10 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
      */
     @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
     Map<String, Object> extraParams;
+
+    /** All invoices will be billed using the specified settings. */
+    @SerializedName("invoice_settings")
+    InvoiceSettings invoiceSettings;
 
     /**
      * Integer representing the multiplier applied to the plan interval. For example, `iterations=2`
@@ -664,20 +692,28 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
 
     private Phase(
         BigDecimal applicationFeePercent,
+        Object billingThresholds,
+        CollectionMethod collectionMethod,
         String coupon,
+        String defaultPaymentMethod,
         Object defaultTaxRates,
         Long endDate,
         Map<String, Object> extraParams,
+        InvoiceSettings invoiceSettings,
         Long iterations,
         List<Plan> plans,
         BigDecimal taxPercent,
         Boolean trial,
         Long trialEnd) {
       this.applicationFeePercent = applicationFeePercent;
+      this.billingThresholds = billingThresholds;
+      this.collectionMethod = collectionMethod;
       this.coupon = coupon;
+      this.defaultPaymentMethod = defaultPaymentMethod;
       this.defaultTaxRates = defaultTaxRates;
       this.endDate = endDate;
       this.extraParams = extraParams;
+      this.invoiceSettings = invoiceSettings;
       this.iterations = iterations;
       this.plans = plans;
       this.taxPercent = taxPercent;
@@ -692,13 +728,21 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
     public static class Builder {
       private BigDecimal applicationFeePercent;
 
+      private Object billingThresholds;
+
+      private CollectionMethod collectionMethod;
+
       private String coupon;
+
+      private String defaultPaymentMethod;
 
       private Object defaultTaxRates;
 
       private Long endDate;
 
       private Map<String, Object> extraParams;
+
+      private InvoiceSettings invoiceSettings;
 
       private Long iterations;
 
@@ -714,10 +758,14 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
       public Phase build() {
         return new Phase(
             this.applicationFeePercent,
+            this.billingThresholds,
+            this.collectionMethod,
             this.coupon,
+            this.defaultPaymentMethod,
             this.defaultTaxRates,
             this.endDate,
             this.extraParams,
+            this.invoiceSettings,
             this.iterations,
             this.plans,
             this.taxPercent,
@@ -737,9 +785,49 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
         return this;
       }
 
+      /**
+       * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
+       * billing period. Pass an empty string to remove previously-defined thresholds.
+       */
+      public Builder setBillingThresholds(BillingThresholds billingThresholds) {
+        this.billingThresholds = billingThresholds;
+        return this;
+      }
+
+      /**
+       * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
+       * billing period. Pass an empty string to remove previously-defined thresholds.
+       */
+      public Builder setBillingThresholds(EmptyParam billingThresholds) {
+        this.billingThresholds = billingThresholds;
+        return this;
+      }
+
+      /**
+       * Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will
+       * attempt to pay the underlying subscription at the end of each billing cycle using the
+       * default source attached to the customer. When sending an invoice, Stripe will email your
+       * customer an invoice with payment instructions. Defaults to `charge_automatically` on
+       * creation.
+       */
+      public Builder setCollectionMethod(CollectionMethod collectionMethod) {
+        this.collectionMethod = collectionMethod;
+        return this;
+      }
+
       /** The identifier of the coupon to apply to this phase of the subscription schedule. */
       public Builder setCoupon(String coupon) {
         this.coupon = coupon;
+        return this;
+      }
+
+      /**
+       * ID of the default payment method for the subscription schedule. It must belong to the
+       * customer associated with the subscription schedule. If not set, invoices will use the
+       * default payment method in the customer's invoice settings.
+       */
+      public Builder setDefaultPaymentMethod(String defaultPaymentMethod) {
+        this.defaultPaymentMethod = defaultPaymentMethod;
         return this;
       }
 
@@ -793,6 +881,12 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
           this.extraParams = new HashMap<>();
         }
         this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** All invoices will be billed using the specified settings. */
+      public Builder setInvoiceSettings(InvoiceSettings invoiceSettings) {
+        this.invoiceSettings = invoiceSettings;
         return this;
       }
 
@@ -862,6 +956,167 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
       public Builder setTrialEnd(Long trialEnd) {
         this.trialEnd = trialEnd;
         return this;
+      }
+    }
+
+    public static class BillingThresholds {
+      /** Monetary threshold that triggers the subscription to advance to a new billing period. */
+      @SerializedName("amount_gte")
+      Long amountGte;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /**
+       * Indicates if the `billing_cycle_anchor` should be reset when a threshold is reached. If
+       * true, `billing_cycle_anchor` will be updated to the date/time the threshold was last
+       * reached; otherwise, the value will remain unchanged.
+       */
+      @SerializedName("reset_billing_cycle_anchor")
+      Boolean resetBillingCycleAnchor;
+
+      private BillingThresholds(
+          Long amountGte, Map<String, Object> extraParams, Boolean resetBillingCycleAnchor) {
+        this.amountGte = amountGte;
+        this.extraParams = extraParams;
+        this.resetBillingCycleAnchor = resetBillingCycleAnchor;
+      }
+
+      public static Builder builder() {
+        return new com.stripe.param.SubscriptionScheduleCreateParams.Phase.BillingThresholds
+            .Builder();
+      }
+
+      public static class Builder {
+        private Long amountGte;
+
+        private Map<String, Object> extraParams;
+
+        private Boolean resetBillingCycleAnchor;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public BillingThresholds build() {
+          return new BillingThresholds(
+              this.amountGte, this.extraParams, this.resetBillingCycleAnchor);
+        }
+
+        /** Monetary threshold that triggers the subscription to advance to a new billing period. */
+        public Builder setAmountGte(Long amountGte) {
+          this.amountGte = amountGte;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link SubscriptionScheduleCreateParams.Phase.BillingThresholds#extraParams} for
+         * the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link SubscriptionScheduleCreateParams.Phase.BillingThresholds#extraParams} for
+         * the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /**
+         * Indicates if the `billing_cycle_anchor` should be reset when a threshold is reached. If
+         * true, `billing_cycle_anchor` will be updated to the date/time the threshold was last
+         * reached; otherwise, the value will remain unchanged.
+         */
+        public Builder setResetBillingCycleAnchor(Boolean resetBillingCycleAnchor) {
+          this.resetBillingCycleAnchor = resetBillingCycleAnchor;
+          return this;
+        }
+      }
+    }
+
+    public static class InvoiceSettings {
+      @SerializedName("days_until_due")
+      Long daysUntilDue;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private InvoiceSettings(Long daysUntilDue, Map<String, Object> extraParams) {
+        this.daysUntilDue = daysUntilDue;
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new com.stripe.param.SubscriptionScheduleCreateParams.Phase.InvoiceSettings
+            .Builder();
+      }
+
+      public static class Builder {
+        private Long daysUntilDue;
+
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public InvoiceSettings build() {
+          return new InvoiceSettings(this.daysUntilDue, this.extraParams);
+        }
+
+        public Builder setDaysUntilDue(Long daysUntilDue) {
+          this.daysUntilDue = daysUntilDue;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link SubscriptionScheduleCreateParams.Phase.InvoiceSettings#extraParams} for
+         * the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link SubscriptionScheduleCreateParams.Phase.InvoiceSettings#extraParams} for
+         * the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
       }
     }
 
@@ -1085,6 +1340,21 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
             return this;
           }
         }
+      }
+    }
+
+    public enum CollectionMethod implements ApiRequestParams.EnumParam {
+      @SerializedName("charge_automatically")
+      CHARGE_AUTOMATICALLY("charge_automatically"),
+
+      @SerializedName("send_invoice")
+      SEND_INVOICE("send_invoice");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      CollectionMethod(String value) {
+        this.value = value;
       }
     }
   }

--- a/src/main/java/com/stripe/param/SubscriptionScheduleUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionScheduleUpdateParams.java
@@ -555,9 +555,33 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
     @SerializedName("application_fee_percent")
     BigDecimal applicationFeePercent;
 
+    /**
+     * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
+     * billing period. Pass an empty string to remove previously-defined thresholds.
+     */
+    @SerializedName("billing_thresholds")
+    Object billingThresholds;
+
+    /**
+     * Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will
+     * attempt to pay the underlying subscription at the end of each billing cycle using the default
+     * source attached to the customer. When sending an invoice, Stripe will email your customer an
+     * invoice with payment instructions. Defaults to `charge_automatically` on creation.
+     */
+    @SerializedName("collection_method")
+    CollectionMethod collectionMethod;
+
     /** The identifier of the coupon to apply to this phase of the subscription schedule. */
     @SerializedName("coupon")
     String coupon;
+
+    /**
+     * ID of the default payment method for the subscription schedule. It must belong to the
+     * customer associated with the subscription schedule. If not set, invoices will use the default
+     * payment method in the customer's invoice settings.
+     */
+    @SerializedName("default_payment_method")
+    String defaultPaymentMethod;
 
     /**
      * The tax rates that will apply to any phase that does not have `tax_rates` set. Invoices
@@ -581,6 +605,10 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
      */
     @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
     Map<String, Object> extraParams;
+
+    /** All invoices will be billed using the specified settings. */
+    @SerializedName("invoice_settings")
+    InvoiceSettings invoiceSettings;
 
     /**
      * Integer representing the multiplier applied to the plan interval. For example, `iterations=2`
@@ -629,10 +657,14 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
 
     private Phase(
         BigDecimal applicationFeePercent,
+        Object billingThresholds,
+        CollectionMethod collectionMethod,
         String coupon,
+        String defaultPaymentMethod,
         Object defaultTaxRates,
         Object endDate,
         Map<String, Object> extraParams,
+        InvoiceSettings invoiceSettings,
         Long iterations,
         List<Plan> plans,
         Object startDate,
@@ -640,10 +672,14 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
         Boolean trial,
         Object trialEnd) {
       this.applicationFeePercent = applicationFeePercent;
+      this.billingThresholds = billingThresholds;
+      this.collectionMethod = collectionMethod;
       this.coupon = coupon;
+      this.defaultPaymentMethod = defaultPaymentMethod;
       this.defaultTaxRates = defaultTaxRates;
       this.endDate = endDate;
       this.extraParams = extraParams;
+      this.invoiceSettings = invoiceSettings;
       this.iterations = iterations;
       this.plans = plans;
       this.startDate = startDate;
@@ -659,13 +695,21 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
     public static class Builder {
       private BigDecimal applicationFeePercent;
 
+      private Object billingThresholds;
+
+      private CollectionMethod collectionMethod;
+
       private String coupon;
+
+      private String defaultPaymentMethod;
 
       private Object defaultTaxRates;
 
       private Object endDate;
 
       private Map<String, Object> extraParams;
+
+      private InvoiceSettings invoiceSettings;
 
       private Long iterations;
 
@@ -683,10 +727,14 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
       public Phase build() {
         return new Phase(
             this.applicationFeePercent,
+            this.billingThresholds,
+            this.collectionMethod,
             this.coupon,
+            this.defaultPaymentMethod,
             this.defaultTaxRates,
             this.endDate,
             this.extraParams,
+            this.invoiceSettings,
             this.iterations,
             this.plans,
             this.startDate,
@@ -707,9 +755,49 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
         return this;
       }
 
+      /**
+       * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
+       * billing period. Pass an empty string to remove previously-defined thresholds.
+       */
+      public Builder setBillingThresholds(BillingThresholds billingThresholds) {
+        this.billingThresholds = billingThresholds;
+        return this;
+      }
+
+      /**
+       * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
+       * billing period. Pass an empty string to remove previously-defined thresholds.
+       */
+      public Builder setBillingThresholds(EmptyParam billingThresholds) {
+        this.billingThresholds = billingThresholds;
+        return this;
+      }
+
+      /**
+       * Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will
+       * attempt to pay the underlying subscription at the end of each billing cycle using the
+       * default source attached to the customer. When sending an invoice, Stripe will email your
+       * customer an invoice with payment instructions. Defaults to `charge_automatically` on
+       * creation.
+       */
+      public Builder setCollectionMethod(CollectionMethod collectionMethod) {
+        this.collectionMethod = collectionMethod;
+        return this;
+      }
+
       /** The identifier of the coupon to apply to this phase of the subscription schedule. */
       public Builder setCoupon(String coupon) {
         this.coupon = coupon;
+        return this;
+      }
+
+      /**
+       * ID of the default payment method for the subscription schedule. It must belong to the
+       * customer associated with the subscription schedule. If not set, invoices will use the
+       * default payment method in the customer's invoice settings.
+       */
+      public Builder setDefaultPaymentMethod(String defaultPaymentMethod) {
+        this.defaultPaymentMethod = defaultPaymentMethod;
         return this;
       }
 
@@ -772,6 +860,12 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
           this.extraParams = new HashMap<>();
         }
         this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** All invoices will be billed using the specified settings. */
+      public Builder setInvoiceSettings(InvoiceSettings invoiceSettings) {
+        this.invoiceSettings = invoiceSettings;
         return this;
       }
 
@@ -862,6 +956,167 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
       public Builder setTrialEnd(Long trialEnd) {
         this.trialEnd = trialEnd;
         return this;
+      }
+    }
+
+    public static class BillingThresholds {
+      /** Monetary threshold that triggers the subscription to advance to a new billing period. */
+      @SerializedName("amount_gte")
+      Long amountGte;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /**
+       * Indicates if the `billing_cycle_anchor` should be reset when a threshold is reached. If
+       * true, `billing_cycle_anchor` will be updated to the date/time the threshold was last
+       * reached; otherwise, the value will remain unchanged.
+       */
+      @SerializedName("reset_billing_cycle_anchor")
+      Boolean resetBillingCycleAnchor;
+
+      private BillingThresholds(
+          Long amountGte, Map<String, Object> extraParams, Boolean resetBillingCycleAnchor) {
+        this.amountGte = amountGte;
+        this.extraParams = extraParams;
+        this.resetBillingCycleAnchor = resetBillingCycleAnchor;
+      }
+
+      public static Builder builder() {
+        return new com.stripe.param.SubscriptionScheduleUpdateParams.Phase.BillingThresholds
+            .Builder();
+      }
+
+      public static class Builder {
+        private Long amountGte;
+
+        private Map<String, Object> extraParams;
+
+        private Boolean resetBillingCycleAnchor;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public BillingThresholds build() {
+          return new BillingThresholds(
+              this.amountGte, this.extraParams, this.resetBillingCycleAnchor);
+        }
+
+        /** Monetary threshold that triggers the subscription to advance to a new billing period. */
+        public Builder setAmountGte(Long amountGte) {
+          this.amountGte = amountGte;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link SubscriptionScheduleUpdateParams.Phase.BillingThresholds#extraParams} for
+         * the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link SubscriptionScheduleUpdateParams.Phase.BillingThresholds#extraParams} for
+         * the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /**
+         * Indicates if the `billing_cycle_anchor` should be reset when a threshold is reached. If
+         * true, `billing_cycle_anchor` will be updated to the date/time the threshold was last
+         * reached; otherwise, the value will remain unchanged.
+         */
+        public Builder setResetBillingCycleAnchor(Boolean resetBillingCycleAnchor) {
+          this.resetBillingCycleAnchor = resetBillingCycleAnchor;
+          return this;
+        }
+      }
+    }
+
+    public static class InvoiceSettings {
+      @SerializedName("days_until_due")
+      Long daysUntilDue;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private InvoiceSettings(Long daysUntilDue, Map<String, Object> extraParams) {
+        this.daysUntilDue = daysUntilDue;
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new com.stripe.param.SubscriptionScheduleUpdateParams.Phase.InvoiceSettings
+            .Builder();
+      }
+
+      public static class Builder {
+        private Long daysUntilDue;
+
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public InvoiceSettings build() {
+          return new InvoiceSettings(this.daysUntilDue, this.extraParams);
+        }
+
+        public Builder setDaysUntilDue(Long daysUntilDue) {
+          this.daysUntilDue = daysUntilDue;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link SubscriptionScheduleUpdateParams.Phase.InvoiceSettings#extraParams} for
+         * the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link SubscriptionScheduleUpdateParams.Phase.InvoiceSettings#extraParams} for
+         * the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
       }
     }
 
@@ -1085,6 +1340,21 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
             return this;
           }
         }
+      }
+    }
+
+    public enum CollectionMethod implements ApiRequestParams.EnumParam {
+      @SerializedName("charge_automatically")
+      CHARGE_AUTOMATICALLY("charge_automatically"),
+
+      @SerializedName("send_invoice")
+      SEND_INVOICE("send_invoice");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      CollectionMethod(String value) {
+        this.value = value;
       }
     }
 

--- a/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
+++ b/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
@@ -855,6 +855,27 @@ public class WebhookEndpointCreateParams extends ApiRequestParams {
     @SerializedName("source.transaction.updated")
     SOURCE__TRANSACTION__UPDATED("source.transaction.updated"),
 
+    @SerializedName("subscription_schedule.aborted")
+    SUBSCRIPTION_SCHEDULE__ABORTED("subscription_schedule.aborted"),
+
+    @SerializedName("subscription_schedule.canceled")
+    SUBSCRIPTION_SCHEDULE__CANCELED("subscription_schedule.canceled"),
+
+    @SerializedName("subscription_schedule.completed")
+    SUBSCRIPTION_SCHEDULE__COMPLETED("subscription_schedule.completed"),
+
+    @SerializedName("subscription_schedule.created")
+    SUBSCRIPTION_SCHEDULE__CREATED("subscription_schedule.created"),
+
+    @SerializedName("subscription_schedule.expiring")
+    SUBSCRIPTION_SCHEDULE__EXPIRING("subscription_schedule.expiring"),
+
+    @SerializedName("subscription_schedule.released")
+    SUBSCRIPTION_SCHEDULE__RELEASED("subscription_schedule.released"),
+
+    @SerializedName("subscription_schedule.updated")
+    SUBSCRIPTION_SCHEDULE__UPDATED("subscription_schedule.updated"),
+
     @SerializedName("tax_rate.created")
     TAX_RATE__CREATED("tax_rate.created"),
 

--- a/src/main/java/com/stripe/param/WebhookEndpointUpdateParams.java
+++ b/src/main/java/com/stripe/param/WebhookEndpointUpdateParams.java
@@ -548,6 +548,27 @@ public class WebhookEndpointUpdateParams extends ApiRequestParams {
     @SerializedName("source.transaction.updated")
     SOURCE__TRANSACTION__UPDATED("source.transaction.updated"),
 
+    @SerializedName("subscription_schedule.aborted")
+    SUBSCRIPTION_SCHEDULE__ABORTED("subscription_schedule.aborted"),
+
+    @SerializedName("subscription_schedule.canceled")
+    SUBSCRIPTION_SCHEDULE__CANCELED("subscription_schedule.canceled"),
+
+    @SerializedName("subscription_schedule.completed")
+    SUBSCRIPTION_SCHEDULE__COMPLETED("subscription_schedule.completed"),
+
+    @SerializedName("subscription_schedule.created")
+    SUBSCRIPTION_SCHEDULE__CREATED("subscription_schedule.created"),
+
+    @SerializedName("subscription_schedule.expiring")
+    SUBSCRIPTION_SCHEDULE__EXPIRING("subscription_schedule.expiring"),
+
+    @SerializedName("subscription_schedule.released")
+    SUBSCRIPTION_SCHEDULE__RELEASED("subscription_schedule.released"),
+
+    @SerializedName("subscription_schedule.updated")
+    SUBSCRIPTION_SCHEDULE__UPDATED("subscription_schedule.updated"),
+
     @SerializedName("tax_rate.created")
     TAX_RATE__CREATED("tax_rate.created"),
 

--- a/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
+++ b/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
@@ -80,6 +80,10 @@ public class SessionCreateParams extends ApiRequestParams {
   @SerializedName("locale")
   Locale locale;
 
+  /** The mode of the Checkout Session. */
+  @SerializedName("mode")
+  Mode mode;
+
   /** A subset of parameters to be passed to PaymentIntent creation. */
   @SerializedName("payment_intent_data")
   PaymentIntentData paymentIntentData;
@@ -90,6 +94,10 @@ public class SessionCreateParams extends ApiRequestParams {
    */
   @SerializedName("payment_method_types")
   List<PaymentMethodType> paymentMethodTypes;
+
+  /** A subset of parameters to be passed to SetupIntent creation. */
+  @SerializedName("setup_intent_data")
+  SetupIntentData setupIntentData;
 
   /**
    * Describes the type of transaction being performed by Checkout in order to customize relevant
@@ -122,8 +130,10 @@ public class SessionCreateParams extends ApiRequestParams {
       Map<String, Object> extraParams,
       List<LineItem> lineItems,
       Locale locale,
+      Mode mode,
       PaymentIntentData paymentIntentData,
       List<PaymentMethodType> paymentMethodTypes,
+      SetupIntentData setupIntentData,
       SubmitType submitType,
       SubscriptionData subscriptionData,
       String successUrl) {
@@ -136,8 +146,10 @@ public class SessionCreateParams extends ApiRequestParams {
     this.extraParams = extraParams;
     this.lineItems = lineItems;
     this.locale = locale;
+    this.mode = mode;
     this.paymentIntentData = paymentIntentData;
     this.paymentMethodTypes = paymentMethodTypes;
+    this.setupIntentData = setupIntentData;
     this.submitType = submitType;
     this.subscriptionData = subscriptionData;
     this.successUrl = successUrl;
@@ -166,9 +178,13 @@ public class SessionCreateParams extends ApiRequestParams {
 
     private Locale locale;
 
+    private Mode mode;
+
     private PaymentIntentData paymentIntentData;
 
     private List<PaymentMethodType> paymentMethodTypes;
+
+    private SetupIntentData setupIntentData;
 
     private SubmitType submitType;
 
@@ -188,8 +204,10 @@ public class SessionCreateParams extends ApiRequestParams {
           this.extraParams,
           this.lineItems,
           this.locale,
+          this.mode,
           this.paymentIntentData,
           this.paymentMethodTypes,
+          this.setupIntentData,
           this.submitType,
           this.subscriptionData,
           this.successUrl);
@@ -333,6 +351,12 @@ public class SessionCreateParams extends ApiRequestParams {
       return this;
     }
 
+    /** The mode of the Checkout Session. */
+    public Builder setMode(Mode mode) {
+      this.mode = mode;
+      return this;
+    }
+
     /** A subset of parameters to be passed to PaymentIntent creation. */
     public Builder setPaymentIntentData(PaymentIntentData paymentIntentData) {
       this.paymentIntentData = paymentIntentData;
@@ -362,6 +386,12 @@ public class SessionCreateParams extends ApiRequestParams {
         this.paymentMethodTypes = new ArrayList<>();
       }
       this.paymentMethodTypes.addAll(elements);
+      return this;
+    }
+
+    /** A subset of parameters to be passed to SetupIntent creation. */
+    public Builder setSetupIntentData(SetupIntentData setupIntentData) {
+      this.setupIntentData = setupIntentData;
       return this;
     }
 
@@ -1256,6 +1286,135 @@ public class SessionCreateParams extends ApiRequestParams {
     }
   }
 
+  public static class SetupIntentData {
+    /** An arbitrary string attached to the object. Often useful for displaying to users. */
+    @SerializedName("description")
+    String description;
+
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /**
+     * Set of key-value pairs that you can attach to an object. This can be useful for storing
+     * additional information about the object in a structured format.
+     */
+    @SerializedName("metadata")
+    Map<String, String> metadata;
+
+    /**
+     * The Stripe account ID for which these funds are intended. For details, see the PaymentIntents
+     * [use case for connected
+     * accounts](/docs/payments/payment-intents/use-cases#connected-accounts).
+     */
+    @SerializedName("on_behalf_of")
+    String onBehalfOf;
+
+    private SetupIntentData(
+        String description,
+        Map<String, Object> extraParams,
+        Map<String, String> metadata,
+        String onBehalfOf) {
+      this.description = description;
+      this.extraParams = extraParams;
+      this.metadata = metadata;
+      this.onBehalfOf = onBehalfOf;
+    }
+
+    public static Builder builder() {
+      return new com.stripe.param.checkout.SessionCreateParams.SetupIntentData.Builder();
+    }
+
+    public static class Builder {
+      private String description;
+
+      private Map<String, Object> extraParams;
+
+      private Map<String, String> metadata;
+
+      private String onBehalfOf;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public SetupIntentData build() {
+        return new SetupIntentData(
+            this.description, this.extraParams, this.metadata, this.onBehalfOf);
+      }
+
+      /** An arbitrary string attached to the object. Often useful for displaying to users. */
+      public Builder setDescription(String description) {
+        this.description = description;
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * SessionCreateParams.SetupIntentData#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link SessionCreateParams.SetupIntentData#extraParams} for the field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `metadata` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * SessionCreateParams.SetupIntentData#metadata} for the field documentation.
+       */
+      public Builder putMetadata(String key, String value) {
+        if (this.metadata == null) {
+          this.metadata = new HashMap<>();
+        }
+        this.metadata.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `metadata` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link SessionCreateParams.SetupIntentData#metadata} for the field documentation.
+       */
+      public Builder putAllMetadata(Map<String, String> map) {
+        if (this.metadata == null) {
+          this.metadata = new HashMap<>();
+        }
+        this.metadata.putAll(map);
+        return this;
+      }
+
+      /**
+       * The Stripe account ID for which these funds are intended. For details, see the
+       * PaymentIntents [use case for connected
+       * accounts](/docs/payments/payment-intents/use-cases#connected-accounts).
+       */
+      public Builder setOnBehalfOf(String onBehalfOf) {
+        this.onBehalfOf = onBehalfOf;
+        return this;
+      }
+    }
+  }
+
   public static class SubscriptionData {
     /**
      * A non-negative decimal between 0 and 100, with at most two decimal places. This represents
@@ -1606,6 +1765,24 @@ public class SessionCreateParams extends ApiRequestParams {
     private final String value;
 
     Locale(String value) {
+      this.value = value;
+    }
+  }
+
+  public enum Mode implements ApiRequestParams.EnumParam {
+    @SerializedName("payment")
+    PAYMENT("payment"),
+
+    @SerializedName("setup")
+    SETUP("setup"),
+
+    @SerializedName("subscription")
+    SUBSCRIPTION("subscription");
+
+    @Getter(onMethod_ = {@Override})
+    private final String value;
+
+    Mode(String value) {
       this.value = value;
     }
   }


### PR DESCRIPTION
* Add support for `schedule` on `Subscription`
* Add support for `defaultPaymentMethod`, `invoiceSettings`, `collectionMethod` and `billingThresholds` to `SubscriptionSchedule` and its update and create APIs
* Add support for `mode` and `setupIntent` on Checkout `Session` and its create API
* Add support for `schedule` and `subscriptionCancelAt` to the `Invoice` Upcoming API
* Add support for new event types `subscription_schedule.*`