### PR TITLE
Update library for API version `2019-10-17`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 env:
   global:
     # If changing this number, please also change it in `BaseStripeTest.java`.
-  - STRIPE_MOCK_VERSION=0.68.0
+  - STRIPE_MOCK_VERSION=0.69.0
 
 matrix:
   include:

--- a/src/main/java/com/stripe/Stripe.java
+++ b/src/main/java/com/stripe/Stripe.java
@@ -9,7 +9,7 @@ public abstract class Stripe {
   public static final int DEFAULT_CONNECT_TIMEOUT = 30 * 1000;
   public static final int DEFAULT_READ_TIMEOUT = 80 * 1000;
 
-  public static final String API_VERSION = "2019-10-08";
+  public static final String API_VERSION = "2019-10-17";
   public static final String CONNECT_API_BASE = "https://connect.stripe.com";
   public static final String LIVE_API_BASE = "https://api.stripe.com";
   public static final String UPLOAD_API_BASE = "https://files.stripe.com";

--- a/src/main/java/com/stripe/model/Customer.java
+++ b/src/main/java/com/stripe/model/Customer.java
@@ -20,10 +20,6 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class Customer extends ApiResource implements HasId, MetadataStore<Customer> {
-  /** This field has been renamed to `balance` and will be removed in a future API version. */
-  @SerializedName("account_balance")
-  Long accountBalance;
-
   /** The customer's address. */
   @SerializedName("address")
   Address address;

--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -91,12 +91,6 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
   Boolean autoAdvance;
 
   /**
-   * This field has been renamed to `collection_method` and will be removed in a future API version.
-   */
-  @SerializedName("billing")
-  String billing;
-
-  /**
    * Indicates the reason why the invoice was created. `subscription_cycle` indicates an invoice
    * created by a subscription advancing into a new period. `subscription_create` indicates an
    * invoice created due to creating a subscription. `subscription_update` indicates an invoice

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -30,12 +30,6 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
   BigDecimal applicationFeePercent;
 
   /**
-   * This field has been renamed to `collection_method` and will be removed in a future API version.
-   */
-  @SerializedName("billing")
-  String billing;
-
-  /**
    * Determines the date of the first full invoice, and, for plans with `month` or `year` intervals,
    * the day of the month for subsequent invoices.
    */
@@ -212,13 +206,6 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
   @Getter(lombok.AccessLevel.NONE)
   @Setter(lombok.AccessLevel.NONE)
   ExpandableField<SubscriptionSchedule> schedule;
-
-  /**
-   * Date of the last substantial change to this subscription. For example, a change to the items
-   * array, or a change of status, will reset this timestamp.
-   */
-  @SerializedName("start")
-  Long start;
 
   /**
    * Date when the subscription was first created. The date might differ from the `created` date due

--- a/src/main/java/com/stripe/model/SubscriptionSchedule.java
+++ b/src/main/java/com/stripe/model/SubscriptionSchedule.java
@@ -24,12 +24,6 @@ import lombok.Setter;
 public class SubscriptionSchedule extends ApiResource
     implements HasId, MetadataStore<SubscriptionSchedule> {
   /**
-   * This field has been renamed to `collection_method` and will be removed in a future API version.
-   */
-  @SerializedName("billing")
-  String billing;
-
-  /**
    * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
    * billing period.
    */

--- a/src/main/java/com/stripe/param/CustomerCreateParams.java
+++ b/src/main/java/com/stripe/param/CustomerCreateParams.java
@@ -12,10 +12,6 @@ import lombok.Getter;
 
 @Getter
 public class CustomerCreateParams extends ApiRequestParams {
-  /** This field has been renamed to `balance` and will be removed in a future API version. */
-  @SerializedName("account_balance")
-  Long accountBalance;
-
   /** The customer's address. */
   @SerializedName("address")
   Object address;
@@ -116,7 +112,6 @@ public class CustomerCreateParams extends ApiRequestParams {
   TaxInfo taxInfo;
 
   private CustomerCreateParams(
-      Long accountBalance,
       Object address,
       Long balance,
       String coupon,
@@ -136,7 +131,6 @@ public class CustomerCreateParams extends ApiRequestParams {
       EnumParam taxExempt,
       List<TaxIdData> taxIdData,
       TaxInfo taxInfo) {
-    this.accountBalance = accountBalance;
     this.address = address;
     this.balance = balance;
     this.coupon = coupon;
@@ -163,8 +157,6 @@ public class CustomerCreateParams extends ApiRequestParams {
   }
 
   public static class Builder {
-    private Long accountBalance;
-
     private Object address;
 
     private Long balance;
@@ -206,7 +198,6 @@ public class CustomerCreateParams extends ApiRequestParams {
     /** Finalize and obtain parameter instance from this builder. */
     public CustomerCreateParams build() {
       return new CustomerCreateParams(
-          this.accountBalance,
           this.address,
           this.balance,
           this.coupon,
@@ -226,12 +217,6 @@ public class CustomerCreateParams extends ApiRequestParams {
           this.taxExempt,
           this.taxIdData,
           this.taxInfo);
-    }
-
-    /** This field has been renamed to `balance` and will be removed in a future API version. */
-    public Builder setAccountBalance(Long accountBalance) {
-      this.accountBalance = accountBalance;
-      return this;
     }
 
     /** The customer's address. */

--- a/src/main/java/com/stripe/param/CustomerUpdateParams.java
+++ b/src/main/java/com/stripe/param/CustomerUpdateParams.java
@@ -12,10 +12,6 @@ import lombok.Getter;
 
 @Getter
 public class CustomerUpdateParams extends ApiRequestParams {
-  /** This field has been renamed to `balance` and will be removed in a future API version. */
-  @SerializedName("account_balance")
-  Long accountBalance;
-
   /** The customer's address. */
   @SerializedName("address")
   Object address;
@@ -127,7 +123,6 @@ public class CustomerUpdateParams extends ApiRequestParams {
   Object trialEnd;
 
   private CustomerUpdateParams(
-      Long accountBalance,
       Object address,
       Long balance,
       Object coupon,
@@ -147,7 +142,6 @@ public class CustomerUpdateParams extends ApiRequestParams {
       EnumParam taxExempt,
       TaxInfo taxInfo,
       Object trialEnd) {
-    this.accountBalance = accountBalance;
     this.address = address;
     this.balance = balance;
     this.coupon = coupon;
@@ -174,8 +168,6 @@ public class CustomerUpdateParams extends ApiRequestParams {
   }
 
   public static class Builder {
-    private Long accountBalance;
-
     private Object address;
 
     private Long balance;
@@ -217,7 +209,6 @@ public class CustomerUpdateParams extends ApiRequestParams {
     /** Finalize and obtain parameter instance from this builder. */
     public CustomerUpdateParams build() {
       return new CustomerUpdateParams(
-          this.accountBalance,
           this.address,
           this.balance,
           this.coupon,
@@ -237,12 +228,6 @@ public class CustomerUpdateParams extends ApiRequestParams {
           this.taxExempt,
           this.taxInfo,
           this.trialEnd);
-    }
-
-    /** This field has been renamed to `balance` and will be removed in a future API version. */
-    public Builder setAccountBalance(Long accountBalance) {
-      this.accountBalance = accountBalance;
-      return this;
     }
 
     /** The customer's address. */

--- a/src/main/java/com/stripe/param/InvoiceCreateParams.java
+++ b/src/main/java/com/stripe/param/InvoiceCreateParams.java
@@ -30,12 +30,6 @@ public class InvoiceCreateParams extends ApiRequestParams {
   Boolean autoAdvance;
 
   /**
-   * This field has been renamed to `collection_method` and will be removed in a future API version.
-   */
-  @SerializedName("billing")
-  Billing billing;
-
-  /**
    * Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will
    * attempt to pay this invoice using the default source attached to the customer. When sending an
    * invoice, Stripe will email this invoice to the customer with payment instructions. Defaults to
@@ -146,7 +140,6 @@ public class InvoiceCreateParams extends ApiRequestParams {
   private InvoiceCreateParams(
       Long applicationFeeAmount,
       Boolean autoAdvance,
-      Billing billing,
       CollectionMethod collectionMethod,
       Object customFields,
       String customer,
@@ -166,7 +159,6 @@ public class InvoiceCreateParams extends ApiRequestParams {
       TransferData transferData) {
     this.applicationFeeAmount = applicationFeeAmount;
     this.autoAdvance = autoAdvance;
-    this.billing = billing;
     this.collectionMethod = collectionMethod;
     this.customFields = customFields;
     this.customer = customer;
@@ -194,8 +186,6 @@ public class InvoiceCreateParams extends ApiRequestParams {
     private Long applicationFeeAmount;
 
     private Boolean autoAdvance;
-
-    private Billing billing;
 
     private CollectionMethod collectionMethod;
 
@@ -236,7 +226,6 @@ public class InvoiceCreateParams extends ApiRequestParams {
       return new InvoiceCreateParams(
           this.applicationFeeAmount,
           this.autoAdvance,
-          this.billing,
           this.collectionMethod,
           this.customFields,
           this.customer,
@@ -274,15 +263,6 @@ public class InvoiceCreateParams extends ApiRequestParams {
      */
     public Builder setAutoAdvance(Boolean autoAdvance) {
       this.autoAdvance = autoAdvance;
-      return this;
-    }
-
-    /**
-     * This field has been renamed to `collection_method` and will be removed in a future API
-     * version.
-     */
-    public Builder setBilling(Billing billing) {
-      this.billing = billing;
       return this;
     }
 
@@ -685,21 +665,6 @@ public class InvoiceCreateParams extends ApiRequestParams {
         this.extraParams.putAll(map);
         return this;
       }
-    }
-  }
-
-  public enum Billing implements ApiRequestParams.EnumParam {
-    @SerializedName("charge_automatically")
-    CHARGE_AUTOMATICALLY("charge_automatically"),
-
-    @SerializedName("send_invoice")
-    SEND_INVOICE("send_invoice");
-
-    @Getter(onMethod_ = {@Override})
-    private final String value;
-
-    Billing(String value) {
-      this.value = value;
     }
   }
 

--- a/src/main/java/com/stripe/param/InvoiceListParams.java
+++ b/src/main/java/com/stripe/param/InvoiceListParams.java
@@ -11,12 +11,6 @@ import lombok.Getter;
 @Getter
 public class InvoiceListParams extends ApiRequestParams {
   /**
-   * This field has been renamed to `collection_method` and will be removed in a future API version.
-   */
-  @SerializedName("billing")
-  Billing billing;
-
-  /**
    * The collection method of the invoice to retrieve. Either `charge_automatically` or
    * `send_invoice`.
    */
@@ -83,7 +77,6 @@ public class InvoiceListParams extends ApiRequestParams {
   String subscription;
 
   private InvoiceListParams(
-      Billing billing,
       CollectionMethod collectionMethod,
       Object created,
       String customer,
@@ -95,7 +88,6 @@ public class InvoiceListParams extends ApiRequestParams {
       String startingAfter,
       Status status,
       String subscription) {
-    this.billing = billing;
     this.collectionMethod = collectionMethod;
     this.created = created;
     this.customer = customer;
@@ -114,8 +106,6 @@ public class InvoiceListParams extends ApiRequestParams {
   }
 
   public static class Builder {
-    private Billing billing;
-
     private CollectionMethod collectionMethod;
 
     private Object created;
@@ -141,7 +131,6 @@ public class InvoiceListParams extends ApiRequestParams {
     /** Finalize and obtain parameter instance from this builder. */
     public InvoiceListParams build() {
       return new InvoiceListParams(
-          this.billing,
           this.collectionMethod,
           this.created,
           this.customer,
@@ -153,15 +142,6 @@ public class InvoiceListParams extends ApiRequestParams {
           this.startingAfter,
           this.status,
           this.subscription);
-    }
-
-    /**
-     * This field has been renamed to `collection_method` and will be removed in a future API
-     * version.
-     */
-    public Builder setBilling(Billing billing) {
-      this.billing = billing;
-      return this;
     }
 
     /**
@@ -509,21 +489,6 @@ public class InvoiceListParams extends ApiRequestParams {
         this.lte = lte;
         return this;
       }
-    }
-  }
-
-  public enum Billing implements ApiRequestParams.EnumParam {
-    @SerializedName("charge_automatically")
-    CHARGE_AUTOMATICALLY("charge_automatically"),
-
-    @SerializedName("send_invoice")
-    SEND_INVOICE("send_invoice");
-
-    @Getter(onMethod_ = {@Override})
-    private final String value;
-
-    Billing(String value) {
-      this.value = value;
     }
   }
 

--- a/src/main/java/com/stripe/param/SubscriptionCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionCreateParams.java
@@ -31,12 +31,6 @@ public class SubscriptionCreateParams extends ApiRequestParams {
   Long backdateStartDate;
 
   /**
-   * This field has been renamed to `collection_method` and will be removed in a future API version.
-   */
-  @SerializedName("billing")
-  Billing billing;
-
-  /**
    * A future timestamp to anchor the subscription's [billing
    * cycle](https://stripe.com/docs/subscriptions/billing-cycle). This is used to determine the date
    * of the first full invoice, and, for plans with `month` or `year` intervals, the day of the
@@ -219,7 +213,6 @@ public class SubscriptionCreateParams extends ApiRequestParams {
   private SubscriptionCreateParams(
       BigDecimal applicationFeePercent,
       Long backdateStartDate,
-      Billing billing,
       Long billingCycleAnchor,
       Object billingThresholds,
       Long cancelAt,
@@ -245,7 +238,6 @@ public class SubscriptionCreateParams extends ApiRequestParams {
       Long trialPeriodDays) {
     this.applicationFeePercent = applicationFeePercent;
     this.backdateStartDate = backdateStartDate;
-    this.billing = billing;
     this.billingCycleAnchor = billingCycleAnchor;
     this.billingThresholds = billingThresholds;
     this.cancelAt = cancelAt;
@@ -279,8 +271,6 @@ public class SubscriptionCreateParams extends ApiRequestParams {
     private BigDecimal applicationFeePercent;
 
     private Long backdateStartDate;
-
-    private Billing billing;
 
     private Long billingCycleAnchor;
 
@@ -333,7 +323,6 @@ public class SubscriptionCreateParams extends ApiRequestParams {
       return new SubscriptionCreateParams(
           this.applicationFeePercent,
           this.backdateStartDate,
-          this.billing,
           this.billingCycleAnchor,
           this.billingThresholds,
           this.cancelAt,
@@ -379,15 +368,6 @@ public class SubscriptionCreateParams extends ApiRequestParams {
      */
     public Builder setBackdateStartDate(Long backdateStartDate) {
       this.backdateStartDate = backdateStartDate;
-      return this;
-    }
-
-    /**
-     * This field has been renamed to `collection_method` and will be removed in a future API
-     * version.
-     */
-    public Builder setBilling(Billing billing) {
-      this.billing = billing;
       return this;
     }
 
@@ -1202,21 +1182,6 @@ public class SubscriptionCreateParams extends ApiRequestParams {
         this.extraParams.putAll(map);
         return this;
       }
-    }
-  }
-
-  public enum Billing implements ApiRequestParams.EnumParam {
-    @SerializedName("charge_automatically")
-    CHARGE_AUTOMATICALLY("charge_automatically"),
-
-    @SerializedName("send_invoice")
-    SEND_INVOICE("send_invoice");
-
-    @Getter(onMethod_ = {@Override})
-    private final String value;
-
-    Billing(String value) {
-      this.value = value;
     }
   }
 

--- a/src/main/java/com/stripe/param/SubscriptionListParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionListParams.java
@@ -11,12 +11,6 @@ import lombok.Getter;
 @Getter
 public class SubscriptionListParams extends ApiRequestParams {
   /**
-   * This field has been renamed to `collection_method` and will be removed in a future API version.
-   */
-  @SerializedName("billing")
-  Billing billing;
-
-  /**
    * The collection method of the subscriptions to retrieve. Either `charge_automatically` or
    * `send_invoice`.
    */
@@ -88,7 +82,6 @@ public class SubscriptionListParams extends ApiRequestParams {
   Status status;
 
   private SubscriptionListParams(
-      Billing billing,
       CollectionMethod collectionMethod,
       Object created,
       Object currentPeriodEnd,
@@ -101,7 +94,6 @@ public class SubscriptionListParams extends ApiRequestParams {
       String plan,
       String startingAfter,
       Status status) {
-    this.billing = billing;
     this.collectionMethod = collectionMethod;
     this.created = created;
     this.currentPeriodEnd = currentPeriodEnd;
@@ -121,8 +113,6 @@ public class SubscriptionListParams extends ApiRequestParams {
   }
 
   public static class Builder {
-    private Billing billing;
-
     private CollectionMethod collectionMethod;
 
     private Object created;
@@ -150,7 +140,6 @@ public class SubscriptionListParams extends ApiRequestParams {
     /** Finalize and obtain parameter instance from this builder. */
     public SubscriptionListParams build() {
       return new SubscriptionListParams(
-          this.billing,
           this.collectionMethod,
           this.created,
           this.currentPeriodEnd,
@@ -163,15 +152,6 @@ public class SubscriptionListParams extends ApiRequestParams {
           this.plan,
           this.startingAfter,
           this.status);
-    }
-
-    /**
-     * This field has been renamed to `collection_method` and will be removed in a future API
-     * version.
-     */
-    public Builder setBilling(Billing billing) {
-      this.billing = billing;
-      return this;
     }
 
     /**
@@ -642,21 +622,6 @@ public class SubscriptionListParams extends ApiRequestParams {
         this.lte = lte;
         return this;
       }
-    }
-  }
-
-  public enum Billing implements ApiRequestParams.EnumParam {
-    @SerializedName("charge_automatically")
-    CHARGE_AUTOMATICALLY("charge_automatically"),
-
-    @SerializedName("send_invoice")
-    SEND_INVOICE("send_invoice");
-
-    @Getter(onMethod_ = {@Override})
-    private final String value;
-
-    Billing(String value) {
-      this.value = value;
     }
   }
 

--- a/src/main/java/com/stripe/param/SubscriptionScheduleCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionScheduleCreateParams.java
@@ -13,12 +13,6 @@ import lombok.Getter;
 @Getter
 public class SubscriptionScheduleCreateParams extends ApiRequestParams {
   /**
-   * This field has been renamed to `collection_method` and will be removed in a future API version.
-   */
-  @SerializedName("billing")
-  Billing billing;
-
-  /**
    * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
    * billing period. Pass an empty string to remove previously-defined thresholds.
    */
@@ -105,18 +99,6 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
   List<Phase> phases;
 
   /**
-   * This parameter has been replaced with `end_behavior` and will be removed in future API
-   * versions. Configures how the subscription schedule behaves when it ends. Possible values are
-   * `none`, `cancel`, `renew`, or `release`. `renew` will create a new subscription schedule
-   * revision by adding a new phase using the most recent phase's `plans` applied to a duration set
-   * by `renewal_interval`. `none` will stop the subscription schedule and cancel the underlying
-   * subscription. `cancel` is semantically the same as `none`. `release` will stop the subscription
-   * schedule, but keep the underlying subscription running.
-   */
-  @SerializedName("renewal_behavior")
-  RenewalBehavior renewalBehavior;
-
-  /**
    * This parameter has been deprecated and will be removed in future API versions. Configuration
    * for renewing the subscription schedule when it ends. Must be set if `renewal_behavior` is
    * `renew`. Otherwise, must not be set.
@@ -129,7 +111,6 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
   Object startDate;
 
   private SubscriptionScheduleCreateParams(
-      Billing billing,
       Object billingThresholds,
       CollectionMethod collectionMethod,
       String customer,
@@ -142,10 +123,8 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
       InvoiceSettings invoiceSettings,
       Map<String, String> metadata,
       List<Phase> phases,
-      RenewalBehavior renewalBehavior,
       RenewalInterval renewalInterval,
       Object startDate) {
-    this.billing = billing;
     this.billingThresholds = billingThresholds;
     this.collectionMethod = collectionMethod;
     this.customer = customer;
@@ -158,7 +137,6 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
     this.invoiceSettings = invoiceSettings;
     this.metadata = metadata;
     this.phases = phases;
-    this.renewalBehavior = renewalBehavior;
     this.renewalInterval = renewalInterval;
     this.startDate = startDate;
   }
@@ -168,8 +146,6 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
   }
 
   public static class Builder {
-    private Billing billing;
-
     private Object billingThresholds;
 
     private CollectionMethod collectionMethod;
@@ -194,8 +170,6 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
 
     private List<Phase> phases;
 
-    private RenewalBehavior renewalBehavior;
-
     private RenewalInterval renewalInterval;
 
     private Object startDate;
@@ -203,7 +177,6 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
     /** Finalize and obtain parameter instance from this builder. */
     public SubscriptionScheduleCreateParams build() {
       return new SubscriptionScheduleCreateParams(
-          this.billing,
           this.billingThresholds,
           this.collectionMethod,
           this.customer,
@@ -216,18 +189,8 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
           this.invoiceSettings,
           this.metadata,
           this.phases,
-          this.renewalBehavior,
           this.renewalInterval,
           this.startDate);
-    }
-
-    /**
-     * This field has been renamed to `collection_method` and will be removed in a future API
-     * version.
-     */
-    public Builder setBilling(Billing billing) {
-      this.billing = billing;
-      return this;
     }
 
     /**
@@ -414,20 +377,6 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
         this.phases = new ArrayList<>();
       }
       this.phases.addAll(elements);
-      return this;
-    }
-
-    /**
-     * This parameter has been replaced with `end_behavior` and will be removed in future API
-     * versions. Configures how the subscription schedule behaves when it ends. Possible values are
-     * `none`, `cancel`, `renew`, or `release`. `renew` will create a new subscription schedule
-     * revision by adding a new phase using the most recent phase's `plans` applied to a duration
-     * set by `renewal_interval`. `none` will stop the subscription schedule and cancel the
-     * underlying subscription. `cancel` is semantically the same as `none`. `release` will stop the
-     * subscription schedule, but keep the underlying subscription running.
-     */
-    public Builder setRenewalBehavior(RenewalBehavior renewalBehavior) {
-      this.renewalBehavior = renewalBehavior;
       return this;
     }
 
@@ -1559,21 +1508,6 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
     }
   }
 
-  public enum Billing implements ApiRequestParams.EnumParam {
-    @SerializedName("charge_automatically")
-    CHARGE_AUTOMATICALLY("charge_automatically"),
-
-    @SerializedName("send_invoice")
-    SEND_INVOICE("send_invoice");
-
-    @Getter(onMethod_ = {@Override})
-    private final String value;
-
-    Billing(String value) {
-      this.value = value;
-    }
-  }
-
   public enum CollectionMethod implements ApiRequestParams.EnumParam {
     @SerializedName("charge_automatically")
     CHARGE_AUTOMATICALLY("charge_automatically"),
@@ -1606,27 +1540,6 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
     private final String value;
 
     EndBehavior(String value) {
-      this.value = value;
-    }
-  }
-
-  public enum RenewalBehavior implements ApiRequestParams.EnumParam {
-    @SerializedName("cancel")
-    CANCEL("cancel"),
-
-    @SerializedName("none")
-    NONE("none"),
-
-    @SerializedName("release")
-    RELEASE("release"),
-
-    @SerializedName("renew")
-    RENEW("renew");
-
-    @Getter(onMethod_ = {@Override})
-    private final String value;
-
-    RenewalBehavior(String value) {
       this.value = value;
     }
   }

--- a/src/main/java/com/stripe/param/SubscriptionScheduleUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionScheduleUpdateParams.java
@@ -13,12 +13,6 @@ import lombok.Getter;
 @Getter
 public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
   /**
-   * This field has been renamed to `collection_method` and will be removed in a future API version.
-   */
-  @SerializedName("billing")
-  Billing billing;
-
-  /**
    * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
    * billing period. Pass an empty string to remove previously-defined thresholds.
    */
@@ -100,18 +94,6 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
   Boolean prorate;
 
   /**
-   * This parameter has been replaced with `end_behavior` and will be removed in future API
-   * versions. Configures how the subscription schedule behaves when it ends. Possible values are
-   * `none`, `cancel`, `renew`, or `release`. `renew` will create a new subscription schedule
-   * revision by adding a new phase using the most recent phase's `plans` applied to a duration set
-   * by `renewal_interval`. `none` will stop the subscription schedule and cancel the underlying
-   * subscription. `cancel` is semantically the same as `none`. `release` will stop the subscription
-   * schedule, but keep the underlying subscription running.
-   */
-  @SerializedName("renewal_behavior")
-  RenewalBehavior renewalBehavior;
-
-  /**
    * This parameter has been deprecated and will be removed in future API versions. Configuration
    * for renewing the subscription schedule when it ends. Must be set if `renewal_behavior` is
    * `renew`. Otherwise, must not be set.
@@ -120,7 +102,6 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
   RenewalInterval renewalInterval;
 
   private SubscriptionScheduleUpdateParams(
-      Billing billing,
       Object billingThresholds,
       CollectionMethod collectionMethod,
       Object defaultPaymentMethod,
@@ -132,9 +113,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
       Map<String, String> metadata,
       List<Phase> phases,
       Boolean prorate,
-      RenewalBehavior renewalBehavior,
       RenewalInterval renewalInterval) {
-    this.billing = billing;
     this.billingThresholds = billingThresholds;
     this.collectionMethod = collectionMethod;
     this.defaultPaymentMethod = defaultPaymentMethod;
@@ -146,7 +125,6 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
     this.metadata = metadata;
     this.phases = phases;
     this.prorate = prorate;
-    this.renewalBehavior = renewalBehavior;
     this.renewalInterval = renewalInterval;
   }
 
@@ -155,8 +133,6 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
   }
 
   public static class Builder {
-    private Billing billing;
-
     private Object billingThresholds;
 
     private CollectionMethod collectionMethod;
@@ -179,14 +155,11 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
 
     private Boolean prorate;
 
-    private RenewalBehavior renewalBehavior;
-
     private RenewalInterval renewalInterval;
 
     /** Finalize and obtain parameter instance from this builder. */
     public SubscriptionScheduleUpdateParams build() {
       return new SubscriptionScheduleUpdateParams(
-          this.billing,
           this.billingThresholds,
           this.collectionMethod,
           this.defaultPaymentMethod,
@@ -198,17 +171,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
           this.metadata,
           this.phases,
           this.prorate,
-          this.renewalBehavior,
           this.renewalInterval);
-    }
-
-    /**
-     * This field has been renamed to `collection_method` and will be removed in a future API
-     * version.
-     */
-    public Builder setBilling(Billing billing) {
-      this.billing = billing;
-      return this;
     }
 
     /**
@@ -407,20 +370,6 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
      */
     public Builder setProrate(Boolean prorate) {
       this.prorate = prorate;
-      return this;
-    }
-
-    /**
-     * This parameter has been replaced with `end_behavior` and will be removed in future API
-     * versions. Configures how the subscription schedule behaves when it ends. Possible values are
-     * `none`, `cancel`, `renew`, or `release`. `renew` will create a new subscription schedule
-     * revision by adding a new phase using the most recent phase's `plans` applied to a duration
-     * set by `renewal_interval`. `none` will stop the subscription schedule and cancel the
-     * underlying subscription. `cancel` is semantically the same as `none`. `release` will stop the
-     * subscription schedule, but keep the underlying subscription running.
-     */
-    public Builder setRenewalBehavior(RenewalBehavior renewalBehavior) {
-      this.renewalBehavior = renewalBehavior;
       return this;
     }
 
@@ -1637,21 +1586,6 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
     }
   }
 
-  public enum Billing implements ApiRequestParams.EnumParam {
-    @SerializedName("charge_automatically")
-    CHARGE_AUTOMATICALLY("charge_automatically"),
-
-    @SerializedName("send_invoice")
-    SEND_INVOICE("send_invoice");
-
-    @Getter(onMethod_ = {@Override})
-    private final String value;
-
-    Billing(String value) {
-      this.value = value;
-    }
-  }
-
   public enum CollectionMethod implements ApiRequestParams.EnumParam {
     @SerializedName("charge_automatically")
     CHARGE_AUTOMATICALLY("charge_automatically"),
@@ -1684,27 +1618,6 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
     private final String value;
 
     EndBehavior(String value) {
-      this.value = value;
-    }
-  }
-
-  public enum RenewalBehavior implements ApiRequestParams.EnumParam {
-    @SerializedName("cancel")
-    CANCEL("cancel"),
-
-    @SerializedName("none")
-    NONE("none"),
-
-    @SerializedName("release")
-    RELEASE("release"),
-
-    @SerializedName("renew")
-    RENEW("renew");
-
-    @Getter(onMethod_ = {@Override})
-    private final String value;
-
-    RenewalBehavior(String value) {
       this.value = value;
     }
   }

--- a/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
@@ -23,12 +23,6 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
   BigDecimal applicationFeePercent;
 
   /**
-   * This field has been renamed to `collection_method` and will be removed in a future API version.
-   */
-  @SerializedName("billing")
-  Billing billing;
-
-  /**
    * Either `now` or `unchanged`. Setting the value to `now` resets the subscription's billing cycle
    * anchor to the current time. For more information, see the billing cycle
    * [documentation](https://stripe.com/docs/billing/subscriptions/billing-cycle).
@@ -208,7 +202,6 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
 
   private SubscriptionUpdateParams(
       BigDecimal applicationFeePercent,
-      Billing billing,
       BillingCycleAnchor billingCycleAnchor,
       Object billingThresholds,
       Object cancelAt,
@@ -232,7 +225,6 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
       Object trialEnd,
       Boolean trialFromPlan) {
     this.applicationFeePercent = applicationFeePercent;
-    this.billing = billing;
     this.billingCycleAnchor = billingCycleAnchor;
     this.billingThresholds = billingThresholds;
     this.cancelAt = cancelAt;
@@ -263,8 +255,6 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
 
   public static class Builder {
     private BigDecimal applicationFeePercent;
-
-    private Billing billing;
 
     private BillingCycleAnchor billingCycleAnchor;
 
@@ -314,7 +304,6 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
     public SubscriptionUpdateParams build() {
       return new SubscriptionUpdateParams(
           this.applicationFeePercent,
-          this.billing,
           this.billingCycleAnchor,
           this.billingThresholds,
           this.cancelAt,
@@ -349,15 +338,6 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
      */
     public Builder setApplicationFeePercent(BigDecimal applicationFeePercent) {
       this.applicationFeePercent = applicationFeePercent;
-      return this;
-    }
-
-    /**
-     * This field has been renamed to `collection_method` and will be removed in a future API
-     * version.
-     */
-    public Builder setBilling(Billing billing) {
-      this.billing = billing;
       return this;
     }
 
@@ -1285,21 +1265,6 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
         this.extraParams.putAll(map);
         return this;
       }
-    }
-  }
-
-  public enum Billing implements ApiRequestParams.EnumParam {
-    @SerializedName("charge_automatically")
-    CHARGE_AUTOMATICALLY("charge_automatically"),
-
-    @SerializedName("send_invoice")
-    SEND_INVOICE("send_invoice");
-
-    @Getter(onMethod_ = {@Override})
-    private final String value;
-
-    Billing(String value) {
-      this.value = value;
     }
   }
 

--- a/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
+++ b/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
@@ -465,7 +465,10 @@ public class WebhookEndpointCreateParams extends ApiRequestParams {
     VERSION_2019_09_09("2019-09-09"),
 
     @SerializedName("2019-10-08")
-    VERSION_2019_10_08("2019-10-08");
+    VERSION_2019_10_08("2019-10-08"),
+
+    @SerializedName("2019-10-17")
+    VERSION_2019_10_17("2019-10-17");
 
     @Getter(onMethod_ = {@Override})
     private final String value;

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -32,7 +32,7 @@ import org.mockito.Mockito;
 
 public class BaseStripeTest {
   // If changing this number, please also change it in `.travis.yml`.
-  private static final String MOCK_MINIMUM_VERSION = "0.68.0";
+  private static final String MOCK_MINIMUM_VERSION = "0.69.0";
 
   private static String port;
 


### PR DESCRIPTION
r? @remi-stripe
cc @stripe/api-libraries

Changes:
- Pin to API version `2019-10-17`
- Remove `account_balance` from Customer model and parameter classes
- Remove `billing` from Invoice, Subscription and Subscription Schedule model and parameter classes
- Remove `start` from Subscription model
- Remove `renewal_behavior` from Subscription Schedule parameter classes