### PR TITLE
Add support for `violated_authorization_controls` on Issuing `Authorization`

### DIFF
--- a/src/main/java/com/stripe/model/PaymentIntent.java
+++ b/src/main/java/com/stripe/model/PaymentIntent.java
@@ -42,8 +42,7 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
 
   /**
    * The amount of the application fee (if any) for the resulting payment. See the PaymentIntents
-   * [use case for connected
-   * accounts](https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts) for
+   * [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts) for
    * details.
    */
   @SerializedName("application_fee_amount")
@@ -70,9 +69,8 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
    * <p>When the capture method is `automatic`, Stripe automatically captures funds when the
    * customer authorizes the payment.
    *
-   * <p>Change `capture_method` to manual if you wish to [separate authorization and
-   * capture](https://stripe.com/docs/payments/payment-intents/creating-payment-intents#separate-authorization-and-capture)
-   * for payment methods that support this.
+   * <p>Change `capture_method` to manual if you wish to use [separate authorization and
+   * capture](https://stripe.com/docs/payments/capture-later) for payment methods that support this.
    */
   @SerializedName("capture_method")
   String captureMethod;
@@ -89,8 +87,8 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
    * stored, logged, embedded in URLs, or exposed to anyone other than the customer. Make sure that
    * you have TLS enabled on any page that includes the client secret.
    *
-   * <p>Please refer to our [quickstart guide](https://stripe.com/docs/payments/payment-intents/web)
-   * to learn about how `client_secret` should be handled.
+   * <p>Refer to our docs to [accept a payment](https://stripe.com/docs/payments/accept-a-payment)
+   * and learn about how `client_secret` should be handled.
    */
   @SerializedName("client_secret")
   String clientSecret;
@@ -106,9 +104,6 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
    * key. The PaymentIntent returns to the `requires_confirmation` state after handling
    * `next_action`s, and requires your server to initiate each payment attempt with an explicit
    * confirmation.
-   *
-   * <p>Learn more about the different [confirmation
-   * flows](https://stripe.com/docs/payments/payment-intents/use-cases#one-time-payments).
    */
   @SerializedName("confirmation_method")
   String confirmationMethod;
@@ -151,7 +146,10 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
   @Setter(lombok.AccessLevel.NONE)
   ExpandableField<Invoice> invoice;
 
-  /** The payment error encountered in the previous PaymentIntent confirmation. */
+  /**
+   * The payment error encountered in the previous PaymentIntent confirmation. It will be cleared if
+   * the PaymentIntent is later updated for any reason.
+   */
   @SerializedName("last_payment_error")
   StripeError lastPaymentError;
 
@@ -185,8 +183,7 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
   /**
    * The account (if any) for which the funds of the PaymentIntent are intended. See the
    * PaymentIntents [use case for connected
-   * accounts](https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts) for
-   * details.
+   * accounts](https://stripe.com/docs/payments/connected-accounts) for details.
    */
   @SerializedName("on_behalf_of")
   @Getter(lombok.AccessLevel.NONE)
@@ -226,8 +223,8 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
    *
    * <p>Use `on_session` if you intend to only reuse the payment method when your customer is
    * present in your checkout flow. Use `off_session` if your customer may or may not be in your
-   * checkout flow. See [Saving card details after a
-   * payment](https://stripe.com/docs/payments/cards/saving-cards-after-payment) to learn more.
+   * checkout flow. For more, learn to [save card details after a
+   * payment](https://stripe.com/docs/payments/save-after-payment).
    *
    * <p>Stripe uses `setup_future_usage` to dynamically optimize your payment flow and comply with
    * regional legislation and network rules. For example, if your customer is impacted by
@@ -279,17 +276,14 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
   /**
    * The data with which to automatically create a Transfer when the payment is finalized. See the
    * PaymentIntents [use case for connected
-   * accounts](https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts) for
-   * details.
+   * accounts](https://stripe.com/docs/payments/connected-accounts) for details.
    */
   @SerializedName("transfer_data")
   TransferData transferData;
 
   /**
    * A string that identifies the resulting payment as part of a group. See the PaymentIntents [use
-   * case for connected
-   * accounts](https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts) for
-   * details.
+   * case for connected accounts](https://stripe.com/docs/payments/connected-accounts) for details.
    */
   @SerializedName("transfer_group")
   String transferGroup;
@@ -946,9 +940,8 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
    *
    * <p>Uncaptured PaymentIntents will be canceled exactly seven days after they are created.
    *
-   * <p>Read the <a
-   * href="/docs/payments/payment-intents/creating-payment-intents#separate-auth-capture">expanded
-   * documentation</a> to learn more about separate authorization and capture.
+   * <p>Learn more about <a href="/docs/payments/capture-later">separate authorization and
+   * capture</a>.
    */
   public PaymentIntent capture() throws StripeException {
     return capture((Map<String, Object>) null, (RequestOptions) null);
@@ -960,9 +953,8 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
    *
    * <p>Uncaptured PaymentIntents will be canceled exactly seven days after they are created.
    *
-   * <p>Read the <a
-   * href="/docs/payments/payment-intents/creating-payment-intents#separate-auth-capture">expanded
-   * documentation</a> to learn more about separate authorization and capture.
+   * <p>Learn more about <a href="/docs/payments/capture-later">separate authorization and
+   * capture</a>.
    */
   public PaymentIntent capture(RequestOptions options) throws StripeException {
     return capture((Map<String, Object>) null, options);
@@ -974,9 +966,8 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
    *
    * <p>Uncaptured PaymentIntents will be canceled exactly seven days after they are created.
    *
-   * <p>Read the <a
-   * href="/docs/payments/payment-intents/creating-payment-intents#separate-auth-capture">expanded
-   * documentation</a> to learn more about separate authorization and capture.
+   * <p>Learn more about <a href="/docs/payments/capture-later">separate authorization and
+   * capture</a>.
    */
   public PaymentIntent capture(Map<String, Object> params) throws StripeException {
     return capture(params, (RequestOptions) null);
@@ -988,9 +979,8 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
    *
    * <p>Uncaptured PaymentIntents will be canceled exactly seven days after they are created.
    *
-   * <p>Read the <a
-   * href="/docs/payments/payment-intents/creating-payment-intents#separate-auth-capture">expanded
-   * documentation</a> to learn more about separate authorization and capture.
+   * <p>Learn more about <a href="/docs/payments/capture-later">separate authorization and
+   * capture</a>.
    */
   public PaymentIntent capture(Map<String, Object> params, RequestOptions options)
       throws StripeException {
@@ -1009,9 +999,8 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
    *
    * <p>Uncaptured PaymentIntents will be canceled exactly seven days after they are created.
    *
-   * <p>Read the <a
-   * href="/docs/payments/payment-intents/creating-payment-intents#separate-auth-capture">expanded
-   * documentation</a> to learn more about separate authorization and capture.
+   * <p>Learn more about <a href="/docs/payments/capture-later">separate authorization and
+   * capture</a>.
    */
   public PaymentIntent capture(PaymentIntentCaptureParams params) throws StripeException {
     return capture(params, (RequestOptions) null);
@@ -1023,9 +1012,8 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
    *
    * <p>Uncaptured PaymentIntents will be canceled exactly seven days after they are created.
    *
-   * <p>Read the <a
-   * href="/docs/payments/payment-intents/creating-payment-intents#separate-auth-capture">expanded
-   * documentation</a> to learn more about separate authorization and capture.
+   * <p>Learn more about <a href="/docs/payments/capture-later">separate authorization and
+   * capture</a>.
    */
   public PaymentIntent capture(PaymentIntentCaptureParams params, RequestOptions options)
       throws StripeException {

--- a/src/main/java/com/stripe/model/Plan.java
+++ b/src/main/java/com/stripe/model/Plan.java
@@ -146,8 +146,8 @@ public class Plan extends ApiResource implements HasId, MetadataStore<Plan> {
 
   /**
    * Configures how the quantity per period should be determined, can be either `metered` or
-   * `licensed`. `licensed` will automatically bill the `quantity` set for a plan when adding it to
-   * a subscription, `metered` will aggregate the total usage based on usage records. Defaults to
+   * `licensed`. `licensed` will automatically bill the `quantity` set when adding it to a
+   * subscription, `metered` will aggregate the total usage based on usage records. Defaults to
    * `licensed`.
    */
   @SerializedName("usage_type")

--- a/src/main/java/com/stripe/model/Product.java
+++ b/src/main/java/com/stripe/model/Product.java
@@ -25,7 +25,6 @@ public class Product extends ApiResource implements HasId, MetadataStore<Product
 
   /**
    * A list of up to 5 attributes that each SKU can provide values for (e.g., `["color", "size"]`).
-   * Only applicable to products of `type=good`.
    */
   @SerializedName("attributes")
   List<String> attributes;
@@ -227,9 +226,6 @@ public class Product extends ApiResource implements HasId, MetadataStore<Product
   /**
    * Updates the specific product by setting the values of the parameters passed. Any parameters not
    * provided will be left unchanged.
-   *
-   * <p>Note that a product’s <code>attributes</code> are not editable. Instead, you would need to
-   * deactivate the existing product and create a new one with the new attribute values.
    */
   @Override
   public Product update(Map<String, Object> params) throws StripeException {
@@ -239,9 +235,6 @@ public class Product extends ApiResource implements HasId, MetadataStore<Product
   /**
    * Updates the specific product by setting the values of the parameters passed. Any parameters not
    * provided will be left unchanged.
-   *
-   * <p>Note that a product’s <code>attributes</code> are not editable. Instead, you would need to
-   * deactivate the existing product and create a new one with the new attribute values.
    */
   @Override
   public Product update(Map<String, Object> params, RequestOptions options) throws StripeException {
@@ -256,9 +249,6 @@ public class Product extends ApiResource implements HasId, MetadataStore<Product
   /**
    * Updates the specific product by setting the values of the parameters passed. Any parameters not
    * provided will be left unchanged.
-   *
-   * <p>Note that a product’s <code>attributes</code> are not editable. Instead, you would need to
-   * deactivate the existing product and create a new one with the new attribute values.
    */
   public Product update(ProductUpdateParams params) throws StripeException {
     return update(params, (RequestOptions) null);
@@ -267,9 +257,6 @@ public class Product extends ApiResource implements HasId, MetadataStore<Product
   /**
    * Updates the specific product by setting the values of the parameters passed. Any parameters not
    * provided will be left unchanged.
-   *
-   * <p>Note that a product’s <code>attributes</code> are not editable. Instead, you would need to
-   * deactivate the existing product and create a new one with the new attribute values.
    */
   public Product update(ProductUpdateParams params, RequestOptions options) throws StripeException {
     String url =

--- a/src/main/java/com/stripe/model/issuing/Authorization.java
+++ b/src/main/java/com/stripe/model/issuing/Authorization.java
@@ -419,13 +419,34 @@ public class Authorization extends ApiResource
     @SerializedName("held_currency")
     String heldCurrency;
 
-    /**
-     * One of `authentication_failed`, `authorization_controls`, `card_active`, `card_inactive`,
-     * `insufficient_funds`, `account_compliance_disabled`, `account_inactive`, `suspected_fraud`,
-     * `webhook_approved`, `webhook_declined`, or `webhook_timeout`.
-     */
+    /** The reason for the approval or decline. */
     @SerializedName("reason")
     String reason;
+
+    /**
+     * When an authorization is declined due to `authorization_controls`, this array contains
+     * details about the authorization controls that were violated. Otherwise, it is empty.
+     */
+    @SerializedName("violated_authorization_controls")
+    List<Authorization.RequestHistory.ViolatedAuthorizationControl> violatedAuthorizationControls;
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class ViolatedAuthorizationControl extends StripeObject {
+      /**
+       * Entity which the authorization control acts on. One of `account`, `card`, or `cardholder`.
+       */
+      @SerializedName("entity")
+      String entity;
+
+      /**
+       * Name of the authorization control. One of `allowed_categories`, `blocked_categories`,
+       * `max_amount`, `max_approvals`, or `spending_limits`.
+       */
+      @SerializedName("name")
+      String name;
+    }
   }
 
   @Getter

--- a/src/main/java/com/stripe/model/terminal/Reader.java
+++ b/src/main/java/com/stripe/model/terminal/Reader.java
@@ -28,7 +28,7 @@ public class Reader extends ApiResource implements HasId {
   @SerializedName("device_sw_version")
   String deviceSwVersion;
 
-  /** Type of reader, e.g., `verifone_P400` or `bbpos_chipper2x`. */
+  /** Type of reader, one of ["bbpos_chipper2x", "verifone_P400"]. */
   @SerializedName("device_type")
   String deviceType;
 

--- a/src/main/java/com/stripe/param/ChargeCreateParams.java
+++ b/src/main/java/com/stripe/param/ChargeCreateParams.java
@@ -37,7 +37,7 @@ public class ChargeCreateParams extends ApiRequestParams {
    * Whether to immediately capture the charge. Defaults to `true`. When `false`, the charge issues
    * an authorization (or pre-authorization), and will need to be [captured](#capture_charge) later.
    * Uncaptured charges expire in _seven days_. For more information, see the [authorizing charges
-   * and settling later](https://stripe.com/docs/charges#auth-and-capture) documentation.
+   * and settling later](https://stripe.com/docs/charges/placing-a-hold) documentation.
    */
   @SerializedName("capture")
   Boolean capture;
@@ -297,7 +297,7 @@ public class ChargeCreateParams extends ApiRequestParams {
      * issues an authorization (or pre-authorization), and will need to be
      * [captured](#capture_charge) later. Uncaptured charges expire in _seven days_. For more
      * information, see the [authorizing charges and settling
-     * later](https://stripe.com/docs/charges#auth-and-capture) documentation.
+     * later](https://stripe.com/docs/charges/placing-a-hold) documentation.
      */
     public Builder setCapture(Boolean capture) {
       this.capture = capture;

--- a/src/main/java/com/stripe/param/InvoiceUpcomingParams.java
+++ b/src/main/java/com/stripe/param/InvoiceUpcomingParams.java
@@ -1020,8 +1020,10 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
     Long quantity;
 
     /**
-     * The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates` on
-     * the subscription do not apply to this `subscription_item`.
+     * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
+     * override the
+     * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
+     * on the Subscription.
      */
     @SerializedName("tax_rates")
     Object taxRates;
@@ -1216,8 +1218,10 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
       }
 
       /**
-       * The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates` on
-       * the subscription do not apply to this `subscription_item`.
+       * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
+       * override the
+       * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
+       * on the Subscription.
        */
       public Builder setTaxRates(EmptyParam taxRates) {
         this.taxRates = taxRates;
@@ -1225,8 +1229,10 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
       }
 
       /**
-       * The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates` on
-       * the subscription do not apply to this `subscription_item`.
+       * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
+       * override the
+       * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
+       * on the Subscription.
        */
       public Builder setTaxRates(List<String> taxRates) {
         this.taxRates = taxRates;

--- a/src/main/java/com/stripe/param/PaymentIntentCaptureParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentCaptureParams.java
@@ -21,8 +21,7 @@ public class PaymentIntentCaptureParams extends ApiRequestParams {
   /**
    * The amount of the application fee (if any) that will be applied to the payment and transferred
    * to the application owner's Stripe account. For more information, see the PaymentIntents [use
-   * case for connected
-   * accounts](https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts).
+   * case for connected accounts](https://stripe.com/docs/payments/connected-accounts).
    */
   @SerializedName("application_fee_amount")
   Long applicationFeeAmount;
@@ -58,7 +57,7 @@ public class PaymentIntentCaptureParams extends ApiRequestParams {
   /**
    * The parameters used to automatically create a Transfer when the payment is captured. For more
    * information, see the PaymentIntents [use case for connected
-   * accounts](https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts).
+   * accounts](https://stripe.com/docs/payments/connected-accounts).
    */
   @SerializedName("transfer_data")
   TransferData transferData;
@@ -125,7 +124,7 @@ public class PaymentIntentCaptureParams extends ApiRequestParams {
      * The amount of the application fee (if any) that will be applied to the payment and
      * transferred to the application owner's Stripe account. For more information, see the
      * PaymentIntents [use case for connected
-     * accounts](https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts).
+     * accounts](https://stripe.com/docs/payments/connected-accounts).
      */
     public Builder setApplicationFeeAmount(Long applicationFeeAmount) {
       this.applicationFeeAmount = applicationFeeAmount;
@@ -207,7 +206,7 @@ public class PaymentIntentCaptureParams extends ApiRequestParams {
     /**
      * The parameters used to automatically create a Transfer when the payment is captured. For more
      * information, see the PaymentIntents [use case for connected
-     * accounts](https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts).
+     * accounts](https://stripe.com/docs/payments/connected-accounts).
      */
     public Builder setTransferData(TransferData transferData) {
       this.transferData = transferData;

--- a/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
@@ -43,8 +43,9 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
   Object offSession;
 
   /**
-   * ID of the payment method (a PaymentMethod, Card, BankAccount, or saved Source object) to attach
-   * to this PaymentIntent.
+   * ID of the payment method (a PaymentMethod, Card, or [compatible
+   * Source](https://stripe.com/docs/payments/payment-methods#compatibility) object) to attach to
+   * this PaymentIntent.
    */
   @SerializedName("payment_method")
   String paymentMethod;
@@ -73,6 +74,13 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
    *
    * <p>If the payment method is already saved to a customer, this does nothing. If this type of
    * payment method cannot be saved to a customer, the request will error.
+   *
+   * <p>_Note that saving a payment method using this parameter does not guarantee that the payment
+   * method can be charged._ To ensure that only payment methods which can be charged are saved to a
+   * customer, you can [manually
+   * save](https://stripe.com/docs/api/customers/create#create_customer-source) the payment method
+   * in response to the [`payment_intent.succeeded`
+   * webhook](https://stripe.com/docs/api/events/types#event_types-payment_intent.succeeded).
    */
   @SerializedName("save_payment_method")
   Boolean savePaymentMethod;
@@ -291,8 +299,9 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
     }
 
     /**
-     * ID of the payment method (a PaymentMethod, Card, BankAccount, or saved Source object) to
-     * attach to this PaymentIntent.
+     * ID of the payment method (a PaymentMethod, Card, or [compatible
+     * Source](https://stripe.com/docs/payments/payment-methods#compatibility) object) to attach to
+     * this PaymentIntent.
      */
     public Builder setPaymentMethod(String paymentMethod) {
       this.paymentMethod = paymentMethod;
@@ -335,6 +344,13 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
      *
      * <p>If the payment method is already saved to a customer, this does nothing. If this type of
      * payment method cannot be saved to a customer, the request will error.
+     *
+     * <p>_Note that saving a payment method using this parameter does not guarantee that the
+     * payment method can be charged._ To ensure that only payment methods which can be charged are
+     * saved to a customer, you can [manually
+     * save](https://stripe.com/docs/api/customers/create#create_customer-source) the payment method
+     * in response to the [`payment_intent.succeeded`
+     * webhook](https://stripe.com/docs/api/events/types#event_types-payment_intent.succeeded).
      */
     public Builder setSavePaymentMethod(Boolean savePaymentMethod) {
       this.savePaymentMethod = savePaymentMethod;

--- a/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
@@ -25,8 +25,7 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
   /**
    * The amount of the application fee (if any) that will be applied to the payment and transferred
    * to the application owner's Stripe account. For more information, see the PaymentIntents [use
-   * case for connected
-   * accounts](https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts).
+   * case for connected accounts](https://stripe.com/docs/payments/connected-accounts).
    */
   @SerializedName("application_fee_amount")
   Long applicationFeeAmount;
@@ -37,9 +36,8 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
    * <p>When the capture method is `automatic`, Stripe automatically captures funds when the
    * customer authorizes the payment.
    *
-   * <p>Change `capture_method` to manual if you wish to [separate authorization and
-   * capture](https://stripe.com/docs/payments/payment-intents/creating-payment-intents#separate-authorization-and-capture)
-   * for payment methods that support this.
+   * <p>Change `capture_method` to manual if you wish to use [separate authorization and
+   * capture](https://stripe.com/docs/payments/capture-later) for payment methods that support this.
    */
   @SerializedName("capture_method")
   CaptureMethod captureMethod;
@@ -64,9 +62,6 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
    * key. The PaymentIntent returns to the `requires_confirmation` state after handling
    * `next_action`s, and requires your server to initiate each payment attempt with an explicit
    * confirmation.
-   *
-   * <p>Learn more about the different [confirmation
-   * flows](https://stripe.com/docs/payments/payment-intents/use-cases#one-time-payments).
    */
   @SerializedName("confirmation_method")
   ConfirmationMethod confirmationMethod;
@@ -139,15 +134,15 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
 
   /**
    * The Stripe account ID for which these funds are intended. For details, see the PaymentIntents
-   * [use case for connected
-   * accounts](https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts).
+   * [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts).
    */
   @SerializedName("on_behalf_of")
   String onBehalfOf;
 
   /**
-   * ID of the payment method (a PaymentMethod, Card, BankAccount, or saved Source object) to attach
-   * to this PaymentIntent.
+   * ID of the payment method (a PaymentMethod, Card, or [compatible
+   * Source](https://stripe.com/docs/payments/payment-methods#compatibility) object) to attach to
+   * this PaymentIntent.
    */
   @SerializedName("payment_method")
   String paymentMethod;
@@ -183,6 +178,13 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
    *
    * <p>If the payment method is already saved to a customer, this does nothing. If this type of
    * payment method cannot be saved to a customer, the request will error.
+   *
+   * <p>_Note that saving a payment method using this parameter does not guarantee that the payment
+   * method can be charged._ To ensure that only payment methods which can be charged are saved to a
+   * customer, you can [manually
+   * save](https://stripe.com/docs/api/customers/create#create_customer-source) the payment method
+   * in response to the [`payment_intent.succeeded`
+   * webhook](https://stripe.com/docs/api/events/types#event_types-payment_intent.succeeded).
    */
   @SerializedName("save_payment_method")
   Boolean savePaymentMethod;
@@ -196,8 +198,8 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
    *
    * <p>Use `on_session` if you intend to only reuse the payment method when your customer is
    * present in your checkout flow. Use `off_session` if your customer may or may not be in your
-   * checkout flow. See [Saving card details after a
-   * payment](https://stripe.com/docs/payments/cards/saving-cards-after-payment) to learn more.
+   * checkout flow. For more, learn to [save card details after a
+   * payment](https://stripe.com/docs/payments/save-after-payment).
    *
    * <p>Stripe uses `setup_future_usage` to dynamically optimize your payment flow and comply with
    * regional legislation and network rules. For example, if your customer is impacted by
@@ -240,16 +242,14 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
   /**
    * The parameters used to automatically create a Transfer when the payment succeeds. For more
    * information, see the PaymentIntents [use case for connected
-   * accounts](https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts).
+   * accounts](https://stripe.com/docs/payments/connected-accounts).
    */
   @SerializedName("transfer_data")
   TransferData transferData;
 
   /**
    * A string that identifies the resulting payment as part of a group. See the PaymentIntents [use
-   * case for connected
-   * accounts](https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts) for
-   * details.
+   * case for connected accounts](https://stripe.com/docs/payments/connected-accounts) for details.
    */
   @SerializedName("transfer_group")
   String transferGroup;
@@ -436,7 +436,7 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
      * The amount of the application fee (if any) that will be applied to the payment and
      * transferred to the application owner's Stripe account. For more information, see the
      * PaymentIntents [use case for connected
-     * accounts](https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts).
+     * accounts](https://stripe.com/docs/payments/connected-accounts).
      */
     public Builder setApplicationFeeAmount(Long applicationFeeAmount) {
       this.applicationFeeAmount = applicationFeeAmount;
@@ -449,9 +449,9 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
      * <p>When the capture method is `automatic`, Stripe automatically captures funds when the
      * customer authorizes the payment.
      *
-     * <p>Change `capture_method` to manual if you wish to [separate authorization and
-     * capture](https://stripe.com/docs/payments/payment-intents/creating-payment-intents#separate-authorization-and-capture)
-     * for payment methods that support this.
+     * <p>Change `capture_method` to manual if you wish to use [separate authorization and
+     * capture](https://stripe.com/docs/payments/capture-later) for payment methods that support
+     * this.
      */
     public Builder setCaptureMethod(CaptureMethod captureMethod) {
       this.captureMethod = captureMethod;
@@ -480,9 +480,6 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
      * key. The PaymentIntent returns to the `requires_confirmation` state after handling
      * `next_action`s, and requires your server to initiate each payment attempt with an explicit
      * confirmation.
-     *
-     * <p>Learn more about the different [confirmation
-     * flows](https://stripe.com/docs/payments/payment-intents/use-cases#one-time-payments).
      */
     public Builder setConfirmationMethod(ConfirmationMethod confirmationMethod) {
       this.confirmationMethod = confirmationMethod;
@@ -640,8 +637,7 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
 
     /**
      * The Stripe account ID for which these funds are intended. For details, see the PaymentIntents
-     * [use case for connected
-     * accounts](https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts).
+     * [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts).
      */
     public Builder setOnBehalfOf(String onBehalfOf) {
       this.onBehalfOf = onBehalfOf;
@@ -649,8 +645,9 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     }
 
     /**
-     * ID of the payment method (a PaymentMethod, Card, BankAccount, or saved Source object) to
-     * attach to this PaymentIntent.
+     * ID of the payment method (a PaymentMethod, Card, or [compatible
+     * Source](https://stripe.com/docs/payments/payment-methods#compatibility) object) to attach to
+     * this PaymentIntent.
      */
     public Builder setPaymentMethod(String paymentMethod) {
       this.paymentMethod = paymentMethod;
@@ -713,6 +710,13 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
      *
      * <p>If the payment method is already saved to a customer, this does nothing. If this type of
      * payment method cannot be saved to a customer, the request will error.
+     *
+     * <p>_Note that saving a payment method using this parameter does not guarantee that the
+     * payment method can be charged._ To ensure that only payment methods which can be charged are
+     * saved to a customer, you can [manually
+     * save](https://stripe.com/docs/api/customers/create#create_customer-source) the payment method
+     * in response to the [`payment_intent.succeeded`
+     * webhook](https://stripe.com/docs/api/events/types#event_types-payment_intent.succeeded).
      */
     public Builder setSavePaymentMethod(Boolean savePaymentMethod) {
       this.savePaymentMethod = savePaymentMethod;
@@ -728,8 +732,8 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
      *
      * <p>Use `on_session` if you intend to only reuse the payment method when your customer is
      * present in your checkout flow. Use `off_session` if your customer may or may not be in your
-     * checkout flow. See [Saving card details after a
-     * payment](https://stripe.com/docs/payments/cards/saving-cards-after-payment) to learn more.
+     * checkout flow. For more, learn to [save card details after a
+     * payment](https://stripe.com/docs/payments/save-after-payment).
      *
      * <p>Stripe uses `setup_future_usage` to dynamically optimize your payment flow and comply with
      * regional legislation and network rules. For example, if your customer is impacted by
@@ -783,7 +787,7 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     /**
      * The parameters used to automatically create a Transfer when the payment succeeds. For more
      * information, see the PaymentIntents [use case for connected
-     * accounts](https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts).
+     * accounts](https://stripe.com/docs/payments/connected-accounts).
      */
     public Builder setTransferData(TransferData transferData) {
       this.transferData = transferData;
@@ -792,8 +796,7 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
 
     /**
      * A string that identifies the resulting payment as part of a group. See the PaymentIntents
-     * [use case for connected
-     * accounts](https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts) for
+     * [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts) for
      * details.
      */
     public Builder setTransferGroup(String transferGroup) {

--- a/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
@@ -18,8 +18,7 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
 
   /**
    * The amount of the application fee (if any) for the resulting payment. See the PaymentIntents
-   * [use case for connected
-   * accounts](https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts) for
+   * [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts) for
    * details.
    */
   @SerializedName("application_fee_amount")
@@ -67,8 +66,9 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
   Map<String, String> metadata;
 
   /**
-   * ID of the payment method (a PaymentMethod, Card, BankAccount, or saved Source object) to attach
-   * to this PaymentIntent.
+   * ID of the payment method (a PaymentMethod, Card, or [compatible
+   * Source](https://stripe.com/docs/payments/payment-methods#compatibility) object) to attach to
+   * this PaymentIntent.
    */
   @SerializedName("payment_method")
   Object paymentMethod;
@@ -88,6 +88,13 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
    *
    * <p>If the payment method is already saved to a customer, this does nothing. If this type of
    * payment method cannot be saved to a customer, the request will error.
+   *
+   * <p>_Note that saving a payment method using this parameter does not guarantee that the payment
+   * method can be charged._ To ensure that only payment methods which can be charged are saved to a
+   * customer, you can [manually
+   * save](https://stripe.com/docs/api/customers/create#create_customer-source) the payment method
+   * in response to the [`payment_intent.succeeded`
+   * webhook](https://stripe.com/docs/api/events/types#event_types-payment_intent.succeeded).
    */
   @SerializedName("save_payment_method")
   Boolean savePaymentMethod;
@@ -147,7 +154,7 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
   /**
    * The parameters used to automatically create a Transfer when the payment succeeds. For more
    * information, see the PaymentIntents [use case for connected
-   * accounts](https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts).
+   * accounts](https://stripe.com/docs/payments/connected-accounts).
    */
   @SerializedName("transfer_data")
   TransferData transferData;
@@ -155,8 +162,7 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
   /**
    * A string that identifies the resulting payment as part of a group. `transfer_group` may only be
    * provided if it has not been set. See the PaymentIntents [use case for connected
-   * accounts](https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts) for
-   * details.
+   * accounts](https://stripe.com/docs/payments/connected-accounts) for details.
    */
   @SerializedName("transfer_group")
   Object transferGroup;
@@ -277,8 +283,7 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
 
     /**
      * The amount of the application fee (if any) for the resulting payment. See the PaymentIntents
-     * [use case for connected
-     * accounts](https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts) for
+     * [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts) for
      * details.
      */
     public Builder setApplicationFeeAmount(Long applicationFeeAmount) {
@@ -288,8 +293,7 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
 
     /**
      * The amount of the application fee (if any) for the resulting payment. See the PaymentIntents
-     * [use case for connected
-     * accounts](https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts) for
+     * [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts) for
      * details.
      */
     public Builder setApplicationFeeAmount(EmptyParam applicationFeeAmount) {
@@ -430,8 +434,9 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     }
 
     /**
-     * ID of the payment method (a PaymentMethod, Card, BankAccount, or saved Source object) to
-     * attach to this PaymentIntent.
+     * ID of the payment method (a PaymentMethod, Card, or [compatible
+     * Source](https://stripe.com/docs/payments/payment-methods#compatibility) object) to attach to
+     * this PaymentIntent.
      */
     public Builder setPaymentMethod(String paymentMethod) {
       this.paymentMethod = paymentMethod;
@@ -439,8 +444,9 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     }
 
     /**
-     * ID of the payment method (a PaymentMethod, Card, BankAccount, or saved Source object) to
-     * attach to this PaymentIntent.
+     * ID of the payment method (a PaymentMethod, Card, or [compatible
+     * Source](https://stripe.com/docs/payments/payment-methods#compatibility) object) to attach to
+     * this PaymentIntent.
      */
     public Builder setPaymentMethod(EmptyParam paymentMethod) {
       this.paymentMethod = paymentMethod;
@@ -492,6 +498,13 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
      *
      * <p>If the payment method is already saved to a customer, this does nothing. If this type of
      * payment method cannot be saved to a customer, the request will error.
+     *
+     * <p>_Note that saving a payment method using this parameter does not guarantee that the
+     * payment method can be charged._ To ensure that only payment methods which can be charged are
+     * saved to a customer, you can [manually
+     * save](https://stripe.com/docs/api/customers/create#create_customer-source) the payment method
+     * in response to the [`payment_intent.succeeded`
+     * webhook](https://stripe.com/docs/api/events/types#event_types-payment_intent.succeeded).
      */
     public Builder setSavePaymentMethod(Boolean savePaymentMethod) {
       this.savePaymentMethod = savePaymentMethod;
@@ -627,7 +640,7 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     /**
      * The parameters used to automatically create a Transfer when the payment succeeds. For more
      * information, see the PaymentIntents [use case for connected
-     * accounts](https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts).
+     * accounts](https://stripe.com/docs/payments/connected-accounts).
      */
     public Builder setTransferData(TransferData transferData) {
       this.transferData = transferData;
@@ -637,8 +650,7 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     /**
      * A string that identifies the resulting payment as part of a group. `transfer_group` may only
      * be provided if it has not been set. See the PaymentIntents [use case for connected
-     * accounts](https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts) for
-     * details.
+     * accounts](https://stripe.com/docs/payments/connected-accounts) for details.
      */
     public Builder setTransferGroup(String transferGroup) {
       this.transferGroup = transferGroup;
@@ -648,8 +660,7 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     /**
      * A string that identifies the resulting payment as part of a group. `transfer_group` may only
      * be provided if it has not been set. See the PaymentIntents [use case for connected
-     * accounts](https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts) for
-     * details.
+     * accounts](https://stripe.com/docs/payments/connected-accounts) for details.
      */
     public Builder setTransferGroup(EmptyParam transferGroup) {
       this.transferGroup = transferGroup;

--- a/src/main/java/com/stripe/param/PlanCreateParams.java
+++ b/src/main/java/com/stripe/param/PlanCreateParams.java
@@ -90,8 +90,9 @@ public class PlanCreateParams extends ApiRequestParams {
   Long intervalCount;
 
   /**
-   * A set of key-value pairs that you can attach to a plan object. It can be useful for storing
-   * additional information about the plan in a structured format.
+   * Set of key-value pairs that you can attach to an object. This can be useful for storing
+   * additional information about the object in a structured format. Individual keys can be unset by
+   * posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
    */
   @SerializedName("metadata")
   Map<String, String> metadata;

--- a/src/main/java/com/stripe/param/PlanListParams.java
+++ b/src/main/java/com/stripe/param/PlanListParams.java
@@ -11,8 +11,7 @@ import lombok.Getter;
 @Getter
 public class PlanListParams extends ApiRequestParams {
   /**
-   * Only return plans that are active or inactive (e.g., pass `false` to list all inactive
-   * products).
+   * Only return plans that are active or inactive (e.g., pass `false` to list all inactive plans).
    */
   @SerializedName("active")
   Boolean active;
@@ -121,7 +120,7 @@ public class PlanListParams extends ApiRequestParams {
 
     /**
      * Only return plans that are active or inactive (e.g., pass `false` to list all inactive
-     * products).
+     * plans).
      */
     public Builder setActive(Boolean active) {
       this.active = active;

--- a/src/main/java/com/stripe/param/PlanUpdateParams.java
+++ b/src/main/java/com/stripe/param/PlanUpdateParams.java
@@ -29,8 +29,9 @@ public class PlanUpdateParams extends ApiRequestParams {
   Map<String, Object> extraParams;
 
   /**
-   * A set of key-value pairs that you can attach to a plan object. It can be useful for storing
-   * additional information about the plan in a structured format.
+   * Set of key-value pairs that you can attach to an object. This can be useful for storing
+   * additional information about the object in a structured format. Individual keys can be unset by
+   * posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
    */
   @SerializedName("metadata")
   Map<String, String> metadata;

--- a/src/main/java/com/stripe/param/ProductUpdateParams.java
+++ b/src/main/java/com/stripe/param/ProductUpdateParams.java
@@ -18,23 +18,23 @@ public class ProductUpdateParams extends ApiRequestParams {
 
   /**
    * A list of up to 5 alphanumeric attributes that each SKU can provide values for (e.g.,
-   * `["color", "size"]`). ' 'If a value for `attributes` is specified, the list specified will
-   * replace the existing attributes list on this product. Any attributes not present after the
-   * update will be deleted from the SKUs for this product. May only be set if type=`good`.
+   * `["color", "size"]`). If a value for `attributes` is specified, the list specified will replace
+   * the existing attributes list on this product. Any attributes not present after the update will
+   * be deleted from the SKUs for this product.
    */
   @SerializedName("attributes")
   Object attributes;
 
   /**
    * A short one-line description of the product, meant to be displayable to the customer. May only
-   * be set if type=`good`.
+   * be set if `type=good`.
    */
   @SerializedName("caption")
   Object caption;
 
   /**
    * An array of Connect application names or identifiers that should not be able to order the SKUs
-   * for this product. May only be set if type=`good`.
+   * for this product. May only be set if `type=good`.
    */
   @SerializedName("deactivate_on")
   List<String> deactivateOn;
@@ -62,7 +62,7 @@ public class ProductUpdateParams extends ApiRequestParams {
 
   /**
    * A list of up to 8 URLs of images for this product, meant to be displayable to the customer. May
-   * only be set if type=`good`.
+   * only be set if `type=good`.
    */
   @SerializedName("images")
   Object images;
@@ -83,14 +83,14 @@ public class ProductUpdateParams extends ApiRequestParams {
 
   /**
    * The dimensions of this product for shipping purposes. A SKU associated with this product can
-   * override this value by having its own `package_dimensions`. May only be set if type=`good`.
+   * override this value by having its own `package_dimensions`. May only be set if `type=good`.
    */
   @SerializedName("package_dimensions")
   Object packageDimensions;
 
   /**
    * Whether this product is shipped (i.e., physical goods). Defaults to `true`. May only be set if
-   * type=`good`.
+   * `type=good`.
    */
   @SerializedName("shippable")
   Boolean shippable;
@@ -100,18 +100,20 @@ public class ProductUpdateParams extends ApiRequestParams {
    * 22 characters. The statement description may not include "' characters, and will appear on your
    * customer's statement in capital letters. Non-ASCII characters are automatically stripped. While
    * most banks display this information consistently, some may display it incorrectly or not at
-   * all. It must contain at least one letter.
+   * all. It must contain at least one letter. May only be set if `type=service`.
    */
   @SerializedName("statement_descriptor")
   Object statementDescriptor;
 
   /**
    * A label that represents units of this product in Stripe and on customers’ receipts and
-   * invoices. When set, this will be included in associated invoice line item descriptions.
+   * invoices. When set, this will be included in associated invoice line item descriptions. May
+   * only be set if `type=service`.
    */
   @SerializedName("unit_label")
   Object unitLabel;
 
+  /** A URL of a publicly-accessible webpage for this product. May only be set if `type=good`. */
   @SerializedName("url")
   Object url;
 
@@ -239,9 +241,9 @@ public class ProductUpdateParams extends ApiRequestParams {
 
     /**
      * A list of up to 5 alphanumeric attributes that each SKU can provide values for (e.g.,
-     * `["color", "size"]`). ' 'If a value for `attributes` is specified, the list specified will
+     * `["color", "size"]`). If a value for `attributes` is specified, the list specified will
      * replace the existing attributes list on this product. Any attributes not present after the
-     * update will be deleted from the SKUs for this product. May only be set if type=`good`.
+     * update will be deleted from the SKUs for this product.
      */
     public Builder setAttributes(EmptyParam attributes) {
       this.attributes = attributes;
@@ -250,9 +252,9 @@ public class ProductUpdateParams extends ApiRequestParams {
 
     /**
      * A list of up to 5 alphanumeric attributes that each SKU can provide values for (e.g.,
-     * `["color", "size"]`). ' 'If a value for `attributes` is specified, the list specified will
+     * `["color", "size"]`). If a value for `attributes` is specified, the list specified will
      * replace the existing attributes list on this product. Any attributes not present after the
-     * update will be deleted from the SKUs for this product. May only be set if type=`good`.
+     * update will be deleted from the SKUs for this product.
      */
     public Builder setAttributes(List<String> attributes) {
       this.attributes = attributes;
@@ -261,7 +263,7 @@ public class ProductUpdateParams extends ApiRequestParams {
 
     /**
      * A short one-line description of the product, meant to be displayable to the customer. May
-     * only be set if type=`good`.
+     * only be set if `type=good`.
      */
     public Builder setCaption(String caption) {
       this.caption = caption;
@@ -270,7 +272,7 @@ public class ProductUpdateParams extends ApiRequestParams {
 
     /**
      * A short one-line description of the product, meant to be displayable to the customer. May
-     * only be set if type=`good`.
+     * only be set if `type=good`.
      */
     public Builder setCaption(EmptyParam caption) {
       this.caption = caption;
@@ -405,7 +407,7 @@ public class ProductUpdateParams extends ApiRequestParams {
 
     /**
      * A list of up to 8 URLs of images for this product, meant to be displayable to the customer.
-     * May only be set if type=`good`.
+     * May only be set if `type=good`.
      */
     public Builder setImages(EmptyParam images) {
       this.images = images;
@@ -414,7 +416,7 @@ public class ProductUpdateParams extends ApiRequestParams {
 
     /**
      * A list of up to 8 URLs of images for this product, meant to be displayable to the customer.
-     * May only be set if type=`good`.
+     * May only be set if `type=good`.
      */
     public Builder setImages(List<String> images) {
       this.images = images;
@@ -467,7 +469,7 @@ public class ProductUpdateParams extends ApiRequestParams {
 
     /**
      * The dimensions of this product for shipping purposes. A SKU associated with this product can
-     * override this value by having its own `package_dimensions`. May only be set if type=`good`.
+     * override this value by having its own `package_dimensions`. May only be set if `type=good`.
      */
     public Builder setPackageDimensions(PackageDimensions packageDimensions) {
       this.packageDimensions = packageDimensions;
@@ -476,7 +478,7 @@ public class ProductUpdateParams extends ApiRequestParams {
 
     /**
      * The dimensions of this product for shipping purposes. A SKU associated with this product can
-     * override this value by having its own `package_dimensions`. May only be set if type=`good`.
+     * override this value by having its own `package_dimensions`. May only be set if `type=good`.
      */
     public Builder setPackageDimensions(EmptyParam packageDimensions) {
       this.packageDimensions = packageDimensions;
@@ -485,7 +487,7 @@ public class ProductUpdateParams extends ApiRequestParams {
 
     /**
      * Whether this product is shipped (i.e., physical goods). Defaults to `true`. May only be set
-     * if type=`good`.
+     * if `type=good`.
      */
     public Builder setShippable(Boolean shippable) {
       this.shippable = shippable;
@@ -497,7 +499,8 @@ public class ProductUpdateParams extends ApiRequestParams {
      * to 22 characters. The statement description may not include "' characters, and will appear on
      * your customer's statement in capital letters. Non-ASCII characters are automatically
      * stripped. While most banks display this information consistently, some may display it
-     * incorrectly or not at all. It must contain at least one letter.
+     * incorrectly or not at all. It must contain at least one letter. May only be set if
+     * `type=service`.
      */
     public Builder setStatementDescriptor(String statementDescriptor) {
       this.statementDescriptor = statementDescriptor;
@@ -509,7 +512,8 @@ public class ProductUpdateParams extends ApiRequestParams {
      * to 22 characters. The statement description may not include "' characters, and will appear on
      * your customer's statement in capital letters. Non-ASCII characters are automatically
      * stripped. While most banks display this information consistently, some may display it
-     * incorrectly or not at all. It must contain at least one letter.
+     * incorrectly or not at all. It must contain at least one letter. May only be set if
+     * `type=service`.
      */
     public Builder setStatementDescriptor(EmptyParam statementDescriptor) {
       this.statementDescriptor = statementDescriptor;
@@ -518,7 +522,8 @@ public class ProductUpdateParams extends ApiRequestParams {
 
     /**
      * A label that represents units of this product in Stripe and on customers’ receipts and
-     * invoices. When set, this will be included in associated invoice line item descriptions.
+     * invoices. When set, this will be included in associated invoice line item descriptions. May
+     * only be set if `type=service`.
      */
     public Builder setUnitLabel(String unitLabel) {
       this.unitLabel = unitLabel;
@@ -527,18 +532,21 @@ public class ProductUpdateParams extends ApiRequestParams {
 
     /**
      * A label that represents units of this product in Stripe and on customers’ receipts and
-     * invoices. When set, this will be included in associated invoice line item descriptions.
+     * invoices. When set, this will be included in associated invoice line item descriptions. May
+     * only be set if `type=service`.
      */
     public Builder setUnitLabel(EmptyParam unitLabel) {
       this.unitLabel = unitLabel;
       return this;
     }
 
+    /** A URL of a publicly-accessible webpage for this product. May only be set if `type=good`. */
     public Builder setUrl(String url) {
       this.url = url;
       return this;
     }
 
+    /** A URL of a publicly-accessible webpage for this product. May only be set if `type=good`. */
     public Builder setUrl(EmptyParam url) {
       this.url = url;
       return this;

--- a/src/main/java/com/stripe/param/SetupIntentConfirmParams.java
+++ b/src/main/java/com/stripe/param/SetupIntentConfirmParams.java
@@ -28,8 +28,8 @@ public class SetupIntentConfirmParams extends ApiRequestParams {
   Object mandateData;
 
   /**
-   * ID of the payment method (a PaymentMethod, Card, BankAccount, or saved Source object) to attach
-   * to this SetupIntent.
+   * ID of the payment method (a PaymentMethod, Card, or saved Source object) to attach to this
+   * SetupIntent.
    */
   @SerializedName("payment_method")
   String paymentMethod;
@@ -149,8 +149,8 @@ public class SetupIntentConfirmParams extends ApiRequestParams {
     }
 
     /**
-     * ID of the payment method (a PaymentMethod, Card, BankAccount, or saved Source object) to
-     * attach to this SetupIntent.
+     * ID of the payment method (a PaymentMethod, Card, or saved Source object) to attach to this
+     * SetupIntent.
      */
     public Builder setPaymentMethod(String paymentMethod) {
       this.paymentMethod = paymentMethod;

--- a/src/main/java/com/stripe/param/SetupIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/SetupIntentCreateParams.java
@@ -63,8 +63,8 @@ public class SetupIntentCreateParams extends ApiRequestParams {
   String onBehalfOf;
 
   /**
-   * ID of the payment method (a PaymentMethod, Card, BankAccount, or saved Source object) to attach
-   * to this SetupIntent.
+   * ID of the payment method (a PaymentMethod, Card, or saved Source object) to attach to this
+   * SetupIntent.
    */
   @SerializedName("payment_method")
   String paymentMethod;
@@ -305,8 +305,8 @@ public class SetupIntentCreateParams extends ApiRequestParams {
     }
 
     /**
-     * ID of the payment method (a PaymentMethod, Card, BankAccount, or saved Source object) to
-     * attach to this SetupIntent.
+     * ID of the payment method (a PaymentMethod, Card, or saved Source object) to attach to this
+     * SetupIntent.
      */
     public Builder setPaymentMethod(String paymentMethod) {
       this.paymentMethod = paymentMethod;

--- a/src/main/java/com/stripe/param/SetupIntentUpdateParams.java
+++ b/src/main/java/com/stripe/param/SetupIntentUpdateParams.java
@@ -45,8 +45,8 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
   Map<String, String> metadata;
 
   /**
-   * ID of the payment method (a PaymentMethod, Card, BankAccount, or saved Source object) to attach
-   * to this SetupIntent.
+   * ID of the payment method (a PaymentMethod, Card, or saved Source object) to attach to this
+   * SetupIntent.
    */
   @SerializedName("payment_method")
   Object paymentMethod;
@@ -221,8 +221,8 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
     }
 
     /**
-     * ID of the payment method (a PaymentMethod, Card, BankAccount, or saved Source object) to
-     * attach to this SetupIntent.
+     * ID of the payment method (a PaymentMethod, Card, or saved Source object) to attach to this
+     * SetupIntent.
      */
     public Builder setPaymentMethod(String paymentMethod) {
       this.paymentMethod = paymentMethod;
@@ -230,8 +230,8 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
     }
 
     /**
-     * ID of the payment method (a PaymentMethod, Card, BankAccount, or saved Source object) to
-     * attach to this SetupIntent.
+     * ID of the payment method (a PaymentMethod, Card, or saved Source object) to attach to this
+     * SetupIntent.
      */
     public Builder setPaymentMethod(EmptyParam paymentMethod) {
       this.paymentMethod = paymentMethod;

--- a/src/main/java/com/stripe/param/SubscriptionCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionCreateParams.java
@@ -981,8 +981,10 @@ public class SubscriptionCreateParams extends ApiRequestParams {
     Long quantity;
 
     /**
-     * The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates` on
-     * the subscription do not apply to this `subscription_item`.
+     * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
+     * override the
+     * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
+     * on the Subscription.
      */
     @SerializedName("tax_rates")
     Object taxRates;
@@ -1141,8 +1143,10 @@ public class SubscriptionCreateParams extends ApiRequestParams {
       }
 
       /**
-       * The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates` on
-       * the subscription do not apply to this `subscription_item`.
+       * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
+       * override the
+       * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
+       * on the Subscription.
        */
       public Builder setTaxRates(EmptyParam taxRates) {
         this.taxRates = taxRates;
@@ -1150,8 +1154,10 @@ public class SubscriptionCreateParams extends ApiRequestParams {
       }
 
       /**
-       * The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates` on
-       * the subscription do not apply to this `subscription_item`.
+       * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
+       * override the
+       * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
+       * on the Subscription.
        */
       public Builder setTaxRates(List<String> taxRates) {
         this.taxRates = taxRates;

--- a/src/main/java/com/stripe/param/SubscriptionItemCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionItemCreateParams.java
@@ -69,8 +69,10 @@ public class SubscriptionItemCreateParams extends ApiRequestParams {
   String subscription;
 
   /**
-   * The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates` on the
-   * subscription do not apply to this `subscription_item`.
+   * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will override
+   * the
+   * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
+   * on the Subscription.
    */
   @SerializedName("tax_rates")
   Object taxRates;
@@ -311,8 +313,10 @@ public class SubscriptionItemCreateParams extends ApiRequestParams {
     }
 
     /**
-     * The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates` on
-     * the subscription do not apply to this `subscription_item`.
+     * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
+     * override the
+     * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
+     * on the Subscription.
      */
     public Builder setTaxRates(EmptyParam taxRates) {
       this.taxRates = taxRates;
@@ -320,8 +324,10 @@ public class SubscriptionItemCreateParams extends ApiRequestParams {
     }
 
     /**
-     * The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates` on
-     * the subscription do not apply to this `subscription_item`.
+     * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
+     * override the
+     * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
+     * on the Subscription.
      */
     public Builder setTaxRates(List<String> taxRates) {
       this.taxRates = taxRates;

--- a/src/main/java/com/stripe/param/SubscriptionItemUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionItemUpdateParams.java
@@ -68,8 +68,10 @@ public class SubscriptionItemUpdateParams extends ApiRequestParams {
   Long quantity;
 
   /**
-   * The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates` on the
-   * subscription do not apply to this `subscription_item`.
+   * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will override
+   * the
+   * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
+   * on the Subscription.
    */
   @SerializedName("tax_rates")
   Object taxRates;
@@ -315,8 +317,10 @@ public class SubscriptionItemUpdateParams extends ApiRequestParams {
     }
 
     /**
-     * The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates` on
-     * the subscription do not apply to this `subscription_item`.
+     * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
+     * override the
+     * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
+     * on the Subscription.
      */
     public Builder setTaxRates(EmptyParam taxRates) {
       this.taxRates = taxRates;
@@ -324,8 +328,10 @@ public class SubscriptionItemUpdateParams extends ApiRequestParams {
     }
 
     /**
-     * The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates` on
-     * the subscription do not apply to this `subscription_item`.
+     * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
+     * override the
+     * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
+     * on the Subscription.
      */
     public Builder setTaxRates(List<String> taxRates) {
       this.taxRates = taxRates;

--- a/src/main/java/com/stripe/param/SubscriptionScheduleCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionScheduleCreateParams.java
@@ -45,8 +45,9 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
   /**
    * Migrate an existing subscription to be managed by a subscription schedule. If this parameter is
    * set, a subscription schedule will be created using the subscription's plan(s), set to
-   * auto-renew using the subscription's interval. Other parameters cannot be set since their values
-   * will be inferred from the subscription.
+   * auto-renew using the subscription's interval. When using this parameter, other parameters (such
+   * as phase values) cannot be set. To create a subscription schedule with other modifications, we
+   * recommend making two separate API calls.
    */
   @SerializedName("from_subscription")
   String fromSubscription;
@@ -66,7 +67,12 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
   @SerializedName("phases")
   List<Phase> phases;
 
-  /** The date at which the subscription schedule starts. */
+  /**
+   * When the subscription schedule starts. We recommend using `now` so that it starts the
+   * subscription immediately. You can also use a Unix timestamp to backdate the subscription so
+   * that it starts on a past date, or set a future date for the subscription to start on. When you
+   * backdate, the `billing_cycle_anchor` of the subscription is equivalent to the `start_date`.
+   */
   @SerializedName("start_date")
   Object startDate;
 
@@ -206,8 +212,9 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
     /**
      * Migrate an existing subscription to be managed by a subscription schedule. If this parameter
      * is set, a subscription schedule will be created using the subscription's plan(s), set to
-     * auto-renew using the subscription's interval. Other parameters cannot be set since their
-     * values will be inferred from the subscription.
+     * auto-renew using the subscription's interval. When using this parameter, other parameters
+     * (such as phase values) cannot be set. To create a subscription schedule with other
+     * modifications, we recommend making two separate API calls.
      */
     public Builder setFromSubscription(String fromSubscription) {
       this.fromSubscription = fromSubscription;
@@ -266,13 +273,25 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
       return this;
     }
 
-    /** The date at which the subscription schedule starts. */
+    /**
+     * When the subscription schedule starts. We recommend using `now` so that it starts the
+     * subscription immediately. You can also use a Unix timestamp to backdate the subscription so
+     * that it starts on a past date, or set a future date for the subscription to start on. When
+     * you backdate, the `billing_cycle_anchor` of the subscription is equivalent to the
+     * `start_date`.
+     */
     public Builder setStartDate(Long startDate) {
       this.startDate = startDate;
       return this;
     }
 
-    /** The date at which the subscription schedule starts. */
+    /**
+     * When the subscription schedule starts. We recommend using `now` so that it starts the
+     * subscription immediately. You can also use a Unix timestamp to backdate the subscription so
+     * that it starts on a past date, or set a future date for the subscription to start on. When
+     * you backdate, the `billing_cycle_anchor` of the subscription is equivalent to the
+     * `start_date`.
+     */
     public Builder setStartDate(StartDate startDate) {
       this.startDate = startDate;
       return this;
@@ -653,8 +672,12 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
     String defaultPaymentMethod;
 
     /**
-     * The tax rates that will apply to any phase that does not have `tax_rates` set. Invoices
-     * created will have their `default_tax_rates` populated from the phase.
+     * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will set the
+     * Subscription's
+     * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates),
+     * which means they will be the Invoice's
+     * [`default_tax_rates`](https://stripe.com/docs/api/invoices/create#create_invoice-default_tax_rates)
+     * for any Invoices issued by the Subscription during this Phase.
      */
     @SerializedName("default_tax_rates")
     Object defaultTaxRates;
@@ -891,8 +914,12 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
       }
 
       /**
-       * The tax rates that will apply to any phase that does not have `tax_rates` set. Invoices
-       * created will have their `default_tax_rates` populated from the phase.
+       * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will set
+       * the Subscription's
+       * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates),
+       * which means they will be the Invoice's
+       * [`default_tax_rates`](https://stripe.com/docs/api/invoices/create#create_invoice-default_tax_rates)
+       * for any Invoices issued by the Subscription during this Phase.
        */
       public Builder setDefaultTaxRates(EmptyParam defaultTaxRates) {
         this.defaultTaxRates = defaultTaxRates;
@@ -900,8 +927,12 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
       }
 
       /**
-       * The tax rates that will apply to any phase that does not have `tax_rates` set. Invoices
-       * created will have their `default_tax_rates` populated from the phase.
+       * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will set
+       * the Subscription's
+       * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates),
+       * which means they will be the Invoice's
+       * [`default_tax_rates`](https://stripe.com/docs/api/invoices/create#create_invoice-default_tax_rates)
+       * for any Invoices issued by the Subscription during this Phase.
        */
       public Builder setDefaultTaxRates(List<String> defaultTaxRates) {
         this.defaultTaxRates = defaultTaxRates;
@@ -1209,8 +1240,10 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
       Long quantity;
 
       /**
-       * The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates` on
-       * the subscription do not apply to this `subscription_item`.
+       * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
+       * override the
+       * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
+       * on the Subscription.
        */
       @SerializedName("tax_rates")
       Object taxRates;
@@ -1339,8 +1372,10 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
         }
 
         /**
-         * The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates`
-         * on the subscription do not apply to this `subscription_item`.
+         * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
+         * override the
+         * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
+         * on the Subscription.
          */
         public Builder setTaxRates(EmptyParam taxRates) {
           this.taxRates = taxRates;
@@ -1348,8 +1383,10 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
         }
 
         /**
-         * The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates`
-         * on the subscription do not apply to this `subscription_item`.
+         * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
+         * override the
+         * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
+         * on the Subscription.
          */
         public Builder setTaxRates(List<String> taxRates) {
           this.taxRates = taxRates;

--- a/src/main/java/com/stripe/param/SubscriptionScheduleUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionScheduleUpdateParams.java
@@ -624,8 +624,12 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
     Object defaultPaymentMethod;
 
     /**
-     * The tax rates that will apply to any phase that does not have `tax_rates` set. Invoices
-     * created will have their `default_tax_rates` populated from the phase.
+     * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will set the
+     * Subscription's
+     * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates),
+     * which means they will be the Invoice's
+     * [`default_tax_rates`](https://stripe.com/docs/api/invoices/create#create_invoice-default_tax_rates)
+     * for any Invoices issued by the Subscription during this Phase.
      */
     @SerializedName("default_tax_rates")
     Object defaultTaxRates;
@@ -665,7 +669,10 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
     @SerializedName("plans")
     List<Plan> plans;
 
-    /** The date at which this phase of the subscription schedule starts. */
+    /**
+     * The date at which this phase of the subscription schedule starts or `now`. Must be set on the
+     * first phase.
+     */
     @SerializedName("start_date")
     Object startDate;
 
@@ -887,8 +894,12 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
       }
 
       /**
-       * The tax rates that will apply to any phase that does not have `tax_rates` set. Invoices
-       * created will have their `default_tax_rates` populated from the phase.
+       * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will set
+       * the Subscription's
+       * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates),
+       * which means they will be the Invoice's
+       * [`default_tax_rates`](https://stripe.com/docs/api/invoices/create#create_invoice-default_tax_rates)
+       * for any Invoices issued by the Subscription during this Phase.
        */
       public Builder setDefaultTaxRates(EmptyParam defaultTaxRates) {
         this.defaultTaxRates = defaultTaxRates;
@@ -896,8 +907,12 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
       }
 
       /**
-       * The tax rates that will apply to any phase that does not have `tax_rates` set. Invoices
-       * created will have their `default_tax_rates` populated from the phase.
+       * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will set
+       * the Subscription's
+       * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates),
+       * which means they will be the Invoice's
+       * [`default_tax_rates`](https://stripe.com/docs/api/invoices/create#create_invoice-default_tax_rates)
+       * for any Invoices issued by the Subscription during this Phase.
        */
       public Builder setDefaultTaxRates(List<String> defaultTaxRates) {
         this.defaultTaxRates = defaultTaxRates;
@@ -990,13 +1005,19 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
         return this;
       }
 
-      /** The date at which this phase of the subscription schedule starts. */
+      /**
+       * The date at which this phase of the subscription schedule starts or `now`. Must be set on
+       * the first phase.
+       */
       public Builder setStartDate(Long startDate) {
         this.startDate = startDate;
         return this;
       }
 
-      /** The date at which this phase of the subscription schedule starts. */
+      /**
+       * The date at which this phase of the subscription schedule starts or `now`. Must be set on
+       * the first phase.
+       */
       public Builder setStartDate(StartDate startDate) {
         this.startDate = startDate;
         return this;
@@ -1235,8 +1256,10 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
       Long quantity;
 
       /**
-       * The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates` on
-       * the subscription do not apply to this `subscription_item`.
+       * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
+       * override the
+       * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
+       * on the Subscription.
        */
       @SerializedName("tax_rates")
       Object taxRates;
@@ -1371,8 +1394,10 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
         }
 
         /**
-         * The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates`
-         * on the subscription do not apply to this `subscription_item`.
+         * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
+         * override the
+         * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
+         * on the Subscription.
          */
         public Builder setTaxRates(EmptyParam taxRates) {
           this.taxRates = taxRates;
@@ -1380,8 +1405,10 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
         }
 
         /**
-         * The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates`
-         * on the subscription do not apply to this `subscription_item`.
+         * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
+         * override the
+         * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
+         * on the Subscription.
          */
         public Builder setTaxRates(List<String> taxRates) {
           this.taxRates = taxRates;

--- a/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
@@ -1010,8 +1010,10 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
     Long quantity;
 
     /**
-     * The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates` on
-     * the subscription do not apply to this `subscription_item`.
+     * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
+     * override the
+     * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
+     * on the Subscription.
      */
     @SerializedName("tax_rates")
     Object taxRates;
@@ -1218,8 +1220,10 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
       }
 
       /**
-       * The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates` on
-       * the subscription do not apply to this `subscription_item`.
+       * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
+       * override the
+       * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
+       * on the Subscription.
        */
       public Builder setTaxRates(EmptyParam taxRates) {
         this.taxRates = taxRates;
@@ -1227,8 +1231,10 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
       }
 
       /**
-       * The tax rates which apply to this `subscription_item`. When set, the `default_tax_rates` on
-       * the subscription do not apply to this `subscription_item`.
+       * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
+       * override the
+       * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
+       * on the Subscription.
        */
       public Builder setTaxRates(List<String> taxRates) {
         this.taxRates = taxRates;

--- a/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
+++ b/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
@@ -94,7 +94,7 @@ public class SessionCreateParams extends ApiRequestParams {
 
   /**
    * A list of the types of payment methods (e.g. card) this Checkout Session is allowed to accept.
-   * The only supported value today is `card`.
+   * The only supported values today are `card` and `ideal`.
    */
   @SerializedName("payment_method_types")
   List<PaymentMethodType> paymentMethodTypes;
@@ -625,7 +625,7 @@ public class SessionCreateParams extends ApiRequestParams {
      * transferred to the application owner's Stripe account. To use an application fee, the request
      * must be made on behalf of another account, using the `Stripe-Account` header or an OAuth key.
      * For more information, see the PaymentIntents [use case for connected
-     * accounts](https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts).
+     * accounts](https://stripe.com/docs/payments/connected-accounts).
      */
     @SerializedName("application_fee_amount")
     Long applicationFeeAmount;
@@ -656,8 +656,7 @@ public class SessionCreateParams extends ApiRequestParams {
 
     /**
      * The Stripe account ID for which these funds are intended. For details, see the PaymentIntents
-     * [use case for connected
-     * accounts](/docs/payments/payment-intents/use-cases#connected-accounts).
+     * [use case for connected accounts](/docs/payments/connected-accounts).
      */
     @SerializedName("on_behalf_of")
     String onBehalfOf;
@@ -675,8 +674,8 @@ public class SessionCreateParams extends ApiRequestParams {
      *
      * <p>Use `on_session` if you intend to only reuse the payment method when your customer is
      * present in your checkout flow. Use `off_session` if your customer may or may not be in your
-     * checkout flow. See [Saving card details after a
-     * payment](https://stripe.com/docs/payments/cards/saving-cards-after-payment) to learn more.
+     * checkout flow. For more, learn to [save card details after a
+     * payment](https://stripe.com/docs/payments/save-after-payment).
      *
      * <p>Stripe uses `setup_future_usage` to dynamically optimize your payment flow and comply with
      * regional legislation and network rules. For example, if your customer is impacted by
@@ -703,7 +702,7 @@ public class SessionCreateParams extends ApiRequestParams {
     /**
      * The parameters used to automatically create a Transfer when the payment succeeds. For more
      * information, see the PaymentIntents [use case for connected
-     * accounts](https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts).
+     * accounts](https://stripe.com/docs/payments/connected-accounts).
      */
     @SerializedName("transfer_data")
     TransferData transferData;
@@ -781,7 +780,7 @@ public class SessionCreateParams extends ApiRequestParams {
        * transferred to the application owner's Stripe account. To use an application fee, the
        * request must be made on behalf of another account, using the `Stripe-Account` header or an
        * OAuth key. For more information, see the PaymentIntents [use case for connected
-       * accounts](https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts).
+       * accounts](https://stripe.com/docs/payments/connected-accounts).
        */
       public Builder setApplicationFeeAmount(Long applicationFeeAmount) {
         this.applicationFeeAmount = applicationFeeAmount;
@@ -854,8 +853,7 @@ public class SessionCreateParams extends ApiRequestParams {
 
       /**
        * The Stripe account ID for which these funds are intended. For details, see the
-       * PaymentIntents [use case for connected
-       * accounts](/docs/payments/payment-intents/use-cases#connected-accounts).
+       * PaymentIntents [use case for connected accounts](/docs/payments/connected-accounts).
        */
       public Builder setOnBehalfOf(String onBehalfOf) {
         this.onBehalfOf = onBehalfOf;
@@ -877,8 +875,8 @@ public class SessionCreateParams extends ApiRequestParams {
        *
        * <p>Use `on_session` if you intend to only reuse the payment method when your customer is
        * present in your checkout flow. Use `off_session` if your customer may or may not be in your
-       * checkout flow. See [Saving card details after a
-       * payment](https://stripe.com/docs/payments/cards/saving-cards-after-payment) to learn more.
+       * checkout flow. For more, learn to [save card details after a
+       * payment](https://stripe.com/docs/payments/save-after-payment).
        *
        * <p>Stripe uses `setup_future_usage` to dynamically optimize your payment flow and comply
        * with regional legislation and network rules. For example, if your customer is impacted by
@@ -911,7 +909,7 @@ public class SessionCreateParams extends ApiRequestParams {
       /**
        * The parameters used to automatically create a Transfer when the payment succeeds. For more
        * information, see the PaymentIntents [use case for connected
-       * accounts](https://stripe.com/docs/payments/payment-intents/use-cases#connected-accounts).
+       * accounts](https://stripe.com/docs/payments/connected-accounts).
        */
       public Builder setTransferData(TransferData transferData) {
         this.transferData = transferData;

--- a/src/main/java/com/stripe/param/issuing/CardUpdateParams.java
+++ b/src/main/java/com/stripe/param/issuing/CardUpdateParams.java
@@ -21,7 +21,7 @@ public class CardUpdateParams extends ApiRequestParams {
 
   /**
    * The [Cardholder](https://stripe.com/docs/api#issuing_cardholder_object) to associate the card
-   * with.
+   * with. (This field is deprecated and will be removed from future versions of the API.)
    */
   @SerializedName("cardholder")
   Object cardholder;
@@ -104,7 +104,7 @@ public class CardUpdateParams extends ApiRequestParams {
 
     /**
      * The [Cardholder](https://stripe.com/docs/api#issuing_cardholder_object) to associate the card
-     * with.
+     * with. (This field is deprecated and will be removed from future versions of the API.)
      */
     public Builder setCardholder(String cardholder) {
       this.cardholder = cardholder;
@@ -113,7 +113,7 @@ public class CardUpdateParams extends ApiRequestParams {
 
     /**
      * The [Cardholder](https://stripe.com/docs/api#issuing_cardholder_object) to associate the card
-     * with.
+     * with. (This field is deprecated and will be removed from future versions of the API.)
      */
     public Builder setCardholder(EmptyParam cardholder) {
       this.cardholder = cardholder;


### PR DESCRIPTION
Codegen for openapi 69fedb8. This PR adds two things:
* Changes a lot of docs due to a recent change to how enums are handled on our end.
* Add support for `violated_authorization_controls` on Issuing `Authorization`: [docs](https://stripe.com/docs/api/issuing/authorizations/object#issuing_authorization_object-request_history-violated_authorization_controls)

r? @ob-stripe 
cc @stripe/api-libraries 