### PR TITLE
Add additional verification file purpose

### DIFF
--- a/src/main/java/com/stripe/param/FileCreateParams.java
+++ b/src/main/java/com/stripe/param/FileCreateParams.java
@@ -207,6 +207,9 @@ public class FileCreateParams extends ApiRequestParams {
   }
 
   public enum Purpose implements ApiRequestParams.EnumParam {
+    @SerializedName("additional_verification")
+    ADDITIONAL_VERIFICATION("additional_verification"),
+
     @SerializedName("business_icon")
     BUSINESS_ICON("business_icon"),
 

--- a/src/main/java/com/stripe/param/FileListParams.java
+++ b/src/main/java/com/stripe/param/FileListParams.java
@@ -235,6 +235,9 @@ public class FileListParams extends ApiRequestParams {
   }
 
   public enum Purpose implements ApiRequestParams.EnumParam {
+    @SerializedName("additional_verification")
+    ADDITIONAL_VERIFICATION("additional_verification"),
+
     @SerializedName("business_icon")
     BUSINESS_ICON("business_icon"),
 


### PR DESCRIPTION
Creating a Account of business type Company requires company.verification file to be submitted. Based on the API docs, the document's purpose should be `additional_verification` . This type of purpose is missing in `FileCreateParams.Purpose`