### PR TITLE
Remove `ApiResource.RequestType`

### DIFF
--- a/src/main/java/com/stripe/model/File.java
+++ b/src/main/java/com/stripe/model/File.java
@@ -99,7 +99,7 @@ public class File extends ApiResource implements HasId {
    */
   public static File create(Map<String, Object> params, RequestOptions options)
       throws StripeException {
-    return multipartRequest(
+    return request(
         RequestMethod.POST,
         classUrl(File.class, Stripe.getUploadBase()),
         params,

--- a/src/main/java/com/stripe/net/ApiResource.java
+++ b/src/main/java/com/stripe/net/ApiResource.java
@@ -123,11 +123,6 @@ public abstract class ApiResource extends StripeObject {
     DELETE
   }
 
-  public enum RequestType {
-    NORMAL,
-    MULTIPART
-  }
-
   /** URL-encodes a string. */
   public static String urlEncode(String str) {
     // Preserve original behavior that passing null for an object id will lead
@@ -165,17 +160,6 @@ public abstract class ApiResource extends StripeObject {
     return urlEncode(id);
   }
 
-  public static <T> T multipartRequest(
-      ApiResource.RequestMethod method,
-      String url,
-      Map<String, Object> params,
-      Class<T> clazz,
-      RequestOptions options)
-      throws StripeException {
-    return ApiResource.stripeResponseGetter.request(
-        method, url, params, clazz, ApiResource.RequestType.MULTIPART, options);
-  }
-
   public static <T> T request(
       ApiResource.RequestMethod method,
       String url,
@@ -194,8 +178,7 @@ public abstract class ApiResource extends StripeObject {
       Class<T> clazz,
       RequestOptions options)
       throws StripeException {
-    return ApiResource.stripeResponseGetter.request(
-        method, url, params, clazz, ApiResource.RequestType.NORMAL, options);
+    return ApiResource.stripeResponseGetter.request(method, url, params, clazz, options);
   }
 
   public static <T extends StripeCollectionInterface<?>> T requestCollection(

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -30,7 +30,6 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
       String url,
       Map<String, Object> params,
       Class<T> clazz,
-      ApiResource.RequestType type,
       RequestOptions options)
       throws StripeException {
     StripeRequest request = new StripeRequest(method, url, params, options);
@@ -65,7 +64,6 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
       String url,
       Map<String, Object> params,
       Class<T> clazz,
-      ApiResource.RequestType type,
       RequestOptions options)
       throws StripeException {
     StripeRequest request = new StripeRequest(method, url, params, options);

--- a/src/main/java/com/stripe/net/OAuth.java
+++ b/src/main/java/com/stripe/net/OAuth.java
@@ -47,12 +47,7 @@ public final class OAuth {
       throws StripeException {
     String url = Stripe.getConnectBase() + "/oauth/token";
     return OAuth.stripeResponseGetter.oauthRequest(
-        ApiResource.RequestMethod.POST,
-        url,
-        params,
-        TokenResponse.class,
-        ApiResource.RequestType.NORMAL,
-        options);
+        ApiResource.RequestMethod.POST, url, params, TokenResponse.class, options);
   }
 
   /**
@@ -67,12 +62,7 @@ public final class OAuth {
     String url = Stripe.getConnectBase() + "/oauth/deauthorize";
     params.put("client_id", getClientId(params, options));
     return OAuth.stripeResponseGetter.oauthRequest(
-        ApiResource.RequestMethod.POST,
-        url,
-        params,
-        DeauthorizedAccount.class,
-        ApiResource.RequestType.NORMAL,
-        options);
+        ApiResource.RequestMethod.POST, url, params, DeauthorizedAccount.class, options);
   }
 
   /**

--- a/src/main/java/com/stripe/net/StripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/StripeResponseGetter.java
@@ -9,7 +9,6 @@ public interface StripeResponseGetter {
       String url,
       Map<String, Object> params,
       Class<T> clazz,
-      ApiResource.RequestType type,
       RequestOptions options)
       throws StripeException;
 
@@ -18,7 +17,6 @@ public interface StripeResponseGetter {
       String url,
       Map<String, Object> params,
       Class<T> clazz,
-      ApiResource.RequestType type,
       RequestOptions options)
       throws StripeException;
 }

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -137,26 +137,24 @@ public class BaseStripeTest {
   }
 
   /**
-   * {@code params}, {@code requestType} and {@code options} defaults to {@code null}.
+   * {@code params} and {@code options} defaults to {@code null}.
    *
-   * @see BaseStripeTest#verifyRequest(ApiResource.RequestMethod, String, Map,
-   *     ApiResource.RequestType, RequestOptions)
+   * @see BaseStripeTest#verifyRequest(ApiResource.RequestMethod, String, Map, RequestOptions)
    */
   public static <T> void verifyRequest(ApiResource.RequestMethod method, String path)
       throws StripeException {
-    verifyRequest(method, path, null, null, null);
+    verifyRequest(method, path, null, null);
   }
 
   /**
-   * {@code requestType} and {@code options} defaults to {@code null}.
+   * {@code options} defaults to {@code null}.
    *
-   * @see BaseStripeTest#verifyRequest(ApiResource.RequestMethod, String, Map,
-   *     ApiResource.RequestType, RequestOptions)
+   * @see BaseStripeTest#verifyRequest(ApiResource.RequestMethod, String, Map, RequestOptions)
    */
   public static <T> void verifyRequest(
       ApiResource.RequestMethod method, String path, Map<String, Object> params)
       throws StripeException {
-    verifyRequest(method, path, params, null, null);
+    verifyRequest(method, path, params, null);
   }
 
   /**
@@ -165,15 +163,12 @@ public class BaseStripeTest {
    * @param method HTTP method (GET, POST or DELETE)
    * @param path request path (e.g. "/v1/charges"). Can also be an abolute URL.
    * @param params map containing the parameters. If null, the parameters are not checked.
-   * @param requestType request type (NORMAL or MULTIPART). If null, the request type is not
-   *     checked.
    * @param options request options. If null, the options are not checked.
    */
   public static <T> void verifyRequest(
       ApiResource.RequestMethod method,
       String path,
       Map<String, Object> params,
-      ApiResource.RequestType requestType,
       RequestOptions options)
       throws StripeException {
     String url;
@@ -191,9 +186,6 @@ public class BaseStripeTest {
                 ? Mockito.argThat(new ParamMapMatcher(params))
                 : Mockito.<Map<String, Object>>any(),
             Mockito.<Class<T>>any(),
-            (requestType != null)
-                ? Mockito.eq(requestType)
-                : Mockito.any(ApiResource.RequestType.class),
             (options != null)
                 ? Mockito.argThat(new RequestOptionsMatcher(options))
                 : Mockito.<RequestOptions>any());
@@ -210,22 +202,22 @@ public class BaseStripeTest {
   }
 
   /**
-   * {@code params}, {@code requestType} and {@code options} defaults to {@code null}.
+   * {@code params} and {@code options} defaults to {@code null}.
    *
-   * @see BaseStripeTest#stubRequest(ApiResource.RequestMethod, String, Map,
-   *     ApiResource.RequestType, RequestOptions, Class, String)
+   * @see BaseStripeTest#stubRequest(ApiResource.RequestMethod, String, Map, RequestOptions, Class,
+   *     String)
    */
   public static <T> void stubRequest(
       ApiResource.RequestMethod method, String path, Class<T> clazz, String response)
       throws StripeException {
-    stubRequest(method, path, null, null, null, clazz, response);
+    stubRequest(method, path, null, null, clazz, response);
   }
 
   /**
-   * {@code requestType} and {@code options} defaults to {@code null}.
+   * {@code options} defaults to {@code null}.
    *
-   * @see BaseStripeTest#stubRequest(ApiResource.RequestMethod, String, Map,
-   *     ApiResource.RequestType, RequestOptions, Class, String)
+   * @see BaseStripeTest#stubRequest(ApiResource.RequestMethod, String, Map, RequestOptions, Class,
+   *     String)
    */
   public static <T> void stubRequest(
       ApiResource.RequestMethod method,
@@ -234,7 +226,7 @@ public class BaseStripeTest {
       Class<T> clazz,
       String response)
       throws StripeException {
-    stubRequest(method, path, params, null, null, clazz, response);
+    stubRequest(method, path, params, null, clazz, response);
   }
 
   /**
@@ -244,8 +236,6 @@ public class BaseStripeTest {
    * @param method HTTP method (GET, POST or DELETE)
    * @param path request path (e.g. "/v1/charges"). Can also be an abolute URL.
    * @param params map containing the parameters. If null, the parameters are not checked.
-   * @param requestType request type (NORMAL or MULTIPART). If null, the request type is not
-   *     checked.
    * @param options request options. If null, the options are not checked.
    * @param clazz Class of the API resource that will be returned for the stubbed request.
    * @param response JSON payload of the API resource that will be returned for the stubbed request.
@@ -254,7 +244,6 @@ public class BaseStripeTest {
       ApiResource.RequestMethod method,
       String path,
       Map<String, Object> params,
-      ApiResource.RequestType requestType,
       RequestOptions options,
       Class<T> clazz,
       String response)
@@ -275,9 +264,6 @@ public class BaseStripeTest {
                 ? Mockito.argThat(new ParamMapMatcher(params))
                 : Mockito.<Map<String, Object>>any(),
             Mockito.<Class<T>>any(),
-            (requestType != null)
-                ? Mockito.eq(requestType)
-                : Mockito.any(ApiResource.RequestType.class),
             (options != null)
                 ? Mockito.argThat(new RequestOptionsMatcher(options))
                 : Mockito.<RequestOptions>any());
@@ -292,7 +278,6 @@ public class BaseStripeTest {
             Mockito.anyString(),
             Mockito.<Map<String, Object>>any(),
             Mockito.<Class<T>>any(),
-            Mockito.any(ApiResource.RequestType.class),
             Mockito.<RequestOptions>any());
   }
 

--- a/src/test/java/com/stripe/functional/EphemeralKeyTest.java
+++ b/src/test/java/com/stripe/functional/EphemeralKeyTest.java
@@ -33,7 +33,7 @@ public class EphemeralKeyTest extends BaseStripeTest {
     final EphemeralKey key = EphemeralKey.create(params, options);
 
     assertNotNull(key);
-    verifyRequest(ApiResource.RequestMethod.POST, "/v1/ephemeral_keys", params, null, options);
+    verifyRequest(ApiResource.RequestMethod.POST, "/v1/ephemeral_keys", params, options);
   }
 
   @Test
@@ -67,7 +67,6 @@ public class EphemeralKeyTest extends BaseStripeTest {
         ImmutableMap.of(
             "customer", "cust_123",
             "issuing_card", "card_123"),
-        null,
         options);
   }
 

--- a/src/test/java/com/stripe/functional/FileTest.java
+++ b/src/test/java/com/stripe/functional/FileTest.java
@@ -31,12 +31,7 @@ public class FileTest extends BaseStripeTest {
     final com.stripe.model.File file = com.stripe.model.File.create(params);
 
     assertNotNull(file);
-    verifyRequest(
-        ApiResource.RequestMethod.POST,
-        "/v1/files",
-        params,
-        ApiResource.RequestType.MULTIPART,
-        null);
+    verifyRequest(ApiResource.RequestMethod.POST, "/v1/files", params, null);
   }
 
   @Test
@@ -63,7 +58,6 @@ public class FileTest extends BaseStripeTest {
             fileObject,
             "file_link_data",
             ImmutableMap.of("create", true, "expires_at", 123)),
-        ApiResource.RequestType.MULTIPART,
         null);
   }
 
@@ -88,12 +82,7 @@ public class FileTest extends BaseStripeTest {
     final com.stripe.model.File file = com.stripe.model.File.create(params);
 
     assertNotNull(file);
-    verifyRequest(
-        ApiResource.RequestMethod.POST,
-        "/v1/files",
-        params,
-        ApiResource.RequestType.MULTIPART,
-        null);
+    verifyRequest(ApiResource.RequestMethod.POST, "/v1/files", params, null);
   }
 
   @Test

--- a/src/test/java/com/stripe/model/PagingIteratorTest.java
+++ b/src/test/java/com/stripe/model/PagingIteratorTest.java
@@ -71,7 +71,6 @@ public class PagingIteratorTest extends BaseStripeTest {
             Mockito.anyString(),
             Mockito.<Map<String, Object>>any(),
             Mockito.<Class<PageableModelCollection>>any(),
-            Mockito.any(ApiResource.RequestType.class),
             Mockito.<RequestOptions>any());
   }
 
@@ -144,9 +143,9 @@ public class PagingIteratorTest extends BaseStripeTest {
     assertEquals("pm_126", models.get(3).getId());
     assertEquals("pm_127", models.get(4).getId());
 
-    verifyRequest(ApiResource.RequestMethod.GET, "/v1/pageable_models", page0Params, null, options);
-    verifyRequest(ApiResource.RequestMethod.GET, "/v1/pageable_models", page1Params, null, options);
-    verifyRequest(ApiResource.RequestMethod.GET, "/v1/pageable_models", page2Params, null, options);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/pageable_models", page0Params, options);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/pageable_models", page1Params, options);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/pageable_models", page2Params, options);
     verifyNoMoreInteractions(networkSpy);
   }
 }


### PR DESCRIPTION
r? @brandur-stripe @richardm-stripe 
cc @stripe/api-libraries 

Remove `ApiResource.RequestType`. It is no longer useful: we now decide whether a request should be encoded as form-data or multiform based on the parameters. If there is at least one `File` or `Stream` value in the parameters, then the request will be encoded as multiform, otherwise it's encoded as form-data.

This affects the `StripeResponseGetter` public interface, so it is a breaking change (though it would only affect users providing custom implementations).