### PR TITLE
Move to API version 2019-12-03

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 env:
   global:
     # If changing this number, please also change it in `BaseStripeTest.java`.
-  - STRIPE_MOCK_VERSION=0.72.0
+  - STRIPE_MOCK_VERSION=0.78.0
 
 matrix:
   include:

--- a/src/main/java/com/stripe/Stripe.java
+++ b/src/main/java/com/stripe/Stripe.java
@@ -9,7 +9,7 @@ public abstract class Stripe {
   public static final int DEFAULT_CONNECT_TIMEOUT = 30 * 1000;
   public static final int DEFAULT_READ_TIMEOUT = 80 * 1000;
 
-  public static final String API_VERSION = "2019-11-05";
+  public static final String API_VERSION = "2019-12-03";
   public static final String CONNECT_API_BASE = "https://connect.stripe.com";
   public static final String LIVE_API_BASE = "https://api.stripe.com";
   public static final String UPLOAD_API_BASE = "https://files.stripe.com";

--- a/src/main/java/com/stripe/model/Account.java
+++ b/src/main/java/com/stripe/model/Account.java
@@ -661,7 +661,7 @@ public class Account extends ApiResource implements MetadataStore<Account>, Paym
      * Whether the company's owners have been provided. This Boolean will be `true` if you've
      * manually indicated that all owners are provided via [the `owners_provided`
      * parameter](https://stripe.com/docs/api/accounts/update#update_account-company-owners_provided),
-     * or if Stripe determined that all owners were provided. Stripe determines ownership
+     * or if Stripe determined that sufficient owners were provided. Stripe determines ownership
      * requirements using both the number of owners provided and their total percent ownership
      * (calculated by adding the `percent_ownership` of each owner together).
      */

--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -1276,22 +1276,22 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
       @EqualsAndHashCode(callSuper = false)
       public static class Checks extends StripeObject {
         /**
-         * If a address line1 was provided, results of the check, one of 'pass', 'failed',
-         * 'unavailable' or 'unchecked'.
+         * If a address line1 was provided, results of the check, one of `pass`, `fail`,
+         * `unavailable`, or `unchecked`.
          */
         @SerializedName("address_line1_check")
         String addressLine1Check;
 
         /**
-         * If a address postal code was provided, results of the check, one of 'pass', 'failed',
-         * 'unavailable' or 'unchecked'.
+         * If a address postal code was provided, results of the check, one of `pass`, `fail`,
+         * `unavailable`, or `unchecked`.
          */
         @SerializedName("address_postal_code_check")
         String addressPostalCodeCheck;
 
         /**
-         * If a CVC was provided, results of the check, one of 'pass', 'failed', 'unavailable' or
-         * 'unchecked'.
+         * If a CVC was provided, results of the check, one of `pass`, `fail`, `unavailable`, or
+         * `unchecked`.
          */
         @SerializedName("cvc_check")
         String cvcCheck;

--- a/src/main/java/com/stripe/model/Customer.java
+++ b/src/main/java/com/stripe/model/Customer.java
@@ -143,24 +143,6 @@ public class Customer extends ApiResource implements HasId, MetadataStore<Custom
   @SerializedName("tax_ids")
   TaxIdCollection taxIds;
 
-  /**
-   * The customer's tax information. Appears on invoices emailed to this customer. This field has
-   * been deprecated and will be removed in a future API version, for further information view the
-   * [migration
-   * guide](https://stripe.com/docs/billing/migration/taxes#moving-from-taxinfo-to-customer-tax-ids).
-   */
-  @SerializedName("tax_info")
-  TaxInfo taxInfo;
-
-  /**
-   * Describes the status of looking up the tax ID provided in `tax_info`. This field has been
-   * deprecated and will be removed in a future API version, for further information view the
-   * [migration
-   * guide](https://stripe.com/docs/billing/migration/taxes#moving-from-taxinfo-to-customer-tax-ids).
-   */
-  @SerializedName("tax_info_verification")
-  TaxInfoVerification taxInfoVerification;
-
   /** Get id of expandable `defaultSource` object. */
   public String getDefaultSource() {
     return (this.defaultSource != null) ? this.defaultSource.getId() : null;
@@ -530,34 +512,5 @@ public class Customer extends ApiResource implements HasId, MetadataStore<Custom
       this.defaultPaymentMethod =
           new ExpandableField<PaymentMethod>(expandableObject.getId(), expandableObject);
     }
-  }
-
-  @Getter
-  @Setter
-  @EqualsAndHashCode(callSuper = false)
-  public static class TaxInfo extends StripeObject {
-    /** The customer's tax ID number. */
-    @SerializedName("tax_id")
-    String taxId;
-
-    /** The type of ID number. */
-    @SerializedName("type")
-    String type;
-  }
-
-  @Getter
-  @Setter
-  @EqualsAndHashCode(callSuper = false)
-  public static class TaxInfoVerification extends StripeObject {
-    /**
-     * The state of verification for this customer. Possible values are `unverified`, `pending`, or
-     * `verified`.
-     */
-    @SerializedName("status")
-    String status;
-
-    /** The official name associated with the tax ID returned from the external provider. */
-    @SerializedName("verified_name")
-    String verifiedName;
   }
 }

--- a/src/main/java/com/stripe/model/PaymentMethod.java
+++ b/src/main/java/com/stripe/model/PaymentMethod.java
@@ -443,22 +443,22 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
     @EqualsAndHashCode(callSuper = false)
     public static class Checks extends StripeObject {
       /**
-       * If a address line1 was provided, results of the check, one of 'pass', 'failed',
-       * 'unavailable' or 'unchecked'.
+       * If a address line1 was provided, results of the check, one of `pass`, `fail`,
+       * `unavailable`, or `unchecked`.
        */
       @SerializedName("address_line1_check")
       String addressLine1Check;
 
       /**
-       * If a address postal code was provided, results of the check, one of 'pass', 'failed',
-       * 'unavailable' or 'unchecked'.
+       * If a address postal code was provided, results of the check, one of `pass`, `fail`,
+       * `unavailable`, or `unchecked`.
        */
       @SerializedName("address_postal_code_check")
       String addressPostalCodeCheck;
 
       /**
-       * If a CVC was provided, results of the check, one of 'pass', 'failed', 'unavailable' or
-       * 'unchecked'.
+       * If a CVC was provided, results of the check, one of `pass`, `fail`, `unavailable`, or
+       * `unchecked`.
        */
       @SerializedName("cvc_check")
       String cvcCheck;

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -145,9 +145,6 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
   @SerializedName("id")
   String id;
 
-  @SerializedName("invoice_customer_balance_settings")
-  InvoiceCustomerBalanceSettings invoiceCustomerBalanceSettings;
-
   /** List of subscription items, each with an attached plan. */
   @SerializedName("items")
   SubscriptionItemCollection items;
@@ -701,18 +698,6 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
      */
     @SerializedName("reset_billing_cycle_anchor")
     Boolean resetBillingCycleAnchor;
-  }
-
-  @Getter
-  @Setter
-  @EqualsAndHashCode(callSuper = false)
-  public static class InvoiceCustomerBalanceSettings extends StripeObject {
-    /**
-     * Controls whether a customer balance applied to this invoice should be consumed and not
-     * credited or debited back to the customer if voided.
-     */
-    @SerializedName("consume_applied_balance_on_void")
-    Boolean consumeAppliedBalanceOnVoid;
   }
 
   @Getter

--- a/src/main/java/com/stripe/model/issuing/Card.java
+++ b/src/main/java/com/stripe/model/issuing/Card.java
@@ -388,7 +388,7 @@ public class Card extends ApiResource implements HasId, MetadataStore<Card> {
     @SerializedName("address")
     Address address;
 
-    /** The delivery service that shipped a physical product, such as Fedex, UPS, USPS, etc. */
+    /** The delivery service that shipped a card. One of `fedex` or `usps`. */
     @SerializedName("carrier")
     String carrier;
 
@@ -407,10 +407,7 @@ public class Card extends ApiResource implements HasId, MetadataStore<Card> {
     @SerializedName("phone")
     String phone;
 
-    /**
-     * The delivery status of the card. One of `pending`, `shipped`, `delivered`, `returned`,
-     * `failure`, or `canceled`.
-     */
+    /** The delivery status of the card. */
     @SerializedName("status")
     String status;
 
@@ -425,10 +422,7 @@ public class Card extends ApiResource implements HasId, MetadataStore<Card> {
     @SerializedName("tracking_url")
     String trackingUrl;
 
-    /**
-     * One of `bulk` or `individual`. Bulk shipments will be grouped and mailed together, while
-     * individual ones will not.
-     */
+    /** Packaging options. */
     @SerializedName("type")
     String type;
   }

--- a/src/main/java/com/stripe/param/CustomerCreateParams.java
+++ b/src/main/java/com/stripe/param/CustomerCreateParams.java
@@ -102,15 +102,6 @@ public class CustomerCreateParams extends ApiRequestParams {
   @SerializedName("tax_id_data")
   List<TaxIdData> taxIdData;
 
-  /**
-   * The customer's tax information. Appears on invoices emailed to this customer. This parameter
-   * has been deprecated and will be removed in a future API version, for further information view
-   * the [migration
-   * guide](https://stripe.com/docs/billing/migration/taxes#moving-from-taxinfo-to-customer-tax-ids).
-   */
-  @SerializedName("tax_info")
-  TaxInfo taxInfo;
-
   private CustomerCreateParams(
       Object address,
       Long balance,
@@ -129,8 +120,7 @@ public class CustomerCreateParams extends ApiRequestParams {
       Object shipping,
       String source,
       EnumParam taxExempt,
-      List<TaxIdData> taxIdData,
-      TaxInfo taxInfo) {
+      List<TaxIdData> taxIdData) {
     this.address = address;
     this.balance = balance;
     this.coupon = coupon;
@@ -149,7 +139,6 @@ public class CustomerCreateParams extends ApiRequestParams {
     this.source = source;
     this.taxExempt = taxExempt;
     this.taxIdData = taxIdData;
-    this.taxInfo = taxInfo;
   }
 
   public static Builder builder() {
@@ -193,8 +182,6 @@ public class CustomerCreateParams extends ApiRequestParams {
 
     private List<TaxIdData> taxIdData;
 
-    private TaxInfo taxInfo;
-
     /** Finalize and obtain parameter instance from this builder. */
     public CustomerCreateParams build() {
       return new CustomerCreateParams(
@@ -215,8 +202,7 @@ public class CustomerCreateParams extends ApiRequestParams {
           this.shipping,
           this.source,
           this.taxExempt,
-          this.taxIdData,
-          this.taxInfo);
+          this.taxIdData);
     }
 
     /** The customer's address. */
@@ -452,17 +438,6 @@ public class CustomerCreateParams extends ApiRequestParams {
         this.taxIdData = new ArrayList<>();
       }
       this.taxIdData.addAll(elements);
-      return this;
-    }
-
-    /**
-     * The customer's tax information. Appears on invoices emailed to this customer. This parameter
-     * has been deprecated and will be removed in a future API version, for further information view
-     * the [migration
-     * guide](https://stripe.com/docs/billing/migration/taxes#moving-from-taxinfo-to-customer-tax-ids).
-     */
-    public Builder setTaxInfo(TaxInfo taxInfo) {
-      this.taxInfo = taxInfo;
       return this;
     }
   }
@@ -1169,99 +1144,6 @@ public class CustomerCreateParams extends ApiRequestParams {
 
       @SerializedName("za_vat")
       ZA_VAT("za_vat");
-
-      @Getter(onMethod_ = {@Override})
-      private final String value;
-
-      Type(String value) {
-        this.value = value;
-      }
-    }
-  }
-
-  @Getter
-  public static class TaxInfo {
-    /**
-     * Map of extra parameters for custom features not available in this client library. The content
-     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
-     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
-     * param object. Effectively, this map is flattened to its parent instance.
-     */
-    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
-    Map<String, Object> extraParams;
-
-    /** The customer's tax ID number. */
-    @SerializedName("tax_id")
-    String taxId;
-
-    /** The type of ID number. The only possible value is `vat` */
-    @SerializedName("type")
-    Type type;
-
-    private TaxInfo(Map<String, Object> extraParams, String taxId, Type type) {
-      this.extraParams = extraParams;
-      this.taxId = taxId;
-      this.type = type;
-    }
-
-    public static Builder builder() {
-      return new Builder();
-    }
-
-    public static class Builder {
-      private Map<String, Object> extraParams;
-
-      private String taxId;
-
-      private Type type;
-
-      /** Finalize and obtain parameter instance from this builder. */
-      public TaxInfo build() {
-        return new TaxInfo(this.extraParams, this.taxId, this.type);
-      }
-
-      /**
-       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
-       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
-       * CustomerCreateParams.TaxInfo#extraParams} for the field documentation.
-       */
-      public Builder putExtraParam(String key, Object value) {
-        if (this.extraParams == null) {
-          this.extraParams = new HashMap<>();
-        }
-        this.extraParams.put(key, value);
-        return this;
-      }
-
-      /**
-       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
-       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
-       * See {@link CustomerCreateParams.TaxInfo#extraParams} for the field documentation.
-       */
-      public Builder putAllExtraParam(Map<String, Object> map) {
-        if (this.extraParams == null) {
-          this.extraParams = new HashMap<>();
-        }
-        this.extraParams.putAll(map);
-        return this;
-      }
-
-      /** The customer's tax ID number. */
-      public Builder setTaxId(String taxId) {
-        this.taxId = taxId;
-        return this;
-      }
-
-      /** The type of ID number. The only possible value is `vat` */
-      public Builder setType(Type type) {
-        this.type = type;
-        return this;
-      }
-    }
-
-    public enum Type implements ApiRequestParams.EnumParam {
-      @SerializedName("vat")
-      VAT("vat");
 
       @Getter(onMethod_ = {@Override})
       private final String value;

--- a/src/main/java/com/stripe/param/CustomerUpdateParams.java
+++ b/src/main/java/com/stripe/param/CustomerUpdateParams.java
@@ -104,15 +104,6 @@ public class CustomerUpdateParams extends ApiRequestParams {
   EnumParam taxExempt;
 
   /**
-   * The customer's tax information. Appears on invoices emailed to this customer. This parameter
-   * has been deprecated and will be removed in a future API version, for further information view
-   * the [migration
-   * guide](https://stripe.com/docs/billing/migration/taxes#moving-from-taxinfo-to-customer-tax-ids).
-   */
-  @SerializedName("tax_info")
-  TaxInfo taxInfo;
-
-  /**
    * Unix timestamp representing the end of the trial period the customer will get before being
    * charged for the first time. This will always overwrite any trials that might apply via a
    * subscribed plan. If set, trial_end will override the default trial period of the plan the
@@ -140,7 +131,6 @@ public class CustomerUpdateParams extends ApiRequestParams {
       Object shipping,
       Object source,
       EnumParam taxExempt,
-      TaxInfo taxInfo,
       Object trialEnd) {
     this.address = address;
     this.balance = balance;
@@ -159,7 +149,6 @@ public class CustomerUpdateParams extends ApiRequestParams {
     this.shipping = shipping;
     this.source = source;
     this.taxExempt = taxExempt;
-    this.taxInfo = taxInfo;
     this.trialEnd = trialEnd;
   }
 
@@ -202,8 +191,6 @@ public class CustomerUpdateParams extends ApiRequestParams {
 
     private EnumParam taxExempt;
 
-    private TaxInfo taxInfo;
-
     private Object trialEnd;
 
     /** Finalize and obtain parameter instance from this builder. */
@@ -226,7 +213,6 @@ public class CustomerUpdateParams extends ApiRequestParams {
           this.shipping,
           this.source,
           this.taxExempt,
-          this.taxInfo,
           this.trialEnd);
     }
 
@@ -503,17 +489,6 @@ public class CustomerUpdateParams extends ApiRequestParams {
     /** The customer's tax exemption. One of `none`, `exempt`, or `reverse`. */
     public Builder setTaxExempt(EmptyParam taxExempt) {
       this.taxExempt = taxExempt;
-      return this;
-    }
-
-    /**
-     * The customer's tax information. Appears on invoices emailed to this customer. This parameter
-     * has been deprecated and will be removed in a future API version, for further information view
-     * the [migration
-     * guide](https://stripe.com/docs/billing/migration/taxes#moving-from-taxinfo-to-customer-tax-ids).
-     */
-    public Builder setTaxInfo(TaxInfo taxInfo) {
-      this.taxInfo = taxInfo;
       return this;
     }
 
@@ -1226,105 +1201,6 @@ public class CustomerUpdateParams extends ApiRequestParams {
           this.state = state;
           return this;
         }
-      }
-    }
-  }
-
-  @Getter
-  public static class TaxInfo {
-    /**
-     * Map of extra parameters for custom features not available in this client library. The content
-     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
-     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
-     * param object. Effectively, this map is flattened to its parent instance.
-     */
-    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
-    Map<String, Object> extraParams;
-
-    /** The customer's tax ID number. */
-    @SerializedName("tax_id")
-    Object taxId;
-
-    /** The type of ID number. The only possible value is `vat` */
-    @SerializedName("type")
-    Type type;
-
-    private TaxInfo(Map<String, Object> extraParams, Object taxId, Type type) {
-      this.extraParams = extraParams;
-      this.taxId = taxId;
-      this.type = type;
-    }
-
-    public static Builder builder() {
-      return new Builder();
-    }
-
-    public static class Builder {
-      private Map<String, Object> extraParams;
-
-      private Object taxId;
-
-      private Type type;
-
-      /** Finalize and obtain parameter instance from this builder. */
-      public TaxInfo build() {
-        return new TaxInfo(this.extraParams, this.taxId, this.type);
-      }
-
-      /**
-       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
-       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
-       * CustomerUpdateParams.TaxInfo#extraParams} for the field documentation.
-       */
-      public Builder putExtraParam(String key, Object value) {
-        if (this.extraParams == null) {
-          this.extraParams = new HashMap<>();
-        }
-        this.extraParams.put(key, value);
-        return this;
-      }
-
-      /**
-       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
-       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
-       * See {@link CustomerUpdateParams.TaxInfo#extraParams} for the field documentation.
-       */
-      public Builder putAllExtraParam(Map<String, Object> map) {
-        if (this.extraParams == null) {
-          this.extraParams = new HashMap<>();
-        }
-        this.extraParams.putAll(map);
-        return this;
-      }
-
-      /** The customer's tax ID number. */
-      public Builder setTaxId(String taxId) {
-        this.taxId = taxId;
-        return this;
-      }
-
-      /** The customer's tax ID number. */
-      public Builder setTaxId(EmptyParam taxId) {
-        this.taxId = taxId;
-        return this;
-      }
-
-      /** The type of ID number. The only possible value is `vat` */
-      public Builder setType(Type type) {
-        this.type = type;
-        return this;
-      }
-    }
-
-    public enum Type implements ApiRequestParams.EnumParam {
-      @SerializedName("vat")
-      VAT("vat");
-
-      @Getter(onMethod_ = {@Override})
-      private final String value;
-
-      Type(String value) {
-        this.value = value;
       }
     }
   }

--- a/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
@@ -117,7 +117,8 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
   /**
    * This is a legacy field that will be removed in the future. It is the ID of the Source object to
    * attach to this PaymentIntent. Please use the `payment_method` field instead, which also
-   * supports Source, Card, and BankAccount objects.
+   * supports Cards and [compatible
+   * Source](https://stripe.com/docs/payments/payment-methods#compatibility) objects.
    */
   @SerializedName("source")
   String source;
@@ -426,7 +427,8 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
     /**
      * This is a legacy field that will be removed in the future. It is the ID of the Source object
      * to attach to this PaymentIntent. Please use the `payment_method` field instead, which also
-     * supports Source, Card, and BankAccount objects.
+     * supports Cards and [compatible
+     * Source](https://stripe.com/docs/payments/payment-methods#compatibility) objects.
      */
     public Builder setSource(String source) {
       this.source = source;

--- a/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
@@ -143,6 +143,11 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
    * ID of the payment method (a PaymentMethod, Card, or [compatible
    * Source](https://stripe.com/docs/payments/payment-methods#compatibility) object) to attach to
    * this PaymentIntent.
+   *
+   * <p>If neither the `payment_method` parameter nor the `source` parameter are provided with
+   * `confirm=true`, `source` will be automatically populated with `customer.default_source` to
+   * improve the migration experience for users of the Charges API. We recommend that you explicitly
+   * provide the `payment_method` going forward.
    */
   @SerializedName("payment_method")
   String paymentMethod;
@@ -219,7 +224,12 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
   /**
    * This is a legacy field that will be removed in the future. It is the ID of the Source object to
    * attach to this PaymentIntent. Please use the `payment_method` field instead, which also
-   * supports Source, Card, and BankAccount objects.
+   * supports Cards and [compatible
+   * Source](https://stripe.com/docs/payments/payment-methods#compatibility) objects.If neither the
+   * `payment_method` parameter nor the `source` parameter are provided with `confirm=true`, this
+   * field will be automatically populated with `customer.default_source` to improve the migration
+   * experience for users of the Charges API. We recommend that you explicitly provide the `source`
+   * or `payment_method` parameter going forward.
    */
   @SerializedName("source")
   String source;
@@ -649,6 +659,11 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
      * ID of the payment method (a PaymentMethod, Card, or [compatible
      * Source](https://stripe.com/docs/payments/payment-methods#compatibility) object) to attach to
      * this PaymentIntent.
+     *
+     * <p>If neither the `payment_method` parameter nor the `source` parameter are provided with
+     * `confirm=true`, `source` will be automatically populated with `customer.default_source` to
+     * improve the migration experience for users of the Charges API. We recommend that you
+     * explicitly provide the `payment_method` going forward.
      */
     public Builder setPaymentMethod(String paymentMethod) {
       this.paymentMethod = paymentMethod;
@@ -758,7 +773,12 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     /**
      * This is a legacy field that will be removed in the future. It is the ID of the Source object
      * to attach to this PaymentIntent. Please use the `payment_method` field instead, which also
-     * supports Source, Card, and BankAccount objects.
+     * supports Cards and [compatible
+     * Source](https://stripe.com/docs/payments/payment-methods#compatibility) objects.If neither
+     * the `payment_method` parameter nor the `source` parameter are provided with `confirm=true`,
+     * this field will be automatically populated with `customer.default_source` to improve the
+     * migration experience for users of the Charges API. We recommend that you explicitly provide
+     * the `source` or `payment_method` parameter going forward.
      */
     public Builder setSource(String source) {
       this.source = source;

--- a/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
@@ -138,7 +138,8 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
   /**
    * This is a legacy field that will be removed in the future. It is the ID of the Source object to
    * attach to this PaymentIntent. Please use the `payment_method` field instead, which also
-   * supports Source, Card, and BankAccount objects.
+   * supports Cards and [compatible
+   * Source](https://stripe.com/docs/payments/payment-methods#compatibility) objects.
    */
   @SerializedName("source")
   Object source;
@@ -595,7 +596,8 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     /**
      * This is a legacy field that will be removed in the future. It is the ID of the Source object
      * to attach to this PaymentIntent. Please use the `payment_method` field instead, which also
-     * supports Source, Card, and BankAccount objects.
+     * supports Cards and [compatible
+     * Source](https://stripe.com/docs/payments/payment-methods#compatibility) objects.
      */
     public Builder setSource(String source) {
       this.source = source;
@@ -605,7 +607,8 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     /**
      * This is a legacy field that will be removed in the future. It is the ID of the Source object
      * to attach to this PaymentIntent. Please use the `payment_method` field instead, which also
-     * supports Source, Card, and BankAccount objects.
+     * supports Cards and [compatible
+     * Source](https://stripe.com/docs/payments/payment-methods#compatibility) objects.
      */
     public Builder setSource(EmptyParam source) {
       this.source = source;

--- a/src/main/java/com/stripe/param/SubscriptionCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionCreateParams.java
@@ -122,13 +122,6 @@ public class SubscriptionCreateParams extends ApiRequestParams {
   @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
   Map<String, Object> extraParams;
 
-  /**
-   * Controls whether a customer balance applied to an invoice should be consumed and not credited
-   * or debited back to the customer if voided by this subscription.
-   */
-  @SerializedName("invoice_customer_balance_settings")
-  InvoiceCustomerBalanceSettings invoiceCustomerBalanceSettings;
-
   /** List of subscription items, each with an attached plan. */
   @SerializedName("items")
   List<Item> items;
@@ -241,7 +234,6 @@ public class SubscriptionCreateParams extends ApiRequestParams {
       Object defaultTaxRates,
       List<String> expand,
       Map<String, Object> extraParams,
-      InvoiceCustomerBalanceSettings invoiceCustomerBalanceSettings,
       List<Item> items,
       Map<String, String> metadata,
       Boolean offSession,
@@ -268,7 +260,6 @@ public class SubscriptionCreateParams extends ApiRequestParams {
     this.defaultTaxRates = defaultTaxRates;
     this.expand = expand;
     this.extraParams = extraParams;
-    this.invoiceCustomerBalanceSettings = invoiceCustomerBalanceSettings;
     this.items = items;
     this.metadata = metadata;
     this.offSession = offSession;
@@ -317,8 +308,6 @@ public class SubscriptionCreateParams extends ApiRequestParams {
 
     private Map<String, Object> extraParams;
 
-    private InvoiceCustomerBalanceSettings invoiceCustomerBalanceSettings;
-
     private List<Item> items;
 
     private Map<String, String> metadata;
@@ -359,7 +348,6 @@ public class SubscriptionCreateParams extends ApiRequestParams {
           this.defaultTaxRates,
           this.expand,
           this.extraParams,
-          this.invoiceCustomerBalanceSettings,
           this.items,
           this.metadata,
           this.offSession,
@@ -592,16 +580,6 @@ public class SubscriptionCreateParams extends ApiRequestParams {
         this.extraParams = new HashMap<>();
       }
       this.extraParams.putAll(map);
-      return this;
-    }
-
-    /**
-     * Controls whether a customer balance applied to an invoice should be consumed and not credited
-     * or debited back to the customer if voided by this subscription.
-     */
-    public Builder setInvoiceCustomerBalanceSettings(
-        InvoiceCustomerBalanceSettings invoiceCustomerBalanceSettings) {
-      this.invoiceCustomerBalanceSettings = invoiceCustomerBalanceSettings;
       return this;
     }
 
@@ -885,63 +863,6 @@ public class SubscriptionCreateParams extends ApiRequestParams {
        */
       public Builder setResetBillingCycleAnchor(Boolean resetBillingCycleAnchor) {
         this.resetBillingCycleAnchor = resetBillingCycleAnchor;
-        return this;
-      }
-    }
-  }
-
-  @Getter
-  public static class InvoiceCustomerBalanceSettings {
-    /**
-     * Map of extra parameters for custom features not available in this client library. The content
-     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
-     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
-     * param object. Effectively, this map is flattened to its parent instance.
-     */
-    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
-    Map<String, Object> extraParams;
-
-    private InvoiceCustomerBalanceSettings(Map<String, Object> extraParams) {
-      this.extraParams = extraParams;
-    }
-
-    public static Builder builder() {
-      return new Builder();
-    }
-
-    public static class Builder {
-      private Map<String, Object> extraParams;
-
-      /** Finalize and obtain parameter instance from this builder. */
-      public InvoiceCustomerBalanceSettings build() {
-        return new InvoiceCustomerBalanceSettings(this.extraParams);
-      }
-
-      /**
-       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
-       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
-       * SubscriptionCreateParams.InvoiceCustomerBalanceSettings#extraParams} for the field
-       * documentation.
-       */
-      public Builder putExtraParam(String key, Object value) {
-        if (this.extraParams == null) {
-          this.extraParams = new HashMap<>();
-        }
-        this.extraParams.put(key, value);
-        return this;
-      }
-
-      /**
-       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
-       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
-       * See {@link SubscriptionCreateParams.InvoiceCustomerBalanceSettings#extraParams} for the
-       * field documentation.
-       */
-      public Builder putAllExtraParam(Map<String, Object> map) {
-        if (this.extraParams == null) {
-          this.extraParams = new HashMap<>();
-        }
-        this.extraParams.putAll(map);
         return this;
       }
     }

--- a/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
@@ -110,13 +110,6 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
   @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
   Map<String, Object> extraParams;
 
-  /**
-   * Controls whether a customer balance applied to an invoice should be consumed and not credited
-   * or debited back to the customer if voided by this subscription.
-   */
-  @SerializedName("invoice_customer_balance_settings")
-  InvoiceCustomerBalanceSettings invoiceCustomerBalanceSettings;
-
   /** List of subscription items, each with an attached plan. */
   @SerializedName("items")
   List<Item> items;
@@ -230,7 +223,6 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
       Object defaultTaxRates,
       List<String> expand,
       Map<String, Object> extraParams,
-      InvoiceCustomerBalanceSettings invoiceCustomerBalanceSettings,
       List<Item> items,
       Map<String, String> metadata,
       Boolean offSession,
@@ -255,7 +247,6 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
     this.defaultTaxRates = defaultTaxRates;
     this.expand = expand;
     this.extraParams = extraParams;
-    this.invoiceCustomerBalanceSettings = invoiceCustomerBalanceSettings;
     this.items = items;
     this.metadata = metadata;
     this.offSession = offSession;
@@ -300,8 +291,6 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
 
     private Map<String, Object> extraParams;
 
-    private InvoiceCustomerBalanceSettings invoiceCustomerBalanceSettings;
-
     private List<Item> items;
 
     private Map<String, String> metadata;
@@ -340,7 +329,6 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
           this.defaultTaxRates,
           this.expand,
           this.extraParams,
-          this.invoiceCustomerBalanceSettings,
           this.items,
           this.metadata,
           this.offSession,
@@ -596,16 +584,6 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
         this.extraParams = new HashMap<>();
       }
       this.extraParams.putAll(map);
-      return this;
-    }
-
-    /**
-     * Controls whether a customer balance applied to an invoice should be consumed and not credited
-     * or debited back to the customer if voided by this subscription.
-     */
-    public Builder setInvoiceCustomerBalanceSettings(
-        InvoiceCustomerBalanceSettings invoiceCustomerBalanceSettings) {
-      this.invoiceCustomerBalanceSettings = invoiceCustomerBalanceSettings;
       return this;
     }
 
@@ -902,63 +880,6 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
        */
       public Builder setResetBillingCycleAnchor(Boolean resetBillingCycleAnchor) {
         this.resetBillingCycleAnchor = resetBillingCycleAnchor;
-        return this;
-      }
-    }
-  }
-
-  @Getter
-  public static class InvoiceCustomerBalanceSettings {
-    /**
-     * Map of extra parameters for custom features not available in this client library. The content
-     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
-     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
-     * param object. Effectively, this map is flattened to its parent instance.
-     */
-    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
-    Map<String, Object> extraParams;
-
-    private InvoiceCustomerBalanceSettings(Map<String, Object> extraParams) {
-      this.extraParams = extraParams;
-    }
-
-    public static Builder builder() {
-      return new Builder();
-    }
-
-    public static class Builder {
-      private Map<String, Object> extraParams;
-
-      /** Finalize and obtain parameter instance from this builder. */
-      public InvoiceCustomerBalanceSettings build() {
-        return new InvoiceCustomerBalanceSettings(this.extraParams);
-      }
-
-      /**
-       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
-       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
-       * SubscriptionUpdateParams.InvoiceCustomerBalanceSettings#extraParams} for the field
-       * documentation.
-       */
-      public Builder putExtraParam(String key, Object value) {
-        if (this.extraParams == null) {
-          this.extraParams = new HashMap<>();
-        }
-        this.extraParams.put(key, value);
-        return this;
-      }
-
-      /**
-       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
-       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
-       * See {@link SubscriptionUpdateParams.InvoiceCustomerBalanceSettings#extraParams} for the
-       * field documentation.
-       */
-      public Builder putAllExtraParam(Map<String, Object> map) {
-        if (this.extraParams == null) {
-          this.extraParams = new HashMap<>();
-        }
-        this.extraParams.putAll(map);
         return this;
       }
     }

--- a/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
+++ b/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
@@ -472,7 +472,10 @@ public class WebhookEndpointCreateParams extends ApiRequestParams {
     VERSION_2019_10_17("2019-10-17"),
 
     @SerializedName("2019-11-05")
-    VERSION_2019_11_05("2019-11-05");
+    VERSION_2019_11_05("2019-11-05"),
+
+    @SerializedName("2019-12-03")
+    VERSION_2019_12_03("2019-12-03");
 
     @Getter(onMethod_ = {@Override})
     private final String value;

--- a/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
+++ b/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
@@ -75,8 +75,7 @@ public class SessionCreateParams extends ApiRequestParams {
 
   /**
    * The IETF language tag of the locale Checkout is displayed in. If blank or `auto`, the browser's
-   * locale is used. Supported values are `auto`, `da`, `de`, `en`, `es`, `fi`, `fr`, `it`, `ja`,
-   * `nb`, `nl`, `pl`, `pt`, `sv`, or `zh`.
+   * locale is used.
    */
   @SerializedName("locale")
   Locale locale;
@@ -355,8 +354,7 @@ public class SessionCreateParams extends ApiRequestParams {
 
     /**
      * The IETF language tag of the locale Checkout is displayed in. If blank or `auto`, the
-     * browser's locale is used. Supported values are `auto`, `da`, `de`, `en`, `es`, `fi`, `fr`,
-     * `it`, `ja`, `nb`, `nl`, `pl`, `pt`, `sv`, or `zh`.
+     * browser's locale is used.
      */
     public Builder setLocale(Locale locale) {
       this.locale = locale;

--- a/src/main/java/com/stripe/param/issuing/CardCreateParams.java
+++ b/src/main/java/com/stripe/param/issuing/CardCreateParams.java
@@ -3325,10 +3325,7 @@ public class CardCreateParams extends ApiRequestParams {
     @SerializedName("name")
     String name;
 
-    /**
-     * One of `bulk` or `individual`. Bulk shipments will be grouped and mailed together, while
-     * individual ones will not.
-     */
+    /** Packaging options. */
     @SerializedName("type")
     EnumParam type;
 
@@ -3394,19 +3391,13 @@ public class CardCreateParams extends ApiRequestParams {
         return this;
       }
 
-      /**
-       * One of `bulk` or `individual`. Bulk shipments will be grouped and mailed together, while
-       * individual ones will not.
-       */
+      /** Packaging options. */
       public Builder setType(Type type) {
         this.type = type;
         return this;
       }
 
-      /**
-       * One of `bulk` or `individual`. Bulk shipments will be grouped and mailed together, while
-       * individual ones will not.
-       */
+      /** Packaging options. */
       public Builder setType(EmptyParam type) {
         this.type = type;
         return this;

--- a/src/main/java/com/stripe/param/issuing/CardUpdateParams.java
+++ b/src/main/java/com/stripe/param/issuing/CardUpdateParams.java
@@ -19,13 +19,6 @@ public class CardUpdateParams extends ApiRequestParams {
   @SerializedName("authorization_controls")
   AuthorizationControls authorizationControls;
 
-  /**
-   * The [Cardholder](https://stripe.com/docs/api#issuing_cardholder_object) to associate the card
-   * with. (This field is deprecated and will be removed from future versions of the API.)
-   */
-  @SerializedName("cardholder")
-  Object cardholder;
-
   /** Specifies which fields in the response should be expanded. */
   @SerializedName("expand")
   List<String> expand;
@@ -51,13 +44,11 @@ public class CardUpdateParams extends ApiRequestParams {
 
   private CardUpdateParams(
       AuthorizationControls authorizationControls,
-      Object cardholder,
       List<String> expand,
       Map<String, Object> extraParams,
       Object metadata,
       Status status) {
     this.authorizationControls = authorizationControls;
-    this.cardholder = cardholder;
     this.expand = expand;
     this.extraParams = extraParams;
     this.metadata = metadata;
@@ -71,8 +62,6 @@ public class CardUpdateParams extends ApiRequestParams {
   public static class Builder {
     private AuthorizationControls authorizationControls;
 
-    private Object cardholder;
-
     private List<String> expand;
 
     private Map<String, Object> extraParams;
@@ -84,12 +73,7 @@ public class CardUpdateParams extends ApiRequestParams {
     /** Finalize and obtain parameter instance from this builder. */
     public CardUpdateParams build() {
       return new CardUpdateParams(
-          this.authorizationControls,
-          this.cardholder,
-          this.expand,
-          this.extraParams,
-          this.metadata,
-          this.status);
+          this.authorizationControls, this.expand, this.extraParams, this.metadata, this.status);
     }
 
     /**
@@ -99,24 +83,6 @@ public class CardUpdateParams extends ApiRequestParams {
      */
     public Builder setAuthorizationControls(AuthorizationControls authorizationControls) {
       this.authorizationControls = authorizationControls;
-      return this;
-    }
-
-    /**
-     * The [Cardholder](https://stripe.com/docs/api#issuing_cardholder_object) to associate the card
-     * with. (This field is deprecated and will be removed from future versions of the API.)
-     */
-    public Builder setCardholder(String cardholder) {
-      this.cardholder = cardholder;
-      return this;
-    }
-
-    /**
-     * The [Cardholder](https://stripe.com/docs/api#issuing_cardholder_object) to associate the card
-     * with. (This field is deprecated and will be removed from future versions of the API.)
-     */
-    public Builder setCardholder(EmptyParam cardholder) {
-      this.cardholder = cardholder;
       return this;
     }
 

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -32,7 +32,7 @@ import org.mockito.Mockito;
 
 public class BaseStripeTest {
   // If changing this number, please also change it in `.travis.yml`.
-  private static final String MOCK_MINIMUM_VERSION = "0.72.0";
+  private static final String MOCK_MINIMUM_VERSION = "0.78.0";
 
   private static String port;
 


### PR DESCRIPTION
This PR adds support for multiple API changes:
* Pin to API version `2019-12-03`
* Remove `tax_info` and `tax_info_verification` on `Customer`.
* Remove `cardholder` on Issuing `Card` update.
* Remove `invoice_customer_balance_settings` from `Subscription`.

r? @richardm-stripe 
cc @stripe/api-libraries 
