### PR TITLE
Stop propagating UnsupportedEncodingException

### DIFF
--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -26,7 +26,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.net.Authenticator;
@@ -90,7 +89,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
     return staticOAuthRequest(method, url, params, clazz, type, options);
   }
 
-  private static String urlEncodePair(String k, String v) throws UnsupportedEncodingException {
+  private static String urlEncodePair(String k, String v) {
     return String.format("%s=%s", ApiResource.urlEncode(k), ApiResource.urlEncode(v));
   }
 
@@ -266,8 +265,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
     return conn;
   }
 
-  static String createQuery(Map<String, Object> params)
-      throws UnsupportedEncodingException, InvalidRequestException {
+  static String createQuery(Map<String, Object> params) throws InvalidRequestException {
     StringBuilder queryStringBuffer = new StringBuilder();
     List<Parameter> flatParams = flattenParams(params);
     Iterator<Parameter> it = flatParams.iterator();
@@ -606,21 +604,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
       Map<String, Object> params,
       RequestOptions options)
       throws InvalidRequestException, ApiConnectionException, ApiException {
-    String query;
-    try {
-      query = createQuery(params);
-    } catch (UnsupportedEncodingException e) {
-      throw new InvalidRequestException(
-          "Unable to encode parameters to "
-              + ApiResource.CHARSET
-              + ". Please contact support@stripe.com for assistance.",
-          null,
-          null,
-          null,
-          0,
-          e);
-    }
-
+    String query = createQuery(params);
     return makeUrlConnectionRequest(method, url, query, options);
   }
 

--- a/src/main/java/com/stripe/net/OAuth.java
+++ b/src/main/java/com/stripe/net/OAuth.java
@@ -6,7 +6,6 @@ import com.stripe.exception.InvalidRequestException;
 import com.stripe.exception.StripeException;
 import com.stripe.model.oauth.DeauthorizedAccount;
 import com.stripe.model.oauth.TokenResponse;
-import java.io.UnsupportedEncodingException;
 import java.util.Map;
 
 public final class OAuth {
@@ -31,21 +30,7 @@ public final class OAuth {
     if (params.get("response_type") == null) {
       params.put("response_type", "code");
     }
-    String query;
-    try {
-      query = LiveStripeResponseGetter.createQuery(params);
-    } catch (UnsupportedEncodingException e) {
-      throw new InvalidRequestException(
-          "Unable to encode parameters to "
-              + ApiResource.CHARSET
-              + ". Please contact support@stripe.com for assistance.",
-          null,
-          null,
-          null,
-          0,
-          e);
-    }
-
+    String query = LiveStripeResponseGetter.createQuery(params);
     String url = base + "/oauth/authorize?" + query;
     return url;
   }

--- a/src/test/java/com/stripe/net/ApiResourceTest.java
+++ b/src/test/java/com/stripe/net/ApiResourceTest.java
@@ -4,13 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.stripe.exception.InvalidRequestException;
-import java.io.UnsupportedEncodingException;
 import org.junit.jupiter.api.Test;
 
 class ApiResourceTest {
 
   @Test
-  public void testUrlEncode() throws UnsupportedEncodingException {
+  public void testUrlEncode() {
     assertEquals("cus_123", ApiResource.urlEncode("cus_123"));
     // legacy Ids allow customer-defined and can have arbitrary names
     assertEquals("Plan+100%24%2Fmonth", ApiResource.urlEncode("Plan 100$/month"));

--- a/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
+++ b/src/test/java/com/stripe/net/LiveStripeResponseGetterTest.java
@@ -16,7 +16,6 @@ import com.stripe.net.RequestOptions.RequestOptionsBuilder;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -44,15 +43,14 @@ public class LiveStripeResponseGetterTest {
   }
 
   @Test
-  public void testCreateQuery() throws StripeException, UnsupportedEncodingException {
+  public void testCreateQuery() throws StripeException {
     Map<String, Object> params = new HashMap<>();
     params.put("a", "b");
     assertEquals("a=b", LiveStripeResponseGetter.createQuery(params));
   }
 
   @Test
-  public void testCreateQueryWithNestedParams()
-      throws StripeException, UnsupportedEncodingException {
+  public void testCreateQueryWithNestedParams() throws StripeException {
     /* Use LinkedHashMap because it preserves iteration order */
     final Map<String, Object> params = new LinkedHashMap<>();
     final Map<String, Object> nested = new LinkedHashMap<>();
@@ -65,7 +63,7 @@ public class LiveStripeResponseGetterTest {
   }
 
   @Test
-  public void testCreateQueryWithListParams() throws StripeException, UnsupportedEncodingException {
+  public void testCreateQueryWithListParams() throws StripeException {
     final List<String> nested = new ArrayList<>();
     nested.add("A");
     nested.add("B");
@@ -83,8 +81,7 @@ public class LiveStripeResponseGetterTest {
   }
 
   @Test
-  public void testCreateQueryWithArrayParams()
-      throws StripeException, UnsupportedEncodingException {
+  public void testCreateQueryWithArrayParams() throws StripeException {
 
     final String[] nested = {"A", "B", "C"};
 
@@ -100,8 +97,7 @@ public class LiveStripeResponseGetterTest {
   }
 
   @Test
-  public void testCreateQueryWithListOfHashes()
-      throws StripeException, UnsupportedEncodingException {
+  public void testCreateQueryWithListOfHashes() throws StripeException {
     final Map<String, String> deepNestedMap1 = new LinkedHashMap<>();
     deepNestedMap1.put("A", "A-1");
     deepNestedMap1.put("B", "B-1");
@@ -124,8 +120,7 @@ public class LiveStripeResponseGetterTest {
   }
 
   @Test
-  public void testCreateQueryWithFormEncodedKeys()
-      throws StripeException, UnsupportedEncodingException {
+  public void testCreateQueryWithFormEncodedKeys() throws StripeException {
     /* Use LinkedHashMap because it preserves iteration order */
     final Map<String, Object> params = new LinkedHashMap<>();
 
@@ -147,8 +142,7 @@ public class LiveStripeResponseGetterTest {
 
   @SuppressWarnings("ModifiedButNotUsed")
   @Test
-  public void testCreateQueryWithCollection()
-      throws UnsupportedEncodingException, InvalidRequestException {
+  public void testCreateQueryWithCollection() throws InvalidRequestException {
     // test collections with its own implementation to return iterator giving "A", "B", "C" in order
     final Set<String> nestedTreeSet = new TreeSet<>(String::compareTo);
     nestedTreeSet.add("B");
@@ -185,8 +179,7 @@ public class LiveStripeResponseGetterTest {
   }
 
   @Test
-  public void testCreateQueryWithEmptyCollection()
-      throws StripeException, UnsupportedEncodingException {
+  public void testCreateQueryWithEmptyCollection() throws StripeException {
     final Map<String, Object> params = new HashMap<>();
     params.put("a", new ArrayList<String>());
     assertEquals("a=", LiveStripeResponseGetter.createQuery(params));
@@ -199,7 +192,7 @@ public class LiveStripeResponseGetterTest {
   }
 
   @Test
-  public void testCreateQueryWithEmptyArray() throws StripeException, UnsupportedEncodingException {
+  public void testCreateQueryWithEmptyArray() throws StripeException {
     final String[] array = {};
     final Map<String, Object> params = new HashMap<>();
     params.put("a", array);
@@ -207,15 +200,14 @@ public class LiveStripeResponseGetterTest {
   }
 
   @Test
-  public void testCreateQueryUrlEncodeSpecialCharacters()
-      throws StripeException, UnsupportedEncodingException {
+  public void testCreateQueryUrlEncodeSpecialCharacters() throws StripeException {
     final Map<String, Object> params = new HashMap<>();
     params.put("a", "+foo?");
     assertEquals("a=%2Bfoo%3F", LiveStripeResponseGetter.createQuery(params));
   }
 
   @Test
-  public void testIncorrectAdditionalOwners() throws StripeException, UnsupportedEncodingException {
+  public void testIncorrectAdditionalOwners() throws StripeException {
     final Map<String, String> ownerParams = new HashMap<>();
     ownerParams.put("first_name", "Stripe");
 
@@ -234,7 +226,7 @@ public class LiveStripeResponseGetterTest {
   }
 
   @Test
-  public void testCorrectAdditionalOwners() throws StripeException, UnsupportedEncodingException {
+  public void testCorrectAdditionalOwners() throws StripeException {
     final Map<String, String> ownerParams = new HashMap<>();
     ownerParams.put("first_name", "Stripe");
 

--- a/src/test/java/com/stripe/net/OAuthTest.java
+++ b/src/test/java/com/stripe/net/OAuthTest.java
@@ -13,27 +13,33 @@ import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 public class OAuthTest extends BaseStripeTest {
-  private static Map<String, String> splitQuery(String query) throws UnsupportedEncodingException {
+  private static String urlDecode(String s) {
+    try {
+      return URLDecoder.decode(s, StandardCharsets.UTF_8.name());
+    } catch (UnsupportedEncodingException e) {
+      throw new AssertionError("UTF-8 is unknown");
+    }
+  }
+
+  private static Map<String, String> splitQuery(String query) {
     final Map<String, String> queryPairs = new HashMap<>();
     final String[] pairs = query.split("&", -1);
     for (final String pair : pairs) {
       final int idx = pair.indexOf("=");
-      queryPairs.put(
-          URLDecoder.decode(pair.substring(0, idx), "UTF8"),
-          URLDecoder.decode(pair.substring(idx + 1), "UTF8"));
+      queryPairs.put(urlDecode(pair.substring(0, idx)), urlDecode(pair.substring(idx + 1)));
     }
     return queryPairs;
   }
 
   @Test
   public void testAuthorizeUrl()
-      throws AuthenticationException, InvalidRequestException, MalformedURLException,
-          UnsupportedEncodingException {
+      throws AuthenticationException, InvalidRequestException, MalformedURLException {
     final Map<String, Object> urlParams = new HashMap<>();
     urlParams.put("scope", "read_write");
     urlParams.put("state", "csrf_token");


### PR DESCRIPTION
r? @remi-stripe @richardm-stripe 
cc @stripe/api-libraries 

`UnsupportedEncodingException` when passing `"UTF-8"` as the encoding name can literally never happen (UTF-8 is _always_ a valid encoding), so throwing a checked exception is useless.

Newer (>=10) Java versions have overloads for `URLEncoder.encode/decode` that directly accept a `Charset` instead of a string for the encoding's name and don't throw the checked exception, but since we still need to support Java 8 and 9, I'm doing the next best thing: catch the checked exception ASAP and replace it with a runtime (i.e. unchecked) exception, so callers don't have to worry about handling an exception that will never be thrown in practice.

Also replace a couple `"UTF-8"` literals with `StandardCharsets.UTF_8.name()`, just in case the world decides to rename UTF-8 to something else. Better safe than sorry.
