### PR TITLE
Serialize null values in all maps

### DIFF
--- a/src/test/java/com/stripe/net/ApiRequestParamsConverterTest.java
+++ b/src/test/java/com/stripe/net/ApiRequestParamsConverterTest.java
@@ -228,7 +228,7 @@ public class ApiRequestParamsConverterTest {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void testMetadataWithNullValue() {
+  public void testMapsWithNullValue() {
     HasMetadataParams params = new HasMetadataParams();
     params.metadata = new HashMap<>();
     params.metadata.put("foo", "123");
@@ -236,7 +236,6 @@ public class ApiRequestParamsConverterTest {
 
     params.featureMap = new HashMap<>();
     params.featureMap.put("fooLong", 123L);
-    // should disappear
     params.featureMap.put("barLong", null);
 
     Map<String, Object> untypedParams = toMap(params);
@@ -249,8 +248,9 @@ public class ApiRequestParamsConverterTest {
 
     Map<String, String> featureMap = (Map<String, String>) untypedParams.get("feature_map");
 
-    assertEquals(featureMap.size(), 1);
+    assertEquals(featureMap.size(), 2);
     assertEquals(featureMap.get("fooLong"), 123L);
+    assertEquals(featureMap.get("barLong"), null);
   }
 
   private Map<String, Object> toMap(ApiRequestParams params) {

--- a/src/test/java/com/stripe/param/issuing/TransactionUpdateParamsTest.java
+++ b/src/test/java/com/stripe/param/issuing/TransactionUpdateParamsTest.java
@@ -1,6 +1,7 @@
 package com.stripe.param.issuing;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
@@ -39,12 +40,14 @@ class TransactionUpdateParamsTest {
         TransactionUpdateParams.builder()
             .putMetadata("key_1", "value_1")
             .putMetadata("key_2", "value_2")
+            .putMetadata("key_null", null)
             .build();
 
     Map<String, Object> untypedParams = transactionUpdateParams.toMap();
     assertTrue(untypedParams.get("metadata") instanceof Map<?, ?>);
     assertEquals("value_1", ((Map<String, String>) untypedParams.get("metadata")).get("key_1"));
     assertEquals("value_2", ((Map<String, String>) untypedParams.get("metadata")).get("key_2"));
+    assertNull(((Map<String, String>) untypedParams.get("metadata")).get("key_null"));
   }
 
   @Test


### PR DESCRIPTION
r? @brandur-stripe @richardm-stripe 
cc @stripe/api-libraries 

This PR serializes `null` values in all `Map`s when converting typed parameters classes to untyped maps.

Previously, we were only serializing `null` values in `Map<String, String>` maps. The intention was that only `metadata` fields had this type and that's where we wanted to serialize values.

However, after #849, some metadata fields (such as [`TransactionUpdateParams.metadata`](https://github.com/stripe/stripe-java/blob/49db11cf0ab6707e1c1bbb97f6fa70e8ebffbc13/src/main/java/com/stripe/param/issuing/TransactionUpdateParams.java#L28)) were no longer typed as `Map<String, String>` but rather as `Object` because they became polymorphic (either a `HashMap<String, String>` or an `EmptyParam`).

Due to type erasure, the type parameters are no longer present at runtime and the type adapter that was supposed to serialize null values failed to do so because [this check](https://github.com/stripe/stripe-java/blob/49db11cf0ab6707e1c1bbb97f6fa70e8ebffbc13/src/main/java/com/stripe/net/ApiRequestParamsConverter.java#L101) failed.

This PR simplifies the type adapter by simply checking if the value is a `Map` (or any subclass such as `HashMap`). When that's the case, the type adapter sets `serializeNulls(true)` and then delegates to the normal adapter for the type. As a result, all `null` values are now serialized in all `Map`s. I think that's what we want anyway: if an entry is present in a map, it was necessarily added by the user and should be serialized.

Fixes #893.
