### PR TITLE
Add support for `metadata` on Checkout `Session`

### DIFF
--- a/src/main/java/com/stripe/model/checkout/Session.java
+++ b/src/main/java/com/stripe/model/checkout/Session.java
@@ -91,6 +91,13 @@ public class Session extends ApiResource implements HasId {
   @SerializedName("locale")
   String locale;
 
+  /**
+   * Set of key-value pairs that you can attach to an object. This can be useful for storing
+   * additional information about the object in a structured format.
+   */
+  @SerializedName("metadata")
+  Map<String, String> metadata;
+
   /** The mode of the Checkout Session, one of `payment`, `setup`, or `subscription`. */
   @SerializedName("mode")
   String mode;

--- a/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
+++ b/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
@@ -76,6 +76,14 @@ public class SessionCreateParams extends ApiRequestParams {
   @SerializedName("locale")
   Locale locale;
 
+  /**
+   * Set of key-value pairs that you can attach to an object. This can be useful for storing
+   * additional information about the object in a structured format. Individual keys can be unset by
+   * posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
+   */
+  @SerializedName("metadata")
+  Map<String, String> metadata;
+
   /** The mode of the Checkout Session, one of `payment`, `setup`, or `subscription`. */
   @SerializedName("mode")
   Mode mode;
@@ -134,6 +142,7 @@ public class SessionCreateParams extends ApiRequestParams {
       Map<String, Object> extraParams,
       List<LineItem> lineItems,
       Locale locale,
+      Map<String, String> metadata,
       Mode mode,
       PaymentIntentData paymentIntentData,
       List<PaymentMethodType> paymentMethodTypes,
@@ -150,6 +159,7 @@ public class SessionCreateParams extends ApiRequestParams {
     this.extraParams = extraParams;
     this.lineItems = lineItems;
     this.locale = locale;
+    this.metadata = metadata;
     this.mode = mode;
     this.paymentIntentData = paymentIntentData;
     this.paymentMethodTypes = paymentMethodTypes;
@@ -182,6 +192,8 @@ public class SessionCreateParams extends ApiRequestParams {
 
     private Locale locale;
 
+    private Map<String, String> metadata;
+
     private Mode mode;
 
     private PaymentIntentData paymentIntentData;
@@ -208,6 +220,7 @@ public class SessionCreateParams extends ApiRequestParams {
           this.extraParams,
           this.lineItems,
           this.locale,
+          this.metadata,
           this.mode,
           this.paymentIntentData,
           this.paymentMethodTypes,
@@ -349,6 +362,32 @@ public class SessionCreateParams extends ApiRequestParams {
      */
     public Builder setLocale(Locale locale) {
       this.locale = locale;
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `metadata` map. A map is initialized for the first `put/putAll` call,
+     * and subsequent calls add additional key/value pairs to the original map. See {@link
+     * SessionCreateParams#metadata} for the field documentation.
+     */
+    public Builder putMetadata(String key, String value) {
+      if (this.metadata == null) {
+        this.metadata = new HashMap<>();
+      }
+      this.metadata.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `metadata` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link SessionCreateParams#metadata} for the field documentation.
+     */
+    public Builder putAllMetadata(Map<String, String> map) {
+      if (this.metadata == null) {
+        this.metadata = new HashMap<>();
+      }
+      this.metadata.putAll(map);
       return this;
     }
 


### PR DESCRIPTION
Codegen for openapi fd2f212

r? @ob-stripe 
cc @stripe/api-libraries 