### PR TITLE
Changes for custom HTTP clients

### DIFF
--- a/src/main/java/com/stripe/net/HttpContent.java
+++ b/src/main/java/com/stripe/net/HttpContent.java
@@ -48,6 +48,11 @@ public class HttpContent {
         String.format("application/x-www-form-urlencoded;charset=%s", ApiResource.CHARSET));
   }
 
+  /** The request's content, as a string. */
+  public String stringContent() {
+    return new String(this.byteArrayContent, ApiResource.CHARSET);
+  }
+
   /**
    * Builds a new HttpContent for name/value tuples encoded using {@code multipart/form-data} MIME
    * type.

--- a/src/main/java/com/stripe/net/KeyValuePair.java
+++ b/src/main/java/com/stripe/net/KeyValuePair.java
@@ -9,7 +9,7 @@ import java.util.AbstractMap;
  * @param <K> the type of the key
  * @param <V> the type of the value
  */
-class KeyValuePair<K, V> extends AbstractMap.SimpleEntry<K, V> {
+public class KeyValuePair<K, V> extends AbstractMap.SimpleEntry<K, V> {
   private static final long serialVersionUID = 1L;
 
   /**

--- a/src/main/java/com/stripe/net/StripeRequest.java
+++ b/src/main/java/com/stripe/net/StripeRequest.java
@@ -8,6 +8,7 @@ import com.stripe.util.StringUtils;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,6 +45,9 @@ public class StripeRequest {
    */
   HttpHeaders headers;
 
+  /** The parameters of the request (as an unmodifiable map). */
+  Map<String, Object> params;
+
   /** The special modifiers of the request. */
   RequestOptions options;
 
@@ -63,6 +67,7 @@ public class StripeRequest {
       RequestOptions options)
       throws StripeException {
     try {
+      this.params = (params != null) ? Collections.unmodifiableMap(params) : null;
       this.options = (options != null) ? options : RequestOptions.getDefault();
       this.method = method;
       this.url = buildURL(method, url, params);
@@ -93,6 +98,7 @@ public class StripeRequest {
         this.url,
         this.content,
         this.headers.withAdditionalHeader(name, value),
+        this.params,
         this.options);
   }
 

--- a/src/test/java/com/stripe/net/FormEncoderTest.java
+++ b/src/test/java/com/stripe/net/FormEncoderTest.java
@@ -423,6 +423,56 @@ public class FormEncoderTest extends BaseStripeTest {
   }
 
   @Test
+  public void testFlattenParams() {
+    @Data
+    class TestCase {
+      private final Map<String, Object> data;
+      private final List<KeyValuePair<String, Object>> want;
+    }
+
+    List<TestCase> testCases =
+        new ArrayList<TestCase>() {
+          private static final long serialVersionUID = 1L;
+
+          {
+            // No data
+            add(new TestCase(Collections.emptyMap(), Collections.emptyList()));
+
+            // Already flat parameters
+            add(
+                new TestCase(
+                    ImmutableMap.of("key", "value"),
+                    ImmutableList.of(new KeyValuePair<String, Object>("key", "value"))));
+            add(
+                new TestCase(
+                    ImmutableMap.of("key1", "value1", "key2", "value2"),
+                    ImmutableList.of(
+                        new KeyValuePair<String, Object>("key1", "value1"),
+                        new KeyValuePair<String, Object>("key2", "value2"))));
+
+            // Nested parameters
+            add(
+                new TestCase(
+                    Collections.singletonMap("collection", ImmutableList.of("1", "2", "3")),
+                    ImmutableList.of(
+                        new KeyValuePair<String, Object>("collection[0]", "1"),
+                        new KeyValuePair<String, Object>("collection[1]", "2"),
+                        new KeyValuePair<String, Object>("collection[2]", "3"))));
+            add(
+                new TestCase(
+                    Collections.singletonMap("map", ImmutableMap.of("one", 1, "two", 2)),
+                    ImmutableList.of(
+                        new KeyValuePair<String, Object>("map[one]", "1"),
+                        new KeyValuePair<String, Object>("map[two]", "2"))));
+          }
+        };
+
+    for (TestCase testCase : testCases) {
+      assertEquals(testCase.getWant(), FormEncoder.flattenParams(testCase.getData()));
+    }
+  }
+
+  @Test
   public void testCreateQueryString_old() {
     Map<String, Object> params = new HashMap<>();
     params.put("a", "b");

--- a/src/test/java/com/stripe/net/HttpContentTest.java
+++ b/src/test/java/com/stripe/net/HttpContentTest.java
@@ -166,4 +166,15 @@ public class HttpContentTest extends BaseStripeTest {
             + "--test-boundary--\r\n",
         new String(content.byteArrayContent(), StandardCharsets.UTF_8));
   }
+
+  @Test
+  public void testStringContent() throws IOException {
+    List<KeyValuePair<String, String>> data = new ArrayList<KeyValuePair<String, String>>();
+    data.add(new KeyValuePair<String, String>("key", "value"));
+
+    HttpContent content = HttpContent.buildFormURLEncodedContent(data);
+    String stringContent = content.stringContent();
+    assertEquals(9, stringContent.length());
+    assertEquals("key=value", stringContent);
+  }
 }


### PR DESCRIPTION
r? @brandur-stripe @richardm-stripe 
cc @stripe/api-libraries @Flo354

In the v17 release, I did a large overhaul of the HTTP layer that among other things allows users to provide their own custom HTTP clients. However, the objects that are currently exposed to users are a bit limited. In particular, request bodies are only exposed as a byte array on the `HttpContent` object.

This is fine for our own usecase because our HTTP client (`HttpURLConnectionClient`) only expects a byte array for bodies, but many third-party HTTP libraries provide higher-level abstractions. In order to help users leverage these features, this PR exposes a bit more of our HTTP infrastructure. Specifically:

- `FormEncoder` is now public
- `FormEncoder` has a new public method `flattenParams()` to "pre-encode" a request by flattening nested parameters and encoding all values as strings (except for `File` and `Stream` values, which stay untouched and must be encoded as `multipart` requests)
- `HttpContent` has a new public method `stringContent()` that exposes the body as a `String` (so users don't have to convert the byte array themselves, possibly using the wrong charset)
- `KeyValuePair` is now public (necessary to expose `FormEncoder.flattenParams()` as it returns a list of `KeyValuePair`s)
- `StripeRequest` has a new public method `params()` that returns the raw (unflattened) map of request parameters as an unmodifiable map

Fixes #946.