### PR TITLE
Add support for `shipping.speed` on Issuing `Card` and new `TaxID` types

### DIFF
--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -1259,8 +1259,8 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
   @EqualsAndHashCode(callSuper = false)
   public static class CustomerTaxId extends StripeObject {
     /**
-     * The type of the tax ID, one of `au_abn`, `ch_vat`, `eu_vat`, `in_gst`, `mx_rfc`, `no_vat`,
-     * `nz_gst`, `sg_uen`, `unknown`, or `za_vat`.
+     * The type of the tax ID, one of `au_abn`, `ca_bn`, `ch_vat`, `eu_vat`, `hk_br`, `in_gst`,
+     * `mx_rfc`, `no_vat`, `nz_gst`, `ru_inn`, `sg_uen`, `unknown`, or `za_vat`.
      */
     @SerializedName("type")
     String type;

--- a/src/main/java/com/stripe/model/TaxId.java
+++ b/src/main/java/com/stripe/model/TaxId.java
@@ -53,8 +53,8 @@ public class TaxId extends ApiResource implements HasId {
   String object;
 
   /**
-   * Type of the tax ID, one of `au_abn`, `ch_vat`, `eu_vat`, `in_gst`, `mx_rfc`, `no_vat`,
-   * `nz_gst`, `sg_uen`, `za_vat`, or `unknown`.
+   * Type of the tax ID, one of `au_abn`, `ca_bn`, `ch_vat`, `eu_vat`, `hk_br`, `in_gst`, `mx_rfc`,
+   * `no_vat`, `nz_gst`, `ru_inn`, `sg_uen`, `za_vat`, or `unknown`.
    */
   @SerializedName("type")
   String type;

--- a/src/main/java/com/stripe/model/issuing/Card.java
+++ b/src/main/java/com/stripe/model/issuing/Card.java
@@ -425,6 +425,14 @@ public class Card extends ApiResource implements HasId, MetadataStore<Card> {
     String name;
 
     /**
+     * Shipment speed.
+     *
+     * <p>One of `express`, `overnight`, or `standard`.
+     */
+    @SerializedName("speed")
+    String speed;
+
+    /**
      * The delivery status of the card.
      *
      * <p>One of `canceled`, `delivered`, `failure`, `pending`, `returned`, or `shipped`.

--- a/src/main/java/com/stripe/param/CustomerCreateParams.java
+++ b/src/main/java/com/stripe/param/CustomerCreateParams.java
@@ -1089,8 +1089,8 @@ public class CustomerCreateParams extends ApiRequestParams {
     Map<String, Object> extraParams;
 
     /**
-     * Type of the tax ID, one of `au_abn`, `ch_vat`, `eu_vat`, `in_gst`, `mx_rfc`, `no_vat`,
-     * `nz_gst`, `sg_uen`, or `za_vat`.
+     * Type of the tax ID, one of `au_abn`, `ca_bn`, `ch_vat`, `eu_vat`, `hk_br`, `in_gst`,
+     * `mx_rfc`, `no_vat`, `nz_gst`, `ru_inn`, `sg_uen`, or `za_vat`.
      */
     @SerializedName("type")
     Type type;
@@ -1148,8 +1148,8 @@ public class CustomerCreateParams extends ApiRequestParams {
       }
 
       /**
-       * Type of the tax ID, one of `au_abn`, `ch_vat`, `eu_vat`, `in_gst`, `mx_rfc`, `no_vat`,
-       * `nz_gst`, `sg_uen`, or `za_vat`.
+       * Type of the tax ID, one of `au_abn`, `ca_bn`, `ch_vat`, `eu_vat`, `hk_br`, `in_gst`,
+       * `mx_rfc`, `no_vat`, `nz_gst`, `ru_inn`, `sg_uen`, or `za_vat`.
        */
       public Builder setType(Type type) {
         this.type = type;
@@ -1167,11 +1167,17 @@ public class CustomerCreateParams extends ApiRequestParams {
       @SerializedName("au_abn")
       AU_ABN("au_abn"),
 
+      @SerializedName("ca_bn")
+      CA_BN("ca_bn"),
+
       @SerializedName("ch_vat")
       CH_VAT("ch_vat"),
 
       @SerializedName("eu_vat")
       EU_VAT("eu_vat"),
+
+      @SerializedName("hk_br")
+      HK_BR("hk_br"),
 
       @SerializedName("in_gst")
       IN_GST("in_gst"),
@@ -1184,6 +1190,9 @@ public class CustomerCreateParams extends ApiRequestParams {
 
       @SerializedName("nz_gst")
       NZ_GST("nz_gst"),
+
+      @SerializedName("ru_inn")
+      RU_INN("ru_inn"),
 
       @SerializedName("sg_uen")
       SG_UEN("sg_uen"),

--- a/src/main/java/com/stripe/param/InvoiceUpcomingParams.java
+++ b/src/main/java/com/stripe/param/InvoiceUpcomingParams.java
@@ -71,7 +71,7 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
 
   /**
    * Timestamp indicating when the subscription should be scheduled to cancel. Will prorate if
-   * within the current period if `prorate=true`
+   * within the current period and prorations have been enabled using `proration_behavior`.`
    */
   @SerializedName("subscription_cancel_at")
   Object subscriptionCancelAt;
@@ -419,7 +419,7 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
 
     /**
      * Timestamp indicating when the subscription should be scheduled to cancel. Will prorate if
-     * within the current period if `prorate=true`
+     * within the current period and prorations have been enabled using `proration_behavior`.`
      */
     public Builder setSubscriptionCancelAt(Long subscriptionCancelAt) {
       this.subscriptionCancelAt = subscriptionCancelAt;
@@ -428,7 +428,7 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
 
     /**
      * Timestamp indicating when the subscription should be scheduled to cancel. Will prorate if
-     * within the current period if `prorate=true`
+     * within the current period and prorations have been enabled using `proration_behavior`.`
      */
     public Builder setSubscriptionCancelAt(EmptyParam subscriptionCancelAt) {
       this.subscriptionCancelAt = subscriptionCancelAt;

--- a/src/main/java/com/stripe/param/SubscriptionCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionCreateParams.java
@@ -48,7 +48,8 @@ public class SubscriptionCreateParams extends ApiRequestParams {
 
   /**
    * A timestamp at which the subscription should cancel. If set to a date before the current period
-   * ends this will cause a proration if `prorate=true`.
+   * ends, this will cause a proration if prorations have been enabled using `proration_behavior`.
+   * If set during a future period, this will always cause a proration for that period.
    */
   @SerializedName("cancel_at")
   Long cancelAt;
@@ -165,13 +166,9 @@ public class SubscriptionCreateParams extends ApiRequestParams {
   Object pendingInvoiceItemInterval;
 
   /**
-   * Boolean (defaults to `true`) telling us whether to [credit for unused
-   * time](https://stripe.com/docs/subscriptions/billing-cycle#prorations) when the billing cycle
-   * changes (e.g. when switching plans, resetting `billing_cycle_anchor=now`, or starting a trial),
-   * or if an item's `quantity` changes. If `false`, the anchor period will be free (similar to a
-   * trial) and no proration adjustments will be created. This field has been deprecated and will be
-   * removed in a future API version. Use `proration_behavior=create_prorations` as a replacement
-   * for `prorate=true` and `proration_behavior=none` for `prorate=false`.
+   * This field has been renamed to `proration_behavior`. `prorate=true` can be replaced with
+   * `proration_behavior=create_prorations` and `prorate=false` can be replaced with
+   * `proration_behavior=none`.
    */
   @SerializedName("prorate")
   Boolean prorate;
@@ -435,7 +432,9 @@ public class SubscriptionCreateParams extends ApiRequestParams {
 
     /**
      * A timestamp at which the subscription should cancel. If set to a date before the current
-     * period ends this will cause a proration if `prorate=true`.
+     * period ends, this will cause a proration if prorations have been enabled using
+     * `proration_behavior`. If set during a future period, this will always cause a proration for
+     * that period.
      */
     public Builder setCancelAt(Long cancelAt) {
       this.cancelAt = cancelAt;
@@ -703,14 +702,9 @@ public class SubscriptionCreateParams extends ApiRequestParams {
     }
 
     /**
-     * Boolean (defaults to `true`) telling us whether to [credit for unused
-     * time](https://stripe.com/docs/subscriptions/billing-cycle#prorations) when the billing cycle
-     * changes (e.g. when switching plans, resetting `billing_cycle_anchor=now`, or starting a
-     * trial), or if an item's `quantity` changes. If `false`, the anchor period will be free
-     * (similar to a trial) and no proration adjustments will be created. This field has been
-     * deprecated and will be removed in a future API version. Use
-     * `proration_behavior=create_prorations` as a replacement for `prorate=true` and
-     * `proration_behavior=none` for `prorate=false`.
+     * This field has been renamed to `proration_behavior`. `prorate=true` can be replaced with
+     * `proration_behavior=create_prorations` and `prorate=false` can be replaced with
+     * `proration_behavior=none`.
      */
     public Builder setProrate(Boolean prorate) {
       this.prorate = prorate;

--- a/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
@@ -39,7 +39,8 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
 
   /**
    * A timestamp at which the subscription should cancel. If set to a date before the current period
-   * ends this will cause a proration if `prorate=true`.
+   * ends, this will cause a proration if prorations have been enabled using `proration_behavior`.
+   * If set during a future period, this will always cause a proration for that period.
    */
   @SerializedName("cancel_at")
   Object cancelAt;
@@ -153,13 +154,9 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
   Object pendingInvoiceItemInterval;
 
   /**
-   * Boolean (defaults to `true`) telling us whether to [credit for unused
-   * time](https://stripe.com/docs/subscriptions/billing-cycle#prorations) when the billing cycle
-   * changes (e.g. when switching plans, resetting `billing_cycle_anchor=now`, or starting a trial),
-   * or if an item's `quantity` changes. If `false`, the anchor period will be free (similar to a
-   * trial) and no proration adjustments will be created. This field has been deprecated and will be
-   * removed in a future API version. Use `proration_behavior=create_prorations` as a replacement
-   * for `prorate=true` and `proration_behavior=none` for `prorate=false`.
+   * This field has been renamed to `proration_behavior`. `prorate=true` can be replaced with
+   * `proration_behavior=create_prorations` and `prorate=false` can be replaced with
+   * `proration_behavior=none`.
    */
   @SerializedName("prorate")
   Boolean prorate;
@@ -410,7 +407,9 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
 
     /**
      * A timestamp at which the subscription should cancel. If set to a date before the current
-     * period ends this will cause a proration if `prorate=true`.
+     * period ends, this will cause a proration if prorations have been enabled using
+     * `proration_behavior`. If set during a future period, this will always cause a proration for
+     * that period.
      */
     public Builder setCancelAt(Long cancelAt) {
       this.cancelAt = cancelAt;
@@ -419,7 +418,9 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
 
     /**
      * A timestamp at which the subscription should cancel. If set to a date before the current
-     * period ends this will cause a proration if `prorate=true`.
+     * period ends, this will cause a proration if prorations have been enabled using
+     * `proration_behavior`. If set during a future period, this will always cause a proration for
+     * that period.
      */
     public Builder setCancelAt(EmptyParam cancelAt) {
       this.cancelAt = cancelAt;
@@ -712,14 +713,9 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
     }
 
     /**
-     * Boolean (defaults to `true`) telling us whether to [credit for unused
-     * time](https://stripe.com/docs/subscriptions/billing-cycle#prorations) when the billing cycle
-     * changes (e.g. when switching plans, resetting `billing_cycle_anchor=now`, or starting a
-     * trial), or if an item's `quantity` changes. If `false`, the anchor period will be free
-     * (similar to a trial) and no proration adjustments will be created. This field has been
-     * deprecated and will be removed in a future API version. Use
-     * `proration_behavior=create_prorations` as a replacement for `prorate=true` and
-     * `proration_behavior=none` for `prorate=false`.
+     * This field has been renamed to `proration_behavior`. `prorate=true` can be replaced with
+     * `proration_behavior=create_prorations` and `prorate=false` can be replaced with
+     * `proration_behavior=none`.
      */
     public Builder setProrate(Boolean prorate) {
       this.prorate = prorate;

--- a/src/main/java/com/stripe/param/TaxIdCollectionCreateParams.java
+++ b/src/main/java/com/stripe/param/TaxIdCollectionCreateParams.java
@@ -24,8 +24,8 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
   Map<String, Object> extraParams;
 
   /**
-   * Type of the tax ID, one of `au_abn`, `ch_vat`, `eu_vat`, `in_gst`, `mx_rfc`, `no_vat`,
-   * `nz_gst`, `sg_uen`, or `za_vat`.
+   * Type of the tax ID, one of `au_abn`, `ca_bn`, `ch_vat`, `eu_vat`, `hk_br`, `in_gst`, `mx_rfc`,
+   * `no_vat`, `nz_gst`, `ru_inn`, `sg_uen`, or `za_vat`.
    */
   @SerializedName("type")
   Type type;
@@ -113,8 +113,8 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
     }
 
     /**
-     * Type of the tax ID, one of `au_abn`, `ch_vat`, `eu_vat`, `in_gst`, `mx_rfc`, `no_vat`,
-     * `nz_gst`, `sg_uen`, or `za_vat`.
+     * Type of the tax ID, one of `au_abn`, `ca_bn`, `ch_vat`, `eu_vat`, `hk_br`, `in_gst`,
+     * `mx_rfc`, `no_vat`, `nz_gst`, `ru_inn`, `sg_uen`, or `za_vat`.
      */
     public Builder setType(Type type) {
       this.type = type;
@@ -132,11 +132,17 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
     @SerializedName("au_abn")
     AU_ABN("au_abn"),
 
+    @SerializedName("ca_bn")
+    CA_BN("ca_bn"),
+
     @SerializedName("ch_vat")
     CH_VAT("ch_vat"),
 
     @SerializedName("eu_vat")
     EU_VAT("eu_vat"),
+
+    @SerializedName("hk_br")
+    HK_BR("hk_br"),
 
     @SerializedName("in_gst")
     IN_GST("in_gst"),
@@ -149,6 +155,9 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
 
     @SerializedName("nz_gst")
     NZ_GST("nz_gst"),
+
+    @SerializedName("ru_inn")
+    RU_INN("ru_inn"),
 
     @SerializedName("sg_uen")
     SG_UEN("sg_uen"),

--- a/src/main/java/com/stripe/param/issuing/CardCreateParams.java
+++ b/src/main/java/com/stripe/param/issuing/CardCreateParams.java
@@ -3318,14 +3318,20 @@ public class CardCreateParams extends ApiRequestParams {
     @SerializedName("name")
     String name;
 
+    /** Shipment speed. */
+    @SerializedName("speed")
+    Speed speed;
+
     /** Packaging options. */
     @SerializedName("type")
     Type type;
 
-    private Shipping(Address address, Map<String, Object> extraParams, String name, Type type) {
+    private Shipping(
+        Address address, Map<String, Object> extraParams, String name, Speed speed, Type type) {
       this.address = address;
       this.extraParams = extraParams;
       this.name = name;
+      this.speed = speed;
       this.type = type;
     }
 
@@ -3340,11 +3346,13 @@ public class CardCreateParams extends ApiRequestParams {
 
       private String name;
 
+      private Speed speed;
+
       private Type type;
 
       /** Finalize and obtain parameter instance from this builder. */
       public Shipping build() {
-        return new Shipping(this.address, this.extraParams, this.name, this.type);
+        return new Shipping(this.address, this.extraParams, this.name, this.speed, this.type);
       }
 
       /** The address that the card is shipped to. */
@@ -3382,6 +3390,12 @@ public class CardCreateParams extends ApiRequestParams {
       /** The name printed on the shipping label when shipping the card. */
       public Builder setName(String name) {
         this.name = name;
+        return this;
+      }
+
+      /** Shipment speed. */
+      public Builder setSpeed(Speed speed) {
+        this.speed = speed;
         return this;
       }
 
@@ -3544,6 +3558,24 @@ public class CardCreateParams extends ApiRequestParams {
           this.state = state;
           return this;
         }
+      }
+    }
+
+    public enum Speed implements ApiRequestParams.EnumParam {
+      @SerializedName("express")
+      EXPRESS("express"),
+
+      @SerializedName("overnight")
+      OVERNIGHT("overnight"),
+
+      @SerializedName("standard")
+      STANDARD("standard");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      Speed(String value) {
+        this.value = value;
       }
     }
 


### PR DESCRIPTION
Codegen for openapi 32bf030

r? @ob-stripe 
cc @stripe/api-libraries 