### PR TITLE
Codegen for openapi 2a645b0

### DIFF
--- a/src/main/java/com/stripe/param/SubscriptionCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionCreateParams.java
@@ -123,8 +123,8 @@ public class SubscriptionCreateParams extends ApiRequestParams {
   Map<String, Object> extraParams;
 
   /**
-   * All voided invoices now return the customer balance, independent of
-   * `consume_applied_balance_on_void`.
+   * Controls whether a customer balance applied to an invoice should be consumed and not credited
+   * or debited back to the customer if voided by this subscription.
    */
   @SerializedName("invoice_customer_balance_settings")
   InvoiceCustomerBalanceSettings invoiceCustomerBalanceSettings;
@@ -596,8 +596,8 @@ public class SubscriptionCreateParams extends ApiRequestParams {
     }
 
     /**
-     * All voided invoices now return the customer balance, independent of
-     * `consume_applied_balance_on_void`.
+     * Controls whether a customer balance applied to an invoice should be consumed and not credited
+     * or debited back to the customer if voided by this subscription.
      */
     public Builder setInvoiceCustomerBalanceSettings(
         InvoiceCustomerBalanceSettings invoiceCustomerBalanceSettings) {

--- a/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
@@ -110,8 +110,8 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
   Map<String, Object> extraParams;
 
   /**
-   * All voided invoices now return the customer balance, independent of
-   * `consume_applied_balance_on_void`.
+   * Controls whether a customer balance applied to an invoice should be consumed and not credited
+   * or debited back to the customer if voided by this subscription.
    */
   @SerializedName("invoice_customer_balance_settings")
   InvoiceCustomerBalanceSettings invoiceCustomerBalanceSettings;
@@ -597,8 +597,8 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
     }
 
     /**
-     * All voided invoices now return the customer balance, independent of
-     * `consume_applied_balance_on_void`.
+     * Controls whether a customer balance applied to an invoice should be consumed and not credited
+     * or debited back to the customer if voided by this subscription.
      */
     public Builder setInvoiceCustomerBalanceSettings(
         InvoiceCustomerBalanceSettings invoiceCustomerBalanceSettings) {


### PR DESCRIPTION
This fixes the documentation for a parameter that was incorrect

r? @ob-stripe 
cc @stripe/api-libraries 