### PR TITLE
Add support for `out_of_band_amount` on `CreditNote` creation

### DIFF
--- a/src/main/java/com/stripe/model/CreditNote.java
+++ b/src/main/java/com/stripe/model/CreditNote.java
@@ -214,10 +214,12 @@ public class CreditNote extends ApiResource implements HasId, MetadataStore<Cred
    *       (using <code>refund</code>).
    *   <li>Customer balance credit: credit the customer’s balance (using <code>credit_amount</code>)
    *       which will be automatically applied to their next invoice when it’s finalized.
-   *   <li>Outside of Stripe credit: any positive value from the result of <code>
-   *       amount - refund_amount - credit_amount</code> is represented as an “outside of Stripe”
-   *       credit.
+   *   <li>Outside of Stripe credit: record the amount that is or will be credited outside of Stripe
+   *       (using <code>out_of_band_amount</code>).
    * </ul>
+   *
+   * <p>For post-payment credit notes the sum of the refund, credit and outside of Stripe amounts
+   * must equal the credit note total.
    *
    * <p>You may issue multiple credit notes for an invoice. Each credit note will increment the
    * invoice’s <code>pre_payment_credit_notes_amount</code> or <code>
@@ -239,10 +241,12 @@ public class CreditNote extends ApiResource implements HasId, MetadataStore<Cred
    *       (using <code>refund</code>).
    *   <li>Customer balance credit: credit the customer’s balance (using <code>credit_amount</code>)
    *       which will be automatically applied to their next invoice when it’s finalized.
-   *   <li>Outside of Stripe credit: any positive value from the result of <code>
-   *       amount - refund_amount - credit_amount</code> is represented as an “outside of Stripe”
-   *       credit.
+   *   <li>Outside of Stripe credit: record the amount that is or will be credited outside of Stripe
+   *       (using <code>out_of_band_amount</code>).
    * </ul>
+   *
+   * <p>For post-payment credit notes the sum of the refund, credit and outside of Stripe amounts
+   * must equal the credit note total.
    *
    * <p>You may issue multiple credit notes for an invoice. Each credit note will increment the
    * invoice’s <code>pre_payment_credit_notes_amount</code> or <code>
@@ -267,10 +271,12 @@ public class CreditNote extends ApiResource implements HasId, MetadataStore<Cred
    *       (using <code>refund</code>).
    *   <li>Customer balance credit: credit the customer’s balance (using <code>credit_amount</code>)
    *       which will be automatically applied to their next invoice when it’s finalized.
-   *   <li>Outside of Stripe credit: any positive value from the result of <code>
-   *       amount - refund_amount - credit_amount</code> is represented as an “outside of Stripe”
-   *       credit.
+   *   <li>Outside of Stripe credit: record the amount that is or will be credited outside of Stripe
+   *       (using <code>out_of_band_amount</code>).
    * </ul>
+   *
+   * <p>For post-payment credit notes the sum of the refund, credit and outside of Stripe amounts
+   * must equal the credit note total.
    *
    * <p>You may issue multiple credit notes for an invoice. Each credit note will increment the
    * invoice’s <code>pre_payment_credit_notes_amount</code> or <code>
@@ -292,10 +298,12 @@ public class CreditNote extends ApiResource implements HasId, MetadataStore<Cred
    *       (using <code>refund</code>).
    *   <li>Customer balance credit: credit the customer’s balance (using <code>credit_amount</code>)
    *       which will be automatically applied to their next invoice when it’s finalized.
-   *   <li>Outside of Stripe credit: any positive value from the result of <code>
-   *       amount - refund_amount - credit_amount</code> is represented as an “outside of Stripe”
-   *       credit.
+   *   <li>Outside of Stripe credit: record the amount that is or will be credited outside of Stripe
+   *       (using <code>out_of_band_amount</code>).
    * </ul>
+   *
+   * <p>For post-payment credit notes the sum of the refund, credit and outside of Stripe amounts
+   * must equal the credit note total.
    *
    * <p>You may issue multiple credit notes for an invoice. Each credit note will increment the
    * invoice’s <code>pre_payment_credit_notes_amount</code> or <code>

--- a/src/main/java/com/stripe/model/issuing/Transaction.java
+++ b/src/main/java/com/stripe/model/issuing/Transaction.java
@@ -22,6 +22,10 @@ import lombok.Setter;
 @EqualsAndHashCode(callSuper = false)
 public class Transaction extends ApiResource
     implements MetadataStore<Transaction>, BalanceTransactionSource {
+  /**
+   * The amount of this transaction in your currency. This is the amount that your balance will be
+   * updated by.
+   */
   @SerializedName("amount")
   Long amount;
 
@@ -76,9 +80,14 @@ public class Transaction extends ApiResource
   @SerializedName("livemode")
   Boolean livemode;
 
+  /**
+   * The amount that the merchant will receive, denominated in `merchant_currency`. It will be
+   * different from `amount` if the merchant is taking payment in a different currency.
+   */
   @SerializedName("merchant_amount")
   Long merchantAmount;
 
+  /** The currency with which the merchant is taking payment. */
   @SerializedName("merchant_currency")
   String merchantCurrency;
 

--- a/src/main/java/com/stripe/param/AccountLinkCreateParams.java
+++ b/src/main/java/com/stripe/param/AccountLinkCreateParams.java
@@ -15,8 +15,8 @@ public class AccountLinkCreateParams extends ApiRequestParams {
   String account;
 
   /**
-   * The information the platform wants to collect from users up-front. Possible values are
-   * `currently_due` and `eventually_due`.
+   * Which information the platform needs to collect from the user. One of `currently_due` or
+   * `eventually_due`. Default is `currently_due`.
    */
   @SerializedName("collect")
   Collect collect;
@@ -107,8 +107,8 @@ public class AccountLinkCreateParams extends ApiRequestParams {
     }
 
     /**
-     * The information the platform wants to collect from users up-front. Possible values are
-     * `currently_due` and `eventually_due`.
+     * Which information the platform needs to collect from the user. One of `currently_due` or
+     * `eventually_due`. Default is `currently_due`.
      */
     public Builder setCollect(Collect collect) {
       this.collect = collect;

--- a/src/main/java/com/stripe/param/CreditNoteCreateParams.java
+++ b/src/main/java/com/stripe/param/CreditNoteCreateParams.java
@@ -50,6 +50,10 @@ public class CreditNoteCreateParams extends ApiRequestParams {
   @SerializedName("metadata")
   Map<String, String> metadata;
 
+  /** The integer amount in **%s** representing the amount that is credited outside of Stripe. */
+  @SerializedName("out_of_band_amount")
+  Long outOfBandAmount;
+
   /**
    * Reason for issuing this credit note, one of `duplicate`, `fraudulent`, `order_change`, or
    * `product_unsatisfactory`.
@@ -76,6 +80,7 @@ public class CreditNoteCreateParams extends ApiRequestParams {
       String invoice,
       String memo,
       Map<String, String> metadata,
+      Long outOfBandAmount,
       Reason reason,
       String refund,
       Long refundAmount) {
@@ -86,6 +91,7 @@ public class CreditNoteCreateParams extends ApiRequestParams {
     this.invoice = invoice;
     this.memo = memo;
     this.metadata = metadata;
+    this.outOfBandAmount = outOfBandAmount;
     this.reason = reason;
     this.refund = refund;
     this.refundAmount = refundAmount;
@@ -110,6 +116,8 @@ public class CreditNoteCreateParams extends ApiRequestParams {
 
     private Map<String, String> metadata;
 
+    private Long outOfBandAmount;
+
     private Reason reason;
 
     private String refund;
@@ -126,6 +134,7 @@ public class CreditNoteCreateParams extends ApiRequestParams {
           this.invoice,
           this.memo,
           this.metadata,
+          this.outOfBandAmount,
           this.reason,
           this.refund,
           this.refundAmount);
@@ -233,6 +242,12 @@ public class CreditNoteCreateParams extends ApiRequestParams {
         this.metadata = new HashMap<>();
       }
       this.metadata.putAll(map);
+      return this;
+    }
+
+    /** The integer amount in **%s** representing the amount that is credited outside of Stripe. */
+    public Builder setOutOfBandAmount(Long outOfBandAmount) {
+      this.outOfBandAmount = outOfBandAmount;
       return this;
     }
 

--- a/src/main/java/com/stripe/param/CustomerCreateParams.java
+++ b/src/main/java/com/stripe/param/CustomerCreateParams.java
@@ -604,7 +604,10 @@ public class CustomerCreateParams extends ApiRequestParams {
 
   @Getter
   public static class InvoiceSettings {
-    /** Default custom fields to be displayed on invoices for this customer. */
+    /**
+     * Default custom fields to be displayed on invoices for this customer. When updating, pass an
+     * empty string to remove previously-defined fields.
+     */
     @SerializedName("custom_fields")
     Object customFields;
 
@@ -684,13 +687,19 @@ public class CustomerCreateParams extends ApiRequestParams {
         return this;
       }
 
-      /** Default custom fields to be displayed on invoices for this customer. */
+      /**
+       * Default custom fields to be displayed on invoices for this customer. When updating, pass an
+       * empty string to remove previously-defined fields.
+       */
       public Builder setCustomFields(EmptyParam customFields) {
         this.customFields = customFields;
         return this;
       }
 
-      /** Default custom fields to be displayed on invoices for this customer. */
+      /**
+       * Default custom fields to be displayed on invoices for this customer. When updating, pass an
+       * empty string to remove previously-defined fields.
+       */
       public Builder setCustomFields(List<CustomField> customFields) {
         this.customFields = customFields;
         return this;

--- a/src/main/java/com/stripe/param/CustomerUpdateParams.java
+++ b/src/main/java/com/stripe/param/CustomerUpdateParams.java
@@ -709,7 +709,10 @@ public class CustomerUpdateParams extends ApiRequestParams {
 
   @Getter
   public static class InvoiceSettings {
-    /** Default custom fields to be displayed on invoices for this customer. */
+    /**
+     * Default custom fields to be displayed on invoices for this customer. When updating, pass an
+     * empty string to remove previously-defined fields.
+     */
     @SerializedName("custom_fields")
     Object customFields;
 
@@ -789,13 +792,19 @@ public class CustomerUpdateParams extends ApiRequestParams {
         return this;
       }
 
-      /** Default custom fields to be displayed on invoices for this customer. */
+      /**
+       * Default custom fields to be displayed on invoices for this customer. When updating, pass an
+       * empty string to remove previously-defined fields.
+       */
       public Builder setCustomFields(EmptyParam customFields) {
         this.customFields = customFields;
         return this;
       }
 
-      /** Default custom fields to be displayed on invoices for this customer. */
+      /**
+       * Default custom fields to be displayed on invoices for this customer. When updating, pass an
+       * empty string to remove previously-defined fields.
+       */
       public Builder setCustomFields(List<CustomField> customFields) {
         this.customFields = customFields;
         return this;

--- a/src/main/java/com/stripe/param/InvoiceItemUpdateParams.java
+++ b/src/main/java/com/stripe/param/InvoiceItemUpdateParams.java
@@ -64,7 +64,7 @@ public class InvoiceItemUpdateParams extends ApiRequestParams {
 
   /**
    * The tax rates which apply to the invoice item. When set, the `default_tax_rates` on the invoice
-   * do not apply to this invoice item.
+   * do not apply to this invoice item. Pass an empty string to remove previously-defined tax rates.
    */
   @SerializedName("tax_rates")
   Object taxRates;
@@ -309,7 +309,8 @@ public class InvoiceItemUpdateParams extends ApiRequestParams {
 
     /**
      * The tax rates which apply to the invoice item. When set, the `default_tax_rates` on the
-     * invoice do not apply to this invoice item.
+     * invoice do not apply to this invoice item. Pass an empty string to remove previously-defined
+     * tax rates.
      */
     public Builder setTaxRates(EmptyParam taxRates) {
       this.taxRates = taxRates;
@@ -318,7 +319,8 @@ public class InvoiceItemUpdateParams extends ApiRequestParams {
 
     /**
      * The tax rates which apply to the invoice item. When set, the `default_tax_rates` on the
-     * invoice do not apply to this invoice item.
+     * invoice do not apply to this invoice item. Pass an empty string to remove previously-defined
+     * tax rates.
      */
     public Builder setTaxRates(List<String> taxRates) {
       this.taxRates = taxRates;

--- a/src/main/java/com/stripe/param/InvoiceUpcomingParams.java
+++ b/src/main/java/com/stripe/param/InvoiceUpcomingParams.java
@@ -975,7 +975,7 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
   public static class SubscriptionItem {
     /**
      * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
-     * billing period.
+     * billing period. When updating, pass an empty string to remove previously-defined thresholds.
      */
     @SerializedName("billing_thresholds")
     Object billingThresholds;
@@ -1023,7 +1023,8 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
      * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
      * override the
      * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
-     * on the Subscription.
+     * on the Subscription. When updating, pass an empty string to remove previously-defined tax
+     * rates.
      */
     @SerializedName("tax_rates")
     Object taxRates;
@@ -1088,7 +1089,8 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
 
       /**
        * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
-       * billing period.
+       * billing period. When updating, pass an empty string to remove previously-defined
+       * thresholds.
        */
       public Builder setBillingThresholds(BillingThresholds billingThresholds) {
         this.billingThresholds = billingThresholds;
@@ -1097,7 +1099,8 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
 
       /**
        * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
-       * billing period.
+       * billing period. When updating, pass an empty string to remove previously-defined
+       * thresholds.
        */
       public Builder setBillingThresholds(EmptyParam billingThresholds) {
         this.billingThresholds = billingThresholds;
@@ -1221,7 +1224,8 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
        * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
        * override the
        * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
-       * on the Subscription.
+       * on the Subscription. When updating, pass an empty string to remove previously-defined tax
+       * rates.
        */
       public Builder setTaxRates(EmptyParam taxRates) {
         this.taxRates = taxRates;
@@ -1232,7 +1236,8 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
        * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
        * override the
        * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
-       * on the Subscription.
+       * on the Subscription. When updating, pass an empty string to remove previously-defined tax
+       * rates.
        */
       public Builder setTaxRates(List<String> taxRates) {
         this.taxRates = taxRates;

--- a/src/main/java/com/stripe/param/InvoiceUpdateParams.java
+++ b/src/main/java/com/stripe/param/InvoiceUpdateParams.java
@@ -38,6 +38,7 @@ public class InvoiceUpdateParams extends ApiRequestParams {
   /**
    * A list of up to 4 custom fields to be displayed on the invoice. If a value for `custom_fields`
    * is specified, the list specified will replace the existing custom field list on this invoice.
+   * Pass an empty string to remove previously-defined fields.
    */
   @SerializedName("custom_fields")
   Object customFields;
@@ -67,7 +68,7 @@ public class InvoiceUpdateParams extends ApiRequestParams {
 
   /**
    * The tax rates that will apply to any line item that does not have `tax_rates` set. Pass an
-   * empty string to remove previously-set default tax rates.
+   * empty string to remove previously-defined tax rates.
    */
   @SerializedName("default_tax_rates")
   Object defaultTaxRates;
@@ -287,7 +288,7 @@ public class InvoiceUpdateParams extends ApiRequestParams {
     /**
      * A list of up to 4 custom fields to be displayed on the invoice. If a value for
      * `custom_fields` is specified, the list specified will replace the existing custom field list
-     * on this invoice.
+     * on this invoice. Pass an empty string to remove previously-defined fields.
      */
     public Builder setCustomFields(EmptyParam customFields) {
       this.customFields = customFields;
@@ -297,7 +298,7 @@ public class InvoiceUpdateParams extends ApiRequestParams {
     /**
      * A list of up to 4 custom fields to be displayed on the invoice. If a value for
      * `custom_fields` is specified, the list specified will replace the existing custom field list
-     * on this invoice.
+     * on this invoice. Pass an empty string to remove previously-defined fields.
      */
     public Builder setCustomFields(List<CustomField> customFields) {
       this.customFields = customFields;
@@ -383,7 +384,7 @@ public class InvoiceUpdateParams extends ApiRequestParams {
 
     /**
      * The tax rates that will apply to any line item that does not have `tax_rates` set. Pass an
-     * empty string to remove previously-set default tax rates.
+     * empty string to remove previously-defined tax rates.
      */
     public Builder setDefaultTaxRates(EmptyParam defaultTaxRates) {
       this.defaultTaxRates = defaultTaxRates;
@@ -392,7 +393,7 @@ public class InvoiceUpdateParams extends ApiRequestParams {
 
     /**
      * The tax rates that will apply to any line item that does not have `tax_rates` set. Pass an
-     * empty string to remove previously-set default tax rates.
+     * empty string to remove previously-defined tax rates.
      */
     public Builder setDefaultTaxRates(List<String> defaultTaxRates) {
       this.defaultTaxRates = defaultTaxRates;

--- a/src/main/java/com/stripe/param/SubscriptionCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionCreateParams.java
@@ -951,7 +951,7 @@ public class SubscriptionCreateParams extends ApiRequestParams {
   public static class Item {
     /**
      * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
-     * billing period.
+     * billing period. When updating, pass an empty string to remove previously-defined thresholds.
      */
     @SerializedName("billing_thresholds")
     Object billingThresholds;
@@ -984,7 +984,8 @@ public class SubscriptionCreateParams extends ApiRequestParams {
      * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
      * override the
      * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
-     * on the Subscription.
+     * on the Subscription. When updating, pass an empty string to remove previously-defined tax
+     * rates.
      */
     @SerializedName("tax_rates")
     Object taxRates;
@@ -1034,7 +1035,8 @@ public class SubscriptionCreateParams extends ApiRequestParams {
 
       /**
        * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
-       * billing period.
+       * billing period. When updating, pass an empty string to remove previously-defined
+       * thresholds.
        */
       public Builder setBillingThresholds(BillingThresholds billingThresholds) {
         this.billingThresholds = billingThresholds;
@@ -1043,7 +1045,8 @@ public class SubscriptionCreateParams extends ApiRequestParams {
 
       /**
        * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
-       * billing period.
+       * billing period. When updating, pass an empty string to remove previously-defined
+       * thresholds.
        */
       public Builder setBillingThresholds(EmptyParam billingThresholds) {
         this.billingThresholds = billingThresholds;
@@ -1146,7 +1149,8 @@ public class SubscriptionCreateParams extends ApiRequestParams {
        * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
        * override the
        * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
-       * on the Subscription.
+       * on the Subscription. When updating, pass an empty string to remove previously-defined tax
+       * rates.
        */
       public Builder setTaxRates(EmptyParam taxRates) {
         this.taxRates = taxRates;
@@ -1157,7 +1161,8 @@ public class SubscriptionCreateParams extends ApiRequestParams {
        * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
        * override the
        * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
-       * on the Subscription.
+       * on the Subscription. When updating, pass an empty string to remove previously-defined tax
+       * rates.
        */
       public Builder setTaxRates(List<String> taxRates) {
         this.taxRates = taxRates;

--- a/src/main/java/com/stripe/param/SubscriptionItemCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionItemCreateParams.java
@@ -13,7 +13,7 @@ import lombok.Getter;
 public class SubscriptionItemCreateParams extends ApiRequestParams {
   /**
    * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
-   * billing period.
+   * billing period. When updating, pass an empty string to remove previously-defined thresholds.
    */
   @SerializedName("billing_thresholds")
   Object billingThresholds;
@@ -87,7 +87,8 @@ public class SubscriptionItemCreateParams extends ApiRequestParams {
    * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will override
    * the
    * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
-   * on the Subscription.
+   * on the Subscription. When updating, pass an empty string to remove previously-defined tax
+   * rates.
    */
   @SerializedName("tax_rates")
   Object taxRates;
@@ -162,7 +163,7 @@ public class SubscriptionItemCreateParams extends ApiRequestParams {
 
     /**
      * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
-     * billing period.
+     * billing period. When updating, pass an empty string to remove previously-defined thresholds.
      */
     public Builder setBillingThresholds(BillingThresholds billingThresholds) {
       this.billingThresholds = billingThresholds;
@@ -171,7 +172,7 @@ public class SubscriptionItemCreateParams extends ApiRequestParams {
 
     /**
      * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
-     * billing period.
+     * billing period. When updating, pass an empty string to remove previously-defined thresholds.
      */
     public Builder setBillingThresholds(EmptyParam billingThresholds) {
       this.billingThresholds = billingThresholds;
@@ -346,7 +347,8 @@ public class SubscriptionItemCreateParams extends ApiRequestParams {
      * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
      * override the
      * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
-     * on the Subscription.
+     * on the Subscription. When updating, pass an empty string to remove previously-defined tax
+     * rates.
      */
     public Builder setTaxRates(EmptyParam taxRates) {
       this.taxRates = taxRates;
@@ -357,7 +359,8 @@ public class SubscriptionItemCreateParams extends ApiRequestParams {
      * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
      * override the
      * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
-     * on the Subscription.
+     * on the Subscription. When updating, pass an empty string to remove previously-defined tax
+     * rates.
      */
     public Builder setTaxRates(List<String> taxRates) {
       this.taxRates = taxRates;

--- a/src/main/java/com/stripe/param/SubscriptionItemUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionItemUpdateParams.java
@@ -13,7 +13,7 @@ import lombok.Getter;
 public class SubscriptionItemUpdateParams extends ApiRequestParams {
   /**
    * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
-   * billing period.
+   * billing period. When updating, pass an empty string to remove previously-defined thresholds.
    */
   @SerializedName("billing_thresholds")
   Object billingThresholds;
@@ -86,7 +86,8 @@ public class SubscriptionItemUpdateParams extends ApiRequestParams {
    * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will override
    * the
    * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
-   * on the Subscription.
+   * on the Subscription. When updating, pass an empty string to remove previously-defined tax
+   * rates.
    */
   @SerializedName("tax_rates")
   Object taxRates;
@@ -161,7 +162,7 @@ public class SubscriptionItemUpdateParams extends ApiRequestParams {
 
     /**
      * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
-     * billing period.
+     * billing period. When updating, pass an empty string to remove previously-defined thresholds.
      */
     public Builder setBillingThresholds(BillingThresholds billingThresholds) {
       this.billingThresholds = billingThresholds;
@@ -170,7 +171,7 @@ public class SubscriptionItemUpdateParams extends ApiRequestParams {
 
     /**
      * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
-     * billing period.
+     * billing period. When updating, pass an empty string to remove previously-defined thresholds.
      */
     public Builder setBillingThresholds(EmptyParam billingThresholds) {
       this.billingThresholds = billingThresholds;
@@ -350,7 +351,8 @@ public class SubscriptionItemUpdateParams extends ApiRequestParams {
      * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
      * override the
      * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
-     * on the Subscription.
+     * on the Subscription. When updating, pass an empty string to remove previously-defined tax
+     * rates.
      */
     public Builder setTaxRates(EmptyParam taxRates) {
       this.taxRates = taxRates;
@@ -361,7 +363,8 @@ public class SubscriptionItemUpdateParams extends ApiRequestParams {
      * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
      * override the
      * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
-     * on the Subscription.
+     * on the Subscription. When updating, pass an empty string to remove previously-defined tax
+     * rates.
      */
     public Builder setTaxRates(List<String> taxRates) {
       this.taxRates = taxRates;

--- a/src/main/java/com/stripe/param/SubscriptionScheduleCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionScheduleCreateParams.java
@@ -677,7 +677,8 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
      * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates),
      * which means they will be the Invoice's
      * [`default_tax_rates`](https://stripe.com/docs/api/invoices/create#create_invoice-default_tax_rates)
-     * for any Invoices issued by the Subscription during this Phase.
+     * for any Invoices issued by the Subscription during this Phase. When updating, pass an empty
+     * string to remove previously-defined tax rates.
      */
     @SerializedName("default_tax_rates")
     Object defaultTaxRates;
@@ -919,7 +920,8 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
        * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates),
        * which means they will be the Invoice's
        * [`default_tax_rates`](https://stripe.com/docs/api/invoices/create#create_invoice-default_tax_rates)
-       * for any Invoices issued by the Subscription during this Phase.
+       * for any Invoices issued by the Subscription during this Phase. When updating, pass an empty
+       * string to remove previously-defined tax rates.
        */
       public Builder setDefaultTaxRates(EmptyParam defaultTaxRates) {
         this.defaultTaxRates = defaultTaxRates;
@@ -932,7 +934,8 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
        * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates),
        * which means they will be the Invoice's
        * [`default_tax_rates`](https://stripe.com/docs/api/invoices/create#create_invoice-default_tax_rates)
-       * for any Invoices issued by the Subscription during this Phase.
+       * for any Invoices issued by the Subscription during this Phase. When updating, pass an empty
+       * string to remove previously-defined tax rates.
        */
       public Builder setDefaultTaxRates(List<String> defaultTaxRates) {
         this.defaultTaxRates = defaultTaxRates;
@@ -1214,7 +1217,8 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
     public static class Plan {
       /**
        * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
-       * billing period.
+       * billing period. When updating, pass an empty string to remove previously-defined
+       * thresholds.
        */
       @SerializedName("billing_thresholds")
       Object billingThresholds;
@@ -1243,7 +1247,8 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
        * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
        * override the
        * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
-       * on the Subscription.
+       * on the Subscription. When updating, pass an empty string to remove previously-defined tax
+       * rates.
        */
       @SerializedName("tax_rates")
       Object taxRates;
@@ -1284,7 +1289,8 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
 
         /**
          * Define thresholds at which an invoice will be sent, and the subscription advanced to a
-         * new billing period.
+         * new billing period. When updating, pass an empty string to remove previously-defined
+         * thresholds.
          */
         public Builder setBillingThresholds(BillingThresholds billingThresholds) {
           this.billingThresholds = billingThresholds;
@@ -1293,7 +1299,8 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
 
         /**
          * Define thresholds at which an invoice will be sent, and the subscription advanced to a
-         * new billing period.
+         * new billing period. When updating, pass an empty string to remove previously-defined
+         * thresholds.
          */
         public Builder setBillingThresholds(EmptyParam billingThresholds) {
           this.billingThresholds = billingThresholds;
@@ -1375,7 +1382,8 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
          * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
          * override the
          * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
-         * on the Subscription.
+         * on the Subscription. When updating, pass an empty string to remove previously-defined tax
+         * rates.
          */
         public Builder setTaxRates(EmptyParam taxRates) {
           this.taxRates = taxRates;
@@ -1386,7 +1394,8 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
          * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
          * override the
          * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
-         * on the Subscription.
+         * on the Subscription. When updating, pass an empty string to remove previously-defined tax
+         * rates.
          */
         public Builder setTaxRates(List<String> taxRates) {
           this.taxRates = taxRates;

--- a/src/main/java/com/stripe/param/SubscriptionScheduleUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionScheduleUpdateParams.java
@@ -629,7 +629,8 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
      * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates),
      * which means they will be the Invoice's
      * [`default_tax_rates`](https://stripe.com/docs/api/invoices/create#create_invoice-default_tax_rates)
-     * for any Invoices issued by the Subscription during this Phase.
+     * for any Invoices issued by the Subscription during this Phase. When updating, pass an empty
+     * string to remove previously-defined tax rates.
      */
     @SerializedName("default_tax_rates")
     Object defaultTaxRates;
@@ -899,7 +900,8 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
        * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates),
        * which means they will be the Invoice's
        * [`default_tax_rates`](https://stripe.com/docs/api/invoices/create#create_invoice-default_tax_rates)
-       * for any Invoices issued by the Subscription during this Phase.
+       * for any Invoices issued by the Subscription during this Phase. When updating, pass an empty
+       * string to remove previously-defined tax rates.
        */
       public Builder setDefaultTaxRates(EmptyParam defaultTaxRates) {
         this.defaultTaxRates = defaultTaxRates;
@@ -912,7 +914,8 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
        * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates),
        * which means they will be the Invoice's
        * [`default_tax_rates`](https://stripe.com/docs/api/invoices/create#create_invoice-default_tax_rates)
-       * for any Invoices issued by the Subscription during this Phase.
+       * for any Invoices issued by the Subscription during this Phase. When updating, pass an empty
+       * string to remove previously-defined tax rates.
        */
       public Builder setDefaultTaxRates(List<String> defaultTaxRates) {
         this.defaultTaxRates = defaultTaxRates;
@@ -1230,7 +1233,8 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
     public static class Plan {
       /**
        * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
-       * billing period.
+       * billing period. When updating, pass an empty string to remove previously-defined
+       * thresholds.
        */
       @SerializedName("billing_thresholds")
       Object billingThresholds;
@@ -1259,7 +1263,8 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
        * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
        * override the
        * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
-       * on the Subscription.
+       * on the Subscription. When updating, pass an empty string to remove previously-defined tax
+       * rates.
        */
       @SerializedName("tax_rates")
       Object taxRates;
@@ -1300,7 +1305,8 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
 
         /**
          * Define thresholds at which an invoice will be sent, and the subscription advanced to a
-         * new billing period.
+         * new billing period. When updating, pass an empty string to remove previously-defined
+         * thresholds.
          */
         public Builder setBillingThresholds(BillingThresholds billingThresholds) {
           this.billingThresholds = billingThresholds;
@@ -1309,7 +1315,8 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
 
         /**
          * Define thresholds at which an invoice will be sent, and the subscription advanced to a
-         * new billing period.
+         * new billing period. When updating, pass an empty string to remove previously-defined
+         * thresholds.
          */
         public Builder setBillingThresholds(EmptyParam billingThresholds) {
           this.billingThresholds = billingThresholds;
@@ -1397,7 +1404,8 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
          * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
          * override the
          * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
-         * on the Subscription.
+         * on the Subscription. When updating, pass an empty string to remove previously-defined tax
+         * rates.
          */
         public Builder setTaxRates(EmptyParam taxRates) {
           this.taxRates = taxRates;
@@ -1408,7 +1416,8 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
          * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
          * override the
          * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
-         * on the Subscription.
+         * on the Subscription. When updating, pass an empty string to remove previously-defined tax
+         * rates.
          */
         public Builder setTaxRates(List<String> taxRates) {
           this.taxRates = taxRates;

--- a/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
@@ -91,7 +91,8 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
 
   /**
    * The tax rates that will apply to any subscription item that does not have `tax_rates` set.
-   * Invoices created will have their `default_tax_rates` populated from the subscription.
+   * Invoices created will have their `default_tax_rates` populated from the subscription. Pass an
+   * empty string to remove previously-defined tax rates.
    */
   @SerializedName("default_tax_rates")
   Object defaultTaxRates;
@@ -528,7 +529,8 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
 
     /**
      * The tax rates that will apply to any subscription item that does not have `tax_rates` set.
-     * Invoices created will have their `default_tax_rates` populated from the subscription.
+     * Invoices created will have their `default_tax_rates` populated from the subscription. Pass an
+     * empty string to remove previously-defined tax rates.
      */
     public Builder setDefaultTaxRates(EmptyParam defaultTaxRates) {
       this.defaultTaxRates = defaultTaxRates;
@@ -537,7 +539,8 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
 
     /**
      * The tax rates that will apply to any subscription item that does not have `tax_rates` set.
-     * Invoices created will have their `default_tax_rates` populated from the subscription.
+     * Invoices created will have their `default_tax_rates` populated from the subscription. Pass an
+     * empty string to remove previously-defined tax rates.
      */
     public Builder setDefaultTaxRates(List<String> defaultTaxRates) {
       this.defaultTaxRates = defaultTaxRates;
@@ -965,7 +968,7 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
   public static class Item {
     /**
      * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
-     * billing period.
+     * billing period. When updating, pass an empty string to remove previously-defined thresholds.
      */
     @SerializedName("billing_thresholds")
     Object billingThresholds;
@@ -1013,7 +1016,8 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
      * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
      * override the
      * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
-     * on the Subscription.
+     * on the Subscription. When updating, pass an empty string to remove previously-defined tax
+     * rates.
      */
     @SerializedName("tax_rates")
     Object taxRates;
@@ -1078,7 +1082,8 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
 
       /**
        * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
-       * billing period.
+       * billing period. When updating, pass an empty string to remove previously-defined
+       * thresholds.
        */
       public Builder setBillingThresholds(BillingThresholds billingThresholds) {
         this.billingThresholds = billingThresholds;
@@ -1087,7 +1092,8 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
 
       /**
        * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
-       * billing period.
+       * billing period. When updating, pass an empty string to remove previously-defined
+       * thresholds.
        */
       public Builder setBillingThresholds(EmptyParam billingThresholds) {
         this.billingThresholds = billingThresholds;
@@ -1223,7 +1229,8 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
        * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
        * override the
        * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
-       * on the Subscription.
+       * on the Subscription. When updating, pass an empty string to remove previously-defined tax
+       * rates.
        */
       public Builder setTaxRates(EmptyParam taxRates) {
         this.taxRates = taxRates;
@@ -1234,7 +1241,8 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
        * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will
        * override the
        * [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates)
-       * on the Subscription.
+       * on the Subscription. When updating, pass an empty string to remove previously-defined tax
+       * rates.
        */
       public Builder setTaxRates(List<String> taxRates) {
         this.taxRates = taxRates;


### PR DESCRIPTION
Codegen for openapi dcece9b

r? @richardm-stripe 
cc @stripe/api-libraries 