### PR TITLE
Make stripeError transient on StripeException

### DIFF
--- a/src/main/java/com/stripe/exception/StripeException.java
+++ b/src/main/java/com/stripe/exception/StripeException.java
@@ -9,7 +9,8 @@ public abstract class StripeException extends Exception {
   private static final long serialVersionUID = 2L;
 
   /** The error resource returned by Stripe's API that caused the exception. */
-  @Setter StripeError stripeError;
+  // transient so the exception can be serialized, as StripeObject does not implement Serializable
+  @Setter transient StripeError stripeError;
 
   private String code;
   private String requestId;


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Make `stripeError` transient on `StripeException`. This ensures that `StripeException` is serializable, as it implements the `Serializable` interface (all exceptions do) and `StripeObject`s are not serializable.

I briefly considered making `StripeObject`s serializable, but it seems like the general consensus is that Java's serialization mechanism is flawed and shouldn't be used in new code (https://stackoverflow.com/a/53889695/5307473) so this is the easiest fix.

Fixes #832.
 