### PR TITLE
Add `maxNetworkRetries` as a global and per-request setting

### DIFF
--- a/src/main/java/com/stripe/Stripe.java
+++ b/src/main/java/com/stripe/Stripe.java
@@ -26,6 +26,8 @@ public abstract class Stripe {
   private static volatile int connectTimeout = -1;
   private static volatile int readTimeout = -1;
 
+  private static volatile int maxNetworkRetries = 0;
+
   private static volatile String apiBase = LIVE_API_BASE;
   private static volatile String connectBase = CONNECT_API_BASE;
   private static volatile String uploadBase = UPLOAD_API_BASE;
@@ -128,6 +130,24 @@ public abstract class Stripe {
    */
   public static void setReadTimeout(final int timeout) {
     readTimeout = timeout;
+  }
+
+  /**
+   * Returns the maximum number of times requests will be retried.
+   *
+   * @return the maximum number of times requests will be retried
+   */
+  public static int getMaxNetworkRetries() {
+    return maxNetworkRetries;
+  }
+
+  /**
+   * Sets the maximum number of times requests will be retried.
+   *
+   * @param numRetries the maximum number of times requests will be retried
+   */
+  public static void setMaxNetworkRetries(final int numRetries) {
+    maxNetworkRetries = numRetries;
   }
 
   /**

--- a/src/main/java/com/stripe/net/HttpClient.java
+++ b/src/main/java/com/stripe/net/HttpClient.java
@@ -19,27 +19,13 @@ public abstract class HttpClient {
   /** Minimum sleep time between tries to send HTTP requests after network failure. */
   public static final Duration minNetworkRetriesDelay = Duration.ofMillis(500);
 
-  private final int maxNetworkRetries;
-
   private final RequestTelemetry requestTelemetry = new RequestTelemetry();
 
   /** A value indicating whether the client should sleep between automatic request retries. */
   boolean networkRetriesSleep = true;
 
-  /** Initializes a new instance of the {@link HttpClient} class with default parameters. */
-  public HttpClient() {
-    this(0);
-  }
-
-  /**
-   * Initializes a new instance of the {@link HttpClient} class.
-   *
-   * @param maxNetworkRetries the maximum number of times the client will retry requests that fail
-   *     due to an intermittent problem.
-   */
-  public HttpClient(int maxNetworkRetries) {
-    this.maxNetworkRetries = maxNetworkRetries;
-  }
+  /** Initializes a new instance of the {@link HttpClient} class. */
+  public HttpClient() {}
 
   /**
    * Sends the given request to Stripe's API.
@@ -97,7 +83,7 @@ public abstract class HttpClient {
         requestException = e;
       }
 
-      if (!this.shouldRetry(retry, requestException, response)) {
+      if (!this.shouldRetry(retry, requestException, request, response)) {
         break;
       }
 
@@ -178,9 +164,10 @@ public abstract class HttpClient {
     return str;
   }
 
-  private boolean shouldRetry(int numRetries, StripeException exception, StripeResponse response) {
+  private boolean shouldRetry(
+      int numRetries, StripeException exception, StripeRequest request, StripeResponse response) {
     // Do not retry if we are out of retries.
-    if (numRetries >= this.maxNetworkRetries) {
+    if (numRetries >= request.options().getMaxNetworkRetries()) {
       return false;
     }
 

--- a/src/main/java/com/stripe/net/HttpURLConnectionClient.java
+++ b/src/main/java/com/stripe/net/HttpURLConnectionClient.java
@@ -16,22 +16,9 @@ import java.util.Scanner;
 import lombok.Cleanup;
 
 public class HttpURLConnectionClient extends HttpClient {
-  /**
-   * Initializes a new instance of the {@link HttpURLConnectionClient} class with default
-   * parameters.
-   */
+  /** Initializes a new instance of the {@link HttpURLConnectionClient}. */
   public HttpURLConnectionClient() {
     super();
-  }
-
-  /**
-   * Initializes a new instance of the {@link HttpURLConnectionClient} class.
-   *
-   * @param maxNetworkRetries the maximum number of times the client will retry requests that fail
-   *     due to an intermittent problem.
-   */
-  public HttpURLConnectionClient(int maxNetworkRetries) {
-    super(maxNetworkRetries);
   }
 
   /**

--- a/src/main/java/com/stripe/net/RequestOptions.java
+++ b/src/main/java/com/stripe/net/RequestOptions.java
@@ -21,6 +21,8 @@ public class RequestOptions {
   private final int connectTimeout;
   private final int readTimeout;
 
+  private final int maxNetworkRetries;
+
   public static RequestOptions getDefault() {
     return new RequestOptions(
         Stripe.apiKey,
@@ -29,7 +31,8 @@ public class RequestOptions {
         null,
         null,
         Stripe.getConnectTimeout(),
-        Stripe.getReadTimeout());
+        Stripe.getReadTimeout(),
+        Stripe.getMaxNetworkRetries());
   }
 
   private RequestOptions(
@@ -39,7 +42,8 @@ public class RequestOptions {
       String stripeAccount,
       String stripeVersionOverride,
       int connectTimeout,
-      int readTimeout) {
+      int readTimeout,
+      int maxNetworkRetries) {
     this.apiKey = apiKey;
     this.clientId = clientId;
     this.idempotencyKey = idempotencyKey;
@@ -47,6 +51,7 @@ public class RequestOptions {
     this.stripeVersionOverride = stripeVersionOverride;
     this.connectTimeout = connectTimeout;
     this.readTimeout = readTimeout;
+    this.maxNetworkRetries = maxNetworkRetries;
   }
 
   public String getApiKey() {
@@ -81,6 +86,10 @@ public class RequestOptions {
     return connectTimeout;
   }
 
+  public int getMaxNetworkRetries() {
+    return maxNetworkRetries;
+  }
+
   public static RequestOptionsBuilder builder() {
     return new RequestOptionsBuilder();
   }
@@ -102,6 +111,7 @@ public class RequestOptions {
     private String stripeVersionOverride;
     private int connectTimeout;
     private int readTimeout;
+    private int maxNetworkRetries;
 
     /**
      * Constructs a request options builder with the global parameters (API key and client ID) as
@@ -112,6 +122,7 @@ public class RequestOptions {
       this.clientId = Stripe.clientId;
       this.connectTimeout = Stripe.getConnectTimeout();
       this.readTimeout = Stripe.getReadTimeout();
+      this.maxNetworkRetries = Stripe.getMaxNetworkRetries();
     }
 
     public String getApiKey() {
@@ -180,6 +191,20 @@ public class RequestOptions {
       return this;
     }
 
+    public int getMaxNetworkRetries() {
+      return maxNetworkRetries;
+    }
+
+    /**
+     * Sets the maximum number of times the request will be retried in the event of a failure.
+     *
+     * @param maxNetworkRetries the number of times to retry the request
+     */
+    public RequestOptionsBuilder setMaxNetworkRetries(int maxNetworkRetries) {
+      this.maxNetworkRetries = maxNetworkRetries;
+      return this;
+    }
+
     public RequestOptionsBuilder clearIdempotencyKey() {
       this.idempotencyKey = null;
       return this;
@@ -236,7 +261,8 @@ public class RequestOptions {
           normalizeStripeAccount(this.stripeAccount),
           normalizeStripeVersion(this.stripeVersionOverride),
           connectTimeout,
-          readTimeout);
+          readTimeout,
+          maxNetworkRetries);
     }
   }
 

--- a/src/test/java/com/stripe/net/HttpClientTest.java
+++ b/src/test/java/com/stripe/net/HttpClientTest.java
@@ -29,11 +29,15 @@ public class HttpClientTest extends BaseStripeTest {
     this.client =
         Mockito.mock(
             HttpClient.class,
-            withSettings().useConstructor(2).defaultAnswer(Mockito.CALLS_REAL_METHODS));
+            withSettings().useConstructor().defaultAnswer(Mockito.CALLS_REAL_METHODS));
     this.client.networkRetriesSleep = false;
 
     this.request =
-        new StripeRequest(ApiResource.RequestMethod.GET, "http://example.com/get", null, null);
+        new StripeRequest(
+            ApiResource.RequestMethod.GET,
+            "http://example.com/get",
+            null,
+            RequestOptions.builder().setMaxNetworkRetries(2).build());
   }
 
   @Test


### PR DESCRIPTION
r? @brandur-stripe @richardm-stripe 
cc @stripe/api-libraries 

I added support for automatic request retries back in #900, but the setting for the max number of retries was set on the `HttpClient` instance, which users won't be initializing themselves directly in most cases.

In order to make the feature more accessible, this PR changes the setting so that it can be set in one of two ways:
- per request, via `RequestOptions.builder().setMaxNetworkRetries(2).build()`
- globally, via `Stripe.setMaxNetworkRetries(2)`

(The former takes precedence over the latter.)
