### PR TITLE
Add support for `network` on `Charge` and `funding_method` on `SourceTransaction`

### DIFF
--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -1263,6 +1263,13 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
       @SerializedName("moto")
       Boolean moto;
 
+      /**
+       * Identifies which network this charge was processed on. Can be `amex`, `diners`, `discover`,
+       * `interac`, `jcb`, `mastercard`, `unionpay`, `visa`, or `unknown`.
+       */
+      @SerializedName("network")
+      String network;
+
       /** Populated if this transaction used 3D Secure authentication. */
       @SerializedName("three_d_secure")
       ThreeDSecure threeDSecure;
@@ -1506,6 +1513,13 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
       /** The last four digits of the card. */
       @SerializedName("last4")
       String last4;
+
+      /**
+       * Identifies which network this charge was processed on. Can be `amex`, `diners`, `discover`,
+       * `interac`, `jcb`, `mastercard`, `unionpay`, `visa`, or `unknown`.
+       */
+      @SerializedName("network")
+      String network;
 
       /**
        * How were card details read in this transaction. Can be contact_emv, contactless_emv,

--- a/src/main/java/com/stripe/model/SourceTransaction.java
+++ b/src/main/java/com/stripe/model/SourceTransaction.java
@@ -125,6 +125,13 @@ public class SourceTransaction extends StripeObject implements HasId {
     @SerializedName("fingerprint")
     String fingerprint;
 
+    /**
+     * The credit transfer rails the sender used to push money. The three rails are: Faster
+     * Payments, BACS, and CHAPS.
+     */
+    @SerializedName("funding_method")
+    String fundingMethod;
+
     /** Last 4 digits of account number associated with the transfer. */
     @SerializedName("last4")
     String last4;


### PR DESCRIPTION
Codegen for openapi 87e3892
* Add support for `network` on `Charge` for `payment_method_details.card` and `payment_method_details.card_present`.
* Add support for `funding_method` in `SourceTransaction` for `gbp_credit_transfer`.

r? @richardm-stripe 
cc @stripe/api-libraries 