### PR TITLE
Codegen for openapi d8f9ddf

### DIFF
--- a/src/main/java/com/stripe/model/Person.java
+++ b/src/main/java/com/stripe/model/Person.java
@@ -355,8 +355,9 @@ public class Person extends ApiResource implements HasId, MetadataStore<Person> 
 
     /**
      * One of `document_address_mismatch`, `document_dob_mismatch`, `document_duplicate_type`,
-     * `document_id_number_mismatch`, `document_name_mismatch`, `failed_keyed_identity`, or
-     * `failed_other`. A machine-readable code specifying the verification state for the person.
+     * `document_id_number_mismatch`, `document_name_mismatch`, `document_nationality_mismatch`,
+     * `failed_keyed_identity`, or `failed_other`. A machine-readable code specifying the
+     * verification state for the person.
      */
     @SerializedName("details_code")
     String detailsCode;

--- a/src/main/java/com/stripe/model/issuing/Authorization.java
+++ b/src/main/java/com/stripe/model/issuing/Authorization.java
@@ -132,7 +132,7 @@ public class Authorization extends ApiResource
   @SerializedName("request_history")
   List<Authorization.RequestHistory> requestHistory;
 
-  /** One of `pending`, `reversed`, or `closed`. */
+  /** One of `closed`, `pending`, or `reversed`. */
   @SerializedName("status")
   String status;
 
@@ -440,7 +440,7 @@ public class Authorization extends ApiResource
     @SerializedName("address_zip_check")
     String addressZipCheck;
 
-    /** One of `success`, `failure`, `exempt`, or `none`. */
+    /** One of `exempt`, `failure`, `none`, or `success`. */
     @SerializedName("authentication")
     String authentication;
 

--- a/src/main/java/com/stripe/model/issuing/Card.java
+++ b/src/main/java/com/stripe/model/issuing/Card.java
@@ -360,14 +360,6 @@ public class Card extends ApiResource implements HasId, MetadataStore<Card> {
     String currency;
 
     /**
-     * Maximum amount allowed per authorization on this card, in the currency of the card.
-     * Authorization amounts in a different currency will be converted to the card's currency when
-     * evaluating this control.
-     */
-    @SerializedName("max_amount")
-    Long maxAmount;
-
-    /**
      * Maximum count of approved authorizations on this card. Counts all authorizations
      * retroactively.
      */

--- a/src/main/java/com/stripe/param/issuing/CardCreateParams.java
+++ b/src/main/java/com/stripe/param/issuing/CardCreateParams.java
@@ -309,14 +309,6 @@ public class CardCreateParams extends ApiRequestParams {
     Map<String, Object> extraParams;
 
     /**
-     * Maximum amount allowed per authorization on this card, in the currency of the card.
-     * Authorization amounts in a different currency will be converted to the card's currency when
-     * evaluating this control.
-     */
-    @SerializedName("max_amount")
-    Long maxAmount;
-
-    /**
      * Maximum count of approved authorizations on this card. Counts all authorizations
      * retroactively.
      */
@@ -331,13 +323,11 @@ public class CardCreateParams extends ApiRequestParams {
         List<AllowedCategory> allowedCategories,
         List<BlockedCategory> blockedCategories,
         Map<String, Object> extraParams,
-        Long maxAmount,
         Long maxApprovals,
         List<SpendingLimit> spendingLimits) {
       this.allowedCategories = allowedCategories;
       this.blockedCategories = blockedCategories;
       this.extraParams = extraParams;
-      this.maxAmount = maxAmount;
       this.maxApprovals = maxApprovals;
       this.spendingLimits = spendingLimits;
     }
@@ -353,8 +343,6 @@ public class CardCreateParams extends ApiRequestParams {
 
       private Map<String, Object> extraParams;
 
-      private Long maxAmount;
-
       private Long maxApprovals;
 
       private List<SpendingLimit> spendingLimits;
@@ -365,7 +353,6 @@ public class CardCreateParams extends ApiRequestParams {
             this.allowedCategories,
             this.blockedCategories,
             this.extraParams,
-            this.maxAmount,
             this.maxApprovals,
             this.spendingLimits);
       }
@@ -449,16 +436,6 @@ public class CardCreateParams extends ApiRequestParams {
           this.extraParams = new HashMap<>();
         }
         this.extraParams.putAll(map);
-        return this;
-      }
-
-      /**
-       * Maximum amount allowed per authorization on this card, in the currency of the card.
-       * Authorization amounts in a different currency will be converted to the card's currency when
-       * evaluating this control.
-       */
-      public Builder setMaxAmount(Long maxAmount) {
-        this.maxAmount = maxAmount;
         return this;
       }
 

--- a/src/main/java/com/stripe/param/issuing/CardUpdateParams.java
+++ b/src/main/java/com/stripe/param/issuing/CardUpdateParams.java
@@ -248,14 +248,6 @@ public class CardUpdateParams extends ApiRequestParams {
     Map<String, Object> extraParams;
 
     /**
-     * Maximum amount allowed per authorization on this card, in the currency of the card.
-     * Authorization amounts in a different currency will be converted to the card's currency when
-     * evaluating this control.
-     */
-    @SerializedName("max_amount")
-    Long maxAmount;
-
-    /**
      * Maximum count of approved authorizations on this card. Counts all authorizations
      * retroactively.
      */
@@ -270,13 +262,11 @@ public class CardUpdateParams extends ApiRequestParams {
         List<AllowedCategory> allowedCategories,
         List<BlockedCategory> blockedCategories,
         Map<String, Object> extraParams,
-        Long maxAmount,
         Long maxApprovals,
         List<SpendingLimit> spendingLimits) {
       this.allowedCategories = allowedCategories;
       this.blockedCategories = blockedCategories;
       this.extraParams = extraParams;
-      this.maxAmount = maxAmount;
       this.maxApprovals = maxApprovals;
       this.spendingLimits = spendingLimits;
     }
@@ -292,8 +282,6 @@ public class CardUpdateParams extends ApiRequestParams {
 
       private Map<String, Object> extraParams;
 
-      private Long maxAmount;
-
       private Long maxApprovals;
 
       private List<SpendingLimit> spendingLimits;
@@ -304,7 +292,6 @@ public class CardUpdateParams extends ApiRequestParams {
             this.allowedCategories,
             this.blockedCategories,
             this.extraParams,
-            this.maxAmount,
             this.maxApprovals,
             this.spendingLimits);
       }
@@ -388,16 +375,6 @@ public class CardUpdateParams extends ApiRequestParams {
           this.extraParams = new HashMap<>();
         }
         this.extraParams.putAll(map);
-        return this;
-      }
-
-      /**
-       * Maximum amount allowed per authorization on this card, in the currency of the card.
-       * Authorization amounts in a different currency will be converted to the card's currency when
-       * evaluating this control.
-       */
-      public Builder setMaxAmount(Long maxAmount) {
-        this.maxAmount = maxAmount;
         return this;
       }
 


### PR DESCRIPTION
While this is technically a breaking change, only one integration was relying on this parameter and moved off of it so we're releasing as a minor version.

r? @ob-stripe 
cc @stripe/api-libraries 

Leaving the merge/deploy to you.