### PR TITLE
Add `StripeObjectInterface` interface

### DIFF
--- a/src/main/java/com/stripe/model/BalanceTransactionSource.java
+++ b/src/main/java/com/stripe/model/BalanceTransactionSource.java
@@ -1,3 +1,3 @@
 package com.stripe.model;
 
-public interface BalanceTransactionSource extends HasId {}
+public interface BalanceTransactionSource extends StripeObjectInterface, HasId {}

--- a/src/main/java/com/stripe/model/BalanceTransactionSourceTypeAdapterFactory.java
+++ b/src/main/java/com/stripe/model/BalanceTransactionSourceTypeAdapterFactory.java
@@ -117,7 +117,7 @@ public class BalanceTransactionSourceTypeAdapterFactory implements TypeAdapterFa
    * and object value. Do not integrate with this object, but raise an exception and log its content
    * instead.
    */
-  public static class UnknownSubType implements BalanceTransactionSource {
+  public static class UnknownSubType extends StripeObject implements BalanceTransactionSource {
     String id;
     @Getter String object;
     @Getter String rawJson;

--- a/src/main/java/com/stripe/model/ExternalAccount.java
+++ b/src/main/java/com/stripe/model/ExternalAccount.java
@@ -4,7 +4,7 @@ import com.stripe.exception.StripeException;
 import com.stripe.net.RequestOptions;
 import java.util.Map;
 
-public interface ExternalAccount extends HasId {
+public interface ExternalAccount extends StripeObjectInterface, HasId {
   ExternalAccount update(Map<String, Object> params, RequestOptions options) throws StripeException;
 
   ExternalAccount update(Map<String, Object> params) throws StripeException;

--- a/src/main/java/com/stripe/model/ExternalAccountTypeAdapterFactory.java
+++ b/src/main/java/com/stripe/model/ExternalAccountTypeAdapterFactory.java
@@ -64,7 +64,7 @@ public class ExternalAccountTypeAdapterFactory implements TypeAdapterFactory {
    * deserialization, please contact support@stripe.com for assistance and provide the id and object
    * value. Do not integrate with this object, but raise an exception and log its content instead.
    */
-  public static class UnknownSubType implements ExternalAccount {
+  public static class UnknownSubType extends StripeObject implements ExternalAccount {
     String id;
     @Getter String object;
     @Getter String rawJson;

--- a/src/main/java/com/stripe/model/PaymentSource.java
+++ b/src/main/java/com/stripe/model/PaymentSource.java
@@ -1,3 +1,3 @@
 package com.stripe.model;
 
-public interface PaymentSource extends HasId {}
+public interface PaymentSource extends StripeObjectInterface, HasId {}

--- a/src/main/java/com/stripe/model/PaymentSourceTypeAdapterFactory.java
+++ b/src/main/java/com/stripe/model/PaymentSourceTypeAdapterFactory.java
@@ -77,7 +77,7 @@ public class PaymentSourceTypeAdapterFactory implements TypeAdapterFactory {
    * deserialization, please contact support@stripe.com for assistance and provide the id and object
    * value. Do not integrate with this object, but raise an exception and log its content instead.
    */
-  public static class UnknownSubType implements PaymentSource {
+  public static class UnknownSubType extends StripeObject implements PaymentSource {
     String id;
     @Getter String object;
     @Getter String rawJson;

--- a/src/main/java/com/stripe/model/StripeCollectionInterface.java
+++ b/src/main/java/com/stripe/model/StripeCollectionInterface.java
@@ -4,7 +4,7 @@ import com.stripe.net.RequestOptions;
 import java.util.List;
 import java.util.Map;
 
-public interface StripeCollectionInterface<T> {
+public interface StripeCollectionInterface<T> extends StripeObjectInterface {
   List<T> getData();
 
   Boolean getHasMore();

--- a/src/main/java/com/stripe/model/StripeObject.java
+++ b/src/main/java/com/stripe/model/StripeObject.java
@@ -8,7 +8,7 @@ import com.stripe.net.ApiResource;
 import com.stripe.net.StripeResponse;
 import java.lang.reflect.Field;
 
-public abstract class StripeObject {
+public abstract class StripeObject implements StripeObjectInterface {
   public static final Gson PRETTY_PRINT_GSON =
       new GsonBuilder()
           .setPrettyPrinting()
@@ -31,10 +31,12 @@ public abstract class StripeObject {
         PRETTY_PRINT_GSON.toJson(this));
   }
 
+  @Override
   public StripeResponse getLastResponse() {
     return lastResponse;
   }
 
+  @Override
   public void setLastResponse(StripeResponse response) {
     this.lastResponse = response;
   }

--- a/src/main/java/com/stripe/model/StripeObjectInterface.java
+++ b/src/main/java/com/stripe/model/StripeObjectInterface.java
@@ -1,0 +1,9 @@
+package com.stripe.model;
+
+import com.stripe.net.StripeResponse;
+
+public interface StripeObjectInterface {
+  public StripeResponse getLastResponse();
+
+  public void setLastResponse(StripeResponse response);
+}

--- a/src/main/java/com/stripe/net/ApiResource.java
+++ b/src/main/java/com/stripe/net/ApiResource.java
@@ -18,6 +18,7 @@ import com.stripe.model.ExpandableFieldDeserializer;
 import com.stripe.model.HasId;
 import com.stripe.model.StripeCollectionInterface;
 import com.stripe.model.StripeObject;
+import com.stripe.model.StripeObjectInterface;
 import com.stripe.model.StripeRawJsonObject;
 import com.stripe.model.StripeRawJsonObjectDeserializer;
 import com.stripe.util.StringUtils;
@@ -157,7 +158,7 @@ public abstract class ApiResource extends StripeObject {
     return urlEncode(id);
   }
 
-  public static <T> T request(
+  public static <T extends StripeObjectInterface> T request(
       ApiResource.RequestMethod method,
       String url,
       ApiRequestParams params,
@@ -168,7 +169,7 @@ public abstract class ApiResource extends StripeObject {
     return request(method, url, params.toMap(), clazz, options);
   }
 
-  public static <T> T request(
+  public static <T extends StripeObjectInterface> T request(
       ApiResource.RequestMethod method,
       String url,
       Map<String, Object> params,

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -18,6 +18,7 @@ import com.stripe.exception.oauth.UnsupportedGrantTypeException;
 import com.stripe.exception.oauth.UnsupportedResponseTypeException;
 import com.stripe.model.StripeError;
 import com.stripe.model.StripeObject;
+import com.stripe.model.StripeObjectInterface;
 import com.stripe.model.oauth.OAuthError;
 import java.util.Map;
 
@@ -42,7 +43,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
   }
 
   @Override
-  public <T> T request(
+  public <T extends StripeObjectInterface> T request(
       ApiResource.RequestMethod method,
       String url,
       Map<String, Object> params,
@@ -67,16 +68,13 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
       raiseMalformedJsonError(responseBody, responseCode, requestId);
     }
 
-    if (resource instanceof StripeObject) {
-      StripeObject obj = (StripeObject) resource;
-      obj.setLastResponse(response);
-    }
+    resource.setLastResponse(response);
 
     return resource;
   }
 
   @Override
-  public <T> T oauthRequest(
+  public <T extends StripeObjectInterface> T oauthRequest(
       ApiResource.RequestMethod method,
       String url,
       Map<String, Object> params,

--- a/src/main/java/com/stripe/net/StripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/StripeResponseGetter.java
@@ -1,10 +1,11 @@
 package com.stripe.net;
 
 import com.stripe.exception.StripeException;
+import com.stripe.model.StripeObjectInterface;
 import java.util.Map;
 
 public interface StripeResponseGetter {
-  <T> T request(
+  <T extends StripeObjectInterface> T request(
       ApiResource.RequestMethod method,
       String url,
       Map<String, Object> params,
@@ -12,7 +13,7 @@ public interface StripeResponseGetter {
       RequestOptions options)
       throws StripeException;
 
-  <T> T oauthRequest(
+  <T extends StripeObjectInterface> T oauthRequest(
       ApiResource.RequestMethod method,
       String url,
       Map<String, Object> params,

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.reset;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.stripe.exception.StripeException;
+import com.stripe.model.StripeObjectInterface;
 import com.stripe.net.ApiResource;
 import com.stripe.net.LiveStripeResponseGetter;
 import com.stripe.net.OAuth;
@@ -165,7 +166,7 @@ public class BaseStripeTest {
    * @param params map containing the parameters. If null, the parameters are not checked.
    * @param options request options. If null, the options are not checked.
    */
-  public static <T> void verifyRequest(
+  public static <T extends StripeObjectInterface> void verifyRequest(
       ApiResource.RequestMethod method,
       String path,
       Map<String, Object> params,
@@ -207,7 +208,7 @@ public class BaseStripeTest {
    * @see BaseStripeTest#stubRequest(ApiResource.RequestMethod, String, Map, RequestOptions, Class,
    *     String)
    */
-  public static <T> void stubRequest(
+  public static <T extends StripeObjectInterface> void stubRequest(
       ApiResource.RequestMethod method, String path, Class<T> clazz, String response)
       throws StripeException {
     stubRequest(method, path, null, null, clazz, response);
@@ -219,7 +220,7 @@ public class BaseStripeTest {
    * @see BaseStripeTest#stubRequest(ApiResource.RequestMethod, String, Map, RequestOptions, Class,
    *     String)
    */
-  public static <T> void stubRequest(
+  public static <T extends StripeObjectInterface> void stubRequest(
       ApiResource.RequestMethod method,
       String path,
       Map<String, Object> params,
@@ -240,7 +241,7 @@ public class BaseStripeTest {
    * @param clazz Class of the API resource that will be returned for the stubbed request.
    * @param response JSON payload of the API resource that will be returned for the stubbed request.
    */
-  public static <T> void stubRequest(
+  public static <T extends StripeObjectInterface> void stubRequest(
       ApiResource.RequestMethod method,
       String path,
       Map<String, Object> params,
@@ -270,7 +271,8 @@ public class BaseStripeTest {
   }
 
   /** Stubs an OAuth API request. stripe-mock does not supported OAuth endpoints at this time. */
-  public static <T> void stubOAuthRequest(Class<T> clazz, String response) throws StripeException {
+  public static <T extends StripeObjectInterface> void stubOAuthRequest(
+      Class<T> clazz, String response) throws StripeException {
     Mockito.doReturn(ApiResource.GSON.fromJson(response, clazz))
         .when(networkSpy)
         .oauthRequest(

--- a/src/test/java/com/stripe/functional/CustomerTest.java
+++ b/src/test/java/com/stripe/functional/CustomerTest.java
@@ -7,6 +7,7 @@ import com.stripe.BaseStripeTest;
 import com.stripe.exception.StripeException;
 import com.stripe.model.Customer;
 import com.stripe.model.CustomerCollection;
+import com.stripe.model.Discount;
 import com.stripe.net.ApiResource;
 import java.util.HashMap;
 import java.util.Map;
@@ -89,7 +90,7 @@ public class CustomerTest extends BaseStripeTest {
         ApiResource.RequestMethod.DELETE,
         String.format("/v1/customers/%s/discount", customer.getId()),
         null,
-        void.class,
+        Discount.class,
         null);
 
     customer.deleteDiscount();


### PR DESCRIPTION
r? @brandur-stripe @richardm-stripe 
cc @stripe/api-libraries 

This PR adds a new `StripeObjectInterface` interface that is implemented by all `StripeObject`s. This allows for better type safety, because we can now constrain generic methods that return a `StripeObject` class with `<T extends StripeObjectInterface>`.

The reason we couldn't simply do `<T extends StripeObject>` is because of polymorphic resources. Those resources are represented by interfaces (e.g. `ExternalAccount` or `PaymentSource`), and interfaces cannot extend classes, only other interfaces.

This is ready to be reviewed, I'm just tagging it as WIP to avoid merging it before I've had a chance to update the codegen accordingly, since some of the files I've modified here (namely, the interfaces and type adapter factories for polymorphic resources) are generated.
