### PR TITLE
Add support for `endBehavior` on `SubscriptionSchedule`

### DIFF
--- a/src/main/java/com/stripe/model/SubscriptionSchedule.java
+++ b/src/main/java/com/stripe/model/SubscriptionSchedule.java
@@ -97,6 +97,10 @@ public class SubscriptionSchedule extends ApiResource
   @Setter(lombok.AccessLevel.NONE)
   ExpandableField<PaymentSource> defaultSource;
 
+  /** Behavior of the subscription schedule and underlying subscription when it ends. */
+  @SerializedName("end_behavior")
+  String endBehavior;
+
   /** Unique identifier for the object. */
   @Getter(onMethod_ = {@Override})
   @SerializedName("id")

--- a/src/main/java/com/stripe/model/checkout/Session.java
+++ b/src/main/java/com/stripe/model/checkout/Session.java
@@ -97,7 +97,7 @@ public class Session extends ApiResource implements HasId {
   @SerializedName("object")
   String object;
 
-  /** The ID of the PaymentIntent created if SKUs or line items were provided. */
+  /** The ID of the PaymentIntent for `payment` mode. */
   @SerializedName("payment_intent")
   @Getter(lombok.AccessLevel.NONE)
   @Setter(lombok.AccessLevel.NONE)

--- a/src/main/java/com/stripe/param/SetupIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/SetupIntentCreateParams.java
@@ -78,7 +78,7 @@ public class SetupIntentCreateParams extends ApiRequestParams {
    * The URL to redirect your customer back to after they authenticate or cancel their payment on
    * the payment method's app or site. If you'd prefer to redirect to a mobile application, you can
    * alternatively supply an application URI scheme. This parameter can only be used with
-   * [`confirm=true`](https://stripe.com/docs/api/payment_intents/create#create_payment_intent-confirm).
+   * [`confirm=true`](https://stripe.com/docs/api/setup_intents/create#create_setup_intent-confirm).
    */
   @SerializedName("return_url")
   String returnUrl;
@@ -323,7 +323,7 @@ public class SetupIntentCreateParams extends ApiRequestParams {
      * The URL to redirect your customer back to after they authenticate or cancel their payment on
      * the payment method's app or site. If you'd prefer to redirect to a mobile application, you
      * can alternatively supply an application URI scheme. This parameter can only be used with
-     * [`confirm=true`](https://stripe.com/docs/api/payment_intents/create#create_payment_intent-confirm).
+     * [`confirm=true`](https://stripe.com/docs/api/setup_intents/create#create_setup_intent-confirm).
      */
     public Builder setReturnUrl(String returnUrl) {
       this.returnUrl = returnUrl;

--- a/src/main/java/com/stripe/param/SubscriptionScheduleCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionScheduleCreateParams.java
@@ -55,6 +55,9 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
   @SerializedName("default_source")
   String defaultSource;
 
+  @SerializedName("end_behavior")
+  EndBehavior endBehavior;
+
   /** Specifies which fields in the response should be expanded. */
   @SerializedName("expand")
   List<String> expand;
@@ -124,6 +127,7 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
       String customer,
       String defaultPaymentMethod,
       String defaultSource,
+      EndBehavior endBehavior,
       List<String> expand,
       Map<String, Object> extraParams,
       String fromSubscription,
@@ -139,6 +143,7 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
     this.customer = customer;
     this.defaultPaymentMethod = defaultPaymentMethod;
     this.defaultSource = defaultSource;
+    this.endBehavior = endBehavior;
     this.expand = expand;
     this.extraParams = extraParams;
     this.fromSubscription = fromSubscription;
@@ -167,6 +172,8 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
 
     private String defaultSource;
 
+    private EndBehavior endBehavior;
+
     private List<String> expand;
 
     private Map<String, Object> extraParams;
@@ -194,6 +201,7 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
           this.customer,
           this.defaultPaymentMethod,
           this.defaultSource,
+          this.endBehavior,
           this.expand,
           this.extraParams,
           this.fromSubscription,
@@ -266,6 +274,11 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
      */
     public Builder setDefaultSource(String defaultSource) {
       this.defaultSource = defaultSource;
+      return this;
+    }
+
+    public Builder setEndBehavior(EndBehavior endBehavior) {
+      this.endBehavior = endBehavior;
       return this;
     }
 
@@ -1497,7 +1510,31 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
     }
   }
 
+  public enum EndBehavior implements ApiRequestParams.EnumParam {
+    @SerializedName("cancel")
+    CANCEL("cancel"),
+
+    @SerializedName("none")
+    NONE("none"),
+
+    @SerializedName("release")
+    RELEASE("release"),
+
+    @SerializedName("renew")
+    RENEW("renew");
+
+    @Getter(onMethod_ = {@Override})
+    private final String value;
+
+    EndBehavior(String value) {
+      this.value = value;
+    }
+  }
+
   public enum RenewalBehavior implements ApiRequestParams.EnumParam {
+    @SerializedName("cancel")
+    CANCEL("cancel"),
+
     @SerializedName("none")
     NONE("none"),
 

--- a/src/main/java/com/stripe/param/SubscriptionScheduleUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionScheduleUpdateParams.java
@@ -51,6 +51,9 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
   @SerializedName("default_source")
   String defaultSource;
 
+  @SerializedName("end_behavior")
+  EndBehavior endBehavior;
+
   /** Specifies which fields in the response should be expanded. */
   @SerializedName("expand")
   List<String> expand;
@@ -114,6 +117,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
       CollectionMethod collectionMethod,
       String defaultPaymentMethod,
       String defaultSource,
+      EndBehavior endBehavior,
       List<String> expand,
       Map<String, Object> extraParams,
       InvoiceSettings invoiceSettings,
@@ -127,6 +131,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
     this.collectionMethod = collectionMethod;
     this.defaultPaymentMethod = defaultPaymentMethod;
     this.defaultSource = defaultSource;
+    this.endBehavior = endBehavior;
     this.expand = expand;
     this.extraParams = extraParams;
     this.invoiceSettings = invoiceSettings;
@@ -152,6 +157,8 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
 
     private String defaultSource;
 
+    private EndBehavior endBehavior;
+
     private List<String> expand;
 
     private Map<String, Object> extraParams;
@@ -176,6 +183,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
           this.collectionMethod,
           this.defaultPaymentMethod,
           this.defaultSource,
+          this.endBehavior,
           this.expand,
           this.extraParams,
           this.invoiceSettings,
@@ -241,6 +249,11 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
      */
     public Builder setDefaultSource(String defaultSource) {
       this.defaultSource = defaultSource;
+      return this;
+    }
+
+    public Builder setEndBehavior(EndBehavior endBehavior) {
+      this.endBehavior = endBehavior;
       return this;
     }
 
@@ -1533,7 +1546,31 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
     }
   }
 
+  public enum EndBehavior implements ApiRequestParams.EnumParam {
+    @SerializedName("cancel")
+    CANCEL("cancel"),
+
+    @SerializedName("none")
+    NONE("none"),
+
+    @SerializedName("release")
+    RELEASE("release"),
+
+    @SerializedName("renew")
+    RENEW("renew");
+
+    @Getter(onMethod_ = {@Override})
+    private final String value;
+
+    EndBehavior(String value) {
+      this.value = value;
+    }
+  }
+
   public enum RenewalBehavior implements ApiRequestParams.EnumParam {
+    @SerializedName("cancel")
+    CANCEL("cancel"),
+
     @SerializedName("none")
     NONE("none"),
 

--- a/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
+++ b/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
@@ -113,9 +113,9 @@ public class SessionCreateParams extends ApiRequestParams {
   SubscriptionData subscriptionData;
 
   /**
-   * The URL to which Stripe should send customers when payment is complete. If you’d like access to
-   * the Checkout Session for the successful payment, read more about it in our guide on [fulfilling
-   * your payments with webhooks](/docs/payments/checkout/fulfillment#webhooks).
+   * The URL to which Stripe should send customers when payment or setup is complete. If you’d like
+   * access to the Checkout Session for the successful payment, read more about it in our guide on
+   * [fulfilling your payments with webhooks](/docs/payments/checkout/fulfillment#webhooks).
    */
   @SerializedName("success_url")
   String successUrl;
@@ -413,9 +413,10 @@ public class SessionCreateParams extends ApiRequestParams {
     }
 
     /**
-     * The URL to which Stripe should send customers when payment is complete. If you’d like access
-     * to the Checkout Session for the successful payment, read more about it in our guide on
-     * [fulfilling your payments with webhooks](/docs/payments/checkout/fulfillment#webhooks).
+     * The URL to which Stripe should send customers when payment or setup is complete. If you’d
+     * like access to the Checkout Session for the successful payment, read more about it in our
+     * guide on [fulfilling your payments with
+     * webhooks](/docs/payments/checkout/fulfillment#webhooks).
      */
     public Builder setSuccessUrl(String successUrl) {
       this.successUrl = successUrl;


### PR DESCRIPTION
r? @remi-stripe I'm self-approving as it's the same PR approved internally
cc @stripe/api-libraries 

Details: [generated] source: spec3.sdk.yaml@spec-2ff6dcb in master 