### PR TITLE
Add `StreamUtils` class

### DIFF
--- a/src/main/java/com/stripe/net/ApiResource.java
+++ b/src/main/java/com/stripe/net/ApiResource.java
@@ -23,12 +23,13 @@ import com.stripe.model.StripeRawJsonObjectDeserializer;
 import com.stripe.util.StringUtils;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Objects;
 
 public abstract class ApiResource extends StripeObject {
-  public static final String CHARSET = StandardCharsets.UTF_8.name();
+  public static final Charset CHARSET = StandardCharsets.UTF_8;
 
   private static StripeResponseGetter stripeResponseGetter = new LiveStripeResponseGetter();
 
@@ -131,7 +132,7 @@ public abstract class ApiResource extends StripeObject {
       // Don't use strict form encoding by changing the square bracket control
       // characters back to their literals. This is fine by the server, and
       // makes these parameter strings easier to read.
-      return URLEncoder.encode(str, CHARSET).replaceAll("%5B", "[").replaceAll("%5D", "]");
+      return URLEncoder.encode(str, CHARSET.name()).replaceAll("%5B", "[").replaceAll("%5D", "]");
     } catch (UnsupportedEncodingException e) {
       // This can literally never happen, and lets us avoid having to catch
       // UnsupportedEncodingException in callers.

--- a/src/main/java/com/stripe/net/HttpURLConnectionClient.java
+++ b/src/main/java/com/stripe/net/HttpURLConnectionClient.java
@@ -2,8 +2,8 @@ package com.stripe.net;
 
 import com.stripe.Stripe;
 import com.stripe.exception.ApiConnectionException;
+import com.stripe.util.StreamUtils;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Authenticator;
 import java.net.HttpURLConnection;
@@ -12,7 +12,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Scanner;
 import lombok.Cleanup;
 
 public class HttpURLConnectionClient extends HttpClient {
@@ -41,9 +40,9 @@ public class HttpURLConnectionClient extends HttpClient {
       String responseBody;
 
       if (responseCode >= 200 && responseCode < 300) {
-        responseBody = getResponseBody(conn.getInputStream());
+        responseBody = StreamUtils.readToEnd(conn.getInputStream(), ApiResource.CHARSET);
       } else {
-        responseBody = getResponseBody(conn.getErrorStream());
+        responseBody = StreamUtils.readToEnd(conn.getErrorStream(), ApiResource.CHARSET);
       }
 
       return new StripeResponse(responseCode, headers, responseBody);
@@ -109,14 +108,5 @@ public class HttpURLConnectionClient extends HttpClient {
     }
 
     return conn;
-  }
-
-  private static String getResponseBody(InputStream responseStream) throws IOException {
-    try (final Scanner scanner = new Scanner(responseStream, ApiResource.CHARSET)) {
-      // \A is the beginning of the stream boundary
-      final String responseBody = scanner.useDelimiter("\\A").next();
-      responseStream.close();
-      return responseBody;
-    }
   }
 }

--- a/src/main/java/com/stripe/net/MultipartProcessor.java
+++ b/src/main/java/com/stripe/net/MultipartProcessor.java
@@ -6,6 +6,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.net.URLConnection;
+import java.nio.charset.Charset;
 
 public class MultipartProcessor {
   private final String boundary;
@@ -14,7 +15,7 @@ public class MultipartProcessor {
   private PrintWriter writer;
 
   /** Constructs a new multipart body builder. */
-  public MultipartProcessor(OutputStream outputStream, String boundary, String charset)
+  public MultipartProcessor(OutputStream outputStream, String boundary, Charset charset)
       throws IOException {
     this.boundary = boundary;
 

--- a/src/main/java/com/stripe/net/StripeRequest.java
+++ b/src/main/java/com/stripe/net/StripeRequest.java
@@ -131,7 +131,7 @@ public class StripeRequest {
     headerMap.put("Accept", Arrays.asList("application/json"));
 
     // Accept-Charset
-    headerMap.put("Accept-Charset", Arrays.asList(ApiResource.CHARSET));
+    headerMap.put("Accept-Charset", Arrays.asList(ApiResource.CHARSET.name()));
 
     // Authorization
     String apiKey = options.getApiKey();

--- a/src/main/java/com/stripe/util/StreamUtils.java
+++ b/src/main/java/com/stripe/util/StreamUtils.java
@@ -1,0 +1,37 @@
+package com.stripe.util;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.Charset;
+import lombok.Cleanup;
+
+public final class StreamUtils {
+  private static final int DEFAULT_BUF_SIZE = 1024;
+
+  /**
+   * Reads the provided stream until the end and returns a string encoded with the provided charset.
+   *
+   * @param stream the stream to read
+   * @param charset the charset to use
+   * @return a string with the contents of the input stream
+   * @throws NullPointerException if {@code stream} or {@code charset} is {@code null}
+   * @throws IOException if an I/O error occurs
+   */
+  public static String readToEnd(InputStream stream, Charset charset) throws IOException {
+    requireNonNull(stream);
+    requireNonNull(charset);
+
+    final StringBuilder sb = new StringBuilder();
+    final char[] buffer = new char[DEFAULT_BUF_SIZE];
+    @Cleanup final Reader in = new InputStreamReader(stream, charset);
+    int charsRead = 0;
+    while ((charsRead = in.read(buffer, 0, buffer.length)) > 0) {
+      sb.append(buffer, 0, charsRead);
+    }
+    return sb.toString();
+  }
+}

--- a/src/test/java/com/stripe/util/StreamUtilsTest.java
+++ b/src/test/java/com/stripe/util/StreamUtilsTest.java
@@ -1,0 +1,25 @@
+package com.stripe.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.CharBuffer;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+public class StreamUtilsTest {
+  @Test
+  public void testReadToEnd() throws IOException {
+    // Short string
+    String string = "Hello world!";
+    InputStream stream = new ByteArrayInputStream(string.getBytes(StandardCharsets.UTF_8));
+    assertEquals(string, StreamUtils.readToEnd(stream, StandardCharsets.UTF_8));
+
+    // Long string
+    string = CharBuffer.allocate(50000).toString().replace('\0', 'A');
+    stream = new ByteArrayInputStream(string.getBytes(StandardCharsets.UTF_8));
+    assertEquals(string, StreamUtils.readToEnd(stream, StandardCharsets.UTF_8));
+  }
+}


### PR DESCRIPTION
r? @brandur-stripe @richardm-stripe 
cc @stripe/api-libraries 

Amazingly, Java doesn't provide a standard way of extracting the contents of an `InputStream` into a `String`. There are many ways of doing so, [this StackOverflow answer](https://stackoverflow.com/a/35446009/5307473) shows and compares 11 (!) different ways, some of them relying on third-party libraries.

Previously we were using #3, i.e. using `Scanner` to tokenize the stream with `\A` as the delimiter to tokenize the entire stream into a single string. This 1. feels hacky and 2. has pretty bad performance.

In this PR I added a new utility method `StreamUtils.readToEnd()` that uses #6, i.e. using `StringBuilder` and `InputStreamReader`, which feel like the right tools for the job (and should have better performance too).

Tagged as breaking because I changed the type of `ApiResource.CHARSET` from `String` to `Charset`, as well as the constructor of `MultipartProcessor`, though this shouldn't impact many users.
