### PR TITLE
Add support for `use_stripe_sdk` on `PaymentIntent` creation and confirmation

### DIFF
--- a/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
@@ -106,6 +106,13 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
   @SerializedName("source")
   String source;
 
+  /**
+   * Set to `true` only when using manual confirmation and the iOS or Android SDKs to handle
+   * additional authentication steps.
+   */
+  @SerializedName("use_stripe_sdk")
+  Boolean useStripeSdk;
+
   private PaymentIntentConfirmParams(
       List<String> expand,
       Map<String, Object> extraParams,
@@ -117,7 +124,8 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       Boolean savePaymentMethod,
       EnumParam setupFutureUsage,
       Object shipping,
-      String source) {
+      String source,
+      Boolean useStripeSdk) {
     this.expand = expand;
     this.extraParams = extraParams;
     this.offSession = offSession;
@@ -129,6 +137,7 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
     this.setupFutureUsage = setupFutureUsage;
     this.shipping = shipping;
     this.source = source;
+    this.useStripeSdk = useStripeSdk;
   }
 
   public static Builder builder() {
@@ -158,6 +167,8 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
 
     private String source;
 
+    private Boolean useStripeSdk;
+
     /** Finalize and obtain parameter instance from this builder. */
     public PaymentIntentConfirmParams build() {
       return new PaymentIntentConfirmParams(
@@ -171,7 +182,8 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
           this.savePaymentMethod,
           this.setupFutureUsage,
           this.shipping,
-          this.source);
+          this.source,
+          this.useStripeSdk);
     }
 
     /**
@@ -372,6 +384,15 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
      */
     public Builder setSource(String source) {
       this.source = source;
+      return this;
+    }
+
+    /**
+     * Set to `true` only when using manual confirmation and the iOS or Android SDKs to handle
+     * additional authentication steps.
+     */
+    public Builder setUseStripeSdk(Boolean useStripeSdk) {
+      this.useStripeSdk = useStripeSdk;
       return this;
     }
   }

--- a/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
@@ -240,6 +240,13 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
   @SerializedName("transfer_group")
   String transferGroup;
 
+  /**
+   * Set to `true` only when using manual confirmation and the iOS or Android SDKs to handle
+   * additional authentication steps.
+   */
+  @SerializedName("use_stripe_sdk")
+  Boolean useStripeSdk;
+
   private PaymentIntentCreateParams(
       Long amount,
       Long applicationFeeAmount,
@@ -266,7 +273,8 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       String statementDescriptor,
       String statementDescriptorSuffix,
       TransferData transferData,
-      String transferGroup) {
+      String transferGroup,
+      Boolean useStripeSdk) {
     this.amount = amount;
     this.applicationFeeAmount = applicationFeeAmount;
     this.captureMethod = captureMethod;
@@ -293,6 +301,7 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     this.statementDescriptorSuffix = statementDescriptorSuffix;
     this.transferData = transferData;
     this.transferGroup = transferGroup;
+    this.useStripeSdk = useStripeSdk;
   }
 
   public static Builder builder() {
@@ -352,6 +361,8 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
 
     private String transferGroup;
 
+    private Boolean useStripeSdk;
+
     /** Finalize and obtain parameter instance from this builder. */
     public PaymentIntentCreateParams build() {
       return new PaymentIntentCreateParams(
@@ -380,7 +391,8 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
           this.statementDescriptor,
           this.statementDescriptorSuffix,
           this.transferData,
-          this.transferGroup);
+          this.transferGroup,
+          this.useStripeSdk);
     }
 
     /**
@@ -744,6 +756,15 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
      */
     public Builder setTransferGroup(String transferGroup) {
       this.transferGroup = transferGroup;
+      return this;
+    }
+
+    /**
+     * Set to `true` only when using manual confirmation and the iOS or Android SDKs to handle
+     * additional authentication steps.
+     */
+    public Builder setUseStripeSdk(Boolean useStripeSdk) {
+      this.useStripeSdk = useStripeSdk;
       return this;
     }
   }


### PR DESCRIPTION
Codegen for openapi ee023e4

r? @ob-stripe 
cc @stripe/api-libraries 
