### PR TITLE
Tweak latency telemetry behavior

### DIFF
--- a/src/test/java/com/stripe/functional/TelemetryTest.java
+++ b/src/test/java/com/stripe/functional/TelemetryTest.java
@@ -11,6 +11,7 @@ import com.stripe.BaseStripeTest;
 import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
 import com.stripe.model.Balance;
+import com.stripe.net.RequestTelemetry;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -41,14 +42,11 @@ public class TelemetryTest extends BaseStripeTest {
 
     Stripe.overrideApiBase(server.url("").toString());
     Stripe.enableTelemetry = true;
+    RequestTelemetry.resetMetrics();
 
     Balance.retrieve();
-    server.takeRequest();
-    // The first request may or may not include a `X-Stripe-Client-Telemetry` header depending on
-    // whether this test is the first to run or not. So we don't test the presence or absence of
-    // the header for the first request.
-    // Ideally we'd have a way of emptying the request metrics queue, but it's private and I don't
-    // want to make it public just for tests.
+    RecordedRequest request1 = server.takeRequest();
+    assertNull(request1.getHeader("X-Stripe-Client-Telemetry"));
 
     Balance.retrieve();
     RecordedRequest request2 = server.takeRequest();
@@ -91,6 +89,7 @@ public class TelemetryTest extends BaseStripeTest {
 
     Stripe.overrideApiBase(server.url("").toString());
     Stripe.enableTelemetry = false;
+    RequestTelemetry.resetMetrics();
 
     Balance.retrieve();
     RecordedRequest request1 = server.takeRequest();
@@ -118,6 +117,7 @@ public class TelemetryTest extends BaseStripeTest {
 
     Stripe.overrideApiBase(server.url("").toString());
     Stripe.enableTelemetry = true;
+    RequestTelemetry.resetMetrics();
 
     Runnable work =
         new Runnable() {


### PR DESCRIPTION
r? @brandur-stripe @richardm-stripe 
cc @stripe/api-libraries 

Small tweak to the latency telemetry behavior: we now check whether `Stripe.enableTelemetry` is set first, which avoids consuming a latency metrics entry from the queue if we're not going to use it.

I also made the `RequestTelemetry` class public and added a `resetMetrics()` method to clear the queue, mostly to make the tests more consistent, otherwise the results can depend on the order in which tests are executed / whether a single telemetry test is executed vs. the entire test suite.

This PR targets the `integration-telemetry` branch. I plan on making a few more changes with the eventual goal of adding non-latency telemetry (such as whether typed parameters are used or not).