### PR TITLE
Multiple API changes

### DIFF
--- a/src/main/java/com/stripe/model/Card.java
+++ b/src/main/java/com/stripe/model/Card.java
@@ -199,8 +199,9 @@ public class Card extends ApiResource
   ExpandableField<Recipient> recipient;
 
   /**
-   * If the card number is tokenized, this is the method that was used. Can be `apple_pay` or
-   * `google_pay`.
+   * If the card number is tokenized, this is the method that was used. Can be
+   * `amex_express_checkout`, `android_pay` (includes Google Pay), `apple_pay`, `masterpass`,
+   * `visa_checkout`, or null.
    */
   @SerializedName("tokenization_method")
   String tokenizationMethod;

--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -1607,10 +1607,10 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
       String accountHolderType;
 
       /**
-       * The customer's bank. Can be one of `affin_bank`, `alliance_bank`, `ambank`, `cimb`,
-       * `bank_islam`, `bank_rakyat`, `bank_muamalat`, `bsn`, `deutsche_bank`, `hong_leong_bank`,
-       * `hsbc`, `kfh`, `maybank2u`, `maybank2e`, `ocbc`, `public_bank`, `pb_enterprise`, `rhb`,
-       * `standard_chartered`, `uob`, or `uob_regional`.
+       * The customer's bank. Can be one of `affin_bank`, `alliance_bank`, `ambank`, `bank_islam`,
+       * `bank_muamalat`, `bank_rakyat`, `bsn`, `cimb`, `hong_leong_bank`, `hsbc`, `kfh`,
+       * `maybank2u`, `ocbc`, `public_bank`, `rhb`, `standard_chartered`, `uob`, `deutsche_bank`,
+       * `maybank2e`, `pb_enterprise`, or `uob_regional`.
        */
       @SerializedName("bank")
       String bank;

--- a/src/main/java/com/stripe/model/CreditNote.java
+++ b/src/main/java/com/stripe/model/CreditNote.java
@@ -150,7 +150,7 @@ public class CreditNote extends ApiResource implements HasId, MetadataStore<Cred
   Long total;
 
   /**
-   * Type of this credit note, one of `post_payment` or `pre_payment`. A `pre_payment` credit note
+   * Type of this credit note, one of `pre_payment` or `post_payment`. A `pre_payment` credit note
    * means it was issued when the invoice was open. A `post_payment` credit note means it was issued
    * when the invoice was paid.
    */

--- a/src/main/java/com/stripe/model/CreditNoteLineItem.java
+++ b/src/main/java/com/stripe/model/CreditNoteLineItem.java
@@ -63,7 +63,7 @@ public class CreditNoteLineItem extends StripeObject implements HasId {
   List<TaxRate> taxRates;
 
   /**
-   * The type of the credit note line item, one of `custom_line_item` or `invoice_line_item`. When
+   * The type of the credit note line item, one of `invoice_line_item` or `custom_line_item`. When
    * the type is `invoice_line_item` there is an additional `invoice_line_item` property on the
    * resource the value of which is the id of the credited line item on the invoice.
    */

--- a/src/main/java/com/stripe/model/CustomerBalanceTransaction.java
+++ b/src/main/java/com/stripe/model/CustomerBalanceTransaction.java
@@ -94,8 +94,8 @@ public class CustomerBalanceTransaction extends ApiResource
 
   /**
    * Transaction type: `adjustment`, `applied_to_invoice`, `credit_note`, `initial`,
-   * `invoice_too_large`, `invoice_too_small`, `unapplied_from_invoice`, or
-   * `unspent_receiver_credit`. See the [Customer Balance
+   * `invoice_too_large`, `invoice_too_small`, `unspent_receiver_credit`, or
+   * `unapplied_from_invoice`. See the [Customer Balance
    * page](https://stripe.com/docs/billing/customer/balance#types) to learn more about transaction
    * types.
    *

--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -1259,9 +1259,9 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
   @EqualsAndHashCode(callSuper = false)
   public static class CustomerTaxId extends StripeObject {
     /**
-     * The type of the tax ID, one of `au_abn`, `ca_bn`, `ch_vat`, `es_cif`, `eu_vat`, `hk_br`,
-     * `in_gst`, `mx_rfc`, `no_vat`, `nz_gst`, `ru_inn`, `sg_uen`, `th_vat`, `tw_vat`, `unknown`, or
-     * `za_vat`.
+     * The type of the tax ID, one of `eu_vat`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`,
+     * `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`,
+     * `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, or `unknown`.
      */
     @SerializedName("type")
     String type;

--- a/src/main/java/com/stripe/model/Mandate.java
+++ b/src/main/java/com/stripe/model/Mandate.java
@@ -54,13 +54,13 @@ public class Mandate extends ApiResource implements HasId {
   SingleUse singleUse;
 
   /**
-   * The status of the Mandate, one of `active`, `inactive`, or `pending`. The Mandate can be used
+   * The status of the Mandate, one of `pending`, `inactive`, or `active`. The Mandate can be used
    * to initiate a payment only if status=active.
    */
   @SerializedName("status")
   String status;
 
-  /** The type of the mandate, one of `multi_use` or `single_use`. */
+  /** The type of the mandate, one of `single_use` or `multi_use`. */
   @SerializedName("type")
   String type;
 

--- a/src/main/java/com/stripe/model/PaymentMethod.java
+++ b/src/main/java/com/stripe/model/PaymentMethod.java
@@ -637,9 +637,9 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
 
     /**
      * The customer's bank, if provided. Can be one of `affin_bank`, `alliance_bank`, `ambank`,
-     * `cimb`, `bank_islam`, `bank_rakyat`, `bank_muamalat`, `bsn`, `deutsche_bank`,
-     * `hong_leong_bank`, `hsbc`, `kfh`, `maybank2u`, `maybank2e`, `ocbc`, `public_bank`,
-     * `pb_enterprise`, `rhb`, `standard_chartered`, `uob`, or `uob_regional`.
+     * `bank_islam`, `bank_muamalat`, `bank_rakyat`, `bsn`, `cimb`, `hong_leong_bank`, `hsbc`,
+     * `kfh`, `maybank2u`, `ocbc`, `public_bank`, `rhb`, `standard_chartered`, `uob`,
+     * `deutsche_bank`, `maybank2e`, `pb_enterprise`, or `uob_regional`.
      */
     @SerializedName("bank")
     String bank;

--- a/src/main/java/com/stripe/model/Payout.java
+++ b/src/main/java/com/stripe/model/Payout.java
@@ -111,7 +111,7 @@ public class Payout extends ApiResource implements MetadataStore<Payout>, Balanc
   /**
    * The method used to send this payout, which can be `standard` or `instant`. `instant` is only
    * supported for payouts to debit cards. (See [Instant payouts for
-   * marketplaces](/blog/instant-payouts-for-marketplaces) for more information.)
+   * marketplaces](https://stripe.com/blog/instant-payouts-for-marketplaces) for more information.)
    */
   @SerializedName("method")
   String method;

--- a/src/main/java/com/stripe/model/TaxId.java
+++ b/src/main/java/com/stripe/model/TaxId.java
@@ -53,8 +53,10 @@ public class TaxId extends ApiResource implements HasId {
   String object;
 
   /**
-   * Type of the tax ID, one of `au_abn`, `ca_bn`, `ch_vat`, `es_cif`, `eu_vat`, `hk_br`, `in_gst`,
-   * `mx_rfc`, `no_vat`, `nz_gst`, `ru_inn`, `sg_uen`, `th_vat`, `tw_vat`, `za_vat`, or `unknown`.
+   * Type of the tax ID, one of `eu_vat`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`,
+   * `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`,
+   * `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, or `ca_qst`. Note that some legacy tax IDs
+   * have type `unknown`
    */
   @SerializedName("type")
   String type;
@@ -116,7 +118,7 @@ public class TaxId extends ApiResource implements HasId {
   @Setter
   @EqualsAndHashCode(callSuper = false)
   public static class Verification extends StripeObject {
-    /** Verification status, one of `pending`, `unavailable`, `unverified`, or `verified`. */
+    /** Verification status, one of `pending`, `verified`, `unverified`, or `unavailable`. */
     @SerializedName("status")
     String status;
 

--- a/src/main/java/com/stripe/model/issuing/Authorization.java
+++ b/src/main/java/com/stripe/model/issuing/Authorization.java
@@ -468,14 +468,14 @@ public class Authorization extends ApiResource
     @EqualsAndHashCode(callSuper = false)
     public static class ViolatedAuthorizationControl extends StripeObject {
       /**
-       * Entity which the authorization control acts on. One of `account`, `card`, or `cardholder`.
+       * Entity which the authorization control acts on. One of `card`, `cardholder`, or `account`.
        */
       @SerializedName("entity")
       String entity;
 
       /**
        * Name of the authorization control. One of `allowed_categories`, `blocked_categories`,
-       * `max_amount`, `max_approvals`, or `spending_limits`.
+       * `spending_limits`, `max_approvals`, or `max_amount`.
        */
       @SerializedName("name")
       String name;
@@ -500,7 +500,7 @@ public class Authorization extends ApiResource
     @SerializedName("address_zip_check")
     String addressZipCheck;
 
-    /** One of `exempt`, `failure`, `none`, or `success`. */
+    /** One of `success`, `failure`, `exempt`, or `none`. */
     @SerializedName("authentication")
     String authentication;
 

--- a/src/main/java/com/stripe/model/issuing/Dispute.java
+++ b/src/main/java/com/stripe/model/issuing/Dispute.java
@@ -75,11 +75,11 @@ public class Dispute extends ApiResource implements HasId, MetadataStore<Dispute
   @SerializedName("object")
   String object;
 
-  /** Reason for this dispute. One of `other` or `fraudulent`. */
+  /** Reason for this dispute. One of `fraudulent` or `other`. */
   @SerializedName("reason")
   String reason;
 
-  /** Current status of dispute. One of `lost`, `under_review`, `unsubmitted`, or `won`. */
+  /** Current status of dispute. One of `unsubmitted`, `under_review`, `won`, or `lost`. */
   @SerializedName("status")
   String status;
 

--- a/src/main/java/com/stripe/param/ChargeCaptureParams.java
+++ b/src/main/java/com/stripe/param/ChargeCaptureParams.java
@@ -17,13 +17,13 @@ public class ChargeCaptureParams extends ApiRequestParams {
   @SerializedName("amount")
   Long amount;
 
-  /** An application fee to add on to this charge. Can only be used with Stripe Connect. */
+  /** An application fee to add on to this charge. */
   @SerializedName("application_fee")
   Long applicationFee;
 
   /**
    * An application fee amount to add on to this charge, which must be less than or equal to the
-   * original amount. Can only be used with Stripe Connect.
+   * original amount.
    */
   @SerializedName("application_fee_amount")
   Long applicationFeeAmount;
@@ -153,7 +153,7 @@ public class ChargeCaptureParams extends ApiRequestParams {
       return this;
     }
 
-    /** An application fee to add on to this charge. Can only be used with Stripe Connect. */
+    /** An application fee to add on to this charge. */
     public Builder setApplicationFee(Long applicationFee) {
       this.applicationFee = applicationFee;
       return this;
@@ -161,7 +161,7 @@ public class ChargeCaptureParams extends ApiRequestParams {
 
     /**
      * An application fee amount to add on to this charge, which must be less than or equal to the
-     * original amount. Can only be used with Stripe Connect.
+     * original amount.
      */
     public Builder setApplicationFeeAmount(Long applicationFeeAmount) {
       this.applicationFeeAmount = applicationFeeAmount;

--- a/src/main/java/com/stripe/param/CreditNoteCreateParams.java
+++ b/src/main/java/com/stripe/param/CreditNoteCreateParams.java
@@ -353,7 +353,7 @@ public class CreditNoteCreateParams extends ApiRequestParams {
     @SerializedName("tax_rates")
     Object taxRates;
 
-    /** Type of the credit note line item, one of `custom_line_item` or `invoice_line_item`. */
+    /** Type of the credit note line item, one of `invoice_line_item` or `custom_line_item`. */
     @SerializedName("type")
     Type type;
 
@@ -532,7 +532,7 @@ public class CreditNoteCreateParams extends ApiRequestParams {
         return this;
       }
 
-      /** Type of the credit note line item, one of `custom_line_item` or `invoice_line_item`. */
+      /** Type of the credit note line item, one of `invoice_line_item` or `custom_line_item`. */
       public Builder setType(Type type) {
         this.type = type;
         return this;

--- a/src/main/java/com/stripe/param/CreditNotePreviewParams.java
+++ b/src/main/java/com/stripe/param/CreditNotePreviewParams.java
@@ -353,7 +353,7 @@ public class CreditNotePreviewParams extends ApiRequestParams {
     @SerializedName("tax_rates")
     Object taxRates;
 
-    /** Type of the credit note line item, one of `custom_line_item` or `invoice_line_item`. */
+    /** Type of the credit note line item, one of `invoice_line_item` or `custom_line_item`. */
     @SerializedName("type")
     Type type;
 
@@ -532,7 +532,7 @@ public class CreditNotePreviewParams extends ApiRequestParams {
         return this;
       }
 
-      /** Type of the credit note line item, one of `custom_line_item` or `invoice_line_item`. */
+      /** Type of the credit note line item, one of `invoice_line_item` or `custom_line_item`. */
       public Builder setType(Type type) {
         this.type = type;
         return this;

--- a/src/main/java/com/stripe/param/CustomerCreateParams.java
+++ b/src/main/java/com/stripe/param/CustomerCreateParams.java
@@ -1089,8 +1089,9 @@ public class CustomerCreateParams extends ApiRequestParams {
     Map<String, Object> extraParams;
 
     /**
-     * Type of the tax ID, one of `au_abn`, `ca_bn`, `ch_vat`, `es_cif`, `eu_vat`, `hk_br`,
-     * `in_gst`, `mx_rfc`, `no_vat`, `nz_gst`, `ru_inn`, `sg_uen`, `th_vat`, `tw_vat`, or `za_vat`.
+     * Type of the tax ID, one of `eu_vat`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`,
+     * `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`,
+     * `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, or `ca_qst`.
      */
     @SerializedName("type")
     Type type;
@@ -1148,9 +1149,9 @@ public class CustomerCreateParams extends ApiRequestParams {
       }
 
       /**
-       * Type of the tax ID, one of `au_abn`, `ca_bn`, `ch_vat`, `es_cif`, `eu_vat`, `hk_br`,
-       * `in_gst`, `mx_rfc`, `no_vat`, `nz_gst`, `ru_inn`, `sg_uen`, `th_vat`, `tw_vat`, or
-       * `za_vat`.
+       * Type of the tax ID, one of `eu_vat`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`,
+       * `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`,
+       * `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, or `ca_qst`.
        */
       public Builder setType(Type type) {
         this.type = type;
@@ -1171,6 +1172,9 @@ public class CustomerCreateParams extends ApiRequestParams {
       @SerializedName("ca_bn")
       CA_BN("ca_bn"),
 
+      @SerializedName("ca_qst")
+      CA_QST("ca_qst"),
+
       @SerializedName("ch_vat")
       CH_VAT("ch_vat"),
 
@@ -1186,8 +1190,20 @@ public class CustomerCreateParams extends ApiRequestParams {
       @SerializedName("in_gst")
       IN_GST("in_gst"),
 
+      @SerializedName("jp_cn")
+      JP_CN("jp_cn"),
+
+      @SerializedName("kr_brn")
+      KR_BRN("kr_brn"),
+
+      @SerializedName("li_uid")
+      LI_UID("li_uid"),
+
       @SerializedName("mx_rfc")
       MX_RFC("mx_rfc"),
+
+      @SerializedName("my_itn")
+      MY_ITN("my_itn"),
 
       @SerializedName("no_vat")
       NO_VAT("no_vat"),
@@ -1206,6 +1222,9 @@ public class CustomerCreateParams extends ApiRequestParams {
 
       @SerializedName("tw_vat")
       TW_VAT("tw_vat"),
+
+      @SerializedName("us_ein")
+      US_EIN("us_ein"),
 
       @SerializedName("za_vat")
       ZA_VAT("za_vat");

--- a/src/main/java/com/stripe/param/TaxIdCollectionCreateParams.java
+++ b/src/main/java/com/stripe/param/TaxIdCollectionCreateParams.java
@@ -24,8 +24,9 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
   Map<String, Object> extraParams;
 
   /**
-   * Type of the tax ID, one of `au_abn`, `ca_bn`, `ch_vat`, `es_cif`, `eu_vat`, `hk_br`, `in_gst`,
-   * `mx_rfc`, `no_vat`, `nz_gst`, `ru_inn`, `sg_uen`, `th_vat`, `tw_vat`, or `za_vat`.
+   * Type of the tax ID, one of `eu_vat`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`,
+   * `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`,
+   * `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, or `ca_qst`.
    */
   @SerializedName("type")
   Type type;
@@ -113,8 +114,9 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
     }
 
     /**
-     * Type of the tax ID, one of `au_abn`, `ca_bn`, `ch_vat`, `es_cif`, `eu_vat`, `hk_br`,
-     * `in_gst`, `mx_rfc`, `no_vat`, `nz_gst`, `ru_inn`, `sg_uen`, `th_vat`, `tw_vat`, or `za_vat`.
+     * Type of the tax ID, one of `eu_vat`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`,
+     * `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`,
+     * `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, or `ca_qst`.
      */
     public Builder setType(Type type) {
       this.type = type;
@@ -135,6 +137,9 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
     @SerializedName("ca_bn")
     CA_BN("ca_bn"),
 
+    @SerializedName("ca_qst")
+    CA_QST("ca_qst"),
+
     @SerializedName("ch_vat")
     CH_VAT("ch_vat"),
 
@@ -150,8 +155,20 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
     @SerializedName("in_gst")
     IN_GST("in_gst"),
 
+    @SerializedName("jp_cn")
+    JP_CN("jp_cn"),
+
+    @SerializedName("kr_brn")
+    KR_BRN("kr_brn"),
+
+    @SerializedName("li_uid")
+    LI_UID("li_uid"),
+
     @SerializedName("mx_rfc")
     MX_RFC("mx_rfc"),
+
+    @SerializedName("my_itn")
+    MY_ITN("my_itn"),
 
     @SerializedName("no_vat")
     NO_VAT("no_vat"),
@@ -170,6 +187,9 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
 
     @SerializedName("tw_vat")
     TW_VAT("tw_vat"),
+
+    @SerializedName("us_ein")
+    US_EIN("us_ein"),
 
     @SerializedName("za_vat")
     ZA_VAT("za_vat");

--- a/src/main/java/com/stripe/param/TokenCreateParams.java
+++ b/src/main/java/com/stripe/param/TokenCreateParams.java
@@ -20,11 +20,10 @@ public class TokenCreateParams extends ApiRequestParams {
   Object card;
 
   /**
-   * The customer (owned by the application's account) for which to create a token. For use only
-   * with [Stripe Connect](https://stripe.com/docs/connect). Also, this can be used only with an
-   * [OAuth access token](https://stripe.com/docs/connect/standard-accounts) or [Stripe-Account
-   * header](https://stripe.com/docs/connect/authentication). For more details, see [Cloning Saved
-   * Payment Methods](https://stripe.com/docs/connect/cloning-saved-payment-methods).
+   * The customer (owned by the application's account) for which to create a token. This can be used
+   * only with an [OAuth access token](https://stripe.com/docs/connect/standard-accounts) or
+   * [Stripe-Account header](https://stripe.com/docs/connect/authentication). For more details, see
+   * [Cloning Saved Payment Methods](https://stripe.com/docs/connect/cloning-saved-payment-methods).
    */
   @SerializedName("customer")
   String customer;
@@ -115,11 +114,11 @@ public class TokenCreateParams extends ApiRequestParams {
     }
 
     /**
-     * The customer (owned by the application's account) for which to create a token. For use only
-     * with [Stripe Connect](https://stripe.com/docs/connect). Also, this can be used only with an
-     * [OAuth access token](https://stripe.com/docs/connect/standard-accounts) or [Stripe-Account
-     * header](https://stripe.com/docs/connect/authentication). For more details, see [Cloning Saved
-     * Payment Methods](https://stripe.com/docs/connect/cloning-saved-payment-methods).
+     * The customer (owned by the application's account) for which to create a token. This can be
+     * used only with an [OAuth access token](https://stripe.com/docs/connect/standard-accounts) or
+     * [Stripe-Account header](https://stripe.com/docs/connect/authentication). For more details,
+     * see [Cloning Saved Payment
+     * Methods](https://stripe.com/docs/connect/cloning-saved-payment-methods).
      */
     public Builder setCustomer(String customer) {
       this.customer = customer;

--- a/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
+++ b/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
@@ -727,6 +727,15 @@ public class SessionCreateParams extends ApiRequestParams {
     String statementDescriptor;
 
     /**
+     * Provides information about the charge that customers see on their statements. Concatenated
+     * with the prefix (shortened descriptor) or statement descriptor that’s set on the account to
+     * form the complete statement descriptor. Maximum 22 characters for the concatenated
+     * descriptor.
+     */
+    @SerializedName("statement_descriptor_suffix")
+    String statementDescriptorSuffix;
+
+    /**
      * The parameters used to automatically create a Transfer when the payment succeeds. For more
      * information, see the PaymentIntents [use case for connected
      * accounts](https://stripe.com/docs/payments/connected-accounts).
@@ -745,6 +754,7 @@ public class SessionCreateParams extends ApiRequestParams {
         SetupFutureUsage setupFutureUsage,
         Shipping shipping,
         String statementDescriptor,
+        String statementDescriptorSuffix,
         TransferData transferData) {
       this.applicationFeeAmount = applicationFeeAmount;
       this.captureMethod = captureMethod;
@@ -756,6 +766,7 @@ public class SessionCreateParams extends ApiRequestParams {
       this.setupFutureUsage = setupFutureUsage;
       this.shipping = shipping;
       this.statementDescriptor = statementDescriptor;
+      this.statementDescriptorSuffix = statementDescriptorSuffix;
       this.transferData = transferData;
     }
 
@@ -784,6 +795,8 @@ public class SessionCreateParams extends ApiRequestParams {
 
       private String statementDescriptor;
 
+      private String statementDescriptorSuffix;
+
       private TransferData transferData;
 
       /** Finalize and obtain parameter instance from this builder. */
@@ -799,6 +812,7 @@ public class SessionCreateParams extends ApiRequestParams {
             this.setupFutureUsage,
             this.shipping,
             this.statementDescriptor,
+            this.statementDescriptorSuffix,
             this.transferData);
       }
 
@@ -928,6 +942,17 @@ public class SessionCreateParams extends ApiRequestParams {
        */
       public Builder setStatementDescriptor(String statementDescriptor) {
         this.statementDescriptor = statementDescriptor;
+        return this;
+      }
+
+      /**
+       * Provides information about the charge that customers see on their statements. Concatenated
+       * with the prefix (shortened descriptor) or statement descriptor that’s set on the account to
+       * form the complete statement descriptor. Maximum 22 characters for the concatenated
+       * descriptor.
+       */
+      public Builder setStatementDescriptorSuffix(String statementDescriptorSuffix) {
+        this.statementDescriptorSuffix = statementDescriptorSuffix;
         return this;
       }
 

--- a/src/main/java/com/stripe/param/issuing/DisputeCreateParams.java
+++ b/src/main/java/com/stripe/param/issuing/DisputeCreateParams.java
@@ -48,7 +48,7 @@ public class DisputeCreateParams extends ApiRequestParams {
   @SerializedName("metadata")
   Map<String, String> metadata;
 
-  /** The reason for the dispute. One of `other` or `fraudulent`. */
+  /** The reason for the dispute. */
   @SerializedName("reason")
   Reason reason;
 
@@ -201,7 +201,7 @@ public class DisputeCreateParams extends ApiRequestParams {
       return this;
     }
 
-    /** The reason for the dispute. One of `other` or `fraudulent`. */
+    /** The reason for the dispute. */
     public Builder setReason(Reason reason) {
       this.reason = reason;
       return this;


### PR DESCRIPTION
Multiple API changes
* Add support for new `type` values for `TaxId`.
* Add support for `payment_intent_data[statement_descriptor_suffix]` on Checkout `Session`.

Codegen for openapi 7562c6b

r? @ob-stripe 
cc @stripe/api-libraries 