### PR TITLE
Deprecate `total_count`

### DIFF
--- a/src/main/java/com/stripe/model/EphemeralKey.java
+++ b/src/main/java/com/stripe/model/EphemeralKey.java
@@ -24,7 +24,7 @@ public class EphemeralKey extends ApiResource implements HasId {
   Long expires;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 
@@ -100,7 +100,7 @@ public class EphemeralKey extends ApiResource implements HasId {
   @Setter
   @EqualsAndHashCode(callSuper = false)
   public static class AssociatedObject extends StripeObject implements HasId {
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     String id;
 
     String type;

--- a/src/main/java/com/stripe/model/Event.java
+++ b/src/main/java/com/stripe/model/Event.java
@@ -34,7 +34,7 @@ public class Event extends ApiResource implements HasId {
   EventData data;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 

--- a/src/main/java/com/stripe/model/File.java
+++ b/src/main/java/com/stripe/model/File.java
@@ -25,7 +25,7 @@ public class File extends ApiResource implements HasId {
   String filename;
 
   /** Unique identifier for the object. */
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
 

--- a/src/main/java/com/stripe/model/StripeCollection.java
+++ b/src/main/java/com/stripe/model/StripeCollection.java
@@ -39,13 +39,13 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject
     implements StripeCollectionInterface<T> {
   String object;
 
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   List<T> data;
 
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   Boolean hasMore;
 
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   String url;
 
   /**
@@ -63,14 +63,14 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject
    * @see <a href="https://stripe.com/docs/api/java#pagination">Pagination</a>
    */
   @Deprecated
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   Long totalCount;
 
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @Setter(onMethod = @__({@Override}))
   private RequestOptions requestOptions;
 
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = {@Override})
   @Setter(onMethod = @__({@Override}))
   private Map<String, Object> requestParams;
 

--- a/src/main/java/com/stripe/model/StripeCollection.java
+++ b/src/main/java/com/stripe/model/StripeCollection.java
@@ -46,9 +46,6 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject
   Boolean hasMore;
 
   @Getter(onMethod = @__({@Override}))
-  Long totalCount;
-
-  @Getter(onMethod = @__({@Override}))
   String url;
 
   /**
@@ -58,6 +55,16 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject
    * @see <a href="https://stripe.com/docs/api/java#pagination">Pagination</a>
    */
   @Deprecated Long count;
+
+  /**
+   * The {@code total_count} attribute.
+   *
+   * @deprecated Use pagination parameters instead.
+   * @see <a href="https://stripe.com/docs/api/java#pagination">Pagination</a>
+   */
+  @Deprecated
+  @Getter(onMethod = @__({@Override}))
+  Long totalCount;
 
   @Getter(onMethod = @__({@Override}))
   @Setter(onMethod = @__({@Override}))

--- a/src/main/java/com/stripe/model/StripeCollectionInterface.java
+++ b/src/main/java/com/stripe/model/StripeCollectionInterface.java
@@ -9,9 +9,16 @@ public interface StripeCollectionInterface<T> {
 
   Boolean getHasMore();
 
-  Long getTotalCount();
-
   String getUrl();
+
+  /**
+   * The {@code total_count} attribute.
+   *
+   * @deprecated Use pagination parameters instead.
+   * @see <a href="https://stripe.com/docs/api/java#pagination">Pagination</a>
+   */
+  @Deprecated
+  Long getTotalCount();
 
   /**
    * Get request options that were used to fetch the collection. This is useful for purposes of

--- a/src/main/java/com/stripe/param/FileCreateParams.java
+++ b/src/main/java/com/stripe/param/FileCreateParams.java
@@ -228,7 +228,7 @@ public class FileCreateParams extends ApiRequestParams {
     @SerializedName("tax_document_user_upload")
     TAX_DOCUMENT_USER_UPLOAD("tax_document_user_upload");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Purpose(String value) {

--- a/src/main/java/com/stripe/param/FileListParams.java
+++ b/src/main/java/com/stripe/param/FileListParams.java
@@ -262,7 +262,7 @@ public class FileListParams extends ApiRequestParams {
     @SerializedName("tax_document_user_upload")
     TAX_DOCUMENT_USER_UPLOAD("tax_document_user_upload");
 
-    @Getter(onMethod = @__({@Override}))
+    @Getter(onMethod_ = {@Override})
     private final String value;
 
     Purpose(String value) {


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Deprecate `total_count`.
