### PR TITLE
Add `HttpContent` class

### DIFF
--- a/src/main/java/com/stripe/net/HttpContent.java
+++ b/src/main/java/com/stripe/net/HttpContent.java
@@ -1,0 +1,108 @@
+package com.stripe.net;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.UUID;
+import lombok.Value;
+import lombok.experimental.Accessors;
+
+/**
+ * Represents the content of an HTTP request, i.e. the request's body. This class also holds the
+ * value of the {@code Content-Type} header, which can depend on the body in some cases (e.g. for
+ * multipart requests).
+ */
+@Value
+@Accessors(fluent = true)
+public class HttpContent {
+  /** The request's content, as a byte array. */
+  byte[] byteArrayContent;
+
+  /** The value of the {@code Content-Type} header. */
+  String contentType;
+
+  private HttpContent(byte[] byteArrayContent, String contentType) {
+    this.byteArrayContent = byteArrayContent;
+    this.contentType = contentType;
+  }
+
+  /**
+   * Builds a new HttpContent for name/value tuples encoded using {@code
+   * application/x-www-form-urlencoded} MIME type.
+   *
+   * @param nameValueCollection the collection of name/value tuples to encode
+   * @return the encoded HttpContent instance
+   * @throws IllegalArgumentException if nameValueCollection is null
+   */
+  public static HttpContent buildFormURLEncodedContent(
+      Collection<KeyValuePair<String, String>> nameValueCollection) throws IOException {
+    if (nameValueCollection == null) {
+      throw new IllegalArgumentException("nameValueCollection may not be null");
+    }
+
+    return new HttpContent(
+        FormEncoder.createQueryString(nameValueCollection).getBytes(ApiResource.CHARSET),
+        String.format("application/x-www-form-urlencoded;charset=%s", ApiResource.CHARSET));
+  }
+
+  /**
+   * Builds a new HttpContent for name/value tuples encoded using {@code multipart/form-data} MIME
+   * type.
+   *
+   * @param nameValueCollection the collection of name/value tuples to encode
+   * @return the encoded HttpContent instance
+   * @throws IllegalArgumentException if nameValueCollection is null
+   */
+  public static HttpContent buildMultipartFormDataContent(
+      Collection<KeyValuePair<String, Object>> nameValueCollection) throws IOException {
+    String boundary = UUID.randomUUID().toString();
+    return buildMultipartFormDataContent(nameValueCollection, boundary);
+  }
+
+  /**
+   * Builds a new HttpContent for name/value tuples encoded using {@code multipart/form-data} MIME
+   * type.
+   *
+   * @param nameValueCollection the collection of name/value tuples to encode
+   * @param boundary the boundary
+   * @return the encoded HttpContent instance
+   * @throws IllegalArgumentException if nameValueCollection is null
+   */
+  public static HttpContent buildMultipartFormDataContent(
+      Collection<KeyValuePair<String, Object>> nameValueCollection, String boundary)
+      throws IOException {
+    if (nameValueCollection == null) {
+      throw new IllegalArgumentException("nameValueCollection may not be null");
+    }
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    MultipartProcessor multipartProcessor = null;
+    try {
+      multipartProcessor = new MultipartProcessor(baos, boundary, ApiResource.CHARSET);
+
+      for (KeyValuePair<String, Object> entry : nameValueCollection) {
+        String key = entry.getKey();
+        Object value = entry.getValue();
+
+        if (value instanceof File) {
+          File file = (File) value;
+          multipartProcessor.addFileField(key, file.getName(), new FileInputStream(file));
+        } else if (value instanceof InputStream) {
+          multipartProcessor.addFileField(key, "blob", (InputStream) value);
+        } else {
+          multipartProcessor.addFormField(key, (String) value);
+        }
+      }
+    } finally {
+      if (multipartProcessor != null) {
+        multipartProcessor.finish();
+      }
+    }
+
+    return new HttpContent(
+        baos.toByteArray(), String.format("multipart/form-data; boundary=%s", boundary));
+  }
+}

--- a/src/main/java/com/stripe/net/KeyValuePair.java
+++ b/src/main/java/com/stripe/net/KeyValuePair.java
@@ -1,0 +1,24 @@
+package com.stripe.net;
+
+import java.util.AbstractMap;
+
+/**
+ * A KeyValuePair holds a key and a value. This class is used to represent parameters when encoding
+ * API requests.
+ *
+ * @param <K> the type of the key
+ * @param <V> the type of the value
+ */
+class KeyValuePair<K, V> extends AbstractMap.SimpleEntry<K, V> {
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Initializes a new instance of the {@link KeyValuePair} class using the specified key and value.
+   *
+   * @param key the key
+   * @param value the value
+   */
+  public KeyValuePair(K key, V value) {
+    super(key, value);
+  }
+}

--- a/src/main/java/com/stripe/net/MultipartProcessor.java
+++ b/src/main/java/com/stripe/net/MultipartProcessor.java
@@ -6,7 +6,6 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.net.URLConnection;
-import java.util.Random;
 
 public class MultipartProcessor {
   private final String boundary;
@@ -14,24 +13,12 @@ public class MultipartProcessor {
   private OutputStream outputStream;
   private PrintWriter writer;
 
-  /**
-   * Generates a random MIME multipart boundary.
-   *
-   * @return boundary value
-   */
-  public static String getBoundary() {
-    Random random = new Random();
-    Long positiveRandomLong = random.nextLong();
-    positiveRandomLong = (positiveRandomLong == Long.MIN_VALUE) ? 0 : Math.abs(positiveRandomLong);
-    return String.valueOf(positiveRandomLong);
-  }
-
   /** Constructs a new multipart body builder. */
-  public MultipartProcessor(java.net.HttpURLConnection conn, String boundary, String charset)
+  public MultipartProcessor(OutputStream outputStream, String boundary, String charset)
       throws IOException {
     this.boundary = boundary;
 
-    this.outputStream = conn.getOutputStream();
+    this.outputStream = outputStream;
     this.writer = new PrintWriter(new OutputStreamWriter(outputStream, charset), true);
   }
 

--- a/src/test/java/com/stripe/net/HttpContentTest.java
+++ b/src/test/java/com/stripe/net/HttpContentTest.java
@@ -1,0 +1,174 @@
+package com.stripe.net;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.stripe.BaseStripeTest;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class HttpContentTest extends BaseStripeTest {
+  @Test
+  public void TestBuildFormURLEncodedContentNull() throws IOException {
+    Throwable exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              HttpContent.buildFormURLEncodedContent(null);
+            });
+    assertTrue(exception.getMessage().contains("nameValueCollection may not be null"));
+  }
+
+  @Test
+  public void TestBuildFormURLEncodedContentEmptySourceSuccess() throws IOException {
+    HttpContent content =
+        HttpContent.buildFormURLEncodedContent(new ArrayList<KeyValuePair<String, String>>());
+    assertEquals(0, content.byteArrayContent().length);
+  }
+
+  @Test
+  public void TestBuildFormURLEncodedContentEmptySourceCorrectContentType() throws IOException {
+    HttpContent content =
+        HttpContent.buildFormURLEncodedContent(new ArrayList<KeyValuePair<String, String>>());
+    assertEquals("application/x-www-form-urlencoded;charset=UTF-8", content.contentType());
+  }
+
+  @Test
+  public void TestBuildFormURLEncodedContentOneEntrySeparatedByEquals() throws IOException {
+    List<KeyValuePair<String, String>> data = new ArrayList<KeyValuePair<String, String>>();
+    data.add(new KeyValuePair<String, String>("key", "value"));
+
+    HttpContent content = HttpContent.buildFormURLEncodedContent(data);
+    assertEquals(9, content.byteArrayContent().length);
+    assertEquals("key=value", new String(content.byteArrayContent(), StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void TestBuildFormURLEncodedContentOneUnicodeEntryEncoded() throws IOException {
+    List<KeyValuePair<String, String>> data = new ArrayList<KeyValuePair<String, String>>();
+    data.add(new KeyValuePair<String, String>("key", "valueク"));
+
+    HttpContent content = HttpContent.buildFormURLEncodedContent(data);
+    assertEquals(18, content.byteArrayContent().length);
+    assertEquals(
+        "key=value%E3%82%AF", new String(content.byteArrayContent(), StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void TestBuildFormURLEncodedContentTwoEntriesSeparatedByAnd() throws IOException {
+    List<KeyValuePair<String, String>> data = new ArrayList<KeyValuePair<String, String>>();
+    data.add(new KeyValuePair<String, String>("key1", "value1"));
+    data.add(new KeyValuePair<String, String>("key2", "value2"));
+
+    HttpContent content = HttpContent.buildFormURLEncodedContent(data);
+    assertEquals(23, content.byteArrayContent().length);
+    assertEquals(
+        "key1=value1&key2=value2", new String(content.byteArrayContent(), StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void TestBuildFormURLEncodedContentWithSpacesEncodedAsPlus() throws IOException {
+    List<KeyValuePair<String, String>> data = new ArrayList<KeyValuePair<String, String>>();
+    data.add(new KeyValuePair<String, String>("key 1", "val%20ue 1"));
+    data.add(new KeyValuePair<String, String>("key 2", "val%ue 2"));
+
+    HttpContent content = HttpContent.buildFormURLEncodedContent(data);
+    assertEquals(35, content.byteArrayContent().length);
+    assertEquals(
+        "key+1=val%2520ue+1&key+2=val%25ue+2",
+        new String(content.byteArrayContent(), StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void TestBuildFormURLEncodedContentWithSquareBracketsUnencoded() throws IOException {
+    List<KeyValuePair<String, String>> data = new ArrayList<KeyValuePair<String, String>>();
+    data.add(new KeyValuePair<String, String>("key[subkey]", "[#value]"));
+
+    HttpContent content = HttpContent.buildFormURLEncodedContent(data);
+    assertEquals(22, content.byteArrayContent().length);
+    assertEquals(
+        "key[subkey]=[%23value]", new String(content.byteArrayContent(), StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void TestBuildMultipartFormDataContentNull() throws IOException {
+    Throwable exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              HttpContent.buildMultipartFormDataContent(null);
+            });
+    assertTrue(exception.getMessage().contains("nameValueCollection may not be null"));
+  }
+
+  @Test
+  public void TestBuildMultipartFormDataContentNullEmptySourceCorrectContentType()
+      throws IOException {
+    HttpContent content =
+        HttpContent.buildMultipartFormDataContent(
+            new ArrayList<KeyValuePair<String, Object>>(), "test-boundary");
+    assertEquals("multipart/form-data; boundary=test-boundary", content.contentType());
+  }
+
+  @Test
+  public void TestBuildMultipartFormDataContentNullEmptySourceSuccess() throws IOException {
+    List<KeyValuePair<String, Object>> data = new ArrayList<KeyValuePair<String, Object>>();
+
+    HttpContent content = HttpContent.buildMultipartFormDataContent(data, "test-boundary");
+    assertEquals(19, content.byteArrayContent().length);
+    assertEquals(
+        "--test-boundary--\r\n", new String(content.byteArrayContent(), StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void TestBuildMultipartFormDataContentNullOneStringEntrySuccess() throws IOException {
+    List<KeyValuePair<String, Object>> data = new ArrayList<KeyValuePair<String, Object>>();
+    data.add(new KeyValuePair<String, Object>("key", "valueク"));
+
+    HttpContent content = HttpContent.buildMultipartFormDataContent(data, "test-boundary");
+    assertEquals(92, content.byteArrayContent().length);
+    assertEquals(
+        "--test-boundary\r\nContent-Disposition: form-data; name=\"key\"\r\n\r\nvalueク\r\n"
+            + "--test-boundary--\r\n",
+        new String(content.byteArrayContent(), StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void TestBuildMultipartFormDataContentNullOneStreamEntrySuccess() throws IOException {
+    List<KeyValuePair<String, Object>> data = new ArrayList<KeyValuePair<String, Object>>();
+    data.add(
+        new KeyValuePair<String, Object>(
+            "key", new ByteArrayInputStream("Hello World!".getBytes(StandardCharsets.UTF_8))));
+
+    HttpContent content = HttpContent.buildMultipartFormDataContent(data, "test-boundary");
+    assertEquals(168, content.byteArrayContent().length);
+    assertEquals(
+        "--test-boundary\r\nContent-Disposition: form-data; name=\"key\"; filename=\"blob\"\r\n"
+            + "Content-Type: null\r\nContent-Transfer-Encoding: binary\r\n\r\nHello World!\r\n"
+            + "--test-boundary--\r\n",
+        new String(content.byteArrayContent(), StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void TestBuildMultipartFormDataContentNullTwoEntriesSuccess() throws IOException {
+    List<KeyValuePair<String, Object>> data = new ArrayList<KeyValuePair<String, Object>>();
+    data.add(
+        new KeyValuePair<String, Object>(
+            "key", new ByteArrayInputStream("Hello クWorld!".getBytes(StandardCharsets.UTF_8))));
+    data.add(new KeyValuePair<String, Object>("key", "String!ク"));
+
+    HttpContent content = HttpContent.buildMultipartFormDataContent(data, "test-boundary");
+    assertEquals(246, content.byteArrayContent().length);
+    assertEquals(
+        "--test-boundary\r\nContent-Disposition: form-data; name=\"key\"; filename=\"blob\"\r\n"
+            + "Content-Type: null\r\nContent-Transfer-Encoding: binary\r\n\r\nHello クWorld!\r\n"
+            + "--test-boundary\r\nContent-Disposition: form-data; name=\"key\"\r\n\r\nString!ク\r\n"
+            + "--test-boundary--\r\n",
+        new String(content.byteArrayContent(), StandardCharsets.UTF_8));
+  }
+}


### PR DESCRIPTION
r? @brandur-stripe @richardm-stripe 
cc @stripe/api-libraries 

This PR:
- adds a new `HttpContent` class that represents an HTTP request's content, i.e. the body and the `Content-Type` header (which can depend on the body, e.g. for multipart requests the header contains the boundary used to separate fields in the body).
- adds a new `FormEncoder.createHttpContent()` method that builds and returns an `HttpContent` instance as needed (automatically choosing between form-data encoding and multipart encoding depending on whether all the parameters are strings or not)
- removes the now useless `FormEncoder.encodeMultipartParams()` method
- updates `HttpURLConnectionClient` to use `HttpContent`. The resulting code is a little bit weird, but will be refactored in a future PR
- updates `MultipartProcessor` to write to a provided `OutputStream` instead of directly to a connection's `OutputStream`
- removes the `MultipartProcessor.getBoundary()` method (the boundary is now initialized by `HttpContent`, and is a random UUIDv4 unless explicitly provided)
- adds a bunch of tests to ensure the encoding is working as expected.
