### PR TITLE
Remove support for `count` and `total_count` in list objects

### DIFF
--- a/src/main/java/com/stripe/model/StripeCollection.java
+++ b/src/main/java/com/stripe/model/StripeCollection.java
@@ -48,24 +48,6 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject
   @Getter(onMethod_ = {@Override})
   String url;
 
-  /**
-   * The {@code count} attribute.
-   *
-   * @deprecated Use pagination parameters instead.
-   * @see <a href="https://stripe.com/docs/api/java#pagination">Pagination</a>
-   */
-  @Deprecated Long count;
-
-  /**
-   * The {@code total_count} attribute.
-   *
-   * @deprecated Use pagination parameters instead.
-   * @see <a href="https://stripe.com/docs/api/java#pagination">Pagination</a>
-   */
-  @Deprecated
-  @Getter(onMethod_ = {@Override})
-  Long totalCount;
-
   @Getter(onMethod_ = {@Override})
   @Setter(onMethod = @__({@Override}))
   private RequestOptions requestOptions;

--- a/src/main/java/com/stripe/model/StripeCollectionInterface.java
+++ b/src/main/java/com/stripe/model/StripeCollectionInterface.java
@@ -12,15 +12,6 @@ public interface StripeCollectionInterface<T> {
   String getUrl();
 
   /**
-   * The {@code total_count} attribute.
-   *
-   * @deprecated Use pagination parameters instead.
-   * @see <a href="https://stripe.com/docs/api/java#pagination">Pagination</a>
-   */
-  @Deprecated
-  Long getTotalCount();
-
-  /**
    * Get request options that were used to fetch the collection. This is useful for purposes of
    * pagination.
    */


### PR DESCRIPTION
r? @brandur-stripe @remi-stripe @richardm-stripe 
cc @stripe/api-libraries 

Remove support for `count` and `total_count` in list objects.