### PR TITLE
Add support for `default_settings` on `SubscriptionSchedule` and `dispute` on `Charge` list

### DIFF
--- a/src/main/java/com/stripe/model/SubscriptionSchedule.java
+++ b/src/main/java/com/stripe/model/SubscriptionSchedule.java
@@ -78,6 +78,9 @@ public class SubscriptionSchedule extends ApiResource
   @Setter(lombok.AccessLevel.NONE)
   ExpandableField<PaymentMethod> defaultPaymentMethod;
 
+  @SerializedName("default_settings")
+  DefaultSettings defaultSettings;
+
   /**
    * ID of the default payment source for the subscription schedule. If not set, defaults to the
    * customer's default source.
@@ -528,6 +531,59 @@ public class SubscriptionSchedule extends ApiResource
 
     @SerializedName("start_date")
     Long startDate;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class DefaultSettings extends StripeObject {
+    /**
+     * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
+     * billing period.
+     */
+    @SerializedName("billing_thresholds")
+    Subscription.BillingThresholds billingThresholds;
+
+    /**
+     * Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will
+     * attempt to pay the underlying subscription at the end of each billing cycle using the default
+     * source attached to the customer. When sending an invoice, Stripe will email your customer an
+     * invoice with payment instructions.
+     */
+    @SerializedName("collection_method")
+    String collectionMethod;
+
+    /**
+     * ID of the default payment method for the subscription schedule. If not set, invoices will use
+     * the default payment method in the customer's invoice settings.
+     */
+    @SerializedName("default_payment_method")
+    @Getter(lombok.AccessLevel.NONE)
+    @Setter(lombok.AccessLevel.NONE)
+    ExpandableField<PaymentMethod> defaultPaymentMethod;
+
+    /** The subscription schedule's default invoice settings. */
+    @SerializedName("invoice_settings")
+    InvoiceSettings invoiceSettings;
+
+    /** Get id of expandable `defaultPaymentMethod` object. */
+    public String getDefaultPaymentMethod() {
+      return (this.defaultPaymentMethod != null) ? this.defaultPaymentMethod.getId() : null;
+    }
+
+    public void setDefaultPaymentMethod(String id) {
+      this.defaultPaymentMethod = ApiResource.setExpandableFieldId(id, this.defaultPaymentMethod);
+    }
+
+    /** Get expanded `defaultPaymentMethod`. */
+    public PaymentMethod getDefaultPaymentMethodObject() {
+      return (this.defaultPaymentMethod != null) ? this.defaultPaymentMethod.getExpanded() : null;
+    }
+
+    public void setDefaultPaymentMethodObject(PaymentMethod expandableObject) {
+      this.defaultPaymentMethod =
+          new ExpandableField<PaymentMethod>(expandableObject.getId(), expandableObject);
+    }
   }
 
   @Getter

--- a/src/main/java/com/stripe/param/DisputeListParams.java
+++ b/src/main/java/com/stripe/param/DisputeListParams.java
@@ -10,6 +10,10 @@ import lombok.Getter;
 
 @Getter
 public class DisputeListParams extends ApiRequestParams {
+  /** Only return disputes that are associated by the Charge specified by this Charge ID. */
+  @SerializedName("charge")
+  String charge;
+
   @SerializedName("created")
   Object created;
 
@@ -52,12 +56,14 @@ public class DisputeListParams extends ApiRequestParams {
   String startingAfter;
 
   private DisputeListParams(
+      String charge,
       Object created,
       String endingBefore,
       List<String> expand,
       Map<String, Object> extraParams,
       Long limit,
       String startingAfter) {
+    this.charge = charge;
     this.created = created;
     this.endingBefore = endingBefore;
     this.expand = expand;
@@ -71,6 +77,8 @@ public class DisputeListParams extends ApiRequestParams {
   }
 
   public static class Builder {
+    private String charge;
+
     private Object created;
 
     private String endingBefore;
@@ -86,12 +94,19 @@ public class DisputeListParams extends ApiRequestParams {
     /** Finalize and obtain parameter instance from this builder. */
     public DisputeListParams build() {
       return new DisputeListParams(
+          this.charge,
           this.created,
           this.endingBefore,
           this.expand,
           this.extraParams,
           this.limit,
           this.startingAfter);
+    }
+
+    /** Only return disputes that are associated by the Charge specified by this Charge ID. */
+    public Builder setCharge(String charge) {
+      this.charge = charge;
+      return this;
     }
 
     public Builder setCreated(Created created) {

--- a/src/main/java/com/stripe/param/SubscriptionScheduleCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionScheduleCreateParams.java
@@ -40,6 +40,10 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
   @SerializedName("default_payment_method")
   String defaultPaymentMethod;
 
+  /** Object representing the subscription schedule's default settings. */
+  @SerializedName("default_settings")
+  DefaultSettings defaultSettings;
+
   /**
    * ID of the default payment source for the subscription schedule. It must belong to the customer
    * associated with the subscription schedule and be in a chargeable state. If not set, defaults to
@@ -107,6 +111,7 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
       CollectionMethod collectionMethod,
       String customer,
       String defaultPaymentMethod,
+      DefaultSettings defaultSettings,
       String defaultSource,
       EndBehavior endBehavior,
       List<String> expand,
@@ -120,6 +125,7 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
     this.collectionMethod = collectionMethod;
     this.customer = customer;
     this.defaultPaymentMethod = defaultPaymentMethod;
+    this.defaultSettings = defaultSettings;
     this.defaultSource = defaultSource;
     this.endBehavior = endBehavior;
     this.expand = expand;
@@ -143,6 +149,8 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
     private String customer;
 
     private String defaultPaymentMethod;
+
+    private DefaultSettings defaultSettings;
 
     private String defaultSource;
 
@@ -169,6 +177,7 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
           this.collectionMethod,
           this.customer,
           this.defaultPaymentMethod,
+          this.defaultSettings,
           this.defaultSource,
           this.endBehavior,
           this.expand,
@@ -222,6 +231,12 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
      */
     public Builder setDefaultPaymentMethod(String defaultPaymentMethod) {
       this.defaultPaymentMethod = defaultPaymentMethod;
+      return this;
+    }
+
+    /** Object representing the subscription schedule's default settings. */
+    public Builder setDefaultSettings(DefaultSettings defaultSettings) {
+      this.defaultSettings = defaultSettings;
       return this;
     }
 
@@ -469,6 +484,338 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
       public Builder setResetBillingCycleAnchor(Boolean resetBillingCycleAnchor) {
         this.resetBillingCycleAnchor = resetBillingCycleAnchor;
         return this;
+      }
+    }
+  }
+
+  @Getter
+  public static class DefaultSettings {
+    /**
+     * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
+     * billing period. Pass an empty string to remove previously-defined thresholds.
+     */
+    @SerializedName("billing_thresholds")
+    Object billingThresholds;
+
+    /**
+     * Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will
+     * attempt to pay the underlying subscription at the end of each billing cycle using the default
+     * source attached to the customer. When sending an invoice, Stripe will email your customer an
+     * invoice with payment instructions. Defaults to `charge_automatically` on creation.
+     */
+    @SerializedName("collection_method")
+    CollectionMethod collectionMethod;
+
+    /**
+     * ID of the default payment method for the subscription schedule. It must belong to the
+     * customer associated with the subscription schedule. If not set, invoices will use the default
+     * payment method in the customer's invoice settings.
+     */
+    @SerializedName("default_payment_method")
+    String defaultPaymentMethod;
+
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /** All invoices will be billed using the specified settings. */
+    @SerializedName("invoice_settings")
+    InvoiceSettings invoiceSettings;
+
+    private DefaultSettings(
+        Object billingThresholds,
+        CollectionMethod collectionMethod,
+        String defaultPaymentMethod,
+        Map<String, Object> extraParams,
+        InvoiceSettings invoiceSettings) {
+      this.billingThresholds = billingThresholds;
+      this.collectionMethod = collectionMethod;
+      this.defaultPaymentMethod = defaultPaymentMethod;
+      this.extraParams = extraParams;
+      this.invoiceSettings = invoiceSettings;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Object billingThresholds;
+
+      private CollectionMethod collectionMethod;
+
+      private String defaultPaymentMethod;
+
+      private Map<String, Object> extraParams;
+
+      private InvoiceSettings invoiceSettings;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public DefaultSettings build() {
+        return new DefaultSettings(
+            this.billingThresholds,
+            this.collectionMethod,
+            this.defaultPaymentMethod,
+            this.extraParams,
+            this.invoiceSettings);
+      }
+
+      /**
+       * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
+       * billing period. Pass an empty string to remove previously-defined thresholds.
+       */
+      public Builder setBillingThresholds(BillingThresholds billingThresholds) {
+        this.billingThresholds = billingThresholds;
+        return this;
+      }
+
+      /**
+       * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
+       * billing period. Pass an empty string to remove previously-defined thresholds.
+       */
+      public Builder setBillingThresholds(EmptyParam billingThresholds) {
+        this.billingThresholds = billingThresholds;
+        return this;
+      }
+
+      /**
+       * Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will
+       * attempt to pay the underlying subscription at the end of each billing cycle using the
+       * default source attached to the customer. When sending an invoice, Stripe will email your
+       * customer an invoice with payment instructions. Defaults to `charge_automatically` on
+       * creation.
+       */
+      public Builder setCollectionMethod(CollectionMethod collectionMethod) {
+        this.collectionMethod = collectionMethod;
+        return this;
+      }
+
+      /**
+       * ID of the default payment method for the subscription schedule. It must belong to the
+       * customer associated with the subscription schedule. If not set, invoices will use the
+       * default payment method in the customer's invoice settings.
+       */
+      public Builder setDefaultPaymentMethod(String defaultPaymentMethod) {
+        this.defaultPaymentMethod = defaultPaymentMethod;
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * SubscriptionScheduleCreateParams.DefaultSettings#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link SubscriptionScheduleCreateParams.DefaultSettings#extraParams} for the field
+       * documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** All invoices will be billed using the specified settings. */
+      public Builder setInvoiceSettings(InvoiceSettings invoiceSettings) {
+        this.invoiceSettings = invoiceSettings;
+        return this;
+      }
+    }
+
+    @Getter
+    public static class BillingThresholds {
+      /** Monetary threshold that triggers the subscription to advance to a new billing period. */
+      @SerializedName("amount_gte")
+      Long amountGte;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /**
+       * Indicates if the `billing_cycle_anchor` should be reset when a threshold is reached. If
+       * true, `billing_cycle_anchor` will be updated to the date/time the threshold was last
+       * reached; otherwise, the value will remain unchanged.
+       */
+      @SerializedName("reset_billing_cycle_anchor")
+      Boolean resetBillingCycleAnchor;
+
+      private BillingThresholds(
+          Long amountGte, Map<String, Object> extraParams, Boolean resetBillingCycleAnchor) {
+        this.amountGte = amountGte;
+        this.extraParams = extraParams;
+        this.resetBillingCycleAnchor = resetBillingCycleAnchor;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Long amountGte;
+
+        private Map<String, Object> extraParams;
+
+        private Boolean resetBillingCycleAnchor;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public BillingThresholds build() {
+          return new BillingThresholds(
+              this.amountGte, this.extraParams, this.resetBillingCycleAnchor);
+        }
+
+        /** Monetary threshold that triggers the subscription to advance to a new billing period. */
+        public Builder setAmountGte(Long amountGte) {
+          this.amountGte = amountGte;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * SubscriptionScheduleCreateParams.DefaultSettings.BillingThresholds#extraParams} for the
+         * field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * SubscriptionScheduleCreateParams.DefaultSettings.BillingThresholds#extraParams} for the
+         * field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /**
+         * Indicates if the `billing_cycle_anchor` should be reset when a threshold is reached. If
+         * true, `billing_cycle_anchor` will be updated to the date/time the threshold was last
+         * reached; otherwise, the value will remain unchanged.
+         */
+        public Builder setResetBillingCycleAnchor(Boolean resetBillingCycleAnchor) {
+          this.resetBillingCycleAnchor = resetBillingCycleAnchor;
+          return this;
+        }
+      }
+    }
+
+    @Getter
+    public static class InvoiceSettings {
+      @SerializedName("days_until_due")
+      Long daysUntilDue;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private InvoiceSettings(Long daysUntilDue, Map<String, Object> extraParams) {
+        this.daysUntilDue = daysUntilDue;
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Long daysUntilDue;
+
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public InvoiceSettings build() {
+          return new InvoiceSettings(this.daysUntilDue, this.extraParams);
+        }
+
+        public Builder setDaysUntilDue(Long daysUntilDue) {
+          this.daysUntilDue = daysUntilDue;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * SubscriptionScheduleCreateParams.DefaultSettings.InvoiceSettings#extraParams} for the
+         * field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * SubscriptionScheduleCreateParams.DefaultSettings.InvoiceSettings#extraParams} for the
+         * field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+      }
+    }
+
+    public enum CollectionMethod implements ApiRequestParams.EnumParam {
+      @SerializedName("charge_automatically")
+      CHARGE_AUTOMATICALLY("charge_automatically"),
+
+      @SerializedName("send_invoice")
+      SEND_INVOICE("send_invoice");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      CollectionMethod(String value) {
+        this.value = value;
       }
     }
   }

--- a/src/main/java/com/stripe/param/SubscriptionScheduleUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionScheduleUpdateParams.java
@@ -36,6 +36,10 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
   @SerializedName("default_payment_method")
   Object defaultPaymentMethod;
 
+  /** Object representing the subscription schedule's default settings. */
+  @SerializedName("default_settings")
+  DefaultSettings defaultSettings;
+
   /**
    * ID of the default payment source for the subscription schedule. It must belong to the customer
    * associated with the subscription schedule and be in a chargeable state. If not set, defaults to
@@ -97,6 +101,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
       Object billingThresholds,
       CollectionMethod collectionMethod,
       Object defaultPaymentMethod,
+      DefaultSettings defaultSettings,
       Object defaultSource,
       EndBehavior endBehavior,
       List<String> expand,
@@ -108,6 +113,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
     this.billingThresholds = billingThresholds;
     this.collectionMethod = collectionMethod;
     this.defaultPaymentMethod = defaultPaymentMethod;
+    this.defaultSettings = defaultSettings;
     this.defaultSource = defaultSource;
     this.endBehavior = endBehavior;
     this.expand = expand;
@@ -128,6 +134,8 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
     private CollectionMethod collectionMethod;
 
     private Object defaultPaymentMethod;
+
+    private DefaultSettings defaultSettings;
 
     private Object defaultSource;
 
@@ -151,6 +159,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
           this.billingThresholds,
           this.collectionMethod,
           this.defaultPaymentMethod,
+          this.defaultSettings,
           this.defaultSource,
           this.endBehavior,
           this.expand,
@@ -207,6 +216,12 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
      */
     public Builder setDefaultPaymentMethod(EmptyParam defaultPaymentMethod) {
       this.defaultPaymentMethod = defaultPaymentMethod;
+      return this;
+    }
+
+    /** Object representing the subscription schedule's default settings. */
+    public Builder setDefaultSettings(DefaultSettings defaultSettings) {
+      this.defaultSettings = defaultSettings;
       return this;
     }
 
@@ -450,6 +465,348 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
       public Builder setResetBillingCycleAnchor(Boolean resetBillingCycleAnchor) {
         this.resetBillingCycleAnchor = resetBillingCycleAnchor;
         return this;
+      }
+    }
+  }
+
+  @Getter
+  public static class DefaultSettings {
+    /**
+     * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
+     * billing period. Pass an empty string to remove previously-defined thresholds.
+     */
+    @SerializedName("billing_thresholds")
+    Object billingThresholds;
+
+    /**
+     * Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will
+     * attempt to pay the underlying subscription at the end of each billing cycle using the default
+     * source attached to the customer. When sending an invoice, Stripe will email your customer an
+     * invoice with payment instructions. Defaults to `charge_automatically` on creation.
+     */
+    @SerializedName("collection_method")
+    CollectionMethod collectionMethod;
+
+    /**
+     * ID of the default payment method for the subscription schedule. It must belong to the
+     * customer associated with the subscription schedule. If not set, invoices will use the default
+     * payment method in the customer's invoice settings.
+     */
+    @SerializedName("default_payment_method")
+    Object defaultPaymentMethod;
+
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /** All invoices will be billed using the specified settings. */
+    @SerializedName("invoice_settings")
+    InvoiceSettings invoiceSettings;
+
+    private DefaultSettings(
+        Object billingThresholds,
+        CollectionMethod collectionMethod,
+        Object defaultPaymentMethod,
+        Map<String, Object> extraParams,
+        InvoiceSettings invoiceSettings) {
+      this.billingThresholds = billingThresholds;
+      this.collectionMethod = collectionMethod;
+      this.defaultPaymentMethod = defaultPaymentMethod;
+      this.extraParams = extraParams;
+      this.invoiceSettings = invoiceSettings;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Object billingThresholds;
+
+      private CollectionMethod collectionMethod;
+
+      private Object defaultPaymentMethod;
+
+      private Map<String, Object> extraParams;
+
+      private InvoiceSettings invoiceSettings;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public DefaultSettings build() {
+        return new DefaultSettings(
+            this.billingThresholds,
+            this.collectionMethod,
+            this.defaultPaymentMethod,
+            this.extraParams,
+            this.invoiceSettings);
+      }
+
+      /**
+       * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
+       * billing period. Pass an empty string to remove previously-defined thresholds.
+       */
+      public Builder setBillingThresholds(BillingThresholds billingThresholds) {
+        this.billingThresholds = billingThresholds;
+        return this;
+      }
+
+      /**
+       * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
+       * billing period. Pass an empty string to remove previously-defined thresholds.
+       */
+      public Builder setBillingThresholds(EmptyParam billingThresholds) {
+        this.billingThresholds = billingThresholds;
+        return this;
+      }
+
+      /**
+       * Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will
+       * attempt to pay the underlying subscription at the end of each billing cycle using the
+       * default source attached to the customer. When sending an invoice, Stripe will email your
+       * customer an invoice with payment instructions. Defaults to `charge_automatically` on
+       * creation.
+       */
+      public Builder setCollectionMethod(CollectionMethod collectionMethod) {
+        this.collectionMethod = collectionMethod;
+        return this;
+      }
+
+      /**
+       * ID of the default payment method for the subscription schedule. It must belong to the
+       * customer associated with the subscription schedule. If not set, invoices will use the
+       * default payment method in the customer's invoice settings.
+       */
+      public Builder setDefaultPaymentMethod(String defaultPaymentMethod) {
+        this.defaultPaymentMethod = defaultPaymentMethod;
+        return this;
+      }
+
+      /**
+       * ID of the default payment method for the subscription schedule. It must belong to the
+       * customer associated with the subscription schedule. If not set, invoices will use the
+       * default payment method in the customer's invoice settings.
+       */
+      public Builder setDefaultPaymentMethod(EmptyParam defaultPaymentMethod) {
+        this.defaultPaymentMethod = defaultPaymentMethod;
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * SubscriptionScheduleUpdateParams.DefaultSettings#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link SubscriptionScheduleUpdateParams.DefaultSettings#extraParams} for the field
+       * documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** All invoices will be billed using the specified settings. */
+      public Builder setInvoiceSettings(InvoiceSettings invoiceSettings) {
+        this.invoiceSettings = invoiceSettings;
+        return this;
+      }
+    }
+
+    @Getter
+    public static class BillingThresholds {
+      /** Monetary threshold that triggers the subscription to advance to a new billing period. */
+      @SerializedName("amount_gte")
+      Long amountGte;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /**
+       * Indicates if the `billing_cycle_anchor` should be reset when a threshold is reached. If
+       * true, `billing_cycle_anchor` will be updated to the date/time the threshold was last
+       * reached; otherwise, the value will remain unchanged.
+       */
+      @SerializedName("reset_billing_cycle_anchor")
+      Boolean resetBillingCycleAnchor;
+
+      private BillingThresholds(
+          Long amountGte, Map<String, Object> extraParams, Boolean resetBillingCycleAnchor) {
+        this.amountGte = amountGte;
+        this.extraParams = extraParams;
+        this.resetBillingCycleAnchor = resetBillingCycleAnchor;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Long amountGte;
+
+        private Map<String, Object> extraParams;
+
+        private Boolean resetBillingCycleAnchor;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public BillingThresholds build() {
+          return new BillingThresholds(
+              this.amountGte, this.extraParams, this.resetBillingCycleAnchor);
+        }
+
+        /** Monetary threshold that triggers the subscription to advance to a new billing period. */
+        public Builder setAmountGte(Long amountGte) {
+          this.amountGte = amountGte;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * SubscriptionScheduleUpdateParams.DefaultSettings.BillingThresholds#extraParams} for the
+         * field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * SubscriptionScheduleUpdateParams.DefaultSettings.BillingThresholds#extraParams} for the
+         * field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /**
+         * Indicates if the `billing_cycle_anchor` should be reset when a threshold is reached. If
+         * true, `billing_cycle_anchor` will be updated to the date/time the threshold was last
+         * reached; otherwise, the value will remain unchanged.
+         */
+        public Builder setResetBillingCycleAnchor(Boolean resetBillingCycleAnchor) {
+          this.resetBillingCycleAnchor = resetBillingCycleAnchor;
+          return this;
+        }
+      }
+    }
+
+    @Getter
+    public static class InvoiceSettings {
+      @SerializedName("days_until_due")
+      Long daysUntilDue;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private InvoiceSettings(Long daysUntilDue, Map<String, Object> extraParams) {
+        this.daysUntilDue = daysUntilDue;
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Long daysUntilDue;
+
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public InvoiceSettings build() {
+          return new InvoiceSettings(this.daysUntilDue, this.extraParams);
+        }
+
+        public Builder setDaysUntilDue(Long daysUntilDue) {
+          this.daysUntilDue = daysUntilDue;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * SubscriptionScheduleUpdateParams.DefaultSettings.InvoiceSettings#extraParams} for the
+         * field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * SubscriptionScheduleUpdateParams.DefaultSettings.InvoiceSettings#extraParams} for the
+         * field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+      }
+    }
+
+    public enum CollectionMethod implements ApiRequestParams.EnumParam {
+      @SerializedName("charge_automatically")
+      CHARGE_AUTOMATICALLY("charge_automatically"),
+
+      @SerializedName("send_invoice")
+      SEND_INVOICE("send_invoice");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      CollectionMethod(String value) {
+        this.value = value;
       }
     }
   }


### PR DESCRIPTION
Codegen for openapi e9e946f
* Add support for `default_settings` on `SubscriptionSchedule`.
* Add support for `dispute` filter when listing `Charge`s.

r? @ob-stripe 
cc @stripe/api-libraries 