### PR TITLE
Add support for `company.structure` on `Account` and new types of `TaxId`

### DIFF
--- a/src/main/java/com/stripe/model/Account.java
+++ b/src/main/java/com/stripe/model/Account.java
@@ -29,7 +29,7 @@ public class Account extends ApiResource implements MetadataStore<Account>, Paym
   /**
    * The business type.
    *
-   * <p>One of `company`, or `individual`.
+   * <p>One of `company`, `government_entity`, `individual`, or `non_profit`.
    */
   @SerializedName("business_type")
   String businessType;
@@ -702,6 +702,17 @@ public class Account extends ApiResource implements MetadataStore<Account>, Paym
     /** The company's phone number (used for verification). */
     @SerializedName("phone")
     String phone;
+
+    /**
+     * The category identifying the legal structure of the company or legal entity.
+     *
+     * <p>One of `government_instrumentality`, `governmental_unit`, `incorporated_non_profit`,
+     * `multi_member_llc`, `private_corporation`, `private_partnership`, `public_corporation`,
+     * `public_partnership`, `tax_exempt_government_instrumentality`, `unincorporated_association`,
+     * or `unincorporated_non_profit`.
+     */
+    @SerializedName("structure")
+    String structure;
 
     /** Whether the company's business ID number was provided. */
     @SerializedName("tax_id_provided")

--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -1260,7 +1260,8 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
   public static class CustomerTaxId extends StripeObject {
     /**
      * The type of the tax ID, one of `au_abn`, `ca_bn`, `ch_vat`, `es_cif`, `eu_vat`, `hk_br`,
-     * `in_gst`, `mx_rfc`, `no_vat`, `nz_gst`, `ru_inn`, `sg_uen`, `unknown`, or `za_vat`.
+     * `in_gst`, `mx_rfc`, `no_vat`, `nz_gst`, `ru_inn`, `sg_uen`, `th_vat`, `tw_vat`, `unknown`, or
+     * `za_vat`.
      */
     @SerializedName("type")
     String type;

--- a/src/main/java/com/stripe/model/TaxId.java
+++ b/src/main/java/com/stripe/model/TaxId.java
@@ -54,7 +54,7 @@ public class TaxId extends ApiResource implements HasId {
 
   /**
    * Type of the tax ID, one of `au_abn`, `ca_bn`, `ch_vat`, `es_cif`, `eu_vat`, `hk_br`, `in_gst`,
-   * `mx_rfc`, `no_vat`, `nz_gst`, `ru_inn`, `sg_uen`, `za_vat`, or `unknown`.
+   * `mx_rfc`, `no_vat`, `nz_gst`, `ru_inn`, `sg_uen`, `th_vat`, `tw_vat`, `za_vat`, or `unknown`.
    */
   @SerializedName("type")
   String type;

--- a/src/main/java/com/stripe/param/AccountCreateParams.java
+++ b/src/main/java/com/stripe/param/AccountCreateParams.java
@@ -2,6 +2,7 @@ package com.stripe.param;
 
 import com.google.gson.annotations.SerializedName;
 import com.stripe.net.ApiRequestParams;
+import com.stripe.net.ApiRequestParams.EnumParam;
 import com.stripe.param.common.EmptyParam;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -25,7 +26,7 @@ public class AccountCreateParams extends ApiRequestParams {
 
   /**
    * Information about the company or business. This field is null unless `business_type` is set to
-   * `company`.
+   * `company`, `government_entity`, or `non_profit`.
    */
   @SerializedName("company")
   Company company;
@@ -242,7 +243,7 @@ public class AccountCreateParams extends ApiRequestParams {
 
     /**
      * Information about the company or business. This field is null unless `business_type` is set
-     * to `company`.
+     * to `company`, `government_entity`, or `non_profit`.
      */
     public Builder setCompany(Company company) {
       this.company = company;
@@ -673,6 +674,10 @@ public class AccountCreateParams extends ApiRequestParams {
     @SerializedName("phone")
     String phone;
 
+    /** The category identifying the legal structure of the company or legal entity. */
+    @SerializedName("structure")
+    EnumParam structure;
+
     /**
      * The business ID number of the company, as appropriate for the company’s country. (Examples
      * are an Employer ID Number in the U.S., a Business Number in Canada, or a Company Number in
@@ -705,6 +710,7 @@ public class AccountCreateParams extends ApiRequestParams {
         String nameKanji,
         Boolean ownersProvided,
         String phone,
+        EnumParam structure,
         String taxId,
         String taxIdRegistrar,
         String vatId,
@@ -720,6 +726,7 @@ public class AccountCreateParams extends ApiRequestParams {
       this.nameKanji = nameKanji;
       this.ownersProvided = ownersProvided;
       this.phone = phone;
+      this.structure = structure;
       this.taxId = taxId;
       this.taxIdRegistrar = taxIdRegistrar;
       this.vatId = vatId;
@@ -753,6 +760,8 @@ public class AccountCreateParams extends ApiRequestParams {
 
       private String phone;
 
+      private EnumParam structure;
+
       private String taxId;
 
       private String taxIdRegistrar;
@@ -775,6 +784,7 @@ public class AccountCreateParams extends ApiRequestParams {
             this.nameKanji,
             this.ownersProvided,
             this.phone,
+            this.structure,
             this.taxId,
             this.taxIdRegistrar,
             this.vatId,
@@ -879,6 +889,18 @@ public class AccountCreateParams extends ApiRequestParams {
       /** The company's phone number (used for verification). */
       public Builder setPhone(String phone) {
         this.phone = phone;
+        return this;
+      }
+
+      /** The category identifying the legal structure of the company or legal entity. */
+      public Builder setStructure(Structure structure) {
+        this.structure = structure;
+        return this;
+      }
+
+      /** The category identifying the legal structure of the company or legal entity. */
+      public Builder setStructure(EmptyParam structure) {
+        this.structure = structure;
         return this;
       }
 
@@ -1573,6 +1595,48 @@ public class AccountCreateParams extends ApiRequestParams {
             return this;
           }
         }
+      }
+    }
+
+    public enum Structure implements ApiRequestParams.EnumParam {
+      @SerializedName("government_instrumentality")
+      GOVERNMENT_INSTRUMENTALITY("government_instrumentality"),
+
+      @SerializedName("governmental_unit")
+      GOVERNMENTAL_UNIT("governmental_unit"),
+
+      @SerializedName("incorporated_non_profit")
+      INCORPORATED_NON_PROFIT("incorporated_non_profit"),
+
+      @SerializedName("multi_member_llc")
+      MULTI_MEMBER_LLC("multi_member_llc"),
+
+      @SerializedName("private_corporation")
+      PRIVATE_CORPORATION("private_corporation"),
+
+      @SerializedName("private_partnership")
+      PRIVATE_PARTNERSHIP("private_partnership"),
+
+      @SerializedName("public_corporation")
+      PUBLIC_CORPORATION("public_corporation"),
+
+      @SerializedName("public_partnership")
+      PUBLIC_PARTNERSHIP("public_partnership"),
+
+      @SerializedName("tax_exempt_government_instrumentality")
+      TAX_EXEMPT_GOVERNMENT_INSTRUMENTALITY("tax_exempt_government_instrumentality"),
+
+      @SerializedName("unincorporated_association")
+      UNINCORPORATED_ASSOCIATION("unincorporated_association"),
+
+      @SerializedName("unincorporated_non_profit")
+      UNINCORPORATED_NON_PROFIT("unincorporated_non_profit");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      Structure(String value) {
+        this.value = value;
       }
     }
   }
@@ -3845,8 +3909,14 @@ public class AccountCreateParams extends ApiRequestParams {
     @SerializedName("company")
     COMPANY("company"),
 
+    @SerializedName("government_entity")
+    GOVERNMENT_ENTITY("government_entity"),
+
     @SerializedName("individual")
-    INDIVIDUAL("individual");
+    INDIVIDUAL("individual"),
+
+    @SerializedName("non_profit")
+    NON_PROFIT("non_profit");
 
     @Getter(onMethod_ = {@Override})
     private final String value;

--- a/src/main/java/com/stripe/param/AccountUpdateParams.java
+++ b/src/main/java/com/stripe/param/AccountUpdateParams.java
@@ -2,6 +2,7 @@ package com.stripe.param;
 
 import com.google.gson.annotations.SerializedName;
 import com.stripe.net.ApiRequestParams;
+import com.stripe.net.ApiRequestParams.EnumParam;
 import com.stripe.param.common.EmptyParam;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -25,7 +26,7 @@ public class AccountUpdateParams extends ApiRequestParams {
 
   /**
    * Information about the company or business. This field is null unless `business_type` is set to
-   * `company`.
+   * `company`, `government_entity`, or `non_profit`.
    */
   @SerializedName("company")
   Company company;
@@ -231,7 +232,7 @@ public class AccountUpdateParams extends ApiRequestParams {
 
     /**
      * Information about the company or business. This field is null unless `business_type` is set
-     * to `company`.
+     * to `company`, `government_entity`, or `non_profit`.
      */
     public Builder setCompany(Company company) {
       this.company = company;
@@ -727,6 +728,10 @@ public class AccountUpdateParams extends ApiRequestParams {
     @SerializedName("phone")
     Object phone;
 
+    /** The category identifying the legal structure of the company or legal entity. */
+    @SerializedName("structure")
+    EnumParam structure;
+
     /**
      * The business ID number of the company, as appropriate for the company’s country. (Examples
      * are an Employer ID Number in the U.S., a Business Number in Canada, or a Company Number in
@@ -759,6 +764,7 @@ public class AccountUpdateParams extends ApiRequestParams {
         Object nameKanji,
         Boolean ownersProvided,
         Object phone,
+        EnumParam structure,
         Object taxId,
         Object taxIdRegistrar,
         Object vatId,
@@ -774,6 +780,7 @@ public class AccountUpdateParams extends ApiRequestParams {
       this.nameKanji = nameKanji;
       this.ownersProvided = ownersProvided;
       this.phone = phone;
+      this.structure = structure;
       this.taxId = taxId;
       this.taxIdRegistrar = taxIdRegistrar;
       this.vatId = vatId;
@@ -807,6 +814,8 @@ public class AccountUpdateParams extends ApiRequestParams {
 
       private Object phone;
 
+      private EnumParam structure;
+
       private Object taxId;
 
       private Object taxIdRegistrar;
@@ -829,6 +838,7 @@ public class AccountUpdateParams extends ApiRequestParams {
             this.nameKanji,
             this.ownersProvided,
             this.phone,
+            this.structure,
             this.taxId,
             this.taxIdRegistrar,
             this.vatId,
@@ -957,6 +967,18 @@ public class AccountUpdateParams extends ApiRequestParams {
       /** The company's phone number (used for verification). */
       public Builder setPhone(EmptyParam phone) {
         this.phone = phone;
+        return this;
+      }
+
+      /** The category identifying the legal structure of the company or legal entity. */
+      public Builder setStructure(Structure structure) {
+        this.structure = structure;
+        return this;
+      }
+
+      /** The category identifying the legal structure of the company or legal entity. */
+      public Builder setStructure(EmptyParam structure) {
+        this.structure = structure;
         return this;
       }
 
@@ -1822,6 +1844,48 @@ public class AccountUpdateParams extends ApiRequestParams {
             return this;
           }
         }
+      }
+    }
+
+    public enum Structure implements ApiRequestParams.EnumParam {
+      @SerializedName("government_instrumentality")
+      GOVERNMENT_INSTRUMENTALITY("government_instrumentality"),
+
+      @SerializedName("governmental_unit")
+      GOVERNMENTAL_UNIT("governmental_unit"),
+
+      @SerializedName("incorporated_non_profit")
+      INCORPORATED_NON_PROFIT("incorporated_non_profit"),
+
+      @SerializedName("multi_member_llc")
+      MULTI_MEMBER_LLC("multi_member_llc"),
+
+      @SerializedName("private_corporation")
+      PRIVATE_CORPORATION("private_corporation"),
+
+      @SerializedName("private_partnership")
+      PRIVATE_PARTNERSHIP("private_partnership"),
+
+      @SerializedName("public_corporation")
+      PUBLIC_CORPORATION("public_corporation"),
+
+      @SerializedName("public_partnership")
+      PUBLIC_PARTNERSHIP("public_partnership"),
+
+      @SerializedName("tax_exempt_government_instrumentality")
+      TAX_EXEMPT_GOVERNMENT_INSTRUMENTALITY("tax_exempt_government_instrumentality"),
+
+      @SerializedName("unincorporated_association")
+      UNINCORPORATED_ASSOCIATION("unincorporated_association"),
+
+      @SerializedName("unincorporated_non_profit")
+      UNINCORPORATED_NON_PROFIT("unincorporated_non_profit");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      Structure(String value) {
+        this.value = value;
       }
     }
   }
@@ -4430,8 +4494,14 @@ public class AccountUpdateParams extends ApiRequestParams {
     @SerializedName("company")
     COMPANY("company"),
 
+    @SerializedName("government_entity")
+    GOVERNMENT_ENTITY("government_entity"),
+
     @SerializedName("individual")
-    INDIVIDUAL("individual");
+    INDIVIDUAL("individual"),
+
+    @SerializedName("non_profit")
+    NON_PROFIT("non_profit");
 
     @Getter(onMethod_ = {@Override})
     private final String value;

--- a/src/main/java/com/stripe/param/CustomerCreateParams.java
+++ b/src/main/java/com/stripe/param/CustomerCreateParams.java
@@ -1090,7 +1090,7 @@ public class CustomerCreateParams extends ApiRequestParams {
 
     /**
      * Type of the tax ID, one of `au_abn`, `ca_bn`, `ch_vat`, `es_cif`, `eu_vat`, `hk_br`,
-     * `in_gst`, `mx_rfc`, `no_vat`, `nz_gst`, `ru_inn`, `sg_uen`, or `za_vat`.
+     * `in_gst`, `mx_rfc`, `no_vat`, `nz_gst`, `ru_inn`, `sg_uen`, `th_vat`, `tw_vat`, or `za_vat`.
      */
     @SerializedName("type")
     Type type;
@@ -1149,7 +1149,8 @@ public class CustomerCreateParams extends ApiRequestParams {
 
       /**
        * Type of the tax ID, one of `au_abn`, `ca_bn`, `ch_vat`, `es_cif`, `eu_vat`, `hk_br`,
-       * `in_gst`, `mx_rfc`, `no_vat`, `nz_gst`, `ru_inn`, `sg_uen`, or `za_vat`.
+       * `in_gst`, `mx_rfc`, `no_vat`, `nz_gst`, `ru_inn`, `sg_uen`, `th_vat`, `tw_vat`, or
+       * `za_vat`.
        */
       public Builder setType(Type type) {
         this.type = type;
@@ -1199,6 +1200,12 @@ public class CustomerCreateParams extends ApiRequestParams {
 
       @SerializedName("sg_uen")
       SG_UEN("sg_uen"),
+
+      @SerializedName("th_vat")
+      TH_VAT("th_vat"),
+
+      @SerializedName("tw_vat")
+      TW_VAT("tw_vat"),
 
       @SerializedName("za_vat")
       ZA_VAT("za_vat");

--- a/src/main/java/com/stripe/param/PlanCreateParams.java
+++ b/src/main/java/com/stripe/param/PlanCreateParams.java
@@ -532,11 +532,13 @@ public class PlanCreateParams extends ApiRequestParams {
     String name;
 
     /**
-     * An arbitrary string to be displayed on your customer's credit card statement. This may be up
-     * to 22 characters. The statement description may not include "' characters, and will appear on
-     * your customer's statement in capital letters. Non-ASCII characters are automatically
-     * stripped. While most banks display this information consistently, some may display it
-     * incorrectly or not at all.
+     * An arbitrary string to be displayed on your customer's credit card or bank statement. While
+     * most banks display this information consistently, some may display it incorrectly or not at
+     * all.
+     *
+     * <p>This may be up to 22 characters. The statement description may not include `&lt;`, `&gt;`,
+     * `\`, `"`, `'` characters, and will appear on your customer's statement in capital letters.
+     * Non-ASCII characters are automatically stripped.
      */
     @SerializedName("statement_descriptor")
     String statementDescriptor;
@@ -673,11 +675,13 @@ public class PlanCreateParams extends ApiRequestParams {
       }
 
       /**
-       * An arbitrary string to be displayed on your customer's credit card statement. This may be
-       * up to 22 characters. The statement description may not include "' characters, and will
-       * appear on your customer's statement in capital letters. Non-ASCII characters are
-       * automatically stripped. While most banks display this information consistently, some may
-       * display it incorrectly or not at all.
+       * An arbitrary string to be displayed on your customer's credit card or bank statement. While
+       * most banks display this information consistently, some may display it incorrectly or not at
+       * all.
+       *
+       * <p>This may be up to 22 characters. The statement description may not include `&lt;`,
+       * `&gt;`, `\`, `"`, `'` characters, and will appear on your customer's statement in capital
+       * letters. Non-ASCII characters are automatically stripped.
        */
       public Builder setStatementDescriptor(String statementDescriptor) {
         this.statementDescriptor = statementDescriptor;

--- a/src/main/java/com/stripe/param/ProductCreateParams.java
+++ b/src/main/java/com/stripe/param/ProductCreateParams.java
@@ -98,11 +98,13 @@ public class ProductCreateParams extends ApiRequestParams {
   Boolean shippable;
 
   /**
-   * An arbitrary string to be displayed on your customer's credit card statement. This may be up to
-   * 22 characters. The statement description may not include "' characters, and will appear on your
-   * customer's statement in capital letters. Non-ASCII characters are automatically stripped. While
+   * An arbitrary string to be displayed on your customer's credit card or bank statement. While
    * most banks display this information consistently, some may display it incorrectly or not at
-   * all. It must contain at least one letter.
+   * all.
+   *
+   * <p>This may be up to 22 characters. The statement description may not include `&lt;`, `&gt;`,
+   * `\`, `"`, `'` characters, and will appear on your customer's statement in capital letters.
+   * Non-ASCII characters are automatically stripped. It must contain at least one letter.
    */
   @SerializedName("statement_descriptor")
   String statementDescriptor;
@@ -443,11 +445,13 @@ public class ProductCreateParams extends ApiRequestParams {
     }
 
     /**
-     * An arbitrary string to be displayed on your customer's credit card statement. This may be up
-     * to 22 characters. The statement description may not include "' characters, and will appear on
-     * your customer's statement in capital letters. Non-ASCII characters are automatically
-     * stripped. While most banks display this information consistently, some may display it
-     * incorrectly or not at all. It must contain at least one letter.
+     * An arbitrary string to be displayed on your customer's credit card or bank statement. While
+     * most banks display this information consistently, some may display it incorrectly or not at
+     * all.
+     *
+     * <p>This may be up to 22 characters. The statement description may not include `&lt;`, `&gt;`,
+     * `\`, `"`, `'` characters, and will appear on your customer's statement in capital letters.
+     * Non-ASCII characters are automatically stripped. It must contain at least one letter.
      */
     public Builder setStatementDescriptor(String statementDescriptor) {
       this.statementDescriptor = statementDescriptor;

--- a/src/main/java/com/stripe/param/ProductUpdateParams.java
+++ b/src/main/java/com/stripe/param/ProductUpdateParams.java
@@ -97,11 +97,14 @@ public class ProductUpdateParams extends ApiRequestParams {
   Boolean shippable;
 
   /**
-   * An arbitrary string to be displayed on your customer's credit card statement. This may be up to
-   * 22 characters. The statement description may not include "' characters, and will appear on your
-   * customer's statement in capital letters. Non-ASCII characters are automatically stripped. While
+   * An arbitrary string to be displayed on your customer's credit card or bank statement. While
    * most banks display this information consistently, some may display it incorrectly or not at
-   * all. It must contain at least one letter. May only be set if `type=service`.
+   * all.
+   *
+   * <p>This may be up to 22 characters. The statement description may not include `&lt;`, `&gt;`,
+   * `\`, `"`, `'` characters, and will appear on your customer's statement in capital letters.
+   * Non-ASCII characters are automatically stripped. It must contain at least one letter. May only
+   * be set if `type=service`.
    */
   @SerializedName("statement_descriptor")
   Object statementDescriptor;
@@ -496,12 +499,14 @@ public class ProductUpdateParams extends ApiRequestParams {
     }
 
     /**
-     * An arbitrary string to be displayed on your customer's credit card statement. This may be up
-     * to 22 characters. The statement description may not include "' characters, and will appear on
-     * your customer's statement in capital letters. Non-ASCII characters are automatically
-     * stripped. While most banks display this information consistently, some may display it
-     * incorrectly or not at all. It must contain at least one letter. May only be set if
-     * `type=service`.
+     * An arbitrary string to be displayed on your customer's credit card or bank statement. While
+     * most banks display this information consistently, some may display it incorrectly or not at
+     * all.
+     *
+     * <p>This may be up to 22 characters. The statement description may not include `&lt;`, `&gt;`,
+     * `\`, `"`, `'` characters, and will appear on your customer's statement in capital letters.
+     * Non-ASCII characters are automatically stripped. It must contain at least one letter. May
+     * only be set if `type=service`.
      */
     public Builder setStatementDescriptor(String statementDescriptor) {
       this.statementDescriptor = statementDescriptor;
@@ -509,12 +514,14 @@ public class ProductUpdateParams extends ApiRequestParams {
     }
 
     /**
-     * An arbitrary string to be displayed on your customer's credit card statement. This may be up
-     * to 22 characters. The statement description may not include "' characters, and will appear on
-     * your customer's statement in capital letters. Non-ASCII characters are automatically
-     * stripped. While most banks display this information consistently, some may display it
-     * incorrectly or not at all. It must contain at least one letter. May only be set if
-     * `type=service`.
+     * An arbitrary string to be displayed on your customer's credit card or bank statement. While
+     * most banks display this information consistently, some may display it incorrectly or not at
+     * all.
+     *
+     * <p>This may be up to 22 characters. The statement description may not include `&lt;`, `&gt;`,
+     * `\`, `"`, `'` characters, and will appear on your customer's statement in capital letters.
+     * Non-ASCII characters are automatically stripped. It must contain at least one letter. May
+     * only be set if `type=service`.
      */
     public Builder setStatementDescriptor(EmptyParam statementDescriptor) {
       this.statementDescriptor = statementDescriptor;

--- a/src/main/java/com/stripe/param/TaxIdCollectionCreateParams.java
+++ b/src/main/java/com/stripe/param/TaxIdCollectionCreateParams.java
@@ -25,7 +25,7 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
 
   /**
    * Type of the tax ID, one of `au_abn`, `ca_bn`, `ch_vat`, `es_cif`, `eu_vat`, `hk_br`, `in_gst`,
-   * `mx_rfc`, `no_vat`, `nz_gst`, `ru_inn`, `sg_uen`, or `za_vat`.
+   * `mx_rfc`, `no_vat`, `nz_gst`, `ru_inn`, `sg_uen`, `th_vat`, `tw_vat`, or `za_vat`.
    */
   @SerializedName("type")
   Type type;
@@ -114,7 +114,7 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
 
     /**
      * Type of the tax ID, one of `au_abn`, `ca_bn`, `ch_vat`, `es_cif`, `eu_vat`, `hk_br`,
-     * `in_gst`, `mx_rfc`, `no_vat`, `nz_gst`, `ru_inn`, `sg_uen`, or `za_vat`.
+     * `in_gst`, `mx_rfc`, `no_vat`, `nz_gst`, `ru_inn`, `sg_uen`, `th_vat`, `tw_vat`, or `za_vat`.
      */
     public Builder setType(Type type) {
       this.type = type;
@@ -164,6 +164,12 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
 
     @SerializedName("sg_uen")
     SG_UEN("sg_uen"),
+
+    @SerializedName("th_vat")
+    TH_VAT("th_vat"),
+
+    @SerializedName("tw_vat")
+    TW_VAT("tw_vat"),
 
     @SerializedName("za_vat")
     ZA_VAT("za_vat");


### PR DESCRIPTION
This PR adds multiple changes to the API
* Add support for `company.structure` on `Account`
* Add support for new enum values for `business_profile.type`
* Add support for `th_vat` and `tw_vat` as type of `TaxId`

Codegen for openapi 056753a

r? @richardm-stripe 
cc @stripe/api-libraries 