### PR TITLE
Support `authentication` on Issuing `Authorization` and `url` on `MerchantData`

### DIFF
--- a/src/main/java/com/stripe/model/Capability.java
+++ b/src/main/java/com/stripe/model/Capability.java
@@ -25,7 +25,7 @@ public class Capability extends ApiResource implements HasId {
   @Setter(lombok.AccessLevel.NONE)
   ExpandableField<Account> account;
 
-  /** Unique identifier for the object. */
+  /** The identifier for the capability. */
   @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;

--- a/src/main/java/com/stripe/model/PaymentIntent.java
+++ b/src/main/java/com/stripe/model/PaymentIntent.java
@@ -230,8 +230,7 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
    * <p>Use `on_session` if you intend to only reuse the payment method when your customer is
    * present in your checkout flow. Use `off_session` if your customer may or may not be in your
    * checkout flow. See [Saving card details after a
-   * payment](https://stripe.com/docs/payments/cards/saving-cards#saving-card-after-payment) to
-   * learn more.
+   * payment](https://stripe.com/docs/payments/cards/saving-cards-after-payment) to learn more.
    *
    * <p>Stripe uses `setup_future_usage` to dynamically optimize your payment flow and comply with
    * regional legislation and network rules. For example, if your customer is impacted by

--- a/src/main/java/com/stripe/model/issuing/Authorization.java
+++ b/src/main/java/com/stripe/model/issuing/Authorization.java
@@ -434,6 +434,10 @@ public class Authorization extends ApiResource
     @SerializedName("address_zip_check")
     String addressZipCheck;
 
+    /** One of `success`, `failure`, `exempt`, or `none`. */
+    @SerializedName("authentication")
+    String authentication;
+
     /** One of `match`, `mismatch`, or `not_provided`. */
     @SerializedName("cvc_check")
     String cvcCheck;

--- a/src/main/java/com/stripe/model/issuing/MerchantData.java
+++ b/src/main/java/com/stripe/model/issuing/MerchantData.java
@@ -42,4 +42,8 @@ public class MerchantData extends StripeObject {
   /** State where the seller is located. */
   @SerializedName("state")
   String state;
+
+  /** The url an online purchase was made from. */
+  @SerializedName("url")
+  String url;
 }

--- a/src/main/java/com/stripe/param/InvoiceUpcomingParams.java
+++ b/src/main/java/com/stripe/param/InvoiceUpcomingParams.java
@@ -83,6 +83,7 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
   @SerializedName("subscription_cancel_at_period_end")
   Boolean subscriptionCancelAtPeriodEnd;
 
+  /** This simulates the subscription being canceled or expired immediately. */
   @SerializedName("subscription_cancel_now")
   Boolean subscriptionCancelNow;
 
@@ -421,6 +422,7 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
       return this;
     }
 
+    /** This simulates the subscription being canceled or expired immediately. */
     public Builder setSubscriptionCancelNow(Boolean subscriptionCancelNow) {
       this.subscriptionCancelNow = subscriptionCancelNow;
       return this;

--- a/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
@@ -183,8 +183,7 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
    * <p>Use `on_session` if you intend to only reuse the payment method when your customer is
    * present in your checkout flow. Use `off_session` if your customer may or may not be in your
    * checkout flow. See [Saving card details after a
-   * payment](https://stripe.com/docs/payments/cards/saving-cards#saving-card-after-payment) to
-   * learn more.
+   * payment](https://stripe.com/docs/payments/cards/saving-cards-after-payment) to learn more.
    *
    * <p>Stripe uses `setup_future_usage` to dynamically optimize your payment flow and comply with
    * regional legislation and network rules. For example, if your customer is impacted by
@@ -676,8 +675,7 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
      * <p>Use `on_session` if you intend to only reuse the payment method when your customer is
      * present in your checkout flow. Use `off_session` if your customer may or may not be in your
      * checkout flow. See [Saving card details after a
-     * payment](https://stripe.com/docs/payments/cards/saving-cards#saving-card-after-payment) to
-     * learn more.
+     * payment](https://stripe.com/docs/payments/cards/saving-cards-after-payment) to learn more.
      *
      * <p>Stripe uses `setup_future_usage` to dynamically optimize your payment flow and comply with
      * regional legislation and network rules. For example, if your customer is impacted by

--- a/src/main/java/com/stripe/param/SubscriptionScheduleCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionScheduleCreateParams.java
@@ -101,10 +101,11 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
 
   /**
    * Configures how the subscription schedule behaves when it ends. Possible values are `none`,
-   * `renew`, or `release`. `renew` will create a new subscription schedule revision by adding a new
-   * phase using the most recent phase's `plans` applied to a duration set by `renewal_interval`.
-   * `none` will stop the subscription schedule and cancel the underlying subscription. `release`
-   * will stop the subscription schedule, but keep the underlying subscription running.
+   * `cancel`, `renew`, or `release`. `renew` will create a new subscription schedule revision by
+   * adding a new phase using the most recent phase's `plans` applied to a duration set by
+   * `renewal_interval`. `none` will stop the subscription schedule and cancel the underlying
+   * subscription. `cancel` is semantically the same as `none`. `release` will stop the subscription
+   * schedule, but keep the underlying subscription running.
    */
   @SerializedName("renewal_behavior")
   RenewalBehavior renewalBehavior;
@@ -405,11 +406,11 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
 
     /**
      * Configures how the subscription schedule behaves when it ends. Possible values are `none`,
-     * `renew`, or `release`. `renew` will create a new subscription schedule revision by adding a
-     * new phase using the most recent phase's `plans` applied to a duration set by
+     * `cancel`, `renew`, or `release`. `renew` will create a new subscription schedule revision by
+     * adding a new phase using the most recent phase's `plans` applied to a duration set by
      * `renewal_interval`. `none` will stop the subscription schedule and cancel the underlying
-     * subscription. `release` will stop the subscription schedule, but keep the underlying
-     * subscription running.
+     * subscription. `cancel` is semantically the same as `none`. `release` will stop the
+     * subscription schedule, but keep the underlying subscription running.
      */
     public Builder setRenewalBehavior(RenewalBehavior renewalBehavior) {
       this.renewalBehavior = renewalBehavior;

--- a/src/main/java/com/stripe/param/SubscriptionScheduleUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionScheduleUpdateParams.java
@@ -96,10 +96,11 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
 
   /**
    * Configures how the subscription schedule behaves when it ends. Possible values are `none`,
-   * `renew`, or `release`. `renew` will create a new subscription schedule revision by adding a new
-   * phase using the most recent phase's `plans` applied to a duration set by `renewal_interval`.
-   * `none` will stop the subscription schedule and cancel the underlying subscription. `release`
-   * will stop the subscription schedule, but keep the underlying subscription running.
+   * `cancel`, `renew`, or `release`. `renew` will create a new subscription schedule revision by
+   * adding a new phase using the most recent phase's `plans` applied to a duration set by
+   * `renewal_interval`. `none` will stop the subscription schedule and cancel the underlying
+   * subscription. `cancel` is semantically the same as `none`. `release` will stop the subscription
+   * schedule, but keep the underlying subscription running.
    */
   @SerializedName("renewal_behavior")
   RenewalBehavior renewalBehavior;
@@ -378,11 +379,11 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
 
     /**
      * Configures how the subscription schedule behaves when it ends. Possible values are `none`,
-     * `renew`, or `release`. `renew` will create a new subscription schedule revision by adding a
-     * new phase using the most recent phase's `plans` applied to a duration set by
+     * `cancel`, `renew`, or `release`. `renew` will create a new subscription schedule revision by
+     * adding a new phase using the most recent phase's `plans` applied to a duration set by
      * `renewal_interval`. `none` will stop the subscription schedule and cancel the underlying
-     * subscription. `release` will stop the subscription schedule, but keep the underlying
-     * subscription running.
+     * subscription. `cancel` is semantically the same as `none`. `release` will stop the
+     * subscription schedule, but keep the underlying subscription running.
      */
     public Builder setRenewalBehavior(RenewalBehavior renewalBehavior) {
       this.renewalBehavior = renewalBehavior;

--- a/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
+++ b/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
@@ -653,8 +653,7 @@ public class SessionCreateParams extends ApiRequestParams {
      * <p>Use `on_session` if you intend to only reuse the payment method when your customer is
      * present in your checkout flow. Use `off_session` if your customer may or may not be in your
      * checkout flow. See [Saving card details after a
-     * payment](https://stripe.com/docs/payments/cards/saving-cards#saving-card-after-payment) to
-     * learn more.
+     * payment](https://stripe.com/docs/payments/cards/saving-cards-after-payment) to learn more.
      *
      * <p>Stripe uses `setup_future_usage` to dynamically optimize your payment flow and comply with
      * regional legislation and network rules. For example, if your customer is impacted by
@@ -856,8 +855,7 @@ public class SessionCreateParams extends ApiRequestParams {
        * <p>Use `on_session` if you intend to only reuse the payment method when your customer is
        * present in your checkout flow. Use `off_session` if your customer may or may not be in your
        * checkout flow. See [Saving card details after a
-       * payment](https://stripe.com/docs/payments/cards/saving-cards#saving-card-after-payment) to
-       * learn more.
+       * payment](https://stripe.com/docs/payments/cards/saving-cards-after-payment) to learn more.
        *
        * <p>Stripe uses `setup_future_usage` to dynamically optimize your payment flow and comply
        * with regional legislation and network rules. For example, if your customer is impacted by


### PR DESCRIPTION
r? @remi-stripe (self-approving since it's the same PR as internally)
cc @stripe/api-libraries 