### PR TITLE
Codegen for openapi 28a5c69 + new API version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 env:
   global:
     # If changing this number, please also change it in `BaseStripeTest.java`.
-  - STRIPE_MOCK_VERSION=0.70.0
+  - STRIPE_MOCK_VERSION=0.71.0
 
 matrix:
   include:

--- a/src/main/java/com/stripe/Stripe.java
+++ b/src/main/java/com/stripe/Stripe.java
@@ -9,7 +9,7 @@ public abstract class Stripe {
   public static final int DEFAULT_CONNECT_TIMEOUT = 30 * 1000;
   public static final int DEFAULT_READ_TIMEOUT = 80 * 1000;
 
-  public static final String API_VERSION = "2019-10-17";
+  public static final String API_VERSION = "2019-11-05";
   public static final String CONNECT_API_BASE = "https://connect.stripe.com";
   public static final String LIVE_API_BASE = "https://api.stripe.com";
   public static final String UPLOAD_API_BASE = "https://files.stripe.com";

--- a/src/main/java/com/stripe/model/SubscriptionSchedule.java
+++ b/src/main/java/com/stripe/model/SubscriptionSchedule.java
@@ -24,26 +24,10 @@ import lombok.Setter;
 public class SubscriptionSchedule extends ApiResource
     implements HasId, MetadataStore<SubscriptionSchedule> {
   /**
-   * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
-   * billing period.
-   */
-  @SerializedName("billing_thresholds")
-  Subscription.BillingThresholds billingThresholds;
-
-  /**
    * Time at which the subscription schedule was canceled. Measured in seconds since the Unix epoch.
    */
   @SerializedName("canceled_at")
   Long canceledAt;
-
-  /**
-   * Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will
-   * attempt to pay the underlying subscription at the end of each billing cycle using the default
-   * source attached to the customer. When sending an invoice, Stripe will email your customer an
-   * invoice with payment instructions.
-   */
-  @SerializedName("collection_method")
-  String collectionMethod;
 
   /**
    * Time at which the subscription schedule was completed. Measured in seconds since the Unix
@@ -69,23 +53,8 @@ public class SubscriptionSchedule extends ApiResource
   @Setter(lombok.AccessLevel.NONE)
   ExpandableField<Customer> customer;
 
-  /**
-   * ID of the default payment method for the subscription schedule. If not set, invoices will use
-   * the default payment method in the customer's invoice settings.
-   */
-  @SerializedName("default_payment_method")
-  @Getter(lombok.AccessLevel.NONE)
-  @Setter(lombok.AccessLevel.NONE)
-  ExpandableField<PaymentMethod> defaultPaymentMethod;
-
-  /**
-   * ID of the default payment source for the subscription schedule. If not set, defaults to the
-   * customer's default source.
-   */
-  @SerializedName("default_source")
-  @Getter(lombok.AccessLevel.NONE)
-  @Setter(lombok.AccessLevel.NONE)
-  ExpandableField<PaymentSource> defaultSource;
+  @SerializedName("default_settings")
+  DefaultSettings defaultSettings;
 
   /** Behavior of the subscription schedule and underlying subscription when it ends. */
   @SerializedName("end_behavior")
@@ -95,10 +64,6 @@ public class SubscriptionSchedule extends ApiResource
   @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
-
-  /** The subscription schedule's default invoice settings. */
-  @SerializedName("invoice_settings")
-  InvoiceSettings invoiceSettings;
 
   /**
    * Has the value `true` if the object exists in live mode or the value `false` if the object
@@ -166,44 +131,6 @@ public class SubscriptionSchedule extends ApiResource
 
   public void setCustomerObject(Customer expandableObject) {
     this.customer = new ExpandableField<Customer>(expandableObject.getId(), expandableObject);
-  }
-
-  /** Get id of expandable `defaultPaymentMethod` object. */
-  public String getDefaultPaymentMethod() {
-    return (this.defaultPaymentMethod != null) ? this.defaultPaymentMethod.getId() : null;
-  }
-
-  public void setDefaultPaymentMethod(String id) {
-    this.defaultPaymentMethod = ApiResource.setExpandableFieldId(id, this.defaultPaymentMethod);
-  }
-
-  /** Get expanded `defaultPaymentMethod`. */
-  public PaymentMethod getDefaultPaymentMethodObject() {
-    return (this.defaultPaymentMethod != null) ? this.defaultPaymentMethod.getExpanded() : null;
-  }
-
-  public void setDefaultPaymentMethodObject(PaymentMethod expandableObject) {
-    this.defaultPaymentMethod =
-        new ExpandableField<PaymentMethod>(expandableObject.getId(), expandableObject);
-  }
-
-  /** Get id of expandable `defaultSource` object. */
-  public String getDefaultSource() {
-    return (this.defaultSource != null) ? this.defaultSource.getId() : null;
-  }
-
-  public void setDefaultSource(String id) {
-    this.defaultSource = ApiResource.setExpandableFieldId(id, this.defaultSource);
-  }
-
-  /** Get expanded `defaultSource`. */
-  public PaymentSource getDefaultSourceObject() {
-    return (this.defaultSource != null) ? this.defaultSource.getExpanded() : null;
-  }
-
-  public void setDefaultSourceObject(PaymentSource expandableObject) {
-    this.defaultSource =
-        new ExpandableField<PaymentSource>(expandableObject.getId(), expandableObject);
   }
 
   /** Get id of expandable `subscription` object. */
@@ -528,6 +455,59 @@ public class SubscriptionSchedule extends ApiResource
 
     @SerializedName("start_date")
     Long startDate;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class DefaultSettings extends StripeObject {
+    /**
+     * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
+     * billing period.
+     */
+    @SerializedName("billing_thresholds")
+    Subscription.BillingThresholds billingThresholds;
+
+    /**
+     * Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will
+     * attempt to pay the underlying subscription at the end of each billing cycle using the default
+     * source attached to the customer. When sending an invoice, Stripe will email your customer an
+     * invoice with payment instructions.
+     */
+    @SerializedName("collection_method")
+    String collectionMethod;
+
+    /**
+     * ID of the default payment method for the subscription schedule. If not set, invoices will use
+     * the default payment method in the customer's invoice settings.
+     */
+    @SerializedName("default_payment_method")
+    @Getter(lombok.AccessLevel.NONE)
+    @Setter(lombok.AccessLevel.NONE)
+    ExpandableField<PaymentMethod> defaultPaymentMethod;
+
+    /** The subscription schedule's default invoice settings. */
+    @SerializedName("invoice_settings")
+    InvoiceSettings invoiceSettings;
+
+    /** Get id of expandable `defaultPaymentMethod` object. */
+    public String getDefaultPaymentMethod() {
+      return (this.defaultPaymentMethod != null) ? this.defaultPaymentMethod.getId() : null;
+    }
+
+    public void setDefaultPaymentMethod(String id) {
+      this.defaultPaymentMethod = ApiResource.setExpandableFieldId(id, this.defaultPaymentMethod);
+    }
+
+    /** Get expanded `defaultPaymentMethod`. */
+    public PaymentMethod getDefaultPaymentMethodObject() {
+      return (this.defaultPaymentMethod != null) ? this.defaultPaymentMethod.getExpanded() : null;
+    }
+
+    public void setDefaultPaymentMethodObject(PaymentMethod expandableObject) {
+      this.defaultPaymentMethod =
+          new ExpandableField<PaymentMethod>(expandableObject.getId(), expandableObject);
+    }
   }
 
   @Getter

--- a/src/main/java/com/stripe/param/AccountCreateParams.java
+++ b/src/main/java/com/stripe/param/AccountCreateParams.java
@@ -98,9 +98,9 @@ public class AccountCreateParams extends ApiRequestParams {
   Map<String, String> metadata;
 
   /**
-   * The set of capabilities you want to unlock for this account (US only). Each capability will be
-   * inactive until you have provided its specific requirements and Stripe has verified them. An
-   * account may have some of its requested capabilities be active and some be inactive.
+   * The set of capabilities you want to unlock for this account. Each capability will be inactive
+   * until you have provided its specific requirements and Stripe has verified them. An account may
+   * have some of its requested capabilities be active and some be inactive.
    */
   @SerializedName("requested_capabilities")
   List<RequestedCapability> requestedCapabilities;

--- a/src/main/java/com/stripe/param/AccountUpdateParams.java
+++ b/src/main/java/com/stripe/param/AccountUpdateParams.java
@@ -90,9 +90,9 @@ public class AccountUpdateParams extends ApiRequestParams {
   Map<String, String> metadata;
 
   /**
-   * The set of capabilities you want to unlock for this account (US only). Each capability will be
-   * inactive until you have provided its specific requirements and Stripe has verified them. An
-   * account may have some of its requested capabilities be active and some be inactive.
+   * The set of capabilities you want to unlock for this account. Each capability will be inactive
+   * until you have provided its specific requirements and Stripe has verified them. An account may
+   * have some of its requested capabilities be active and some be inactive.
    */
   @SerializedName("requested_capabilities")
   List<RequestedCapability> requestedCapabilities;

--- a/src/main/java/com/stripe/param/DisputeListParams.java
+++ b/src/main/java/com/stripe/param/DisputeListParams.java
@@ -10,6 +10,10 @@ import lombok.Getter;
 
 @Getter
 public class DisputeListParams extends ApiRequestParams {
+  /** Only return disputes that are associated by the Charge specified by this Charge ID. */
+  @SerializedName("charge")
+  String charge;
+
   @SerializedName("created")
   Object created;
 
@@ -52,12 +56,14 @@ public class DisputeListParams extends ApiRequestParams {
   String startingAfter;
 
   private DisputeListParams(
+      String charge,
       Object created,
       String endingBefore,
       List<String> expand,
       Map<String, Object> extraParams,
       Long limit,
       String startingAfter) {
+    this.charge = charge;
     this.created = created;
     this.endingBefore = endingBefore;
     this.expand = expand;
@@ -71,6 +77,8 @@ public class DisputeListParams extends ApiRequestParams {
   }
 
   public static class Builder {
+    private String charge;
+
     private Object created;
 
     private String endingBefore;
@@ -86,12 +94,19 @@ public class DisputeListParams extends ApiRequestParams {
     /** Finalize and obtain parameter instance from this builder. */
     public DisputeListParams build() {
       return new DisputeListParams(
+          this.charge,
           this.created,
           this.endingBefore,
           this.expand,
           this.extraParams,
           this.limit,
           this.startingAfter);
+    }
+
+    /** Only return disputes that are associated by the Charge specified by this Charge ID. */
+    public Builder setCharge(String charge) {
+      this.charge = charge;
+      return this;
     }
 
     public Builder setCreated(Created created) {

--- a/src/main/java/com/stripe/param/SubscriptionScheduleCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionScheduleCreateParams.java
@@ -12,41 +12,13 @@ import lombok.Getter;
 
 @Getter
 public class SubscriptionScheduleCreateParams extends ApiRequestParams {
-  /**
-   * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
-   * billing period. Pass an empty string to remove previously-defined thresholds.
-   */
-  @SerializedName("billing_thresholds")
-  Object billingThresholds;
-
-  /**
-   * Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will
-   * attempt to pay the underlying subscription at the end of each billing cycle using the default
-   * source attached to the customer. When sending an invoice, Stripe will email your customer an
-   * invoice with payment instructions. Defaults to `charge_automatically` on creation.
-   */
-  @SerializedName("collection_method")
-  CollectionMethod collectionMethod;
-
   /** The identifier of the customer to create the subscription schedule for. */
   @SerializedName("customer")
   String customer;
 
-  /**
-   * ID of the default payment method for the subscription schedule. It must belong to the customer
-   * associated with the subscription schedule. If not set, invoices will use the default payment
-   * method in the customer's invoice settings.
-   */
-  @SerializedName("default_payment_method")
-  String defaultPaymentMethod;
-
-  /**
-   * ID of the default payment source for the subscription schedule. It must belong to the customer
-   * associated with the subscription schedule and be in a chargeable state. If not set, defaults to
-   * the customer's default source.
-   */
-  @SerializedName("default_source")
-  String defaultSource;
+  /** Object representing the subscription schedule's default settings. */
+  @SerializedName("default_settings")
+  DefaultSettings defaultSettings;
 
   /**
    * Configures how the subscription schedule behaves when it ends. Possible values are `release` or
@@ -79,10 +51,6 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
   @SerializedName("from_subscription")
   String fromSubscription;
 
-  /** All invoices will be billed using the specified settings. */
-  @SerializedName("invoice_settings")
-  InvoiceSettings invoiceSettings;
-
   /**
    * Set of key-value pairs that you can attach to an object. This can be useful for storing
    * additional information about the object in a structured format.
@@ -103,29 +71,21 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
   Object startDate;
 
   private SubscriptionScheduleCreateParams(
-      Object billingThresholds,
-      CollectionMethod collectionMethod,
       String customer,
-      String defaultPaymentMethod,
-      String defaultSource,
+      DefaultSettings defaultSettings,
       EndBehavior endBehavior,
       List<String> expand,
       Map<String, Object> extraParams,
       String fromSubscription,
-      InvoiceSettings invoiceSettings,
       Map<String, String> metadata,
       List<Phase> phases,
       Object startDate) {
-    this.billingThresholds = billingThresholds;
-    this.collectionMethod = collectionMethod;
     this.customer = customer;
-    this.defaultPaymentMethod = defaultPaymentMethod;
-    this.defaultSource = defaultSource;
+    this.defaultSettings = defaultSettings;
     this.endBehavior = endBehavior;
     this.expand = expand;
     this.extraParams = extraParams;
     this.fromSubscription = fromSubscription;
-    this.invoiceSettings = invoiceSettings;
     this.metadata = metadata;
     this.phases = phases;
     this.startDate = startDate;
@@ -136,15 +96,9 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
   }
 
   public static class Builder {
-    private Object billingThresholds;
-
-    private CollectionMethod collectionMethod;
-
     private String customer;
 
-    private String defaultPaymentMethod;
-
-    private String defaultSource;
+    private DefaultSettings defaultSettings;
 
     private EndBehavior endBehavior;
 
@@ -153,8 +107,6 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
     private Map<String, Object> extraParams;
 
     private String fromSubscription;
-
-    private InvoiceSettings invoiceSettings;
 
     private Map<String, String> metadata;
 
@@ -165,48 +117,15 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
     /** Finalize and obtain parameter instance from this builder. */
     public SubscriptionScheduleCreateParams build() {
       return new SubscriptionScheduleCreateParams(
-          this.billingThresholds,
-          this.collectionMethod,
           this.customer,
-          this.defaultPaymentMethod,
-          this.defaultSource,
+          this.defaultSettings,
           this.endBehavior,
           this.expand,
           this.extraParams,
           this.fromSubscription,
-          this.invoiceSettings,
           this.metadata,
           this.phases,
           this.startDate);
-    }
-
-    /**
-     * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
-     * billing period. Pass an empty string to remove previously-defined thresholds.
-     */
-    public Builder setBillingThresholds(BillingThresholds billingThresholds) {
-      this.billingThresholds = billingThresholds;
-      return this;
-    }
-
-    /**
-     * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
-     * billing period. Pass an empty string to remove previously-defined thresholds.
-     */
-    public Builder setBillingThresholds(EmptyParam billingThresholds) {
-      this.billingThresholds = billingThresholds;
-      return this;
-    }
-
-    /**
-     * Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will
-     * attempt to pay the underlying subscription at the end of each billing cycle using the default
-     * source attached to the customer. When sending an invoice, Stripe will email your customer an
-     * invoice with payment instructions. Defaults to `charge_automatically` on creation.
-     */
-    public Builder setCollectionMethod(CollectionMethod collectionMethod) {
-      this.collectionMethod = collectionMethod;
-      return this;
     }
 
     /** The identifier of the customer to create the subscription schedule for. */
@@ -215,23 +134,9 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
       return this;
     }
 
-    /**
-     * ID of the default payment method for the subscription schedule. It must belong to the
-     * customer associated with the subscription schedule. If not set, invoices will use the default
-     * payment method in the customer's invoice settings.
-     */
-    public Builder setDefaultPaymentMethod(String defaultPaymentMethod) {
-      this.defaultPaymentMethod = defaultPaymentMethod;
-      return this;
-    }
-
-    /**
-     * ID of the default payment source for the subscription schedule. It must belong to the
-     * customer associated with the subscription schedule and be in a chargeable state. If not set,
-     * defaults to the customer's default source.
-     */
-    public Builder setDefaultSource(String defaultSource) {
-      this.defaultSource = defaultSource;
+    /** Object representing the subscription schedule's default settings. */
+    public Builder setDefaultSettings(DefaultSettings defaultSettings) {
+      this.defaultSettings = defaultSettings;
       return this;
     }
 
@@ -309,12 +214,6 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
       return this;
     }
 
-    /** All invoices will be billed using the specified settings. */
-    public Builder setInvoiceSettings(InvoiceSettings invoiceSettings) {
-      this.invoiceSettings = invoiceSettings;
-      return this;
-    }
-
     /**
      * Add a key/value pair to `metadata` map. A map is initialized for the first `put/putAll` call,
      * and subsequent calls add additional key/value pairs to the original map. See {@link
@@ -381,10 +280,30 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
   }
 
   @Getter
-  public static class BillingThresholds {
-    /** Monetary threshold that triggers the subscription to advance to a new billing period. */
-    @SerializedName("amount_gte")
-    Long amountGte;
+  public static class DefaultSettings {
+    /**
+     * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
+     * billing period. Pass an empty string to remove previously-defined thresholds.
+     */
+    @SerializedName("billing_thresholds")
+    Object billingThresholds;
+
+    /**
+     * Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will
+     * attempt to pay the underlying subscription at the end of each billing cycle using the default
+     * source attached to the customer. When sending an invoice, Stripe will email your customer an
+     * invoice with payment instructions. Defaults to `charge_automatically` on creation.
+     */
+    @SerializedName("collection_method")
+    CollectionMethod collectionMethod;
+
+    /**
+     * ID of the default payment method for the subscription schedule. It must belong to the
+     * customer associated with the subscription schedule. If not set, invoices will use the default
+     * payment method in the customer's invoice settings.
+     */
+    @SerializedName("default_payment_method")
+    String defaultPaymentMethod;
 
     /**
      * Map of extra parameters for custom features not available in this client library. The content
@@ -395,19 +314,21 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
     @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
     Map<String, Object> extraParams;
 
-    /**
-     * Indicates if the `billing_cycle_anchor` should be reset when a threshold is reached. If true,
-     * `billing_cycle_anchor` will be updated to the date/time the threshold was last reached;
-     * otherwise, the value will remain unchanged.
-     */
-    @SerializedName("reset_billing_cycle_anchor")
-    Boolean resetBillingCycleAnchor;
+    /** All invoices will be billed using the specified settings. */
+    @SerializedName("invoice_settings")
+    InvoiceSettings invoiceSettings;
 
-    private BillingThresholds(
-        Long amountGte, Map<String, Object> extraParams, Boolean resetBillingCycleAnchor) {
-      this.amountGte = amountGte;
+    private DefaultSettings(
+        Object billingThresholds,
+        CollectionMethod collectionMethod,
+        String defaultPaymentMethod,
+        Map<String, Object> extraParams,
+        InvoiceSettings invoiceSettings) {
+      this.billingThresholds = billingThresholds;
+      this.collectionMethod = collectionMethod;
+      this.defaultPaymentMethod = defaultPaymentMethod;
       this.extraParams = extraParams;
-      this.resetBillingCycleAnchor = resetBillingCycleAnchor;
+      this.invoiceSettings = invoiceSettings;
     }
 
     public static Builder builder() {
@@ -415,29 +336,70 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
     }
 
     public static class Builder {
-      private Long amountGte;
+      private Object billingThresholds;
+
+      private CollectionMethod collectionMethod;
+
+      private String defaultPaymentMethod;
 
       private Map<String, Object> extraParams;
 
-      private Boolean resetBillingCycleAnchor;
+      private InvoiceSettings invoiceSettings;
 
       /** Finalize and obtain parameter instance from this builder. */
-      public BillingThresholds build() {
-        return new BillingThresholds(
-            this.amountGte, this.extraParams, this.resetBillingCycleAnchor);
+      public DefaultSettings build() {
+        return new DefaultSettings(
+            this.billingThresholds,
+            this.collectionMethod,
+            this.defaultPaymentMethod,
+            this.extraParams,
+            this.invoiceSettings);
       }
 
-      /** Monetary threshold that triggers the subscription to advance to a new billing period. */
-      public Builder setAmountGte(Long amountGte) {
-        this.amountGte = amountGte;
+      /**
+       * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
+       * billing period. Pass an empty string to remove previously-defined thresholds.
+       */
+      public Builder setBillingThresholds(BillingThresholds billingThresholds) {
+        this.billingThresholds = billingThresholds;
+        return this;
+      }
+
+      /**
+       * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
+       * billing period. Pass an empty string to remove previously-defined thresholds.
+       */
+      public Builder setBillingThresholds(EmptyParam billingThresholds) {
+        this.billingThresholds = billingThresholds;
+        return this;
+      }
+
+      /**
+       * Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will
+       * attempt to pay the underlying subscription at the end of each billing cycle using the
+       * default source attached to the customer. When sending an invoice, Stripe will email your
+       * customer an invoice with payment instructions. Defaults to `charge_automatically` on
+       * creation.
+       */
+      public Builder setCollectionMethod(CollectionMethod collectionMethod) {
+        this.collectionMethod = collectionMethod;
+        return this;
+      }
+
+      /**
+       * ID of the default payment method for the subscription schedule. It must belong to the
+       * customer associated with the subscription schedule. If not set, invoices will use the
+       * default payment method in the customer's invoice settings.
+       */
+      public Builder setDefaultPaymentMethod(String defaultPaymentMethod) {
+        this.defaultPaymentMethod = defaultPaymentMethod;
         return this;
       }
 
       /**
        * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
        * call, and subsequent calls add additional key/value pairs to the original map. See {@link
-       * SubscriptionScheduleCreateParams.BillingThresholds#extraParams} for the field
-       * documentation.
+       * SubscriptionScheduleCreateParams.DefaultSettings#extraParams} for the field documentation.
        */
       public Builder putExtraParam(String key, Object value) {
         if (this.extraParams == null) {
@@ -450,7 +412,7 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
       /**
        * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
        * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
-       * See {@link SubscriptionScheduleCreateParams.BillingThresholds#extraParams} for the field
+       * See {@link SubscriptionScheduleCreateParams.DefaultSettings#extraParams} for the field
        * documentation.
        */
       public Builder putAllExtraParam(Map<String, Object> map) {
@@ -460,82 +422,191 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
         this.extraParams.putAll(map);
         return this;
       }
+
+      /** All invoices will be billed using the specified settings. */
+      public Builder setInvoiceSettings(InvoiceSettings invoiceSettings) {
+        this.invoiceSettings = invoiceSettings;
+        return this;
+      }
+    }
+
+    @Getter
+    public static class BillingThresholds {
+      /** Monetary threshold that triggers the subscription to advance to a new billing period. */
+      @SerializedName("amount_gte")
+      Long amountGte;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
 
       /**
        * Indicates if the `billing_cycle_anchor` should be reset when a threshold is reached. If
        * true, `billing_cycle_anchor` will be updated to the date/time the threshold was last
        * reached; otherwise, the value will remain unchanged.
        */
-      public Builder setResetBillingCycleAnchor(Boolean resetBillingCycleAnchor) {
+      @SerializedName("reset_billing_cycle_anchor")
+      Boolean resetBillingCycleAnchor;
+
+      private BillingThresholds(
+          Long amountGte, Map<String, Object> extraParams, Boolean resetBillingCycleAnchor) {
+        this.amountGte = amountGte;
+        this.extraParams = extraParams;
         this.resetBillingCycleAnchor = resetBillingCycleAnchor;
-        return this;
-      }
-    }
-  }
-
-  @Getter
-  public static class InvoiceSettings {
-    @SerializedName("days_until_due")
-    Long daysUntilDue;
-
-    /**
-     * Map of extra parameters for custom features not available in this client library. The content
-     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
-     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
-     * param object. Effectively, this map is flattened to its parent instance.
-     */
-    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
-    Map<String, Object> extraParams;
-
-    private InvoiceSettings(Long daysUntilDue, Map<String, Object> extraParams) {
-      this.daysUntilDue = daysUntilDue;
-      this.extraParams = extraParams;
-    }
-
-    public static Builder builder() {
-      return new Builder();
-    }
-
-    public static class Builder {
-      private Long daysUntilDue;
-
-      private Map<String, Object> extraParams;
-
-      /** Finalize and obtain parameter instance from this builder. */
-      public InvoiceSettings build() {
-        return new InvoiceSettings(this.daysUntilDue, this.extraParams);
       }
 
-      public Builder setDaysUntilDue(Long daysUntilDue) {
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Long amountGte;
+
+        private Map<String, Object> extraParams;
+
+        private Boolean resetBillingCycleAnchor;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public BillingThresholds build() {
+          return new BillingThresholds(
+              this.amountGte, this.extraParams, this.resetBillingCycleAnchor);
+        }
+
+        /** Monetary threshold that triggers the subscription to advance to a new billing period. */
+        public Builder setAmountGte(Long amountGte) {
+          this.amountGte = amountGte;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * SubscriptionScheduleCreateParams.DefaultSettings.BillingThresholds#extraParams} for the
+         * field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * SubscriptionScheduleCreateParams.DefaultSettings.BillingThresholds#extraParams} for the
+         * field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /**
+         * Indicates if the `billing_cycle_anchor` should be reset when a threshold is reached. If
+         * true, `billing_cycle_anchor` will be updated to the date/time the threshold was last
+         * reached; otherwise, the value will remain unchanged.
+         */
+        public Builder setResetBillingCycleAnchor(Boolean resetBillingCycleAnchor) {
+          this.resetBillingCycleAnchor = resetBillingCycleAnchor;
+          return this;
+        }
+      }
+    }
+
+    @Getter
+    public static class InvoiceSettings {
+      @SerializedName("days_until_due")
+      Long daysUntilDue;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private InvoiceSettings(Long daysUntilDue, Map<String, Object> extraParams) {
         this.daysUntilDue = daysUntilDue;
-        return this;
+        this.extraParams = extraParams;
       }
 
-      /**
-       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
-       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
-       * SubscriptionScheduleCreateParams.InvoiceSettings#extraParams} for the field documentation.
-       */
-      public Builder putExtraParam(String key, Object value) {
-        if (this.extraParams == null) {
-          this.extraParams = new HashMap<>();
-        }
-        this.extraParams.put(key, value);
-        return this;
+      public static Builder builder() {
+        return new Builder();
       }
 
-      /**
-       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
-       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
-       * See {@link SubscriptionScheduleCreateParams.InvoiceSettings#extraParams} for the field
-       * documentation.
-       */
-      public Builder putAllExtraParam(Map<String, Object> map) {
-        if (this.extraParams == null) {
-          this.extraParams = new HashMap<>();
+      public static class Builder {
+        private Long daysUntilDue;
+
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public InvoiceSettings build() {
+          return new InvoiceSettings(this.daysUntilDue, this.extraParams);
         }
-        this.extraParams.putAll(map);
-        return this;
+
+        public Builder setDaysUntilDue(Long daysUntilDue) {
+          this.daysUntilDue = daysUntilDue;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * SubscriptionScheduleCreateParams.DefaultSettings.InvoiceSettings#extraParams} for the
+         * field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * SubscriptionScheduleCreateParams.DefaultSettings.InvoiceSettings#extraParams} for the
+         * field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+      }
+    }
+
+    public enum CollectionMethod implements ApiRequestParams.EnumParam {
+      @SerializedName("charge_automatically")
+      CHARGE_AUTOMATICALLY("charge_automatically"),
+
+      @SerializedName("send_invoice")
+      SEND_INVOICE("send_invoice");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      CollectionMethod(String value) {
+        this.value = value;
       }
     }
   }
@@ -1373,21 +1444,6 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
       CollectionMethod(String value) {
         this.value = value;
       }
-    }
-  }
-
-  public enum CollectionMethod implements ApiRequestParams.EnumParam {
-    @SerializedName("charge_automatically")
-    CHARGE_AUTOMATICALLY("charge_automatically"),
-
-    @SerializedName("send_invoice")
-    SEND_INVOICE("send_invoice");
-
-    @Getter(onMethod_ = {@Override})
-    private final String value;
-
-    CollectionMethod(String value) {
-      this.value = value;
     }
   }
 

--- a/src/main/java/com/stripe/param/SubscriptionScheduleUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionScheduleUpdateParams.java
@@ -12,37 +12,9 @@ import lombok.Getter;
 
 @Getter
 public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
-  /**
-   * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
-   * billing period. Pass an empty string to remove previously-defined thresholds.
-   */
-  @SerializedName("billing_thresholds")
-  Object billingThresholds;
-
-  /**
-   * Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will
-   * attempt to pay the underlying subscription at the end of each billing cycle using the default
-   * source attached to the customer. When sending an invoice, Stripe will email your customer an
-   * invoice with payment instructions. Defaults to `charge_automatically` on creation.
-   */
-  @SerializedName("collection_method")
-  CollectionMethod collectionMethod;
-
-  /**
-   * ID of the default payment method for the subscription schedule. It must belong to the customer
-   * associated with the subscription schedule. If not set, invoices will use the default payment
-   * method in the customer's invoice settings.
-   */
-  @SerializedName("default_payment_method")
-  Object defaultPaymentMethod;
-
-  /**
-   * ID of the default payment source for the subscription schedule. It must belong to the customer
-   * associated with the subscription schedule and be in a chargeable state. If not set, defaults to
-   * the customer's default source.
-   */
-  @SerializedName("default_source")
-  Object defaultSource;
+  /** Object representing the subscription schedule's default settings. */
+  @SerializedName("default_settings")
+  DefaultSettings defaultSettings;
 
   /**
    * Configures how the subscription schedule behaves when it ends. Possible values are `release` or
@@ -65,10 +37,6 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
    */
   @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
   Map<String, Object> extraParams;
-
-  /** All invoices will be billed using the specified settings. */
-  @SerializedName("invoice_settings")
-  InvoiceSettings invoiceSettings;
 
   /**
    * Set of key-value pairs that you can attach to an object. This can be useful for storing
@@ -94,25 +62,17 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
   Boolean prorate;
 
   private SubscriptionScheduleUpdateParams(
-      Object billingThresholds,
-      CollectionMethod collectionMethod,
-      Object defaultPaymentMethod,
-      Object defaultSource,
+      DefaultSettings defaultSettings,
       EndBehavior endBehavior,
       List<String> expand,
       Map<String, Object> extraParams,
-      InvoiceSettings invoiceSettings,
       Map<String, String> metadata,
       List<Phase> phases,
       Boolean prorate) {
-    this.billingThresholds = billingThresholds;
-    this.collectionMethod = collectionMethod;
-    this.defaultPaymentMethod = defaultPaymentMethod;
-    this.defaultSource = defaultSource;
+    this.defaultSettings = defaultSettings;
     this.endBehavior = endBehavior;
     this.expand = expand;
     this.extraParams = extraParams;
-    this.invoiceSettings = invoiceSettings;
     this.metadata = metadata;
     this.phases = phases;
     this.prorate = prorate;
@@ -123,21 +83,13 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
   }
 
   public static class Builder {
-    private Object billingThresholds;
-
-    private CollectionMethod collectionMethod;
-
-    private Object defaultPaymentMethod;
-
-    private Object defaultSource;
+    private DefaultSettings defaultSettings;
 
     private EndBehavior endBehavior;
 
     private List<String> expand;
 
     private Map<String, Object> extraParams;
-
-    private InvoiceSettings invoiceSettings;
 
     private Map<String, String> metadata;
 
@@ -148,85 +100,18 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
     /** Finalize and obtain parameter instance from this builder. */
     public SubscriptionScheduleUpdateParams build() {
       return new SubscriptionScheduleUpdateParams(
-          this.billingThresholds,
-          this.collectionMethod,
-          this.defaultPaymentMethod,
-          this.defaultSource,
+          this.defaultSettings,
           this.endBehavior,
           this.expand,
           this.extraParams,
-          this.invoiceSettings,
           this.metadata,
           this.phases,
           this.prorate);
     }
 
-    /**
-     * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
-     * billing period. Pass an empty string to remove previously-defined thresholds.
-     */
-    public Builder setBillingThresholds(BillingThresholds billingThresholds) {
-      this.billingThresholds = billingThresholds;
-      return this;
-    }
-
-    /**
-     * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
-     * billing period. Pass an empty string to remove previously-defined thresholds.
-     */
-    public Builder setBillingThresholds(EmptyParam billingThresholds) {
-      this.billingThresholds = billingThresholds;
-      return this;
-    }
-
-    /**
-     * Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will
-     * attempt to pay the underlying subscription at the end of each billing cycle using the default
-     * source attached to the customer. When sending an invoice, Stripe will email your customer an
-     * invoice with payment instructions. Defaults to `charge_automatically` on creation.
-     */
-    public Builder setCollectionMethod(CollectionMethod collectionMethod) {
-      this.collectionMethod = collectionMethod;
-      return this;
-    }
-
-    /**
-     * ID of the default payment method for the subscription schedule. It must belong to the
-     * customer associated with the subscription schedule. If not set, invoices will use the default
-     * payment method in the customer's invoice settings.
-     */
-    public Builder setDefaultPaymentMethod(String defaultPaymentMethod) {
-      this.defaultPaymentMethod = defaultPaymentMethod;
-      return this;
-    }
-
-    /**
-     * ID of the default payment method for the subscription schedule. It must belong to the
-     * customer associated with the subscription schedule. If not set, invoices will use the default
-     * payment method in the customer's invoice settings.
-     */
-    public Builder setDefaultPaymentMethod(EmptyParam defaultPaymentMethod) {
-      this.defaultPaymentMethod = defaultPaymentMethod;
-      return this;
-    }
-
-    /**
-     * ID of the default payment source for the subscription schedule. It must belong to the
-     * customer associated with the subscription schedule and be in a chargeable state. If not set,
-     * defaults to the customer's default source.
-     */
-    public Builder setDefaultSource(String defaultSource) {
-      this.defaultSource = defaultSource;
-      return this;
-    }
-
-    /**
-     * ID of the default payment source for the subscription schedule. It must belong to the
-     * customer associated with the subscription schedule and be in a chargeable state. If not set,
-     * defaults to the customer's default source.
-     */
-    public Builder setDefaultSource(EmptyParam defaultSource) {
-      this.defaultSource = defaultSource;
+    /** Object representing the subscription schedule's default settings. */
+    public Builder setDefaultSettings(DefaultSettings defaultSettings) {
+      this.defaultSettings = defaultSettings;
       return this;
     }
 
@@ -293,12 +178,6 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
       return this;
     }
 
-    /** All invoices will be billed using the specified settings. */
-    public Builder setInvoiceSettings(InvoiceSettings invoiceSettings) {
-      this.invoiceSettings = invoiceSettings;
-      return this;
-    }
-
     /**
      * Add a key/value pair to `metadata` map. A map is initialized for the first `put/putAll` call,
      * and subsequent calls add additional key/value pairs to the original map. See {@link
@@ -362,10 +241,30 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
   }
 
   @Getter
-  public static class BillingThresholds {
-    /** Monetary threshold that triggers the subscription to advance to a new billing period. */
-    @SerializedName("amount_gte")
-    Long amountGte;
+  public static class DefaultSettings {
+    /**
+     * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
+     * billing period. Pass an empty string to remove previously-defined thresholds.
+     */
+    @SerializedName("billing_thresholds")
+    Object billingThresholds;
+
+    /**
+     * Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will
+     * attempt to pay the underlying subscription at the end of each billing cycle using the default
+     * source attached to the customer. When sending an invoice, Stripe will email your customer an
+     * invoice with payment instructions. Defaults to `charge_automatically` on creation.
+     */
+    @SerializedName("collection_method")
+    CollectionMethod collectionMethod;
+
+    /**
+     * ID of the default payment method for the subscription schedule. It must belong to the
+     * customer associated with the subscription schedule. If not set, invoices will use the default
+     * payment method in the customer's invoice settings.
+     */
+    @SerializedName("default_payment_method")
+    Object defaultPaymentMethod;
 
     /**
      * Map of extra parameters for custom features not available in this client library. The content
@@ -376,19 +275,21 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
     @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
     Map<String, Object> extraParams;
 
-    /**
-     * Indicates if the `billing_cycle_anchor` should be reset when a threshold is reached. If true,
-     * `billing_cycle_anchor` will be updated to the date/time the threshold was last reached;
-     * otherwise, the value will remain unchanged.
-     */
-    @SerializedName("reset_billing_cycle_anchor")
-    Boolean resetBillingCycleAnchor;
+    /** All invoices will be billed using the specified settings. */
+    @SerializedName("invoice_settings")
+    InvoiceSettings invoiceSettings;
 
-    private BillingThresholds(
-        Long amountGte, Map<String, Object> extraParams, Boolean resetBillingCycleAnchor) {
-      this.amountGte = amountGte;
+    private DefaultSettings(
+        Object billingThresholds,
+        CollectionMethod collectionMethod,
+        Object defaultPaymentMethod,
+        Map<String, Object> extraParams,
+        InvoiceSettings invoiceSettings) {
+      this.billingThresholds = billingThresholds;
+      this.collectionMethod = collectionMethod;
+      this.defaultPaymentMethod = defaultPaymentMethod;
       this.extraParams = extraParams;
-      this.resetBillingCycleAnchor = resetBillingCycleAnchor;
+      this.invoiceSettings = invoiceSettings;
     }
 
     public static Builder builder() {
@@ -396,29 +297,80 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
     }
 
     public static class Builder {
-      private Long amountGte;
+      private Object billingThresholds;
+
+      private CollectionMethod collectionMethod;
+
+      private Object defaultPaymentMethod;
 
       private Map<String, Object> extraParams;
 
-      private Boolean resetBillingCycleAnchor;
+      private InvoiceSettings invoiceSettings;
 
       /** Finalize and obtain parameter instance from this builder. */
-      public BillingThresholds build() {
-        return new BillingThresholds(
-            this.amountGte, this.extraParams, this.resetBillingCycleAnchor);
+      public DefaultSettings build() {
+        return new DefaultSettings(
+            this.billingThresholds,
+            this.collectionMethod,
+            this.defaultPaymentMethod,
+            this.extraParams,
+            this.invoiceSettings);
       }
 
-      /** Monetary threshold that triggers the subscription to advance to a new billing period. */
-      public Builder setAmountGte(Long amountGte) {
-        this.amountGte = amountGte;
+      /**
+       * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
+       * billing period. Pass an empty string to remove previously-defined thresholds.
+       */
+      public Builder setBillingThresholds(BillingThresholds billingThresholds) {
+        this.billingThresholds = billingThresholds;
+        return this;
+      }
+
+      /**
+       * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
+       * billing period. Pass an empty string to remove previously-defined thresholds.
+       */
+      public Builder setBillingThresholds(EmptyParam billingThresholds) {
+        this.billingThresholds = billingThresholds;
+        return this;
+      }
+
+      /**
+       * Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will
+       * attempt to pay the underlying subscription at the end of each billing cycle using the
+       * default source attached to the customer. When sending an invoice, Stripe will email your
+       * customer an invoice with payment instructions. Defaults to `charge_automatically` on
+       * creation.
+       */
+      public Builder setCollectionMethod(CollectionMethod collectionMethod) {
+        this.collectionMethod = collectionMethod;
+        return this;
+      }
+
+      /**
+       * ID of the default payment method for the subscription schedule. It must belong to the
+       * customer associated with the subscription schedule. If not set, invoices will use the
+       * default payment method in the customer's invoice settings.
+       */
+      public Builder setDefaultPaymentMethod(String defaultPaymentMethod) {
+        this.defaultPaymentMethod = defaultPaymentMethod;
+        return this;
+      }
+
+      /**
+       * ID of the default payment method for the subscription schedule. It must belong to the
+       * customer associated with the subscription schedule. If not set, invoices will use the
+       * default payment method in the customer's invoice settings.
+       */
+      public Builder setDefaultPaymentMethod(EmptyParam defaultPaymentMethod) {
+        this.defaultPaymentMethod = defaultPaymentMethod;
         return this;
       }
 
       /**
        * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
        * call, and subsequent calls add additional key/value pairs to the original map. See {@link
-       * SubscriptionScheduleUpdateParams.BillingThresholds#extraParams} for the field
-       * documentation.
+       * SubscriptionScheduleUpdateParams.DefaultSettings#extraParams} for the field documentation.
        */
       public Builder putExtraParam(String key, Object value) {
         if (this.extraParams == null) {
@@ -431,7 +383,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
       /**
        * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
        * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
-       * See {@link SubscriptionScheduleUpdateParams.BillingThresholds#extraParams} for the field
+       * See {@link SubscriptionScheduleUpdateParams.DefaultSettings#extraParams} for the field
        * documentation.
        */
       public Builder putAllExtraParam(Map<String, Object> map) {
@@ -441,82 +393,191 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
         this.extraParams.putAll(map);
         return this;
       }
+
+      /** All invoices will be billed using the specified settings. */
+      public Builder setInvoiceSettings(InvoiceSettings invoiceSettings) {
+        this.invoiceSettings = invoiceSettings;
+        return this;
+      }
+    }
+
+    @Getter
+    public static class BillingThresholds {
+      /** Monetary threshold that triggers the subscription to advance to a new billing period. */
+      @SerializedName("amount_gte")
+      Long amountGte;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
 
       /**
        * Indicates if the `billing_cycle_anchor` should be reset when a threshold is reached. If
        * true, `billing_cycle_anchor` will be updated to the date/time the threshold was last
        * reached; otherwise, the value will remain unchanged.
        */
-      public Builder setResetBillingCycleAnchor(Boolean resetBillingCycleAnchor) {
+      @SerializedName("reset_billing_cycle_anchor")
+      Boolean resetBillingCycleAnchor;
+
+      private BillingThresholds(
+          Long amountGte, Map<String, Object> extraParams, Boolean resetBillingCycleAnchor) {
+        this.amountGte = amountGte;
+        this.extraParams = extraParams;
         this.resetBillingCycleAnchor = resetBillingCycleAnchor;
-        return this;
-      }
-    }
-  }
-
-  @Getter
-  public static class InvoiceSettings {
-    @SerializedName("days_until_due")
-    Long daysUntilDue;
-
-    /**
-     * Map of extra parameters for custom features not available in this client library. The content
-     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
-     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
-     * param object. Effectively, this map is flattened to its parent instance.
-     */
-    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
-    Map<String, Object> extraParams;
-
-    private InvoiceSettings(Long daysUntilDue, Map<String, Object> extraParams) {
-      this.daysUntilDue = daysUntilDue;
-      this.extraParams = extraParams;
-    }
-
-    public static Builder builder() {
-      return new Builder();
-    }
-
-    public static class Builder {
-      private Long daysUntilDue;
-
-      private Map<String, Object> extraParams;
-
-      /** Finalize and obtain parameter instance from this builder. */
-      public InvoiceSettings build() {
-        return new InvoiceSettings(this.daysUntilDue, this.extraParams);
       }
 
-      public Builder setDaysUntilDue(Long daysUntilDue) {
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Long amountGte;
+
+        private Map<String, Object> extraParams;
+
+        private Boolean resetBillingCycleAnchor;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public BillingThresholds build() {
+          return new BillingThresholds(
+              this.amountGte, this.extraParams, this.resetBillingCycleAnchor);
+        }
+
+        /** Monetary threshold that triggers the subscription to advance to a new billing period. */
+        public Builder setAmountGte(Long amountGte) {
+          this.amountGte = amountGte;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * SubscriptionScheduleUpdateParams.DefaultSettings.BillingThresholds#extraParams} for the
+         * field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * SubscriptionScheduleUpdateParams.DefaultSettings.BillingThresholds#extraParams} for the
+         * field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /**
+         * Indicates if the `billing_cycle_anchor` should be reset when a threshold is reached. If
+         * true, `billing_cycle_anchor` will be updated to the date/time the threshold was last
+         * reached; otherwise, the value will remain unchanged.
+         */
+        public Builder setResetBillingCycleAnchor(Boolean resetBillingCycleAnchor) {
+          this.resetBillingCycleAnchor = resetBillingCycleAnchor;
+          return this;
+        }
+      }
+    }
+
+    @Getter
+    public static class InvoiceSettings {
+      @SerializedName("days_until_due")
+      Long daysUntilDue;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private InvoiceSettings(Long daysUntilDue, Map<String, Object> extraParams) {
         this.daysUntilDue = daysUntilDue;
-        return this;
+        this.extraParams = extraParams;
       }
 
-      /**
-       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
-       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
-       * SubscriptionScheduleUpdateParams.InvoiceSettings#extraParams} for the field documentation.
-       */
-      public Builder putExtraParam(String key, Object value) {
-        if (this.extraParams == null) {
-          this.extraParams = new HashMap<>();
-        }
-        this.extraParams.put(key, value);
-        return this;
+      public static Builder builder() {
+        return new Builder();
       }
 
-      /**
-       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
-       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
-       * See {@link SubscriptionScheduleUpdateParams.InvoiceSettings#extraParams} for the field
-       * documentation.
-       */
-      public Builder putAllExtraParam(Map<String, Object> map) {
-        if (this.extraParams == null) {
-          this.extraParams = new HashMap<>();
+      public static class Builder {
+        private Long daysUntilDue;
+
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public InvoiceSettings build() {
+          return new InvoiceSettings(this.daysUntilDue, this.extraParams);
         }
-        this.extraParams.putAll(map);
-        return this;
+
+        public Builder setDaysUntilDue(Long daysUntilDue) {
+          this.daysUntilDue = daysUntilDue;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * SubscriptionScheduleUpdateParams.DefaultSettings.InvoiceSettings#extraParams} for the
+         * field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * SubscriptionScheduleUpdateParams.DefaultSettings.InvoiceSettings#extraParams} for the
+         * field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+      }
+    }
+
+    public enum CollectionMethod implements ApiRequestParams.EnumParam {
+      @SerializedName("charge_automatically")
+      CHARGE_AUTOMATICALLY("charge_automatically"),
+
+      @SerializedName("send_invoice")
+      SEND_INVOICE("send_invoice");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      CollectionMethod(String value) {
+        this.value = value;
       }
     }
   }
@@ -1451,21 +1512,6 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
       TrialEnd(String value) {
         this.value = value;
       }
-    }
-  }
-
-  public enum CollectionMethod implements ApiRequestParams.EnumParam {
-    @SerializedName("charge_automatically")
-    CHARGE_AUTOMATICALLY("charge_automatically"),
-
-    @SerializedName("send_invoice")
-    SEND_INVOICE("send_invoice");
-
-    @Getter(onMethod_ = {@Override})
-    private final String value;
-
-    CollectionMethod(String value) {
-      this.value = value;
     }
   }
 

--- a/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
+++ b/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
@@ -469,7 +469,10 @@ public class WebhookEndpointCreateParams extends ApiRequestParams {
     VERSION_2019_10_08("2019-10-08"),
 
     @SerializedName("2019-10-17")
-    VERSION_2019_10_17("2019-10-17");
+    VERSION_2019_10_17("2019-10-17"),
+
+    @SerializedName("2019-11-05")
+    VERSION_2019_11_05("2019-11-05");
 
     @Getter(onMethod_ = {@Override})
     private final String value;

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -32,7 +32,7 @@ import org.mockito.Mockito;
 
 public class BaseStripeTest {
   // If changing this number, please also change it in `.travis.yml`.
-  private static final String MOCK_MINIMUM_VERSION = "0.70.0";
+  private static final String MOCK_MINIMUM_VERSION = "0.71.0";
 
   private static String port;
 


### PR DESCRIPTION
Move to the latest API version and add new changes
* Move to API version `2019-11-05`
* Add `default_settings` on `SubscritionSchedule`
* Remove `billing_thresholds` and `collection_method`, `default_payment_method` `default_source` and `invoice_settings` from `SubscriptionSchedule.
* Add `charge` filter when listing `Dispute`.

r? @ob-stripe 
cc @stripe/api-libraries