### PR TITLE
Codegen for openapi a63c117

### DIFF
--- a/src/main/java/com/stripe/model/AccountLink.java
+++ b/src/main/java/com/stripe/model/AccountLink.java
@@ -32,16 +32,16 @@ public class AccountLink extends ApiResource {
   String url;
 
   /**
-   * Creates an AccountLink object that returns a Stripe URL that the user can redirect their user
-   * to in order to take them through the Connect Onboarding flow.
+   * Creates an AccountLink object that returns a single-use Stripe URL that the user can redirect
+   * their user to in order to take them through the Connect Onboarding flow.
    */
   public static AccountLink create(Map<String, Object> params) throws StripeException {
     return create(params, (RequestOptions) null);
   }
 
   /**
-   * Creates an AccountLink object that returns a Stripe URL that the user can redirect their user
-   * to in order to take them through the Connect Onboarding flow.
+   * Creates an AccountLink object that returns a single-use Stripe URL that the user can redirect
+   * their user to in order to take them through the Connect Onboarding flow.
    */
   public static AccountLink create(Map<String, Object> params, RequestOptions options)
       throws StripeException {
@@ -51,16 +51,16 @@ public class AccountLink extends ApiResource {
   }
 
   /**
-   * Creates an AccountLink object that returns a Stripe URL that the user can redirect their user
-   * to in order to take them through the Connect Onboarding flow.
+   * Creates an AccountLink object that returns a single-use Stripe URL that the user can redirect
+   * their user to in order to take them through the Connect Onboarding flow.
    */
   public static AccountLink create(AccountLinkCreateParams params) throws StripeException {
     return create(params, (RequestOptions) null);
   }
 
   /**
-   * Creates an AccountLink object that returns a Stripe URL that the user can redirect their user
-   * to in order to take them through the Connect Onboarding flow.
+   * Creates an AccountLink object that returns a single-use Stripe URL that the user can redirect
+   * their user to in order to take them through the Connect Onboarding flow.
    */
   public static AccountLink create(AccountLinkCreateParams params, RequestOptions options)
       throws StripeException {

--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -1236,6 +1236,15 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
       String iin;
 
       /**
+       * Installment details for this payment (Mexico only).
+       *
+       * <p>For more information, see the [installments integration
+       * guide](https://stripe.com/docs/payments/installments).
+       */
+      @SerializedName("installments")
+      Installments installments;
+
+      /**
        * Issuer bank name of the card. (Only for internal use only and not typically available in
        * standard API requests.)
        */
@@ -1282,6 +1291,15 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
          */
         @SerializedName("cvc_check")
         String cvcCheck;
+      }
+
+      @Getter
+      @Setter
+      @EqualsAndHashCode(callSuper = false)
+      public static class Installments extends StripeObject {
+        /** Installment plan selected for the payment. */
+        @SerializedName("plan")
+        PaymentIntent.PaymentMethodOptions.Card.Installments.Plan plan;
       }
 
       @Getter

--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -1245,8 +1245,8 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
   @EqualsAndHashCode(callSuper = false)
   public static class CustomerTaxId extends StripeObject {
     /**
-     * The type of the tax ID, one of `au_abn`, `ch_vat`, `eu_vat`, `in_gst`, `no_vat`, `nz_gst`,
-     * `unknown`, or `za_vat`.
+     * The type of the tax ID, one of `au_abn`, `ch_vat`, `eu_vat`, `in_gst`, `mx_rfc`, `no_vat`,
+     * `nz_gst`, `unknown`, or `za_vat`.
      */
     @SerializedName("type")
     String type;

--- a/src/main/java/com/stripe/model/PaymentIntent.java
+++ b/src/main/java/com/stripe/model/PaymentIntent.java
@@ -1086,6 +1086,15 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
     @EqualsAndHashCode(callSuper = false)
     public static class Card extends StripeObject {
       /**
+       * Installment details for this payment (Mexico only).
+       *
+       * <p>For more information, see the [installments integration
+       * guide](https://stripe.com/docs/payments/installments).
+       */
+      @SerializedName("installments")
+      Installments installments;
+
+      /**
        * We strongly recommend that you rely on our SCA Engine to automatically prompt your
        * customers for authentication based on risk level and [other
        * requirements](https://stripe.com/docs/strong-customer-authentication). However, if you wish
@@ -1097,6 +1106,46 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
        */
       @SerializedName("request_three_d_secure")
       String requestThreeDSecure;
+
+      @Getter
+      @Setter
+      @EqualsAndHashCode(callSuper = false)
+      public static class Installments extends StripeObject {
+        /** Installment plans that may be selected for this PaymentIntent. */
+        @SerializedName("available_plans")
+        List<PaymentIntent.PaymentMethodOptions.Card.Installments.Plan> availablePlans;
+
+        /** Whether Installments are enabled for this PaymentIntent. */
+        @SerializedName("enabled")
+        Boolean enabled;
+
+        /** Installment plan selected for this PaymentIntent. */
+        @SerializedName("plan")
+        Plan plan;
+
+        @Getter
+        @Setter
+        @EqualsAndHashCode(callSuper = false)
+        public static class Plan extends StripeObject {
+          /**
+           * For `fixed_count` installment plans, this is the number of installment payments your
+           * customer will make to their credit card.
+           */
+          @SerializedName("count")
+          Long count;
+
+          /**
+           * For `fixed_count` installment plans, this is the interval between installment payments
+           * your customer will make to their credit card. One of `month`.
+           */
+          @SerializedName("interval")
+          String interval;
+
+          /** Type of installment plan, one of `fixed_count`. */
+          @SerializedName("type")
+          String type;
+        }
+      }
     }
   }
 

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -170,9 +170,24 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
   @SerializedName("metadata")
   Map<String, String> metadata;
 
+  /**
+   * Specifies the approximate timestamp on which any pending invoice items will be billed according
+   * to the schedule provided at `pending_invoice_item_interval`.
+   */
+  @SerializedName("next_pending_invoice_item_invoice")
+  Long nextPendingInvoiceItemInvoice;
+
   /** String representing the object's type. Objects of the same type share the same value. */
   @SerializedName("object")
   String object;
+
+  /**
+   * Specifies an interval for how often to bill for any pending invoice items. It is analogous to
+   * calling [Create an invoice](https://stripe.com/docs/api#create_invoice) for the given
+   * subscription at the specified interval.
+   */
+  @SerializedName("pending_invoice_item_interval")
+  PendingInvoiceItemInterval pendingInvoiceItemInterval;
 
   /**
    * You can use this [SetupIntent](https://stripe.com/docs/api/setup_intents) to collect user
@@ -683,5 +698,22 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
      */
     @SerializedName("reset_billing_cycle_anchor")
     Boolean resetBillingCycleAnchor;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class PendingInvoiceItemInterval extends StripeObject {
+    /** Specifies invoicing frequency. Either `day`, `week`, `month` or `year`. */
+    @SerializedName("interval")
+    String interval;
+
+    /**
+     * The number of intervals between invoices. For example, `interval=month` and
+     * `interval_count=3` bills every 3 months. Maximum of one year interval allowed (1 year, 12
+     * months, or 52 weeks).
+     */
+    @SerializedName("interval_count")
+    Long intervalCount;
   }
 }

--- a/src/main/java/com/stripe/model/TaxId.java
+++ b/src/main/java/com/stripe/model/TaxId.java
@@ -49,8 +49,8 @@ public class TaxId extends ApiResource implements HasId {
   String object;
 
   /**
-   * Type of the tax ID, one of `au_abn`, `ch_vat`, `eu_vat`, `in_gst`, `no_vat`, `nz_gst`,
-   * `unknown`, or `za_vat`.
+   * Type of the tax ID, one of `au_abn`, `ch_vat`, `eu_vat`, `in_gst`, `mx_rfc`, `no_vat`,
+   * `nz_gst`, `za_vat`, or `unknown`.
    */
   @SerializedName("type")
   String type;

--- a/src/main/java/com/stripe/model/WebhookEndpoint.java
+++ b/src/main/java/com/stripe/model/WebhookEndpoint.java
@@ -36,7 +36,8 @@ public class WebhookEndpoint extends ApiResource implements HasId {
   Boolean deleted;
 
   /**
-   * The list of events to enable for this endpoint. You may specify `['*']` to enable all events.
+   * The list of events to enable for this endpoint. `['*']` indicates that all events are enabled,
+   * except those that require explicit selection.
    */
   @SerializedName("enabled_events")
   List<String> enabledEvents;

--- a/src/main/java/com/stripe/param/AccountLinkCreateParams.java
+++ b/src/main/java/com/stripe/param/AccountLinkCreateParams.java
@@ -38,7 +38,10 @@ public class AccountLinkCreateParams extends ApiRequestParams {
   @SerializedName("failure_url")
   String failureUrl;
 
-  /** The URL that the user will be redirected to upon completing the linked flow successfully. */
+  /**
+   * The URL that the user will be redirected to upon leaving or completing the linked flow
+   * successfully.
+   */
   @SerializedName("success_url")
   String successUrl;
 
@@ -170,7 +173,10 @@ public class AccountLinkCreateParams extends ApiRequestParams {
       return this;
     }
 
-    /** The URL that the user will be redirected to upon completing the linked flow successfully. */
+    /**
+     * The URL that the user will be redirected to upon leaving or completing the linked flow
+     * successfully.
+     */
     public Builder setSuccessUrl(String successUrl) {
       this.successUrl = successUrl;
       return this;

--- a/src/main/java/com/stripe/param/CustomerCreateParams.java
+++ b/src/main/java/com/stripe/param/CustomerCreateParams.java
@@ -1062,8 +1062,8 @@ public class CustomerCreateParams extends ApiRequestParams {
     Map<String, Object> extraParams;
 
     /**
-     * Type of the tax ID, one of `au_abn`, `ch_vat`, `eu_vat`, `in_gst`, `no_vat`, `nz_gst`, or
-     * `za_vat`.
+     * Type of the tax ID, one of `au_abn`, `ch_vat`, `eu_vat`, `in_gst`, `mx_rfc`, `no_vat`,
+     * `nz_gst`, or `za_vat`.
      */
     @SerializedName("type")
     Type type;
@@ -1121,8 +1121,8 @@ public class CustomerCreateParams extends ApiRequestParams {
       }
 
       /**
-       * Type of the tax ID, one of `au_abn`, `ch_vat`, `eu_vat`, `in_gst`, `no_vat`, `nz_gst`, or
-       * `za_vat`.
+       * Type of the tax ID, one of `au_abn`, `ch_vat`, `eu_vat`, `in_gst`, `mx_rfc`, `no_vat`,
+       * `nz_gst`, or `za_vat`.
        */
       public Builder setType(Type type) {
         this.type = type;
@@ -1148,6 +1148,9 @@ public class CustomerCreateParams extends ApiRequestParams {
 
       @SerializedName("in_gst")
       IN_GST("in_gst"),
+
+      @SerializedName("mx_rfc")
+      MX_RFC("mx_rfc"),
 
       @SerializedName("no_vat")
       NO_VAT("no_vat"),

--- a/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
@@ -456,6 +456,15 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       Map<String, Object> extraParams;
 
       /**
+       * Installment configuration for payments attempted on this PaymentIntent (Mexico Only).
+       *
+       * <p>For more information, see the [installments integration
+       * guide](https://stripe.com/docs/payments/installments).
+       */
+      @SerializedName("installments")
+      Installments installments;
+
+      /**
        * When specified, this parameter indicates that a transaction will be marked as MOTO (Mail
        * Order Telephone Order) and thus out of scope for SCA. This parameter can only be provided
        * during confirmation.
@@ -477,8 +486,12 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       RequestThreeDSecure requestThreeDSecure;
 
       private Card(
-          Map<String, Object> extraParams, Boolean moto, RequestThreeDSecure requestThreeDSecure) {
+          Map<String, Object> extraParams,
+          Installments installments,
+          Boolean moto,
+          RequestThreeDSecure requestThreeDSecure) {
         this.extraParams = extraParams;
+        this.installments = installments;
         this.moto = moto;
         this.requestThreeDSecure = requestThreeDSecure;
       }
@@ -490,13 +503,15 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       public static class Builder {
         private Map<String, Object> extraParams;
 
+        private Installments installments;
+
         private Boolean moto;
 
         private RequestThreeDSecure requestThreeDSecure;
 
         /** Finalize and obtain parameter instance from this builder. */
         public Card build() {
-          return new Card(this.extraParams, this.moto, this.requestThreeDSecure);
+          return new Card(this.extraParams, this.installments, this.moto, this.requestThreeDSecure);
         }
 
         /**
@@ -528,6 +543,17 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
         }
 
         /**
+         * Installment configuration for payments attempted on this PaymentIntent (Mexico Only).
+         *
+         * <p>For more information, see the [installments integration
+         * guide](https://stripe.com/docs/payments/installments).
+         */
+        public Builder setInstallments(Installments installments) {
+          this.installments = installments;
+          return this;
+        }
+
+        /**
          * When specified, this parameter indicates that a transaction will be marked as MOTO (Mail
          * Order Telephone Order) and thus out of scope for SCA. This parameter can only be provided
          * during confirmation.
@@ -550,6 +576,250 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
         public Builder setRequestThreeDSecure(RequestThreeDSecure requestThreeDSecure) {
           this.requestThreeDSecure = requestThreeDSecure;
           return this;
+        }
+      }
+
+      @Getter
+      public static class Installments {
+        /**
+         * Setting to true enables installments for this PaymentIntent. This will cause the response
+         * to contain a list of available installment plans. Setting to false will prevent any
+         * selected plan from applying to a charge.
+         */
+        @SerializedName("enabled")
+        Boolean enabled;
+
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /**
+         * The selected installment plan to use for this payment attempt. This parameter can only be
+         * provided during confirmation.
+         */
+        @SerializedName("plan")
+        Object plan;
+
+        private Installments(Boolean enabled, Map<String, Object> extraParams, Object plan) {
+          this.enabled = enabled;
+          this.extraParams = extraParams;
+          this.plan = plan;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Boolean enabled;
+
+          private Map<String, Object> extraParams;
+
+          private Object plan;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public Installments build() {
+            return new Installments(this.enabled, this.extraParams, this.plan);
+          }
+
+          /**
+           * Setting to true enables installments for this PaymentIntent. This will cause the
+           * response to contain a list of available installment plans. Setting to false will
+           * prevent any selected plan from applying to a charge.
+           */
+          public Builder setEnabled(Boolean enabled) {
+            this.enabled = enabled;
+            return this;
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * PaymentIntentConfirmParams.PaymentMethodOptions.Card.Installments#extraParams} for the
+           * field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * PaymentIntentConfirmParams.PaymentMethodOptions.Card.Installments#extraParams} for the
+           * field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /**
+           * The selected installment plan to use for this payment attempt. This parameter can only
+           * be provided during confirmation.
+           */
+          public Builder setPlan(Plan plan) {
+            this.plan = plan;
+            return this;
+          }
+
+          /**
+           * The selected installment plan to use for this payment attempt. This parameter can only
+           * be provided during confirmation.
+           */
+          public Builder setPlan(EmptyParam plan) {
+            this.plan = plan;
+            return this;
+          }
+        }
+
+        @Getter
+        public static class Plan {
+          /**
+           * For `fixed_count` installment plans, this is the number of installment payments your
+           * customer will make to their credit card.
+           */
+          @SerializedName("count")
+          Long count;
+
+          /**
+           * Map of extra parameters for custom features not available in this client library. The
+           * content in this map is not serialized under this field's {@code @SerializedName} value.
+           * Instead, each key/value pair is serialized as if the key is a root-level field
+           * (serialized) name in this param object. Effectively, this map is flattened to its
+           * parent instance.
+           */
+          @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+          Map<String, Object> extraParams;
+
+          /**
+           * For `fixed_count` installment plans, this is the interval between installment payments
+           * your customer will make to their credit card. One of `month`.
+           */
+          @SerializedName("interval")
+          Interval interval;
+
+          /** Type of installment plan, one of `fixed_count`. */
+          @SerializedName("type")
+          Type type;
+
+          private Plan(Long count, Map<String, Object> extraParams, Interval interval, Type type) {
+            this.count = count;
+            this.extraParams = extraParams;
+            this.interval = interval;
+            this.type = type;
+          }
+
+          public static Builder builder() {
+            return new Builder();
+          }
+
+          public static class Builder {
+            private Long count;
+
+            private Map<String, Object> extraParams;
+
+            private Interval interval;
+
+            private Type type;
+
+            /** Finalize and obtain parameter instance from this builder. */
+            public Plan build() {
+              return new Plan(this.count, this.extraParams, this.interval, this.type);
+            }
+
+            /**
+             * For `fixed_count` installment plans, this is the number of installment payments your
+             * customer will make to their credit card.
+             */
+            public Builder setCount(Long count) {
+              this.count = count;
+              return this;
+            }
+
+            /**
+             * Add a key/value pair to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * PaymentIntentConfirmParams.PaymentMethodOptions.Card.Installments.Plan#extraParams}
+             * for the field documentation.
+             */
+            public Builder putExtraParam(String key, Object value) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.put(key, value);
+              return this;
+            }
+
+            /**
+             * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * PaymentIntentConfirmParams.PaymentMethodOptions.Card.Installments.Plan#extraParams}
+             * for the field documentation.
+             */
+            public Builder putAllExtraParam(Map<String, Object> map) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.putAll(map);
+              return this;
+            }
+
+            /**
+             * For `fixed_count` installment plans, this is the interval between installment
+             * payments your customer will make to their credit card. One of `month`.
+             */
+            public Builder setInterval(Interval interval) {
+              this.interval = interval;
+              return this;
+            }
+
+            /** Type of installment plan, one of `fixed_count`. */
+            public Builder setType(Type type) {
+              this.type = type;
+              return this;
+            }
+          }
+
+          public enum Interval implements ApiRequestParams.EnumParam {
+            @SerializedName("month")
+            MONTH("month");
+
+            @Getter(onMethod_ = {@Override})
+            private final String value;
+
+            Interval(String value) {
+              this.value = value;
+            }
+          }
+
+          public enum Type implements ApiRequestParams.EnumParam {
+            @SerializedName("fixed_count")
+            FIXED_COUNT("fixed_count");
+
+            @Getter(onMethod_ = {@Override})
+            private final String value;
+
+            Type(String value) {
+              this.value = value;
+            }
+          }
         }
       }
 

--- a/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
@@ -2,6 +2,7 @@ package com.stripe.param;
 
 import com.google.gson.annotations.SerializedName;
 import com.stripe.net.ApiRequestParams;
+import com.stripe.param.common.EmptyParam;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -827,6 +828,15 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       Map<String, Object> extraParams;
 
       /**
+       * Installment configuration for payments attempted on this PaymentIntent (Mexico Only).
+       *
+       * <p>For more information, see the [installments integration
+       * guide](https://stripe.com/docs/payments/installments).
+       */
+      @SerializedName("installments")
+      Installments installments;
+
+      /**
        * When specified, this parameter indicates that a transaction will be marked as MOTO (Mail
        * Order Telephone Order) and thus out of scope for SCA. This parameter can only be provided
        * during confirmation.
@@ -848,8 +858,12 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       RequestThreeDSecure requestThreeDSecure;
 
       private Card(
-          Map<String, Object> extraParams, Boolean moto, RequestThreeDSecure requestThreeDSecure) {
+          Map<String, Object> extraParams,
+          Installments installments,
+          Boolean moto,
+          RequestThreeDSecure requestThreeDSecure) {
         this.extraParams = extraParams;
+        this.installments = installments;
         this.moto = moto;
         this.requestThreeDSecure = requestThreeDSecure;
       }
@@ -861,13 +875,15 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       public static class Builder {
         private Map<String, Object> extraParams;
 
+        private Installments installments;
+
         private Boolean moto;
 
         private RequestThreeDSecure requestThreeDSecure;
 
         /** Finalize and obtain parameter instance from this builder. */
         public Card build() {
-          return new Card(this.extraParams, this.moto, this.requestThreeDSecure);
+          return new Card(this.extraParams, this.installments, this.moto, this.requestThreeDSecure);
         }
 
         /**
@@ -899,6 +915,17 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
         }
 
         /**
+         * Installment configuration for payments attempted on this PaymentIntent (Mexico Only).
+         *
+         * <p>For more information, see the [installments integration
+         * guide](https://stripe.com/docs/payments/installments).
+         */
+        public Builder setInstallments(Installments installments) {
+          this.installments = installments;
+          return this;
+        }
+
+        /**
          * When specified, this parameter indicates that a transaction will be marked as MOTO (Mail
          * Order Telephone Order) and thus out of scope for SCA. This parameter can only be provided
          * during confirmation.
@@ -921,6 +948,250 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
         public Builder setRequestThreeDSecure(RequestThreeDSecure requestThreeDSecure) {
           this.requestThreeDSecure = requestThreeDSecure;
           return this;
+        }
+      }
+
+      @Getter
+      public static class Installments {
+        /**
+         * Setting to true enables installments for this PaymentIntent. This will cause the response
+         * to contain a list of available installment plans. Setting to false will prevent any
+         * selected plan from applying to a charge.
+         */
+        @SerializedName("enabled")
+        Boolean enabled;
+
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /**
+         * The selected installment plan to use for this payment attempt. This parameter can only be
+         * provided during confirmation.
+         */
+        @SerializedName("plan")
+        Object plan;
+
+        private Installments(Boolean enabled, Map<String, Object> extraParams, Object plan) {
+          this.enabled = enabled;
+          this.extraParams = extraParams;
+          this.plan = plan;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Boolean enabled;
+
+          private Map<String, Object> extraParams;
+
+          private Object plan;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public Installments build() {
+            return new Installments(this.enabled, this.extraParams, this.plan);
+          }
+
+          /**
+           * Setting to true enables installments for this PaymentIntent. This will cause the
+           * response to contain a list of available installment plans. Setting to false will
+           * prevent any selected plan from applying to a charge.
+           */
+          public Builder setEnabled(Boolean enabled) {
+            this.enabled = enabled;
+            return this;
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * PaymentIntentCreateParams.PaymentMethodOptions.Card.Installments#extraParams} for the
+           * field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * PaymentIntentCreateParams.PaymentMethodOptions.Card.Installments#extraParams} for the
+           * field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /**
+           * The selected installment plan to use for this payment attempt. This parameter can only
+           * be provided during confirmation.
+           */
+          public Builder setPlan(Plan plan) {
+            this.plan = plan;
+            return this;
+          }
+
+          /**
+           * The selected installment plan to use for this payment attempt. This parameter can only
+           * be provided during confirmation.
+           */
+          public Builder setPlan(EmptyParam plan) {
+            this.plan = plan;
+            return this;
+          }
+        }
+
+        @Getter
+        public static class Plan {
+          /**
+           * For `fixed_count` installment plans, this is the number of installment payments your
+           * customer will make to their credit card.
+           */
+          @SerializedName("count")
+          Long count;
+
+          /**
+           * Map of extra parameters for custom features not available in this client library. The
+           * content in this map is not serialized under this field's {@code @SerializedName} value.
+           * Instead, each key/value pair is serialized as if the key is a root-level field
+           * (serialized) name in this param object. Effectively, this map is flattened to its
+           * parent instance.
+           */
+          @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+          Map<String, Object> extraParams;
+
+          /**
+           * For `fixed_count` installment plans, this is the interval between installment payments
+           * your customer will make to their credit card. One of `month`.
+           */
+          @SerializedName("interval")
+          Interval interval;
+
+          /** Type of installment plan, one of `fixed_count`. */
+          @SerializedName("type")
+          Type type;
+
+          private Plan(Long count, Map<String, Object> extraParams, Interval interval, Type type) {
+            this.count = count;
+            this.extraParams = extraParams;
+            this.interval = interval;
+            this.type = type;
+          }
+
+          public static Builder builder() {
+            return new Builder();
+          }
+
+          public static class Builder {
+            private Long count;
+
+            private Map<String, Object> extraParams;
+
+            private Interval interval;
+
+            private Type type;
+
+            /** Finalize and obtain parameter instance from this builder. */
+            public Plan build() {
+              return new Plan(this.count, this.extraParams, this.interval, this.type);
+            }
+
+            /**
+             * For `fixed_count` installment plans, this is the number of installment payments your
+             * customer will make to their credit card.
+             */
+            public Builder setCount(Long count) {
+              this.count = count;
+              return this;
+            }
+
+            /**
+             * Add a key/value pair to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * PaymentIntentCreateParams.PaymentMethodOptions.Card.Installments.Plan#extraParams}
+             * for the field documentation.
+             */
+            public Builder putExtraParam(String key, Object value) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.put(key, value);
+              return this;
+            }
+
+            /**
+             * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * PaymentIntentCreateParams.PaymentMethodOptions.Card.Installments.Plan#extraParams}
+             * for the field documentation.
+             */
+            public Builder putAllExtraParam(Map<String, Object> map) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.putAll(map);
+              return this;
+            }
+
+            /**
+             * For `fixed_count` installment plans, this is the interval between installment
+             * payments your customer will make to their credit card. One of `month`.
+             */
+            public Builder setInterval(Interval interval) {
+              this.interval = interval;
+              return this;
+            }
+
+            /** Type of installment plan, one of `fixed_count`. */
+            public Builder setType(Type type) {
+              this.type = type;
+              return this;
+            }
+          }
+
+          public enum Interval implements ApiRequestParams.EnumParam {
+            @SerializedName("month")
+            MONTH("month");
+
+            @Getter(onMethod_ = {@Override})
+            private final String value;
+
+            Interval(String value) {
+              this.value = value;
+            }
+          }
+
+          public enum Type implements ApiRequestParams.EnumParam {
+            @SerializedName("fixed_count")
+            FIXED_COUNT("fixed_count");
+
+            @Getter(onMethod_ = {@Override})
+            private final String value;
+
+            Type(String value) {
+              this.value = value;
+            }
+          }
         }
       }
 

--- a/src/main/java/com/stripe/param/SubscriptionCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionCreateParams.java
@@ -156,6 +156,14 @@ public class SubscriptionCreateParams extends ApiRequestParams {
   PaymentBehavior paymentBehavior;
 
   /**
+   * Specifies an interval for how often to bill for any pending invoice items. It is analogous to
+   * calling [Create an invoice](https://stripe.com/docs/api#create_invoice) for the given
+   * subscription at the specified interval.
+   */
+  @SerializedName("pending_invoice_item_interval")
+  Object pendingInvoiceItemInterval;
+
+  /**
    * Boolean (defaults to `true`) telling us whether to [credit for unused
    * time](https://stripe.com/docs/subscriptions/billing-cycle#prorations) when the billing cycle
    * changes (e.g. when switching plans, resetting `billing_cycle_anchor=now`, or starting a trial),
@@ -230,6 +238,7 @@ public class SubscriptionCreateParams extends ApiRequestParams {
       Map<String, String> metadata,
       Boolean offSession,
       PaymentBehavior paymentBehavior,
+      Object pendingInvoiceItemInterval,
       Boolean prorate,
       Object taxPercent,
       TransferData transferData,
@@ -255,6 +264,7 @@ public class SubscriptionCreateParams extends ApiRequestParams {
     this.metadata = metadata;
     this.offSession = offSession;
     this.paymentBehavior = paymentBehavior;
+    this.pendingInvoiceItemInterval = pendingInvoiceItemInterval;
     this.prorate = prorate;
     this.taxPercent = taxPercent;
     this.transferData = transferData;
@@ -306,6 +316,8 @@ public class SubscriptionCreateParams extends ApiRequestParams {
 
     private PaymentBehavior paymentBehavior;
 
+    private Object pendingInvoiceItemInterval;
+
     private Boolean prorate;
 
     private Object taxPercent;
@@ -340,6 +352,7 @@ public class SubscriptionCreateParams extends ApiRequestParams {
           this.metadata,
           this.offSession,
           this.paymentBehavior,
+          this.pendingInvoiceItemInterval,
           this.prorate,
           this.taxPercent,
           this.transferData,
@@ -645,6 +658,27 @@ public class SubscriptionCreateParams extends ApiRequestParams {
      */
     public Builder setPaymentBehavior(PaymentBehavior paymentBehavior) {
       this.paymentBehavior = paymentBehavior;
+      return this;
+    }
+
+    /**
+     * Specifies an interval for how often to bill for any pending invoice items. It is analogous to
+     * calling [Create an invoice](https://stripe.com/docs/api#create_invoice) for the given
+     * subscription at the specified interval.
+     */
+    public Builder setPendingInvoiceItemInterval(
+        PendingInvoiceItemInterval pendingInvoiceItemInterval) {
+      this.pendingInvoiceItemInterval = pendingInvoiceItemInterval;
+      return this;
+    }
+
+    /**
+     * Specifies an interval for how often to bill for any pending invoice items. It is analogous to
+     * calling [Create an invoice](https://stripe.com/docs/api#create_invoice) for the given
+     * subscription at the specified interval.
+     */
+    public Builder setPendingInvoiceItemInterval(EmptyParam pendingInvoiceItemInterval) {
+      this.pendingInvoiceItemInterval = pendingInvoiceItemInterval;
       return this;
     }
 
@@ -1113,6 +1147,119 @@ public class SubscriptionCreateParams extends ApiRequestParams {
           this.usageGte = usageGte;
           return this;
         }
+      }
+    }
+  }
+
+  @Getter
+  public static class PendingInvoiceItemInterval {
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /** Specifies invoicing frequency. Either `day`, `week`, `month` or `year`. */
+    @SerializedName("interval")
+    Interval interval;
+
+    /**
+     * The number of intervals between invoices. For example, `interval=month` and
+     * `interval_count=3` bills every 3 months. Maximum of one year interval allowed (1 year, 12
+     * months, or 52 weeks).
+     */
+    @SerializedName("interval_count")
+    Long intervalCount;
+
+    private PendingInvoiceItemInterval(
+        Map<String, Object> extraParams, Interval interval, Long intervalCount) {
+      this.extraParams = extraParams;
+      this.interval = interval;
+      this.intervalCount = intervalCount;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Map<String, Object> extraParams;
+
+      private Interval interval;
+
+      private Long intervalCount;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public PendingInvoiceItemInterval build() {
+        return new PendingInvoiceItemInterval(this.extraParams, this.interval, this.intervalCount);
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * SubscriptionCreateParams.PendingInvoiceItemInterval#extraParams} for the field
+       * documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link SubscriptionCreateParams.PendingInvoiceItemInterval#extraParams} for the field
+       * documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** Specifies invoicing frequency. Either `day`, `week`, `month` or `year`. */
+      public Builder setInterval(Interval interval) {
+        this.interval = interval;
+        return this;
+      }
+
+      /**
+       * The number of intervals between invoices. For example, `interval=month` and
+       * `interval_count=3` bills every 3 months. Maximum of one year interval allowed (1 year, 12
+       * months, or 52 weeks).
+       */
+      public Builder setIntervalCount(Long intervalCount) {
+        this.intervalCount = intervalCount;
+        return this;
+      }
+    }
+
+    public enum Interval implements ApiRequestParams.EnumParam {
+      @SerializedName("day")
+      DAY("day"),
+
+      @SerializedName("month")
+      MONTH("month"),
+
+      @SerializedName("week")
+      WEEK("week"),
+
+      @SerializedName("year")
+      YEAR("year");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      Interval(String value) {
+        this.value = value;
       }
     }
   }

--- a/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
@@ -143,6 +143,14 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
   PaymentBehavior paymentBehavior;
 
   /**
+   * Specifies an interval for how often to bill for any pending invoice items. It is analogous to
+   * calling [Create an invoice](https://stripe.com/docs/api#create_invoice) for the given
+   * subscription at the specified interval.
+   */
+  @SerializedName("pending_invoice_item_interval")
+  Object pendingInvoiceItemInterval;
+
+  /**
    * Boolean (defaults to `true`) telling us whether to [credit for unused
    * time](https://stripe.com/docs/subscriptions/billing-cycle#prorations) when the billing cycle
    * changes (e.g. when switching plans, resetting `billing_cycle_anchor=now`, or starting a trial),
@@ -218,6 +226,7 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
       Map<String, String> metadata,
       Boolean offSession,
       PaymentBehavior paymentBehavior,
+      Object pendingInvoiceItemInterval,
       Boolean prorate,
       Long prorationDate,
       Object taxPercent,
@@ -241,6 +250,7 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
     this.metadata = metadata;
     this.offSession = offSession;
     this.paymentBehavior = paymentBehavior;
+    this.pendingInvoiceItemInterval = pendingInvoiceItemInterval;
     this.prorate = prorate;
     this.prorationDate = prorationDate;
     this.taxPercent = taxPercent;
@@ -288,6 +298,8 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
 
     private PaymentBehavior paymentBehavior;
 
+    private Object pendingInvoiceItemInterval;
+
     private Boolean prorate;
 
     private Long prorationDate;
@@ -320,6 +332,7 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
           this.metadata,
           this.offSession,
           this.paymentBehavior,
+          this.pendingInvoiceItemInterval,
           this.prorate,
           this.prorationDate,
           this.taxPercent,
@@ -646,6 +659,27 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
      */
     public Builder setPaymentBehavior(PaymentBehavior paymentBehavior) {
       this.paymentBehavior = paymentBehavior;
+      return this;
+    }
+
+    /**
+     * Specifies an interval for how often to bill for any pending invoice items. It is analogous to
+     * calling [Create an invoice](https://stripe.com/docs/api#create_invoice) for the given
+     * subscription at the specified interval.
+     */
+    public Builder setPendingInvoiceItemInterval(
+        PendingInvoiceItemInterval pendingInvoiceItemInterval) {
+      this.pendingInvoiceItemInterval = pendingInvoiceItemInterval;
+      return this;
+    }
+
+    /**
+     * Specifies an interval for how often to bill for any pending invoice items. It is analogous to
+     * calling [Create an invoice](https://stripe.com/docs/api#create_invoice) for the given
+     * subscription at the specified interval.
+     */
+    public Builder setPendingInvoiceItemInterval(EmptyParam pendingInvoiceItemInterval) {
+      this.pendingInvoiceItemInterval = pendingInvoiceItemInterval;
       return this;
     }
 
@@ -1190,6 +1224,119 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
           this.usageGte = usageGte;
           return this;
         }
+      }
+    }
+  }
+
+  @Getter
+  public static class PendingInvoiceItemInterval {
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /** Specifies invoicing frequency. Either `day`, `week`, `month` or `year`. */
+    @SerializedName("interval")
+    Interval interval;
+
+    /**
+     * The number of intervals between invoices. For example, `interval=month` and
+     * `interval_count=3` bills every 3 months. Maximum of one year interval allowed (1 year, 12
+     * months, or 52 weeks).
+     */
+    @SerializedName("interval_count")
+    Long intervalCount;
+
+    private PendingInvoiceItemInterval(
+        Map<String, Object> extraParams, Interval interval, Long intervalCount) {
+      this.extraParams = extraParams;
+      this.interval = interval;
+      this.intervalCount = intervalCount;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Map<String, Object> extraParams;
+
+      private Interval interval;
+
+      private Long intervalCount;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public PendingInvoiceItemInterval build() {
+        return new PendingInvoiceItemInterval(this.extraParams, this.interval, this.intervalCount);
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * SubscriptionUpdateParams.PendingInvoiceItemInterval#extraParams} for the field
+       * documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link SubscriptionUpdateParams.PendingInvoiceItemInterval#extraParams} for the field
+       * documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** Specifies invoicing frequency. Either `day`, `week`, `month` or `year`. */
+      public Builder setInterval(Interval interval) {
+        this.interval = interval;
+        return this;
+      }
+
+      /**
+       * The number of intervals between invoices. For example, `interval=month` and
+       * `interval_count=3` bills every 3 months. Maximum of one year interval allowed (1 year, 12
+       * months, or 52 weeks).
+       */
+      public Builder setIntervalCount(Long intervalCount) {
+        this.intervalCount = intervalCount;
+        return this;
+      }
+    }
+
+    public enum Interval implements ApiRequestParams.EnumParam {
+      @SerializedName("day")
+      DAY("day"),
+
+      @SerializedName("month")
+      MONTH("month"),
+
+      @SerializedName("week")
+      WEEK("week"),
+
+      @SerializedName("year")
+      YEAR("year");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      Interval(String value) {
+        this.value = value;
       }
     }
   }

--- a/src/main/java/com/stripe/param/TaxIdCollectionCreateParams.java
+++ b/src/main/java/com/stripe/param/TaxIdCollectionCreateParams.java
@@ -24,8 +24,8 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
   Map<String, Object> extraParams;
 
   /**
-   * Type of the tax ID, one of `au_abn`, `ch_vat`, `eu_vat`, `in_gst`, `no_vat`, `nz_gst`, or
-   * `za_vat`.
+   * Type of the tax ID, one of `au_abn`, `ch_vat`, `eu_vat`, `in_gst`, `mx_rfc`, `no_vat`,
+   * `nz_gst`, or `za_vat`.
    */
   @SerializedName("type")
   Type type;
@@ -113,8 +113,8 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
     }
 
     /**
-     * Type of the tax ID, one of `au_abn`, `ch_vat`, `eu_vat`, `in_gst`, `no_vat`, `nz_gst`, or
-     * `za_vat`.
+     * Type of the tax ID, one of `au_abn`, `ch_vat`, `eu_vat`, `in_gst`, `mx_rfc`, `no_vat`,
+     * `nz_gst`, or `za_vat`.
      */
     public Builder setType(Type type) {
       this.type = type;
@@ -140,6 +140,9 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
 
     @SerializedName("in_gst")
     IN_GST("in_gst"),
+
+    @SerializedName("mx_rfc")
+    MX_RFC("mx_rfc"),
 
     @SerializedName("no_vat")
     NO_VAT("no_vat"),

--- a/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
+++ b/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
@@ -25,7 +25,8 @@ public class WebhookEndpointCreateParams extends ApiRequestParams {
   Boolean connect;
 
   /**
-   * The list of events to enable for this endpoint. You may specify `['*']` to enable all events.
+   * The list of events to enable for this endpoint. You may specify `['*']` to enable all events,
+   * except those that require explicit selection.
    */
   @SerializedName("enabled_events")
   List<EnabledEvent> enabledEvents;

--- a/src/main/java/com/stripe/param/WebhookEndpointUpdateParams.java
+++ b/src/main/java/com/stripe/param/WebhookEndpointUpdateParams.java
@@ -16,7 +16,8 @@ public class WebhookEndpointUpdateParams extends ApiRequestParams {
   Boolean disabled;
 
   /**
-   * The list of events to enable for this endpoint. You may specify `['*']` to enable all events.
+   * The list of events to enable for this endpoint. You may specify `['*']` to enable all events,
+   * except those that require explicit selection.
    */
   @SerializedName("enabled_events")
   List<EnabledEvent> enabledEvents;


### PR DESCRIPTION
Multiple API changes merged earlier this week:
* Add support for `mx_rfc` on `TaxId`.
* Add support for `pending_invoice_item_interval` on  `Subscription` creation and update
* Add support for `next_pending_invoice_item_invoice` on `Subscription.
* Add support for `installments` which is a feature on `PaymentIntent` and `PaymentMethod` available on MX Stripe accounts. It's also added inside `payment_method_details[card]` on `Charge`.
* Add support for `next_pending_invoice_item_invoice` as a new `Capability` 

r? @ob-stripe 
cc @stripe/api-libraries 