### PR TITLE
Replace Cobertura with JaCoCo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ script:
   - ./gradlew --version
   - ./gradlew clean
   - if [ "$TRAVIS_JDK_VERSION" == "openjdk8" ]; then ./gradlew check; fi
-  - ./gradlew -Djdk.tls.client.protocols="TLSv1.2" cobertura coveralls
+  - ./gradlew -Djdk.tls.client.protocols="TLSv1.2" jacocoTestReport coveralls
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/build.gradle
+++ b/build.gradle
@@ -12,10 +12,10 @@ buildscript {
 plugins {
     id 'java'
     id 'maven'
+    id 'jacoco'
     id 'io.franzbecker.gradle-lombok' version '3.2.0'
     id "com.diffplug.gradle.spotless" version "3.24.3"
     id "net.ltgt.errorprone" version "0.8.1"
-    id 'net.saliman.cobertura' version '2.6.1'
     id 'com.github.kt3k.coveralls' version '2.8.4'
     id 'biz.aQute.bnd.builder' version '4.2.0'
 }
@@ -132,8 +132,13 @@ spotless {
   }
 }
 
-cobertura {
-    coverageFormats = ['html', 'xml'] // coveralls plugin depends on xml format report
-    coverageIgnoreTrivial = true // ignore getters/setters in coverage report
-    coverageIgnoreMethodAnnotations = ["java.lang.Deprecated", "lombok.Generated"]
+jacocoTestReport {
+    reports {
+        xml.enabled = true // coveralls plugin depends on xml format report
+        html.enabled = true
+    }
+}
+
+coveralls {
+    jacocoReportPath 'build/reports/jacoco/test/jacocoTestReport.xml'
 }


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

So I just noticed that our coverage reports have been [broken](https://travis-ci.org/stripe/stripe-java/jobs/608348053#L2191) for months, because we're using a lambda expression ([here](https://github.com/stripe/stripe-java/blob/1fe663f48821b3a6e9f0444388bf3fd339447ecf/src/main/java/com/stripe/net/ApiRequestParamsConverter.java#L113)) and Cobertura doesn't support them (see https://github.com/cobertura/cobertura/issues/274).

Given that the issue is 4 years old and still not fixed, I've followed the advice of someone in the thread and migrated from Cobertura to JaCoCo, another code coverage tool.

(Our coverage numbers are still fairly abysmal because ~nothing in `com.stripe.param` is tested, but that's a different story.)
