### PR TITLE
Add add/addAll support for "emptyable" params

### DIFF
--- a/src/main/java/com/stripe/param/ChargeUpdateParams.java
+++ b/src/main/java/com/stripe/param/ChargeUpdateParams.java
@@ -329,12 +329,12 @@ public class ChargeUpdateParams extends ApiRequestParams {
         return this;
       }
 
-      public Builder setUserReport(EmptyParam userReport) {
+      public Builder setUserReport(UserReport userReport) {
         this.userReport = userReport;
         return this;
       }
 
-      public Builder setUserReport(UserReport userReport) {
+      public Builder setUserReport(EmptyParam userReport) {
         this.userReport = userReport;
         return this;
       }

--- a/src/main/java/com/stripe/param/CustomerCreateParams.java
+++ b/src/main/java/com/stripe/param/CustomerCreateParams.java
@@ -432,13 +432,13 @@ public class CustomerCreateParams extends ApiRequestParams {
     }
 
     /** The customer's tax exemption. One of `none`, `exempt`, or `reverse`. */
-    public Builder setTaxExempt(EmptyParam taxExempt) {
+    public Builder setTaxExempt(TaxExempt taxExempt) {
       this.taxExempt = taxExempt;
       return this;
     }
 
     /** The customer's tax exemption. One of `none`, `exempt`, or `reverse`. */
-    public Builder setTaxExempt(TaxExempt taxExempt) {
+    public Builder setTaxExempt(EmptyParam taxExempt) {
       this.taxExempt = taxExempt;
       return this;
     }
@@ -667,14 +667,43 @@ public class CustomerCreateParams extends ApiRequestParams {
             this.customFields, this.defaultPaymentMethod, this.extraParams, this.footer);
       }
 
-      /** Default custom fields to be displayed on invoices for this customer. */
-      public Builder setCustomFields(List<CustomField> customFields) {
-        this.customFields = customFields;
+      /**
+       * Add an element to `customFields` list. A list is initialized for the first `add/addAll`
+       * call, and subsequent calls adds additional elements to the original list. See {@link
+       * CustomerCreateParams.InvoiceSettings#customFields} for the field documentation.
+       */
+      @SuppressWarnings("unchecked")
+      public Builder addCustomField(CustomField element) {
+        if (this.customFields == null || this.customFields instanceof EmptyParam) {
+          this.customFields = new ArrayList<CustomerCreateParams.InvoiceSettings.CustomField>();
+        }
+        ((List<CustomerCreateParams.InvoiceSettings.CustomField>) this.customFields).add(element);
+        return this;
+      }
+
+      /**
+       * Add all elements to `customFields` list. A list is initialized for the first `add/addAll`
+       * call, and subsequent calls adds additional elements to the original list. See {@link
+       * CustomerCreateParams.InvoiceSettings#customFields} for the field documentation.
+       */
+      @SuppressWarnings("unchecked")
+      public Builder addAllCustomField(List<CustomField> elements) {
+        if (this.customFields == null || this.customFields instanceof EmptyParam) {
+          this.customFields = new ArrayList<CustomerCreateParams.InvoiceSettings.CustomField>();
+        }
+        ((List<CustomerCreateParams.InvoiceSettings.CustomField>) this.customFields)
+            .addAll(elements);
         return this;
       }
 
       /** Default custom fields to be displayed on invoices for this customer. */
       public Builder setCustomFields(EmptyParam customFields) {
+        this.customFields = customFields;
+        return this;
+      }
+
+      /** Default custom fields to be displayed on invoices for this customer. */
+      public Builder setCustomFields(List<CustomField> customFields) {
         this.customFields = customFields;
         return this;
       }

--- a/src/main/java/com/stripe/param/CustomerUpdateParams.java
+++ b/src/main/java/com/stripe/param/CustomerUpdateParams.java
@@ -449,13 +449,13 @@ public class CustomerUpdateParams extends ApiRequestParams {
     }
 
     /** The customer's tax exemption. One of `none`, `exempt`, or `reverse`. */
-    public Builder setTaxExempt(EmptyParam taxExempt) {
+    public Builder setTaxExempt(TaxExempt taxExempt) {
       this.taxExempt = taxExempt;
       return this;
     }
 
     /** The customer's tax exemption. One of `none`, `exempt`, or `reverse`. */
-    public Builder setTaxExempt(TaxExempt taxExempt) {
+    public Builder setTaxExempt(EmptyParam taxExempt) {
       this.taxExempt = taxExempt;
       return this;
     }
@@ -682,14 +682,43 @@ public class CustomerUpdateParams extends ApiRequestParams {
             this.customFields, this.defaultPaymentMethod, this.extraParams, this.footer);
       }
 
-      /** Default custom fields to be displayed on invoices for this customer. */
-      public Builder setCustomFields(List<CustomField> customFields) {
-        this.customFields = customFields;
+      /**
+       * Add an element to `customFields` list. A list is initialized for the first `add/addAll`
+       * call, and subsequent calls adds additional elements to the original list. See {@link
+       * CustomerUpdateParams.InvoiceSettings#customFields} for the field documentation.
+       */
+      @SuppressWarnings("unchecked")
+      public Builder addCustomField(CustomField element) {
+        if (this.customFields == null || this.customFields instanceof EmptyParam) {
+          this.customFields = new ArrayList<CustomerUpdateParams.InvoiceSettings.CustomField>();
+        }
+        ((List<CustomerUpdateParams.InvoiceSettings.CustomField>) this.customFields).add(element);
+        return this;
+      }
+
+      /**
+       * Add all elements to `customFields` list. A list is initialized for the first `add/addAll`
+       * call, and subsequent calls adds additional elements to the original list. See {@link
+       * CustomerUpdateParams.InvoiceSettings#customFields} for the field documentation.
+       */
+      @SuppressWarnings("unchecked")
+      public Builder addAllCustomField(List<CustomField> elements) {
+        if (this.customFields == null || this.customFields instanceof EmptyParam) {
+          this.customFields = new ArrayList<CustomerUpdateParams.InvoiceSettings.CustomField>();
+        }
+        ((List<CustomerUpdateParams.InvoiceSettings.CustomField>) this.customFields)
+            .addAll(elements);
         return this;
       }
 
       /** Default custom fields to be displayed on invoices for this customer. */
       public Builder setCustomFields(EmptyParam customFields) {
+        this.customFields = customFields;
+        return this;
+      }
+
+      /** Default custom fields to be displayed on invoices for this customer. */
+      public Builder setCustomFields(List<CustomField> customFields) {
         this.customFields = customFields;
         return this;
       }

--- a/src/main/java/com/stripe/param/ExternalAccountUpdateParams.java
+++ b/src/main/java/com/stripe/param/ExternalAccountUpdateParams.java
@@ -170,13 +170,13 @@ public class ExternalAccountUpdateParams extends ApiRequestParams {
     }
 
     /** The type of entity that holds the account. This can be either `individual` or `company`. */
-    public Builder setAccountHolderType(EmptyParam accountHolderType) {
+    public Builder setAccountHolderType(AccountHolderType accountHolderType) {
       this.accountHolderType = accountHolderType;
       return this;
     }
 
     /** The type of entity that holds the account. This can be either `individual` or `company`. */
-    public Builder setAccountHolderType(AccountHolderType accountHolderType) {
+    public Builder setAccountHolderType(EmptyParam accountHolderType) {
       this.accountHolderType = accountHolderType;
       return this;
     }

--- a/src/main/java/com/stripe/param/InvoiceCreateParams.java
+++ b/src/main/java/com/stripe/param/InvoiceCreateParams.java
@@ -296,14 +296,42 @@ public class InvoiceCreateParams extends ApiRequestParams {
       return this;
     }
 
-    /** A list of up to 4 custom fields to be displayed on the invoice. */
-    public Builder setCustomFields(List<CustomField> customFields) {
-      this.customFields = customFields;
+    /**
+     * Add an element to `customFields` list. A list is initialized for the first `add/addAll` call,
+     * and subsequent calls adds additional elements to the original list. See {@link
+     * InvoiceCreateParams#customFields} for the field documentation.
+     */
+    @SuppressWarnings("unchecked")
+    public Builder addCustomField(CustomField element) {
+      if (this.customFields == null || this.customFields instanceof EmptyParam) {
+        this.customFields = new ArrayList<InvoiceCreateParams.CustomField>();
+      }
+      ((List<InvoiceCreateParams.CustomField>) this.customFields).add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `customFields` list. A list is initialized for the first `add/addAll`
+     * call, and subsequent calls adds additional elements to the original list. See {@link
+     * InvoiceCreateParams#customFields} for the field documentation.
+     */
+    @SuppressWarnings("unchecked")
+    public Builder addAllCustomField(List<CustomField> elements) {
+      if (this.customFields == null || this.customFields instanceof EmptyParam) {
+        this.customFields = new ArrayList<InvoiceCreateParams.CustomField>();
+      }
+      ((List<InvoiceCreateParams.CustomField>) this.customFields).addAll(elements);
       return this;
     }
 
     /** A list of up to 4 custom fields to be displayed on the invoice. */
     public Builder setCustomFields(EmptyParam customFields) {
+      this.customFields = customFields;
+      return this;
+    }
+
+    /** A list of up to 4 custom fields to be displayed on the invoice. */
+    public Builder setCustomFields(List<CustomField> customFields) {
       this.customFields = customFields;
       return this;
     }

--- a/src/main/java/com/stripe/param/InvoiceItemUpdateParams.java
+++ b/src/main/java/com/stripe/param/InvoiceItemUpdateParams.java
@@ -269,11 +269,30 @@ public class InvoiceItemUpdateParams extends ApiRequestParams {
     }
 
     /**
-     * The tax rates which apply to the invoice item. When set, the `default_tax_rates` on the
-     * invoice do not apply to this invoice item.
+     * Add an element to `taxRates` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * InvoiceItemUpdateParams#taxRates} for the field documentation.
      */
-    public Builder setTaxRates(List<String> taxRates) {
-      this.taxRates = taxRates;
+    @SuppressWarnings("unchecked")
+    public Builder addTaxRate(String element) {
+      if (this.taxRates == null || this.taxRates instanceof EmptyParam) {
+        this.taxRates = new ArrayList<String>();
+      }
+      ((List<String>) this.taxRates).add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `taxRates` list. A list is initialized for the first `add/addAll` call,
+     * and subsequent calls adds additional elements to the original list. See {@link
+     * InvoiceItemUpdateParams#taxRates} for the field documentation.
+     */
+    @SuppressWarnings("unchecked")
+    public Builder addAllTaxRate(List<String> elements) {
+      if (this.taxRates == null || this.taxRates instanceof EmptyParam) {
+        this.taxRates = new ArrayList<String>();
+      }
+      ((List<String>) this.taxRates).addAll(elements);
       return this;
     }
 
@@ -282,6 +301,15 @@ public class InvoiceItemUpdateParams extends ApiRequestParams {
      * invoice do not apply to this invoice item.
      */
     public Builder setTaxRates(EmptyParam taxRates) {
+      this.taxRates = taxRates;
+      return this;
+    }
+
+    /**
+     * The tax rates which apply to the invoice item. When set, the `default_tax_rates` on the
+     * invoice do not apply to this invoice item.
+     */
+    public Builder setTaxRates(List<String> taxRates) {
       this.taxRates = taxRates;
       return this;
     }

--- a/src/main/java/com/stripe/param/InvoiceUpcomingParams.java
+++ b/src/main/java/com/stripe/param/InvoiceUpcomingParams.java
@@ -427,12 +427,32 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
     }
 
     /**
-     * If provided, the invoice returned will preview updating or creating a subscription with these
-     * default tax rates. The default tax rates will apply to any line item that does not have
-     * `tax_rates` set.
+     * Add an element to `subscriptionDefaultTaxRates` list. A list is initialized for the first
+     * `add/addAll` call, and subsequent calls adds additional elements to the original list. See
+     * {@link InvoiceUpcomingParams#subscriptionDefaultTaxRates} for the field documentation.
      */
-    public Builder setSubscriptionDefaultTaxRates(List<String> subscriptionDefaultTaxRates) {
-      this.subscriptionDefaultTaxRates = subscriptionDefaultTaxRates;
+    @SuppressWarnings("unchecked")
+    public Builder addSubscriptionDefaultTaxRate(String element) {
+      if (this.subscriptionDefaultTaxRates == null
+          || this.subscriptionDefaultTaxRates instanceof EmptyParam) {
+        this.subscriptionDefaultTaxRates = new ArrayList<String>();
+      }
+      ((List<String>) this.subscriptionDefaultTaxRates).add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `subscriptionDefaultTaxRates` list. A list is initialized for the first
+     * `add/addAll` call, and subsequent calls adds additional elements to the original list. See
+     * {@link InvoiceUpcomingParams#subscriptionDefaultTaxRates} for the field documentation.
+     */
+    @SuppressWarnings("unchecked")
+    public Builder addAllSubscriptionDefaultTaxRate(List<String> elements) {
+      if (this.subscriptionDefaultTaxRates == null
+          || this.subscriptionDefaultTaxRates instanceof EmptyParam) {
+        this.subscriptionDefaultTaxRates = new ArrayList<String>();
+      }
+      ((List<String>) this.subscriptionDefaultTaxRates).addAll(elements);
       return this;
     }
 
@@ -442,6 +462,16 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
      * `tax_rates` set.
      */
     public Builder setSubscriptionDefaultTaxRates(EmptyParam subscriptionDefaultTaxRates) {
+      this.subscriptionDefaultTaxRates = subscriptionDefaultTaxRates;
+      return this;
+    }
+
+    /**
+     * If provided, the invoice returned will preview updating or creating a subscription with these
+     * default tax rates. The default tax rates will apply to any line item that does not have
+     * `tax_rates` set.
+     */
+    public Builder setSubscriptionDefaultTaxRates(List<String> subscriptionDefaultTaxRates) {
       this.subscriptionDefaultTaxRates = subscriptionDefaultTaxRates;
       return this;
     }
@@ -797,12 +827,40 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
         return this;
       }
 
-      public Builder setTaxRates(List<String> taxRates) {
-        this.taxRates = taxRates;
+      /**
+       * Add an element to `taxRates` list. A list is initialized for the first `add/addAll` call,
+       * and subsequent calls adds additional elements to the original list. See {@link
+       * InvoiceUpcomingParams.InvoiceItem#taxRates} for the field documentation.
+       */
+      @SuppressWarnings("unchecked")
+      public Builder addTaxRate(String element) {
+        if (this.taxRates == null || this.taxRates instanceof EmptyParam) {
+          this.taxRates = new ArrayList<String>();
+        }
+        ((List<String>) this.taxRates).add(element);
+        return this;
+      }
+
+      /**
+       * Add all elements to `taxRates` list. A list is initialized for the first `add/addAll` call,
+       * and subsequent calls adds additional elements to the original list. See {@link
+       * InvoiceUpcomingParams.InvoiceItem#taxRates} for the field documentation.
+       */
+      @SuppressWarnings("unchecked")
+      public Builder addAllTaxRate(List<String> elements) {
+        if (this.taxRates == null || this.taxRates instanceof EmptyParam) {
+          this.taxRates = new ArrayList<String>();
+        }
+        ((List<String>) this.taxRates).addAll(elements);
         return this;
       }
 
       public Builder setTaxRates(EmptyParam taxRates) {
+        this.taxRates = taxRates;
+        return this;
+      }
+
+      public Builder setTaxRates(List<String> taxRates) {
         this.taxRates = taxRates;
         return this;
       }
@@ -1126,11 +1184,30 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
       }
 
       /**
-       * The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates` on
-       * the subscription do not apply to this `subscription_item`.
+       * Add an element to `taxRates` list. A list is initialized for the first `add/addAll` call,
+       * and subsequent calls adds additional elements to the original list. See {@link
+       * InvoiceUpcomingParams.SubscriptionItem#taxRates} for the field documentation.
        */
-      public Builder setTaxRates(List<String> taxRates) {
-        this.taxRates = taxRates;
+      @SuppressWarnings("unchecked")
+      public Builder addTaxRate(String element) {
+        if (this.taxRates == null || this.taxRates instanceof EmptyParam) {
+          this.taxRates = new ArrayList<String>();
+        }
+        ((List<String>) this.taxRates).add(element);
+        return this;
+      }
+
+      /**
+       * Add all elements to `taxRates` list. A list is initialized for the first `add/addAll` call,
+       * and subsequent calls adds additional elements to the original list. See {@link
+       * InvoiceUpcomingParams.SubscriptionItem#taxRates} for the field documentation.
+       */
+      @SuppressWarnings("unchecked")
+      public Builder addAllTaxRate(List<String> elements) {
+        if (this.taxRates == null || this.taxRates instanceof EmptyParam) {
+          this.taxRates = new ArrayList<String>();
+        }
+        ((List<String>) this.taxRates).addAll(elements);
         return this;
       }
 
@@ -1139,6 +1216,15 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
        * the subscription do not apply to this `subscription_item`.
        */
       public Builder setTaxRates(EmptyParam taxRates) {
+        this.taxRates = taxRates;
+        return this;
+      }
+
+      /**
+       * The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates` on
+       * the subscription do not apply to this `subscription_item`.
+       */
+      public Builder setTaxRates(List<String> taxRates) {
         this.taxRates = taxRates;
         return this;
       }

--- a/src/main/java/com/stripe/param/InvoiceUpdateParams.java
+++ b/src/main/java/com/stripe/param/InvoiceUpdateParams.java
@@ -256,12 +256,30 @@ public class InvoiceUpdateParams extends ApiRequestParams {
     }
 
     /**
-     * A list of up to 4 custom fields to be displayed on the invoice. If a value for
-     * `custom_fields` is specified, the list specified will replace the existing custom field list
-     * on this invoice.
+     * Add an element to `customFields` list. A list is initialized for the first `add/addAll` call,
+     * and subsequent calls adds additional elements to the original list. See {@link
+     * InvoiceUpdateParams#customFields} for the field documentation.
      */
-    public Builder setCustomFields(List<CustomField> customFields) {
-      this.customFields = customFields;
+    @SuppressWarnings("unchecked")
+    public Builder addCustomField(CustomField element) {
+      if (this.customFields == null || this.customFields instanceof EmptyParam) {
+        this.customFields = new ArrayList<InvoiceUpdateParams.CustomField>();
+      }
+      ((List<InvoiceUpdateParams.CustomField>) this.customFields).add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `customFields` list. A list is initialized for the first `add/addAll`
+     * call, and subsequent calls adds additional elements to the original list. See {@link
+     * InvoiceUpdateParams#customFields} for the field documentation.
+     */
+    @SuppressWarnings("unchecked")
+    public Builder addAllCustomField(List<CustomField> elements) {
+      if (this.customFields == null || this.customFields instanceof EmptyParam) {
+        this.customFields = new ArrayList<InvoiceUpdateParams.CustomField>();
+      }
+      ((List<InvoiceUpdateParams.CustomField>) this.customFields).addAll(elements);
       return this;
     }
 
@@ -271,6 +289,16 @@ public class InvoiceUpdateParams extends ApiRequestParams {
      * on this invoice.
      */
     public Builder setCustomFields(EmptyParam customFields) {
+      this.customFields = customFields;
+      return this;
+    }
+
+    /**
+     * A list of up to 4 custom fields to be displayed on the invoice. If a value for
+     * `custom_fields` is specified, the list specified will replace the existing custom field list
+     * on this invoice.
+     */
+    public Builder setCustomFields(List<CustomField> customFields) {
       this.customFields = customFields;
       return this;
     }
@@ -305,11 +333,30 @@ public class InvoiceUpdateParams extends ApiRequestParams {
     }
 
     /**
-     * The tax rates that will apply to any line item that does not have `tax_rates` set. Pass an
-     * empty string to remove previously-set default tax rates.
+     * Add an element to `defaultTaxRates` list. A list is initialized for the first `add/addAll`
+     * call, and subsequent calls adds additional elements to the original list. See {@link
+     * InvoiceUpdateParams#defaultTaxRates} for the field documentation.
      */
-    public Builder setDefaultTaxRates(List<String> defaultTaxRates) {
-      this.defaultTaxRates = defaultTaxRates;
+    @SuppressWarnings("unchecked")
+    public Builder addDefaultTaxRate(String element) {
+      if (this.defaultTaxRates == null || this.defaultTaxRates instanceof EmptyParam) {
+        this.defaultTaxRates = new ArrayList<String>();
+      }
+      ((List<String>) this.defaultTaxRates).add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `defaultTaxRates` list. A list is initialized for the first `add/addAll`
+     * call, and subsequent calls adds additional elements to the original list. See {@link
+     * InvoiceUpdateParams#defaultTaxRates} for the field documentation.
+     */
+    @SuppressWarnings("unchecked")
+    public Builder addAllDefaultTaxRate(List<String> elements) {
+      if (this.defaultTaxRates == null || this.defaultTaxRates instanceof EmptyParam) {
+        this.defaultTaxRates = new ArrayList<String>();
+      }
+      ((List<String>) this.defaultTaxRates).addAll(elements);
       return this;
     }
 
@@ -318,6 +365,15 @@ public class InvoiceUpdateParams extends ApiRequestParams {
      * empty string to remove previously-set default tax rates.
      */
     public Builder setDefaultTaxRates(EmptyParam defaultTaxRates) {
+      this.defaultTaxRates = defaultTaxRates;
+      return this;
+    }
+
+    /**
+     * The tax rates that will apply to any line item that does not have `tax_rates` set. Pass an
+     * empty string to remove previously-set default tax rates.
+     */
+    public Builder setDefaultTaxRates(List<String> defaultTaxRates) {
       this.defaultTaxRates = defaultTaxRates;
       return this;
     }

--- a/src/main/java/com/stripe/param/OrderReturnOrderParams.java
+++ b/src/main/java/com/stripe/param/OrderReturnOrderParams.java
@@ -102,14 +102,42 @@ public class OrderReturnOrderParams extends ApiRequestParams {
       return this;
     }
 
-    /** List of items to return. */
-    public Builder setItems(List<Item> items) {
-      this.items = items;
+    /**
+     * Add an element to `items` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * OrderReturnOrderParams#items} for the field documentation.
+     */
+    @SuppressWarnings("unchecked")
+    public Builder addItem(Item element) {
+      if (this.items == null || this.items instanceof EmptyParam) {
+        this.items = new ArrayList<OrderReturnOrderParams.Item>();
+      }
+      ((List<OrderReturnOrderParams.Item>) this.items).add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `items` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * OrderReturnOrderParams#items} for the field documentation.
+     */
+    @SuppressWarnings("unchecked")
+    public Builder addAllItem(List<Item> elements) {
+      if (this.items == null || this.items instanceof EmptyParam) {
+        this.items = new ArrayList<OrderReturnOrderParams.Item>();
+      }
+      ((List<OrderReturnOrderParams.Item>) this.items).addAll(elements);
       return this;
     }
 
     /** List of items to return. */
     public Builder setItems(EmptyParam items) {
+      this.items = items;
+      return this;
+    }
+
+    /** List of items to return. */
+    public Builder setItems(List<Item> items) {
       this.items = items;
       return this;
     }

--- a/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
@@ -320,7 +320,7 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
      * <p>If `setup_future_usage` is already set and you are performing a request using a
      * publishable key, you may only update the value from `on_session` to `off_session`.
      */
-    public Builder setSetupFutureUsage(EmptyParam setupFutureUsage) {
+    public Builder setSetupFutureUsage(SetupFutureUsage setupFutureUsage) {
       this.setupFutureUsage = setupFutureUsage;
       return this;
     }
@@ -347,7 +347,7 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
      * <p>If `setup_future_usage` is already set and you are performing a request using a
      * publishable key, you may only update the value from `on_session` to `off_session`.
      */
-    public Builder setSetupFutureUsage(SetupFutureUsage setupFutureUsage) {
+    public Builder setSetupFutureUsage(EmptyParam setupFutureUsage) {
       this.setupFutureUsage = setupFutureUsage;
       return this;
     }

--- a/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
@@ -483,7 +483,7 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
      * <p>If `setup_future_usage` is already set and you are performing a request using a
      * publishable key, you may only update the value from `on_session` to `off_session`.
      */
-    public Builder setSetupFutureUsage(EmptyParam setupFutureUsage) {
+    public Builder setSetupFutureUsage(SetupFutureUsage setupFutureUsage) {
       this.setupFutureUsage = setupFutureUsage;
       return this;
     }
@@ -510,7 +510,7 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
      * <p>If `setup_future_usage` is already set and you are performing a request using a
      * publishable key, you may only update the value from `on_session` to `off_session`.
      */
-    public Builder setSetupFutureUsage(SetupFutureUsage setupFutureUsage) {
+    public Builder setSetupFutureUsage(EmptyParam setupFutureUsage) {
       this.setupFutureUsage = setupFutureUsage;
       return this;
     }

--- a/src/main/java/com/stripe/param/ProductUpdateParams.java
+++ b/src/main/java/com/stripe/param/ProductUpdateParams.java
@@ -196,13 +196,30 @@ public class ProductUpdateParams extends ApiRequestParams {
     }
 
     /**
-     * A list of up to 5 alphanumeric attributes that each SKU can provide values for (e.g.,
-     * `["color", "size"]`). If a value for `attributes` is specified, the list specified will
-     * replace the existing attributes list on this product. Any attributes not present after the
-     * update will be deleted from the SKUs for this product.
+     * Add an element to `attributes` list. A list is initialized for the first `add/addAll` call,
+     * and subsequent calls adds additional elements to the original list. See {@link
+     * ProductUpdateParams#attributes} for the field documentation.
      */
-    public Builder setAttributes(List<String> attributes) {
-      this.attributes = attributes;
+    @SuppressWarnings("unchecked")
+    public Builder addAttribute(String element) {
+      if (this.attributes == null || this.attributes instanceof EmptyParam) {
+        this.attributes = new ArrayList<String>();
+      }
+      ((List<String>) this.attributes).add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `attributes` list. A list is initialized for the first `add/addAll` call,
+     * and subsequent calls adds additional elements to the original list. See {@link
+     * ProductUpdateParams#attributes} for the field documentation.
+     */
+    @SuppressWarnings("unchecked")
+    public Builder addAllAttribute(List<String> elements) {
+      if (this.attributes == null || this.attributes instanceof EmptyParam) {
+        this.attributes = new ArrayList<String>();
+      }
+      ((List<String>) this.attributes).addAll(elements);
       return this;
     }
 
@@ -213,6 +230,17 @@ public class ProductUpdateParams extends ApiRequestParams {
      * update will be deleted from the SKUs for this product.
      */
     public Builder setAttributes(EmptyParam attributes) {
+      this.attributes = attributes;
+      return this;
+    }
+
+    /**
+     * A list of up to 5 alphanumeric attributes that each SKU can provide values for (e.g.,
+     * `["color", "size"]`). If a value for `attributes` is specified, the list specified will
+     * replace the existing attributes list on this product. Any attributes not present after the
+     * update will be deleted from the SKUs for this product.
+     */
+    public Builder setAttributes(List<String> attributes) {
       this.attributes = attributes;
       return this;
     }
@@ -308,10 +336,30 @@ public class ProductUpdateParams extends ApiRequestParams {
     }
 
     /**
-     * A list of up to 8 URLs of images for this product, meant to be displayable to the customer.
+     * Add an element to `images` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * ProductUpdateParams#images} for the field documentation.
      */
-    public Builder setImages(List<String> images) {
-      this.images = images;
+    @SuppressWarnings("unchecked")
+    public Builder addImage(String element) {
+      if (this.images == null || this.images instanceof EmptyParam) {
+        this.images = new ArrayList<String>();
+      }
+      ((List<String>) this.images).add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `images` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * ProductUpdateParams#images} for the field documentation.
+     */
+    @SuppressWarnings("unchecked")
+    public Builder addAllImage(List<String> elements) {
+      if (this.images == null || this.images instanceof EmptyParam) {
+        this.images = new ArrayList<String>();
+      }
+      ((List<String>) this.images).addAll(elements);
       return this;
     }
 
@@ -319,6 +367,14 @@ public class ProductUpdateParams extends ApiRequestParams {
      * A list of up to 8 URLs of images for this product, meant to be displayable to the customer.
      */
     public Builder setImages(EmptyParam images) {
+      this.images = images;
+      return this;
+    }
+
+    /**
+     * A list of up to 8 URLs of images for this product, meant to be displayable to the customer.
+     */
+    public Builder setImages(List<String> images) {
       this.images = images;
       return this;
     }

--- a/src/main/java/com/stripe/param/SkuCreateParams.java
+++ b/src/main/java/com/stripe/param/SkuCreateParams.java
@@ -410,7 +410,7 @@ public class SkuCreateParams extends ApiRequestParams {
        * An indicator of the inventory available. Possible values are `in_stock`, `limited`, and
        * `out_of_stock`. Will be present if and only if `type` is `bucket`.
        */
-      public Builder setValue(EmptyParam value) {
+      public Builder setValue(Value value) {
         this.value = value;
         return this;
       }
@@ -419,7 +419,7 @@ public class SkuCreateParams extends ApiRequestParams {
        * An indicator of the inventory available. Possible values are `in_stock`, `limited`, and
        * `out_of_stock`. Will be present if and only if `type` is `bucket`.
        */
-      public Builder setValue(Value value) {
+      public Builder setValue(EmptyParam value) {
         this.value = value;
         return this;
       }

--- a/src/main/java/com/stripe/param/SkuUpdateParams.java
+++ b/src/main/java/com/stripe/param/SkuUpdateParams.java
@@ -402,7 +402,7 @@ public class SkuUpdateParams extends ApiRequestParams {
        * An indicator of the inventory available. Possible values are `in_stock`, `limited`, and
        * `out_of_stock`. Will be present if and only if `type` is `bucket`.
        */
-      public Builder setValue(EmptyParam value) {
+      public Builder setValue(Value value) {
         this.value = value;
         return this;
       }
@@ -411,7 +411,7 @@ public class SkuUpdateParams extends ApiRequestParams {
        * An indicator of the inventory available. Possible values are `in_stock`, `limited`, and
        * `out_of_stock`. Will be present if and only if `type` is `bucket`.
        */
-      public Builder setValue(Value value) {
+      public Builder setValue(EmptyParam value) {
         this.value = value;
         return this;
       }

--- a/src/main/java/com/stripe/param/SubscriptionCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionCreateParams.java
@@ -491,11 +491,30 @@ public class SubscriptionCreateParams extends ApiRequestParams {
     }
 
     /**
-     * The tax rates that will apply to any subscription item that does not have `tax_rates` set.
-     * Invoices created will have their `default_tax_rates` populated from the subscription.
+     * Add an element to `defaultTaxRates` list. A list is initialized for the first `add/addAll`
+     * call, and subsequent calls adds additional elements to the original list. See {@link
+     * SubscriptionCreateParams#defaultTaxRates} for the field documentation.
      */
-    public Builder setDefaultTaxRates(List<String> defaultTaxRates) {
-      this.defaultTaxRates = defaultTaxRates;
+    @SuppressWarnings("unchecked")
+    public Builder addDefaultTaxRate(String element) {
+      if (this.defaultTaxRates == null || this.defaultTaxRates instanceof EmptyParam) {
+        this.defaultTaxRates = new ArrayList<String>();
+      }
+      ((List<String>) this.defaultTaxRates).add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `defaultTaxRates` list. A list is initialized for the first `add/addAll`
+     * call, and subsequent calls adds additional elements to the original list. See {@link
+     * SubscriptionCreateParams#defaultTaxRates} for the field documentation.
+     */
+    @SuppressWarnings("unchecked")
+    public Builder addAllDefaultTaxRate(List<String> elements) {
+      if (this.defaultTaxRates == null || this.defaultTaxRates instanceof EmptyParam) {
+        this.defaultTaxRates = new ArrayList<String>();
+      }
+      ((List<String>) this.defaultTaxRates).addAll(elements);
       return this;
     }
 
@@ -504,6 +523,15 @@ public class SubscriptionCreateParams extends ApiRequestParams {
      * Invoices created will have their `default_tax_rates` populated from the subscription.
      */
     public Builder setDefaultTaxRates(EmptyParam defaultTaxRates) {
+      this.defaultTaxRates = defaultTaxRates;
+      return this;
+    }
+
+    /**
+     * The tax rates that will apply to any subscription item that does not have `tax_rates` set.
+     * Invoices created will have their `default_tax_rates` populated from the subscription.
+     */
+    public Builder setDefaultTaxRates(List<String> defaultTaxRates) {
       this.defaultTaxRates = defaultTaxRates;
       return this;
     }
@@ -988,11 +1016,30 @@ public class SubscriptionCreateParams extends ApiRequestParams {
       }
 
       /**
-       * The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates` on
-       * the subscription do not apply to this `subscription_item`.
+       * Add an element to `taxRates` list. A list is initialized for the first `add/addAll` call,
+       * and subsequent calls adds additional elements to the original list. See {@link
+       * SubscriptionCreateParams.Item#taxRates} for the field documentation.
        */
-      public Builder setTaxRates(List<String> taxRates) {
-        this.taxRates = taxRates;
+      @SuppressWarnings("unchecked")
+      public Builder addTaxRate(String element) {
+        if (this.taxRates == null || this.taxRates instanceof EmptyParam) {
+          this.taxRates = new ArrayList<String>();
+        }
+        ((List<String>) this.taxRates).add(element);
+        return this;
+      }
+
+      /**
+       * Add all elements to `taxRates` list. A list is initialized for the first `add/addAll` call,
+       * and subsequent calls adds additional elements to the original list. See {@link
+       * SubscriptionCreateParams.Item#taxRates} for the field documentation.
+       */
+      @SuppressWarnings("unchecked")
+      public Builder addAllTaxRate(List<String> elements) {
+        if (this.taxRates == null || this.taxRates instanceof EmptyParam) {
+          this.taxRates = new ArrayList<String>();
+        }
+        ((List<String>) this.taxRates).addAll(elements);
         return this;
       }
 
@@ -1001,6 +1048,15 @@ public class SubscriptionCreateParams extends ApiRequestParams {
        * the subscription do not apply to this `subscription_item`.
        */
       public Builder setTaxRates(EmptyParam taxRates) {
+        this.taxRates = taxRates;
+        return this;
+      }
+
+      /**
+       * The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates` on
+       * the subscription do not apply to this `subscription_item`.
+       */
+      public Builder setTaxRates(List<String> taxRates) {
         this.taxRates = taxRates;
         return this;
       }

--- a/src/main/java/com/stripe/param/SubscriptionItemCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionItemCreateParams.java
@@ -268,11 +268,30 @@ public class SubscriptionItemCreateParams extends ApiRequestParams {
     }
 
     /**
-     * The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates` on
-     * the subscription do not apply to this `subscription_item`.
+     * Add an element to `taxRates` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * SubscriptionItemCreateParams#taxRates} for the field documentation.
      */
-    public Builder setTaxRates(List<String> taxRates) {
-      this.taxRates = taxRates;
+    @SuppressWarnings("unchecked")
+    public Builder addTaxRate(String element) {
+      if (this.taxRates == null || this.taxRates instanceof EmptyParam) {
+        this.taxRates = new ArrayList<String>();
+      }
+      ((List<String>) this.taxRates).add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `taxRates` list. A list is initialized for the first `add/addAll` call,
+     * and subsequent calls adds additional elements to the original list. See {@link
+     * SubscriptionItemCreateParams#taxRates} for the field documentation.
+     */
+    @SuppressWarnings("unchecked")
+    public Builder addAllTaxRate(List<String> elements) {
+      if (this.taxRates == null || this.taxRates instanceof EmptyParam) {
+        this.taxRates = new ArrayList<String>();
+      }
+      ((List<String>) this.taxRates).addAll(elements);
       return this;
     }
 
@@ -281,6 +300,15 @@ public class SubscriptionItemCreateParams extends ApiRequestParams {
      * the subscription do not apply to this `subscription_item`.
      */
     public Builder setTaxRates(EmptyParam taxRates) {
+      this.taxRates = taxRates;
+      return this;
+    }
+
+    /**
+     * The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates` on
+     * the subscription do not apply to this `subscription_item`.
+     */
+    public Builder setTaxRates(List<String> taxRates) {
       this.taxRates = taxRates;
       return this;
     }

--- a/src/main/java/com/stripe/param/SubscriptionItemUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionItemUpdateParams.java
@@ -280,11 +280,30 @@ public class SubscriptionItemUpdateParams extends ApiRequestParams {
     }
 
     /**
-     * The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates` on
-     * the subscription do not apply to this `subscription_item`.
+     * Add an element to `taxRates` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * SubscriptionItemUpdateParams#taxRates} for the field documentation.
      */
-    public Builder setTaxRates(List<String> taxRates) {
-      this.taxRates = taxRates;
+    @SuppressWarnings("unchecked")
+    public Builder addTaxRate(String element) {
+      if (this.taxRates == null || this.taxRates instanceof EmptyParam) {
+        this.taxRates = new ArrayList<String>();
+      }
+      ((List<String>) this.taxRates).add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `taxRates` list. A list is initialized for the first `add/addAll` call,
+     * and subsequent calls adds additional elements to the original list. See {@link
+     * SubscriptionItemUpdateParams#taxRates} for the field documentation.
+     */
+    @SuppressWarnings("unchecked")
+    public Builder addAllTaxRate(List<String> elements) {
+      if (this.taxRates == null || this.taxRates instanceof EmptyParam) {
+        this.taxRates = new ArrayList<String>();
+      }
+      ((List<String>) this.taxRates).addAll(elements);
       return this;
     }
 
@@ -293,6 +312,15 @@ public class SubscriptionItemUpdateParams extends ApiRequestParams {
      * the subscription do not apply to this `subscription_item`.
      */
     public Builder setTaxRates(EmptyParam taxRates) {
+      this.taxRates = taxRates;
+      return this;
+    }
+
+    /**
+     * The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates` on
+     * the subscription do not apply to this `subscription_item`.
+     */
+    public Builder setTaxRates(List<String> taxRates) {
       this.taxRates = taxRates;
       return this;
     }

--- a/src/main/java/com/stripe/param/SubscriptionScheduleCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionScheduleCreateParams.java
@@ -844,11 +844,30 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
       }
 
       /**
-       * The tax rates that will apply to any phase that does not have `tax_rates` set. Invoices
-       * created will have their `default_tax_rates` populated from the phase.
+       * Add an element to `defaultTaxRates` list. A list is initialized for the first `add/addAll`
+       * call, and subsequent calls adds additional elements to the original list. See {@link
+       * SubscriptionScheduleCreateParams.Phase#defaultTaxRates} for the field documentation.
        */
-      public Builder setDefaultTaxRates(List<String> defaultTaxRates) {
-        this.defaultTaxRates = defaultTaxRates;
+      @SuppressWarnings("unchecked")
+      public Builder addDefaultTaxRate(String element) {
+        if (this.defaultTaxRates == null || this.defaultTaxRates instanceof EmptyParam) {
+          this.defaultTaxRates = new ArrayList<String>();
+        }
+        ((List<String>) this.defaultTaxRates).add(element);
+        return this;
+      }
+
+      /**
+       * Add all elements to `defaultTaxRates` list. A list is initialized for the first
+       * `add/addAll` call, and subsequent calls adds additional elements to the original list. See
+       * {@link SubscriptionScheduleCreateParams.Phase#defaultTaxRates} for the field documentation.
+       */
+      @SuppressWarnings("unchecked")
+      public Builder addAllDefaultTaxRate(List<String> elements) {
+        if (this.defaultTaxRates == null || this.defaultTaxRates instanceof EmptyParam) {
+          this.defaultTaxRates = new ArrayList<String>();
+        }
+        ((List<String>) this.defaultTaxRates).addAll(elements);
         return this;
       }
 
@@ -857,6 +876,15 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
        * created will have their `default_tax_rates` populated from the phase.
        */
       public Builder setDefaultTaxRates(EmptyParam defaultTaxRates) {
+        this.defaultTaxRates = defaultTaxRates;
+        return this;
+      }
+
+      /**
+       * The tax rates that will apply to any phase that does not have `tax_rates` set. Invoices
+       * created will have their `default_tax_rates` populated from the phase.
+       */
+      public Builder setDefaultTaxRates(List<String> defaultTaxRates) {
         this.defaultTaxRates = defaultTaxRates;
         return this;
       }
@@ -1261,11 +1289,30 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
         }
 
         /**
-         * The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates`
-         * on the subscription do not apply to this `subscription_item`.
+         * Add an element to `taxRates` list. A list is initialized for the first `add/addAll` call,
+         * and subsequent calls adds additional elements to the original list. See {@link
+         * SubscriptionScheduleCreateParams.Phase.Plan#taxRates} for the field documentation.
          */
-        public Builder setTaxRates(List<String> taxRates) {
-          this.taxRates = taxRates;
+        @SuppressWarnings("unchecked")
+        public Builder addTaxRate(String element) {
+          if (this.taxRates == null || this.taxRates instanceof EmptyParam) {
+            this.taxRates = new ArrayList<String>();
+          }
+          ((List<String>) this.taxRates).add(element);
+          return this;
+        }
+
+        /**
+         * Add all elements to `taxRates` list. A list is initialized for the first `add/addAll`
+         * call, and subsequent calls adds additional elements to the original list. See {@link
+         * SubscriptionScheduleCreateParams.Phase.Plan#taxRates} for the field documentation.
+         */
+        @SuppressWarnings("unchecked")
+        public Builder addAllTaxRate(List<String> elements) {
+          if (this.taxRates == null || this.taxRates instanceof EmptyParam) {
+            this.taxRates = new ArrayList<String>();
+          }
+          ((List<String>) this.taxRates).addAll(elements);
           return this;
         }
 
@@ -1274,6 +1321,15 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
          * on the subscription do not apply to this `subscription_item`.
          */
         public Builder setTaxRates(EmptyParam taxRates) {
+          this.taxRates = taxRates;
+          return this;
+        }
+
+        /**
+         * The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates`
+         * on the subscription do not apply to this `subscription_item`.
+         */
+        public Builder setTaxRates(List<String> taxRates) {
           this.taxRates = taxRates;
           return this;
         }

--- a/src/main/java/com/stripe/param/SubscriptionScheduleUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionScheduleUpdateParams.java
@@ -814,11 +814,30 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
       }
 
       /**
-       * The tax rates that will apply to any phase that does not have `tax_rates` set. Invoices
-       * created will have their `default_tax_rates` populated from the phase.
+       * Add an element to `defaultTaxRates` list. A list is initialized for the first `add/addAll`
+       * call, and subsequent calls adds additional elements to the original list. See {@link
+       * SubscriptionScheduleUpdateParams.Phase#defaultTaxRates} for the field documentation.
        */
-      public Builder setDefaultTaxRates(List<String> defaultTaxRates) {
-        this.defaultTaxRates = defaultTaxRates;
+      @SuppressWarnings("unchecked")
+      public Builder addDefaultTaxRate(String element) {
+        if (this.defaultTaxRates == null || this.defaultTaxRates instanceof EmptyParam) {
+          this.defaultTaxRates = new ArrayList<String>();
+        }
+        ((List<String>) this.defaultTaxRates).add(element);
+        return this;
+      }
+
+      /**
+       * Add all elements to `defaultTaxRates` list. A list is initialized for the first
+       * `add/addAll` call, and subsequent calls adds additional elements to the original list. See
+       * {@link SubscriptionScheduleUpdateParams.Phase#defaultTaxRates} for the field documentation.
+       */
+      @SuppressWarnings("unchecked")
+      public Builder addAllDefaultTaxRate(List<String> elements) {
+        if (this.defaultTaxRates == null || this.defaultTaxRates instanceof EmptyParam) {
+          this.defaultTaxRates = new ArrayList<String>();
+        }
+        ((List<String>) this.defaultTaxRates).addAll(elements);
         return this;
       }
 
@@ -827,6 +846,15 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
        * created will have their `default_tax_rates` populated from the phase.
        */
       public Builder setDefaultTaxRates(EmptyParam defaultTaxRates) {
+        this.defaultTaxRates = defaultTaxRates;
+        return this;
+      }
+
+      /**
+       * The tax rates that will apply to any phase that does not have `tax_rates` set. Invoices
+       * created will have their `default_tax_rates` populated from the phase.
+       */
+      public Builder setDefaultTaxRates(List<String> defaultTaxRates) {
         this.defaultTaxRates = defaultTaxRates;
         return this;
       }
@@ -1261,11 +1289,30 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
         }
 
         /**
-         * The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates`
-         * on the subscription do not apply to this `subscription_item`.
+         * Add an element to `taxRates` list. A list is initialized for the first `add/addAll` call,
+         * and subsequent calls adds additional elements to the original list. See {@link
+         * SubscriptionScheduleUpdateParams.Phase.Plan#taxRates} for the field documentation.
          */
-        public Builder setTaxRates(List<String> taxRates) {
-          this.taxRates = taxRates;
+        @SuppressWarnings("unchecked")
+        public Builder addTaxRate(String element) {
+          if (this.taxRates == null || this.taxRates instanceof EmptyParam) {
+            this.taxRates = new ArrayList<String>();
+          }
+          ((List<String>) this.taxRates).add(element);
+          return this;
+        }
+
+        /**
+         * Add all elements to `taxRates` list. A list is initialized for the first `add/addAll`
+         * call, and subsequent calls adds additional elements to the original list. See {@link
+         * SubscriptionScheduleUpdateParams.Phase.Plan#taxRates} for the field documentation.
+         */
+        @SuppressWarnings("unchecked")
+        public Builder addAllTaxRate(List<String> elements) {
+          if (this.taxRates == null || this.taxRates instanceof EmptyParam) {
+            this.taxRates = new ArrayList<String>();
+          }
+          ((List<String>) this.taxRates).addAll(elements);
           return this;
         }
 
@@ -1274,6 +1321,15 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
          * on the subscription do not apply to this `subscription_item`.
          */
         public Builder setTaxRates(EmptyParam taxRates) {
+          this.taxRates = taxRates;
+          return this;
+        }
+
+        /**
+         * The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates`
+         * on the subscription do not apply to this `subscription_item`.
+         */
+        public Builder setTaxRates(List<String> taxRates) {
           this.taxRates = taxRates;
           return this;
         }

--- a/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
@@ -463,11 +463,30 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
     }
 
     /**
-     * The tax rates that will apply to any subscription item that does not have `tax_rates` set.
-     * Invoices created will have their `default_tax_rates` populated from the subscription.
+     * Add an element to `defaultTaxRates` list. A list is initialized for the first `add/addAll`
+     * call, and subsequent calls adds additional elements to the original list. See {@link
+     * SubscriptionUpdateParams#defaultTaxRates} for the field documentation.
      */
-    public Builder setDefaultTaxRates(List<String> defaultTaxRates) {
-      this.defaultTaxRates = defaultTaxRates;
+    @SuppressWarnings("unchecked")
+    public Builder addDefaultTaxRate(String element) {
+      if (this.defaultTaxRates == null || this.defaultTaxRates instanceof EmptyParam) {
+        this.defaultTaxRates = new ArrayList<String>();
+      }
+      ((List<String>) this.defaultTaxRates).add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `defaultTaxRates` list. A list is initialized for the first `add/addAll`
+     * call, and subsequent calls adds additional elements to the original list. See {@link
+     * SubscriptionUpdateParams#defaultTaxRates} for the field documentation.
+     */
+    @SuppressWarnings("unchecked")
+    public Builder addAllDefaultTaxRate(List<String> elements) {
+      if (this.defaultTaxRates == null || this.defaultTaxRates instanceof EmptyParam) {
+        this.defaultTaxRates = new ArrayList<String>();
+      }
+      ((List<String>) this.defaultTaxRates).addAll(elements);
       return this;
     }
 
@@ -476,6 +495,15 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
      * Invoices created will have their `default_tax_rates` populated from the subscription.
      */
     public Builder setDefaultTaxRates(EmptyParam defaultTaxRates) {
+      this.defaultTaxRates = defaultTaxRates;
+      return this;
+    }
+
+    /**
+     * The tax rates that will apply to any subscription item that does not have `tax_rates` set.
+     * Invoices created will have their `default_tax_rates` populated from the subscription.
+     */
+    public Builder setDefaultTaxRates(List<String> defaultTaxRates) {
       this.defaultTaxRates = defaultTaxRates;
       return this;
     }
@@ -1024,11 +1052,30 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
       }
 
       /**
-       * The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates` on
-       * the subscription do not apply to this `subscription_item`.
+       * Add an element to `taxRates` list. A list is initialized for the first `add/addAll` call,
+       * and subsequent calls adds additional elements to the original list. See {@link
+       * SubscriptionUpdateParams.Item#taxRates} for the field documentation.
        */
-      public Builder setTaxRates(List<String> taxRates) {
-        this.taxRates = taxRates;
+      @SuppressWarnings("unchecked")
+      public Builder addTaxRate(String element) {
+        if (this.taxRates == null || this.taxRates instanceof EmptyParam) {
+          this.taxRates = new ArrayList<String>();
+        }
+        ((List<String>) this.taxRates).add(element);
+        return this;
+      }
+
+      /**
+       * Add all elements to `taxRates` list. A list is initialized for the first `add/addAll` call,
+       * and subsequent calls adds additional elements to the original list. See {@link
+       * SubscriptionUpdateParams.Item#taxRates} for the field documentation.
+       */
+      @SuppressWarnings("unchecked")
+      public Builder addAllTaxRate(List<String> elements) {
+        if (this.taxRates == null || this.taxRates instanceof EmptyParam) {
+          this.taxRates = new ArrayList<String>();
+        }
+        ((List<String>) this.taxRates).addAll(elements);
         return this;
       }
 
@@ -1037,6 +1084,15 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
        * the subscription do not apply to this `subscription_item`.
        */
       public Builder setTaxRates(EmptyParam taxRates) {
+        this.taxRates = taxRates;
+        return this;
+      }
+
+      /**
+       * The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates` on
+       * the subscription do not apply to this `subscription_item`.
+       */
+      public Builder setTaxRates(List<String> taxRates) {
         this.taxRates = taxRates;
         return this;
       }

--- a/src/main/java/com/stripe/param/issuing/CardCreateParams.java
+++ b/src/main/java/com/stripe/param/issuing/CardCreateParams.java
@@ -3396,7 +3396,7 @@ public class CardCreateParams extends ApiRequestParams {
        * One of `bulk` or `individual`. Bulk shipments will be grouped and mailed together, while
        * individual ones will not.
        */
-      public Builder setType(EmptyParam type) {
+      public Builder setType(Type type) {
         this.type = type;
         return this;
       }
@@ -3405,7 +3405,7 @@ public class CardCreateParams extends ApiRequestParams {
        * One of `bulk` or `individual`. Bulk shipments will be grouped and mailed together, while
        * individual ones will not.
        */
-      public Builder setType(Type type) {
+      public Builder setType(EmptyParam type) {
         this.type = type;
         return this;
       }


### PR DESCRIPTION
This adds add/addAll methods for a few API resources that are polymorphic between EmptyParam and some other Array parameter type.

This includes:
* `addAttribute`/`addAllAttribute` for `ProductUpdateParams`
* `addCustomField`/`addAllCustomField` for `CustomerCreateParams`, `CustomerUpdateParams`, `InvoiceCreateParams`, and `InvoiceUpdateParams`
* `addDefaultTaxRate`/`addAllDefaultTaxRate` for `InvoiceUpdateParams`, `SubscriptionCreateParams`, `SubscriptionScheduleCreateParams`, `SubscriptionScheduleUpdateParams`, and `SubscriptionUpdateParams`
* `addImage`/`addAllImage` for `ProductUpdateParams`
* `addItem`/`addAllItem` for `OrderReturnOrderParams`
* `addSubscriptionDefaultTaxRate`/`addAllSubscriptionDefaultTaxRate` for `InvoiceUpcomingParams`
* `addTaxRate`/`addAllTaxRate` for `InvoiceItemUpdateParams`, `InvoiceUpcomingParams`, `SubscriptionCreateParams`, `SubscriptionItemCreateParams`, `SubscriptionItemUpdateParams`, `SubscriptionScheduleCreateParams`, `SubscriptionScheduleUpdateParams`, and `SubscriptionUpdateParams`


r? @ob-stripe
cc @stripe/api-libraries

Oh I guess this doesn't contain any of the new ones that will have this for Metadata yet? Those haven't landed in the openapi spec I presume? I guess I'll update this once that happens.