### PR TITLE
Add `Stopwatch` class

### DIFF
--- a/src/main/java/com/stripe/net/HttpURLConnectionClient.java
+++ b/src/main/java/com/stripe/net/HttpURLConnectionClient.java
@@ -4,6 +4,7 @@ import com.stripe.Stripe;
 import com.stripe.exception.ApiConnectionException;
 import com.stripe.exception.AuthenticationException;
 import com.stripe.exception.InvalidRequestException;
+import com.stripe.util.Stopwatch;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -14,7 +15,6 @@ import java.net.HttpURLConnection;
 import java.net.PasswordAuthentication;
 import java.net.URL;
 import java.net.URLStreamHandler;
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -58,7 +58,7 @@ public class HttpURLConnectionClient extends HttpClient {
 
     StripeResponse response;
 
-    long requestStartNanos = System.nanoTime();
+    Stopwatch stopwatch = Stopwatch.startNew();
 
     switch (request.type()) {
       case NORMAL:
@@ -77,9 +77,9 @@ public class HttpURLConnectionClient extends HttpClient {
                 + "support@stripe.com for assistance.");
     }
 
-    Duration requestDuration = Duration.ofNanos(System.nanoTime() - requestStartNanos);
+    stopwatch.stop();
 
-    requestTelemetry.MaybeEnqueueMetrics(response, requestDuration);
+    requestTelemetry.MaybeEnqueueMetrics(response, stopwatch.getElapsed());
 
     return response;
   }

--- a/src/main/java/com/stripe/util/Stopwatch.java
+++ b/src/main/java/com/stripe/util/Stopwatch.java
@@ -1,0 +1,110 @@
+package com.stripe.util;
+
+import java.time.Duration;
+
+/**
+ * This class provides a set of methods and properties that can be used to accurately measure
+ * elapsed time.
+ */
+public class Stopwatch {
+  private long elapsed;
+  private boolean running;
+  private long startTimeStamp;
+
+  /** Initializes a new instance of the {@link Stopwatch} class. */
+  public Stopwatch() {
+    this.reset();
+  }
+
+  /** Starts, or resumes, measuring elapsed time for an interval. */
+  public void start() {
+    if (!this.running) {
+      this.startTimeStamp = getTimestamp();
+      this.running = true;
+    }
+  }
+
+  /**
+   * Initializes a new {@link Stopwatch} instance, sets the elapsed time property to zero, and
+   * starts measuring elapsed time.
+   *
+   * @return a {@link Stopwatch} that has just begun measuring elapsed time
+   */
+  public static Stopwatch startNew() {
+    Stopwatch s = new Stopwatch();
+    s.start();
+    return s;
+  }
+
+  /** Stops measuring elapsed time for an interval. */
+  public void stop() {
+    // Calling stop on a stopped Stopwatch is a no-op.
+    if (!this.running) {
+      return;
+    }
+
+    long endTimeStamp = getTimestamp();
+    long elapsedThisPeriod = endTimeStamp - this.startTimeStamp;
+    this.elapsed += elapsedThisPeriod;
+    this.running = false;
+  }
+
+  /** Stops time interval measurement and resets the elapsed time to zero. */
+  public void reset() {
+    this.elapsed = 0;
+    this.running = false;
+    this.startTimeStamp = 0;
+  }
+
+  /**
+   * Stops time interval measurement, resets the elapsed time to zero, and starts measuring elapsed
+   * time.
+   */
+  public void restart() {
+    this.elapsed = 0;
+    this.running = true;
+    this.startTimeStamp = getTimestamp();
+  }
+
+  /**
+   * Gets a value indicating whether the {@link Stopwatch} timer is running.
+   *
+   * @return {@code true} if the {@link Stopwatch} instance is currently running and measuring
+   *     elapsed time for an interval; otherwise, {@code false}
+   */
+  public boolean isRunning() {
+    return this.running;
+  }
+
+  /**
+   * Gets the total elapsed time measured by the current instance.
+   *
+   * @return a {@link Duration} representing the total elapsed time measured by the current instance
+   */
+  public Duration getElapsed() {
+    return Duration.ofNanos(this.getRawElapsed());
+  }
+
+  /**
+   * Gets the current timestamp with the highest precision available. This should use a monotonic
+   * clock whenever possible.
+   *
+   * @return a long integer representing the current timestamp
+   */
+  public static long getTimestamp() {
+    return System.nanoTime();
+  }
+
+  private long getRawElapsed() {
+    long timeElapsed = this.elapsed;
+
+    // If the Stopwatch is running, add elapsed time since the Stopwatch is started last time.
+    if (this.running) {
+      long currentTimeStamp = getTimestamp();
+      long elapsedUntilNow = currentTimeStamp - this.startTimeStamp;
+      timeElapsed += elapsedUntilNow;
+    }
+
+    return timeElapsed;
+  }
+}

--- a/src/test/java/com/stripe/util/StopwatchTest.java
+++ b/src/test/java/com/stripe/util/StopwatchTest.java
@@ -1,0 +1,76 @@
+package com.stripe.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+public class StopwatchTest {
+  @Test
+  public void testGetTimestamp() {
+    long ts1 = Stopwatch.getTimestamp();
+    sleep();
+    long ts2 = Stopwatch.getTimestamp();
+    assertNotEquals(ts1, ts2);
+  }
+
+  @Test
+  public void testConstructStartAndStop() {
+    Stopwatch watch = new Stopwatch();
+    assertFalse(watch.isRunning());
+    assertTrue(watch.getElapsed().compareTo(Duration.ZERO) == 0);
+    watch.start();
+    assertTrue(watch.isRunning());
+    sleep();
+    assertTrue(watch.getElapsed().compareTo(Duration.ZERO) > 0);
+
+    watch.stop();
+    assertFalse(watch.isRunning());
+
+    Duration e1 = watch.getElapsed();
+    sleep();
+    Duration e2 = watch.getElapsed();
+    assertTrue(e1.compareTo(e2) == 0);
+  }
+
+  @Test
+  public void testStartNewAndReset() {
+    Stopwatch watch = Stopwatch.startNew();
+    assertTrue(watch.isRunning());
+    watch.start(); // should be a no-op
+    assertTrue(watch.isRunning());
+    sleep();
+    assertTrue(watch.getElapsed().compareTo(Duration.ZERO) > 0);
+
+    watch.reset();
+    assertFalse(watch.isRunning());
+    assertTrue(watch.getElapsed().compareTo(Duration.ZERO) == 0);
+  }
+
+  @Test
+  public void testStartNewAndRestart() {
+    Stopwatch watch = Stopwatch.startNew();
+    assertTrue(watch.isRunning());
+    sleep(10);
+    Duration elapsedSinceStart = watch.getElapsed();
+    assertTrue(elapsedSinceStart.compareTo(Duration.ZERO) > 0);
+
+    watch.restart();
+    assertTrue(watch.isRunning());
+    assertTrue(watch.getElapsed().compareTo(elapsedSinceStart) < 0);
+  }
+
+  private static void sleep() {
+    sleep(1);
+  }
+
+  private static void sleep(long millis) {
+    try {
+      Thread.sleep(millis);
+    } catch (InterruptedException e) {
+      return;
+    }
+  }
+}


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Add a `Stopwatch` class to measure elapsed time, and use it for latency telemetry.

The class is basically a port of [its namesake from the .NET stdlib](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.stopwatch?view=netframework-4.8). It does a bit more than we need, but it's still fairly straightforward.

This will help further refactors of `HttpURLConnectionClient`.