### PR TITLE
[generated] source: spec3.sdk.yaml@spec-57fd3b2 in master

### DIFF
--- a/src/main/java/com/stripe/model/InvoiceItem.java
+++ b/src/main/java/com/stripe/model/InvoiceItem.java
@@ -11,6 +11,7 @@ import com.stripe.param.InvoiceItemCreateParams;
 import com.stripe.param.InvoiceItemListParams;
 import com.stripe.param.InvoiceItemRetrieveParams;
 import com.stripe.param.InvoiceItemUpdateParams;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import lombok.EqualsAndHashCode;
@@ -136,6 +137,10 @@ public class InvoiceItem extends ApiResource implements HasId, MetadataStore<Inv
   /** Unit Amount (in the `currency` specified) of the invoice item. */
   @SerializedName("unit_amount")
   Long unitAmount;
+
+  /** Same as `unit_amount`, but contains a decimal value with at most 12 decimal places. */
+  @SerializedName("unit_amount_decimal")
+  BigDecimal unitAmountDecimal;
 
   /** Get id of expandable `customer` object. */
   public String getCustomer() {

--- a/src/main/java/com/stripe/model/Plan.java
+++ b/src/main/java/com/stripe/model/Plan.java
@@ -11,6 +11,7 @@ import com.stripe.param.PlanCreateParams;
 import com.stripe.param.PlanListParams;
 import com.stripe.param.PlanRetrieveParams;
 import com.stripe.param.PlanUpdateParams;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import lombok.EqualsAndHashCode;
@@ -38,6 +39,10 @@ public class Plan extends ApiResource implements HasId, MetadataStore<Plan> {
   /** The amount in %s to be charged on the interval specified. */
   @SerializedName("amount")
   Long amount;
+
+  /** Same as `amount`, but contains a decimal value with at most 12 decimal places. */
+  @SerializedName("amount_decimal")
+  BigDecimal amountDecimal;
 
   /**
    * Describes how to compute the price per period. Either `per_unit` or `tiered`. `per_unit`
@@ -339,9 +344,17 @@ public class Plan extends ApiResource implements HasId, MetadataStore<Plan> {
     @SerializedName("flat_amount")
     Long flatAmount;
 
+    /** Same as `flat_amount`, but contains a decimal value with at most 12 decimal places. */
+    @SerializedName("flat_amount_decimal")
+    BigDecimal flatAmountDecimal;
+
     /** Per unit price for units relevant to the tier. */
     @SerializedName("unit_amount")
     Long unitAmount;
+
+    /** Same as `unit_amount`, but contains a decimal value with at most 12 decimal places. */
+    @SerializedName("unit_amount_decimal")
+    BigDecimal unitAmountDecimal;
 
     /** Up to and including to this quantity will be contained in the tier. */
     @SerializedName("up_to")

--- a/src/main/java/com/stripe/param/InvoiceItemCreateParams.java
+++ b/src/main/java/com/stripe/param/InvoiceItemCreateParams.java
@@ -4,6 +4,7 @@ package com.stripe.param;
 
 import com.google.gson.annotations.SerializedName;
 import com.stripe.net.ApiRequestParams;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -102,6 +103,13 @@ public class InvoiceItemCreateParams extends ApiRequestParams {
   @SerializedName("unit_amount")
   Long unitAmount;
 
+  /**
+   * Same as `unit_amount`, but accepts a decimal value with at most 12 decimal places. Only one of
+   * `unit_amount` and `unit_amount_decimal` can be set.
+   */
+  @SerializedName("unit_amount_decimal")
+  BigDecimal unitAmountDecimal;
+
   private InvoiceItemCreateParams(
       Long amount,
       String currency,
@@ -116,7 +124,8 @@ public class InvoiceItemCreateParams extends ApiRequestParams {
       Long quantity,
       String subscription,
       List<String> taxRates,
-      Long unitAmount) {
+      Long unitAmount,
+      BigDecimal unitAmountDecimal) {
     this.amount = amount;
     this.currency = currency;
     this.customer = customer;
@@ -131,6 +140,7 @@ public class InvoiceItemCreateParams extends ApiRequestParams {
     this.subscription = subscription;
     this.taxRates = taxRates;
     this.unitAmount = unitAmount;
+    this.unitAmountDecimal = unitAmountDecimal;
   }
 
   public static Builder builder() {
@@ -166,6 +176,8 @@ public class InvoiceItemCreateParams extends ApiRequestParams {
 
     private Long unitAmount;
 
+    private BigDecimal unitAmountDecimal;
+
     /** Finalize and obtain parameter instance from this builder. */
     public InvoiceItemCreateParams build() {
       return new InvoiceItemCreateParams(
@@ -182,7 +194,8 @@ public class InvoiceItemCreateParams extends ApiRequestParams {
           this.quantity,
           this.subscription,
           this.taxRates,
-          this.unitAmount);
+          this.unitAmount,
+          this.unitAmountDecimal);
     }
 
     /**
@@ -373,6 +386,15 @@ public class InvoiceItemCreateParams extends ApiRequestParams {
      */
     public Builder setUnitAmount(Long unitAmount) {
       this.unitAmount = unitAmount;
+      return this;
+    }
+
+    /**
+     * Same as `unit_amount`, but accepts a decimal value with at most 12 decimal places. Only one
+     * of `unit_amount` and `unit_amount_decimal` can be set.
+     */
+    public Builder setUnitAmountDecimal(BigDecimal unitAmountDecimal) {
+      this.unitAmountDecimal = unitAmountDecimal;
       return this;
     }
   }

--- a/src/main/java/com/stripe/param/InvoiceItemUpdateParams.java
+++ b/src/main/java/com/stripe/param/InvoiceItemUpdateParams.java
@@ -5,6 +5,7 @@ package com.stripe.param;
 import com.google.gson.annotations.SerializedName;
 import com.stripe.net.ApiRequestParams;
 import com.stripe.param.common.EmptyParam;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -76,6 +77,13 @@ public class InvoiceItemUpdateParams extends ApiRequestParams {
   @SerializedName("unit_amount")
   Long unitAmount;
 
+  /**
+   * Same as `unit_amount`, but accepts a decimal value with at most 12 decimal places. Only one of
+   * `unit_amount` and `unit_amount_decimal` can be set.
+   */
+  @SerializedName("unit_amount_decimal")
+  BigDecimal unitAmountDecimal;
+
   private InvoiceItemUpdateParams(
       Long amount,
       String description,
@@ -86,7 +94,8 @@ public class InvoiceItemUpdateParams extends ApiRequestParams {
       Period period,
       Long quantity,
       Object taxRates,
-      Long unitAmount) {
+      Long unitAmount,
+      BigDecimal unitAmountDecimal) {
     this.amount = amount;
     this.description = description;
     this.discountable = discountable;
@@ -97,6 +106,7 @@ public class InvoiceItemUpdateParams extends ApiRequestParams {
     this.quantity = quantity;
     this.taxRates = taxRates;
     this.unitAmount = unitAmount;
+    this.unitAmountDecimal = unitAmountDecimal;
   }
 
   public static Builder builder() {
@@ -124,6 +134,8 @@ public class InvoiceItemUpdateParams extends ApiRequestParams {
 
     private Long unitAmount;
 
+    private BigDecimal unitAmountDecimal;
+
     /** Finalize and obtain parameter instance from this builder. */
     public InvoiceItemUpdateParams build() {
       return new InvoiceItemUpdateParams(
@@ -136,7 +148,8 @@ public class InvoiceItemUpdateParams extends ApiRequestParams {
           this.period,
           this.quantity,
           this.taxRates,
-          this.unitAmount);
+          this.unitAmount,
+          this.unitAmountDecimal);
     }
 
     /**
@@ -282,6 +295,15 @@ public class InvoiceItemUpdateParams extends ApiRequestParams {
      */
     public Builder setUnitAmount(Long unitAmount) {
       this.unitAmount = unitAmount;
+      return this;
+    }
+
+    /**
+     * Same as `unit_amount`, but accepts a decimal value with at most 12 decimal places. Only one
+     * of `unit_amount` and `unit_amount_decimal` can be set.
+     */
+    public Builder setUnitAmountDecimal(BigDecimal unitAmountDecimal) {
+      this.unitAmountDecimal = unitAmountDecimal;
       return this;
     }
   }

--- a/src/main/java/com/stripe/param/InvoiceUpcomingParams.java
+++ b/src/main/java/com/stripe/param/InvoiceUpcomingParams.java
@@ -610,6 +610,13 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
     @SerializedName("unit_amount")
     Long unitAmount;
 
+    /**
+     * Same as `unit_amount`, but accepts a decimal string with at most 12 decimal places. Only one
+     * of `unit_amount` and `unit_amount_decimal` can be set.
+     */
+    @SerializedName("unit_amount_decimal")
+    BigDecimal unitAmountDecimal;
+
     private InvoiceItem(
         Long amount,
         String currency,
@@ -621,7 +628,8 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
         Period period,
         Long quantity,
         Object taxRates,
-        Long unitAmount) {
+        Long unitAmount,
+        BigDecimal unitAmountDecimal) {
       this.amount = amount;
       this.currency = currency;
       this.description = description;
@@ -633,6 +641,7 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
       this.quantity = quantity;
       this.taxRates = taxRates;
       this.unitAmount = unitAmount;
+      this.unitAmountDecimal = unitAmountDecimal;
     }
 
     public static Builder builder() {
@@ -662,6 +671,8 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
 
       private Long unitAmount;
 
+      private BigDecimal unitAmountDecimal;
+
       /** Finalize and obtain parameter instance from this builder. */
       public InvoiceItem build() {
         return new InvoiceItem(
@@ -675,7 +686,8 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
             this.period,
             this.quantity,
             this.taxRates,
-            this.unitAmount);
+            this.unitAmount,
+            this.unitAmountDecimal);
       }
 
       /** The integer amount in **%s** of previewed invoice item. */
@@ -802,6 +814,15 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
        */
       public Builder setUnitAmount(Long unitAmount) {
         this.unitAmount = unitAmount;
+        return this;
+      }
+
+      /**
+       * Same as `unit_amount`, but accepts a decimal string with at most 12 decimal places. Only
+       * one of `unit_amount` and `unit_amount_decimal` can be set.
+       */
+      public Builder setUnitAmountDecimal(BigDecimal unitAmountDecimal) {
+        this.unitAmountDecimal = unitAmountDecimal;
         return this;
       }
     }

--- a/src/main/java/com/stripe/param/PlanCreateParams.java
+++ b/src/main/java/com/stripe/param/PlanCreateParams.java
@@ -4,6 +4,7 @@ package com.stripe.param;
 
 import com.google.gson.annotations.SerializedName;
 import com.stripe.net.ApiRequestParams;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -31,6 +32,13 @@ public class PlanCreateParams extends ApiRequestParams {
    */
   @SerializedName("amount")
   Long amount;
+
+  /**
+   * Same as `amount`, but accepts a decimal value with at most 12 decimal places. Only one of
+   * `amount` and `amount_decimal` can be set.
+   */
+  @SerializedName("amount_decimal")
+  BigDecimal amountDecimal;
 
   /**
    * Describes how to compute the price per period. Either `per_unit` or `tiered`. `per_unit`
@@ -138,6 +146,7 @@ public class PlanCreateParams extends ApiRequestParams {
       Boolean active,
       AggregateUsage aggregateUsage,
       Long amount,
+      BigDecimal amountDecimal,
       BillingScheme billingScheme,
       String currency,
       List<String> expand,
@@ -156,6 +165,7 @@ public class PlanCreateParams extends ApiRequestParams {
     this.active = active;
     this.aggregateUsage = aggregateUsage;
     this.amount = amount;
+    this.amountDecimal = amountDecimal;
     this.billingScheme = billingScheme;
     this.currency = currency;
     this.expand = expand;
@@ -183,6 +193,8 @@ public class PlanCreateParams extends ApiRequestParams {
     private AggregateUsage aggregateUsage;
 
     private Long amount;
+
+    private BigDecimal amountDecimal;
 
     private BillingScheme billingScheme;
 
@@ -220,6 +232,7 @@ public class PlanCreateParams extends ApiRequestParams {
           this.active,
           this.aggregateUsage,
           this.amount,
+          this.amountDecimal,
           this.billingScheme,
           this.currency,
           this.expand,
@@ -261,6 +274,15 @@ public class PlanCreateParams extends ApiRequestParams {
      */
     public Builder setAmount(Long amount) {
       this.amount = amount;
+      return this;
+    }
+
+    /**
+     * Same as `amount`, but accepts a decimal value with at most 12 decimal places. Only one of
+     * `amount` and `amount_decimal` can be set.
+     */
+    public Builder setAmountDecimal(BigDecimal amountDecimal) {
+      this.amountDecimal = amountDecimal;
       return this;
     }
 
@@ -688,9 +710,23 @@ public class PlanCreateParams extends ApiRequestParams {
     @SerializedName("flat_amount")
     Long flatAmount;
 
+    /**
+     * Same as `flat_amount`, but accepts a decimal value representing an integer in the minor units
+     * of the currency. Only one of `flat_amount` and `flat_amount_decimal` can be set.
+     */
+    @SerializedName("flat_amount_decimal")
+    BigDecimal flatAmountDecimal;
+
     /** The per unit billing amount for each individual unit for which this tier applies. */
     @SerializedName("unit_amount")
     Long unitAmount;
+
+    /**
+     * Same as `unit_amount`, but accepts a decimal value with at most 12 decimal places. Only one
+     * of `unit_amount` and `unit_amount_decimal` can be set.
+     */
+    @SerializedName("unit_amount_decimal")
+    BigDecimal unitAmountDecimal;
 
     /**
      * Specifies the upper bound of this tier. The lower bound of a tier is the upper bound of the
@@ -699,10 +735,18 @@ public class PlanCreateParams extends ApiRequestParams {
     @SerializedName("up_to")
     Object upTo;
 
-    private Tier(Map<String, Object> extraParams, Long flatAmount, Long unitAmount, Object upTo) {
+    private Tier(
+        Map<String, Object> extraParams,
+        Long flatAmount,
+        BigDecimal flatAmountDecimal,
+        Long unitAmount,
+        BigDecimal unitAmountDecimal,
+        Object upTo) {
       this.extraParams = extraParams;
       this.flatAmount = flatAmount;
+      this.flatAmountDecimal = flatAmountDecimal;
       this.unitAmount = unitAmount;
+      this.unitAmountDecimal = unitAmountDecimal;
       this.upTo = upTo;
     }
 
@@ -715,13 +759,23 @@ public class PlanCreateParams extends ApiRequestParams {
 
       private Long flatAmount;
 
+      private BigDecimal flatAmountDecimal;
+
       private Long unitAmount;
+
+      private BigDecimal unitAmountDecimal;
 
       private Object upTo;
 
       /** Finalize and obtain parameter instance from this builder. */
       public Tier build() {
-        return new Tier(this.extraParams, this.flatAmount, this.unitAmount, this.upTo);
+        return new Tier(
+            this.extraParams,
+            this.flatAmount,
+            this.flatAmountDecimal,
+            this.unitAmount,
+            this.unitAmountDecimal,
+            this.upTo);
       }
 
       /**
@@ -758,9 +812,27 @@ public class PlanCreateParams extends ApiRequestParams {
         return this;
       }
 
+      /**
+       * Same as `flat_amount`, but accepts a decimal value representing an integer in the minor
+       * units of the currency. Only one of `flat_amount` and `flat_amount_decimal` can be set.
+       */
+      public Builder setFlatAmountDecimal(BigDecimal flatAmountDecimal) {
+        this.flatAmountDecimal = flatAmountDecimal;
+        return this;
+      }
+
       /** The per unit billing amount for each individual unit for which this tier applies. */
       public Builder setUnitAmount(Long unitAmount) {
         this.unitAmount = unitAmount;
+        return this;
+      }
+
+      /**
+       * Same as `unit_amount`, but accepts a decimal value with at most 12 decimal places. Only one
+       * of `unit_amount` and `unit_amount_decimal` can be set.
+       */
+      public Builder setUnitAmountDecimal(BigDecimal unitAmountDecimal) {
+        this.unitAmountDecimal = unitAmountDecimal;
         return this;
       }
 


### PR DESCRIPTION
Release support for decimal values on Billing resources such as `Plan` or `InvoiceItem`.

r? @ob-stripe 
cc @stripe/api-libraries 