### PR TITLE
Multiple API changes

### DIFF
--- a/src/main/java/com/stripe/model/Balance.java
+++ b/src/main/java/com/stripe/model/Balance.java
@@ -129,6 +129,10 @@ public class Balance extends ApiResource {
       /** Amount for card. */
       @SerializedName("card")
       Long card;
+
+      /** Amount for FPX. */
+      @SerializedName("fpx")
+      Long fpx;
     }
   }
 }

--- a/src/main/java/com/stripe/model/PaymentMethod.java
+++ b/src/main/java/com/stripe/model/PaymentMethod.java
@@ -360,12 +360,18 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
   @Setter
   @EqualsAndHashCode(callSuper = false)
   public static class AuBecsDebit extends StripeObject {
+    /** Six-digit number identifying bank and branch associated with this bank account. */
     @SerializedName("bsb_number")
     String bsbNumber;
 
+    /**
+     * Uniquely identifies this particular bank account. You can use this attribute to check whether
+     * two bank accounts are the same.
+     */
     @SerializedName("fingerprint")
     String fingerprint;
 
+    /** Last four digits of the bank account number. */
     @SerializedName("last4")
     String last4;
   }

--- a/src/main/java/com/stripe/model/Payout.java
+++ b/src/main/java/com/stripe/model/Payout.java
@@ -127,7 +127,10 @@ public class Payout extends ApiResource implements MetadataStore<Payout>, Balanc
   @SerializedName("object")
   String object;
 
-  /** The source balance this payout came from. One of {@code card} or {@code bank_account}. */
+  /**
+   * The source balance this payout came from. One of {@code card}, {@code fpx}, or {@code
+   * bank_account}.
+   */
   @SerializedName("source_type")
   String sourceType;
 

--- a/src/main/java/com/stripe/model/Plan.java
+++ b/src/main/java/com/stripe/model/Plan.java
@@ -26,10 +26,10 @@ public class Plan extends ApiResource implements HasId, MetadataStore<Plan> {
 
   /**
    * Specifies a usage aggregation strategy for plans of {@code usage_type=metered}. Allowed values
-   * are {@code sum} for summing up all usage during a period, {@code last_during_period} for
-   * picking the last usage record reported within a period, {@code last_ever} for picking the last
-   * usage record ever (across period bounds) or {@code max} which picks the usage record with the
-   * maximum reported usage during a period. Defaults to {@code sum}.
+   * are {@code sum} for summing up all usage during a period, {@code last_during_period} for using
+   * the last usage record reported within a period, {@code last_ever} for using the last usage
+   * record ever (across period bounds) or {@code max} which uses the usage record with the maximum
+   * reported usage during a period. Defaults to {@code sum}.
    *
    * <p>One of {@code last_during_period}, {@code last_ever}, {@code max}, or {@code sum}.
    */
@@ -78,14 +78,14 @@ public class Plan extends ApiResource implements HasId, MetadataStore<Plan> {
   String id;
 
   /**
-   * One of {@code day}, {@code week}, {@code month} or {@code year}. The frequency with which a
-   * subscription should be billed.
+   * The frequency at which a subscription is billed. One of {@code day}, {@code week}, {@code
+   * month} or {@code year}.
    */
   @SerializedName("interval")
   String interval;
 
   /**
-   * The number of intervals (specified in the {@code interval} property) between subscription
+   * The number of intervals (specified in the {@code interval} attribute) between subscription
    * billings. For example, {@code interval=month} and {@code interval_count=3} bills every 3
    * months.
    */
@@ -134,8 +134,8 @@ public class Plan extends ApiResource implements HasId, MetadataStore<Plan> {
 
   /**
    * Defines if the tiering price should be {@code graduated} or {@code volume} based. In {@code
-   * volume}-based tiering, the maximum quantity within a period determines the per unit price, in
-   * {@code graduated} tiering pricing can successively change as the quantity grows.
+   * volume}-based tiering, the maximum quantity within a period determines the per unit price. In
+   * {@code graduated} tiering, pricing can change as the quantity grows.
    *
    * <p>One of {@code graduated}, or {@code volume}.
    */
@@ -143,8 +143,8 @@ public class Plan extends ApiResource implements HasId, MetadataStore<Plan> {
   String tiersMode;
 
   /**
-   * Apply a transformation to the reported usage or set quantity before computing the billed price.
-   * Cannot be combined with {@code tiers}.
+   * Apply a transformation to the reported usage or set quantity before computing the amount
+   * billed. Cannot be combined with {@code tiers}.
    */
   @SerializedName("transform_usage")
   TransformUsage transformUsage;
@@ -158,12 +158,10 @@ public class Plan extends ApiResource implements HasId, MetadataStore<Plan> {
   Long trialPeriodDays;
 
   /**
-   * Configures how the quantity per period should be determined, can be either {@code metered} or
-   * {@code licensed}. {@code licensed} will automatically bill the {@code quantity} set when adding
-   * it to a subscription, {@code metered} will aggregate the total usage based on usage records.
-   * Defaults to {@code licensed}.
-   *
-   * <p>One of {@code licensed}, or {@code metered}.
+   * Configures how the quantity per period should be determined. Can be either {@code metered} or
+   * {@code licensed}. {@code licensed} automatically bills the {@code quantity} set when adding it
+   * to a subscription. {@code metered} aggregates the total usage based on usage records. Defaults
+   * to {@code licensed}.
    */
   @SerializedName("usage_type")
   String usageType;

--- a/src/main/java/com/stripe/model/Transfer.java
+++ b/src/main/java/com/stripe/model/Transfer.java
@@ -114,7 +114,10 @@ public class Transfer extends ApiResource
   @Setter(lombok.AccessLevel.NONE)
   ExpandableField<Charge> sourceTransaction;
 
-  /** The source balance this transfer came from. One of {@code card} or {@code bank_account}. */
+  /**
+   * The source balance this transfer came from. One of {@code card}, {@code fpx}, or {@code
+   * bank_account}.
+   */
   @SerializedName("source_type")
   String sourceType;
 

--- a/src/main/java/com/stripe/model/issuing/Authorization.java
+++ b/src/main/java/com/stripe/model/issuing/Authorization.java
@@ -492,27 +492,34 @@ public class Authorization extends ApiResource
   public static class VerificationData extends StripeObject {
     /**
      * Whether the cardholder provided an address first line and if it matched the cardholder’s
-     * {@code billing.address.line1}. One of {@code match}, {@code mismatch}, or {@code
-     * not_provided}.
+     * {@code billing.address.line1}.
+     *
+     * <p>One of {@code match}, {@code mismatch}, or {@code not_provided}.
      */
     @SerializedName("address_line1_check")
     String addressLine1Check;
 
     /**
      * Whether the cardholder provided a zip (or postal code) and if it matched the cardholder’s
-     * {@code billing.address.postal_code}. One of {@code match}, {@code mismatch}, or {@code
-     * not_provided}.
+     * {@code billing.address.postal_code}.
+     *
+     * <p>One of {@code match}, {@code mismatch}, or {@code not_provided}.
      */
     @SerializedName("address_zip_check")
     String addressZipCheck;
 
-    /** One of {@code success}, {@code failure}, {@code exempt}, or {@code none}. */
+    /**
+     * Whether 3DS authentication was performed.
+     *
+     * <p>One of {@code failure}, {@code none}, or {@code success}.
+     */
     @SerializedName("authentication")
     String authentication;
 
     /**
-     * Whether the cardholder provided a CVC and if it matched Stripe’s record. One of {@code
-     * match}, {@code mismatch}, or {@code not_provided}.
+     * Whether the cardholder provided a CVC and if it matched Stripe’s record.
+     *
+     * <p>One of {@code match}, {@code mismatch}, or {@code not_provided}.
      */
     @SerializedName("cvc_check")
     String cvcCheck;

--- a/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
@@ -83,6 +83,10 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
   @SerializedName("payment_method")
   Object paymentMethod;
 
+  /** Payment-method-specific configuration for this PaymentIntent. */
+  @SerializedName("payment_method_options")
+  PaymentMethodOptions paymentMethodOptions;
+
   /** The list of payment method types (e.g. card) that this PaymentIntent is allowed to use. */
   @SerializedName("payment_method_types")
   List<String> paymentMethodTypes;
@@ -192,6 +196,7 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       Map<String, Object> extraParams,
       Map<String, String> metadata,
       Object paymentMethod,
+      PaymentMethodOptions paymentMethodOptions,
       List<String> paymentMethodTypes,
       Object receiptEmail,
       Boolean savePaymentMethod,
@@ -211,6 +216,7 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     this.extraParams = extraParams;
     this.metadata = metadata;
     this.paymentMethod = paymentMethod;
+    this.paymentMethodOptions = paymentMethodOptions;
     this.paymentMethodTypes = paymentMethodTypes;
     this.receiptEmail = receiptEmail;
     this.savePaymentMethod = savePaymentMethod;
@@ -246,6 +252,8 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
 
     private Object paymentMethod;
 
+    private PaymentMethodOptions paymentMethodOptions;
+
     private List<String> paymentMethodTypes;
 
     private Object receiptEmail;
@@ -278,6 +286,7 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
           this.extraParams,
           this.metadata,
           this.paymentMethod,
+          this.paymentMethodOptions,
           this.paymentMethodTypes,
           this.receiptEmail,
           this.savePaymentMethod,
@@ -475,6 +484,12 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
      */
     public Builder setPaymentMethod(EmptyParam paymentMethod) {
       this.paymentMethod = paymentMethod;
+      return this;
+    }
+
+    /** Payment-method-specific configuration for this PaymentIntent. */
+    public Builder setPaymentMethodOptions(PaymentMethodOptions paymentMethodOptions) {
+      this.paymentMethodOptions = paymentMethodOptions;
       return this;
     }
 
@@ -701,6 +716,472 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     public Builder setTransferGroup(EmptyParam transferGroup) {
       this.transferGroup = transferGroup;
       return this;
+    }
+  }
+
+  @Getter
+  public static class PaymentMethodOptions {
+    /** Configuration for any card payments attempted on this PaymentIntent. */
+    @SerializedName("card")
+    Card card;
+
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    private PaymentMethodOptions(Card card, Map<String, Object> extraParams) {
+      this.card = card;
+      this.extraParams = extraParams;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Card card;
+
+      private Map<String, Object> extraParams;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public PaymentMethodOptions build() {
+        return new PaymentMethodOptions(this.card, this.extraParams);
+      }
+
+      /** Configuration for any card payments attempted on this PaymentIntent. */
+      public Builder setCard(Card card) {
+        this.card = card;
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * PaymentIntentUpdateParams.PaymentMethodOptions#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link PaymentIntentUpdateParams.PaymentMethodOptions#extraParams} for the field
+       * documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+    }
+
+    @Getter
+    public static class Card {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /**
+       * Installment configuration for payments attempted on this PaymentIntent (Mexico Only).
+       *
+       * <p>For more information, see the <a
+       * href="https://stripe.com/docs/payments/installments">installments integration guide</a>.
+       */
+      @SerializedName("installments")
+      Installments installments;
+
+      /**
+       * When specified, this parameter indicates that a transaction will be marked as MOTO (Mail
+       * Order Telephone Order) and thus out of scope for SCA. This parameter can only be provided
+       * during confirmation.
+       */
+      @SerializedName("moto")
+      Boolean moto;
+
+      /**
+       * We strongly recommend that you rely on our SCA Engine to automatically prompt your
+       * customers for authentication based on risk level and <a
+       * href="https://stripe.com/docs/strong-customer-authentication">other requirements</a>.
+       * However, if you wish to request 3D Secure based on logic from your own fraud engine,
+       * provide this option. Permitted values include: {@code automatic} or {@code any}. If not
+       * provided, defaults to {@code automatic}. Read our guide on <a
+       * href="https://stripe.com/docs/payments/3d-secure#manual-three-ds">manually requesting 3D
+       * Secure</a> for more information on how this configuration interacts with Radar and our SCA
+       * Engine.
+       */
+      @SerializedName("request_three_d_secure")
+      RequestThreeDSecure requestThreeDSecure;
+
+      private Card(
+          Map<String, Object> extraParams,
+          Installments installments,
+          Boolean moto,
+          RequestThreeDSecure requestThreeDSecure) {
+        this.extraParams = extraParams;
+        this.installments = installments;
+        this.moto = moto;
+        this.requestThreeDSecure = requestThreeDSecure;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private Installments installments;
+
+        private Boolean moto;
+
+        private RequestThreeDSecure requestThreeDSecure;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Card build() {
+          return new Card(this.extraParams, this.installments, this.moto, this.requestThreeDSecure);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentUpdateParams.PaymentMethodOptions.Card#extraParams} for the
+         * field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentUpdateParams.PaymentMethodOptions.Card#extraParams} for the
+         * field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /**
+         * Installment configuration for payments attempted on this PaymentIntent (Mexico Only).
+         *
+         * <p>For more information, see the <a
+         * href="https://stripe.com/docs/payments/installments">installments integration guide</a>.
+         */
+        public Builder setInstallments(Installments installments) {
+          this.installments = installments;
+          return this;
+        }
+
+        /**
+         * When specified, this parameter indicates that a transaction will be marked as MOTO (Mail
+         * Order Telephone Order) and thus out of scope for SCA. This parameter can only be provided
+         * during confirmation.
+         */
+        public Builder setMoto(Boolean moto) {
+          this.moto = moto;
+          return this;
+        }
+
+        /**
+         * We strongly recommend that you rely on our SCA Engine to automatically prompt your
+         * customers for authentication based on risk level and <a
+         * href="https://stripe.com/docs/strong-customer-authentication">other requirements</a>.
+         * However, if you wish to request 3D Secure based on logic from your own fraud engine,
+         * provide this option. Permitted values include: {@code automatic} or {@code any}. If not
+         * provided, defaults to {@code automatic}. Read our guide on <a
+         * href="https://stripe.com/docs/payments/3d-secure#manual-three-ds">manually requesting 3D
+         * Secure</a> for more information on how this configuration interacts with Radar and our
+         * SCA Engine.
+         */
+        public Builder setRequestThreeDSecure(RequestThreeDSecure requestThreeDSecure) {
+          this.requestThreeDSecure = requestThreeDSecure;
+          return this;
+        }
+      }
+
+      @Getter
+      public static class Installments {
+        /**
+         * Setting to true enables installments for this PaymentIntent. This will cause the response
+         * to contain a list of available installment plans. Setting to false will prevent any
+         * selected plan from applying to a charge.
+         */
+        @SerializedName("enabled")
+        Boolean enabled;
+
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /**
+         * The selected installment plan to use for this payment attempt. This parameter can only be
+         * provided during confirmation.
+         */
+        @SerializedName("plan")
+        Object plan;
+
+        private Installments(Boolean enabled, Map<String, Object> extraParams, Object plan) {
+          this.enabled = enabled;
+          this.extraParams = extraParams;
+          this.plan = plan;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Boolean enabled;
+
+          private Map<String, Object> extraParams;
+
+          private Object plan;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public Installments build() {
+            return new Installments(this.enabled, this.extraParams, this.plan);
+          }
+
+          /**
+           * Setting to true enables installments for this PaymentIntent. This will cause the
+           * response to contain a list of available installment plans. Setting to false will
+           * prevent any selected plan from applying to a charge.
+           */
+          public Builder setEnabled(Boolean enabled) {
+            this.enabled = enabled;
+            return this;
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * PaymentIntentUpdateParams.PaymentMethodOptions.Card.Installments#extraParams} for the
+           * field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * PaymentIntentUpdateParams.PaymentMethodOptions.Card.Installments#extraParams} for the
+           * field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /**
+           * The selected installment plan to use for this payment attempt. This parameter can only
+           * be provided during confirmation.
+           */
+          public Builder setPlan(Plan plan) {
+            this.plan = plan;
+            return this;
+          }
+
+          /**
+           * The selected installment plan to use for this payment attempt. This parameter can only
+           * be provided during confirmation.
+           */
+          public Builder setPlan(EmptyParam plan) {
+            this.plan = plan;
+            return this;
+          }
+        }
+
+        @Getter
+        public static class Plan {
+          /**
+           * For {@code fixed_count} installment plans, this is the number of installment payments
+           * your customer will make to their credit card.
+           */
+          @SerializedName("count")
+          Long count;
+
+          /**
+           * Map of extra parameters for custom features not available in this client library. The
+           * content in this map is not serialized under this field's {@code @SerializedName} value.
+           * Instead, each key/value pair is serialized as if the key is a root-level field
+           * (serialized) name in this param object. Effectively, this map is flattened to its
+           * parent instance.
+           */
+          @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+          Map<String, Object> extraParams;
+
+          /**
+           * For {@code fixed_count} installment plans, this is the interval between installment
+           * payments your customer will make to their credit card. One of {@code month}.
+           */
+          @SerializedName("interval")
+          Interval interval;
+
+          /** Type of installment plan, one of {@code fixed_count}. */
+          @SerializedName("type")
+          Type type;
+
+          private Plan(Long count, Map<String, Object> extraParams, Interval interval, Type type) {
+            this.count = count;
+            this.extraParams = extraParams;
+            this.interval = interval;
+            this.type = type;
+          }
+
+          public static Builder builder() {
+            return new Builder();
+          }
+
+          public static class Builder {
+            private Long count;
+
+            private Map<String, Object> extraParams;
+
+            private Interval interval;
+
+            private Type type;
+
+            /** Finalize and obtain parameter instance from this builder. */
+            public Plan build() {
+              return new Plan(this.count, this.extraParams, this.interval, this.type);
+            }
+
+            /**
+             * For {@code fixed_count} installment plans, this is the number of installment payments
+             * your customer will make to their credit card.
+             */
+            public Builder setCount(Long count) {
+              this.count = count;
+              return this;
+            }
+
+            /**
+             * Add a key/value pair to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * PaymentIntentUpdateParams.PaymentMethodOptions.Card.Installments.Plan#extraParams}
+             * for the field documentation.
+             */
+            public Builder putExtraParam(String key, Object value) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.put(key, value);
+              return this;
+            }
+
+            /**
+             * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * PaymentIntentUpdateParams.PaymentMethodOptions.Card.Installments.Plan#extraParams}
+             * for the field documentation.
+             */
+            public Builder putAllExtraParam(Map<String, Object> map) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.putAll(map);
+              return this;
+            }
+
+            /**
+             * For {@code fixed_count} installment plans, this is the interval between installment
+             * payments your customer will make to their credit card. One of {@code month}.
+             */
+            public Builder setInterval(Interval interval) {
+              this.interval = interval;
+              return this;
+            }
+
+            /** Type of installment plan, one of {@code fixed_count}. */
+            public Builder setType(Type type) {
+              this.type = type;
+              return this;
+            }
+          }
+
+          public enum Interval implements ApiRequestParams.EnumParam {
+            @SerializedName("month")
+            MONTH("month");
+
+            @Getter(onMethod_ = {@Override})
+            private final String value;
+
+            Interval(String value) {
+              this.value = value;
+            }
+          }
+
+          public enum Type implements ApiRequestParams.EnumParam {
+            @SerializedName("fixed_count")
+            FIXED_COUNT("fixed_count");
+
+            @Getter(onMethod_ = {@Override})
+            private final String value;
+
+            Type(String value) {
+              this.value = value;
+            }
+          }
+        }
+      }
+
+      public enum RequestThreeDSecure implements ApiRequestParams.EnumParam {
+        @SerializedName("any")
+        ANY("any"),
+
+        @SerializedName("automatic")
+        AUTOMATIC("automatic");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        RequestThreeDSecure(String value) {
+          this.value = value;
+        }
+      }
     }
   }
 

--- a/src/main/java/com/stripe/param/PaymentMethodCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentMethodCreateParams.java
@@ -11,7 +11,7 @@ import lombok.Getter;
 @Getter
 public class PaymentMethodCreateParams extends ApiRequestParams {
   /**
-   * If this is a {@code au_becs_debit} PaymentMethod, this hash contains details about the bank
+   * If this is an {@code au_becs_debit} PaymentMethod, this hash contains details about the bank
    * account.
    */
   @SerializedName("au_becs_debit")
@@ -170,7 +170,7 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
     }
 
     /**
-     * If this is a {@code au_becs_debit} PaymentMethod, this hash contains details about the bank
+     * If this is an {@code au_becs_debit} PaymentMethod, this hash contains details about the bank
      * account.
      */
     public Builder setAuBecsDebit(AuBecsDebit auBecsDebit) {

--- a/src/main/java/com/stripe/param/PaymentMethodListParams.java
+++ b/src/main/java/com/stripe/param/PaymentMethodListParams.java
@@ -207,6 +207,9 @@ public class PaymentMethodListParams extends ApiRequestParams {
     @SerializedName("card_present")
     CARD_PRESENT("card_present"),
 
+    @SerializedName("fpx")
+    FPX("fpx"),
+
     @SerializedName("ideal")
     IDEAL("ideal"),
 

--- a/src/main/java/com/stripe/param/PayoutCreateParams.java
+++ b/src/main/java/com/stripe/param/PayoutCreateParams.java
@@ -66,7 +66,7 @@ public class PayoutCreateParams extends ApiRequestParams {
   /**
    * The balance type of your Stripe balance to draw this payout from. Balances for different
    * payment sources are kept separately. You can find the amounts with the balances API. One of
-   * {@code bank_account} or {@code card}.
+   * {@code bank_account}, {@code card}, or {@code fpx}.
    */
   @SerializedName("source_type")
   SourceType sourceType;
@@ -266,7 +266,7 @@ public class PayoutCreateParams extends ApiRequestParams {
     /**
      * The balance type of your Stripe balance to draw this payout from. Balances for different
      * payment sources are kept separately. You can find the amounts with the balances API. One of
-     * {@code bank_account} or {@code card}.
+     * {@code bank_account}, {@code card}, or {@code fpx}.
      */
     public Builder setSourceType(SourceType sourceType) {
       this.sourceType = sourceType;
@@ -305,7 +305,10 @@ public class PayoutCreateParams extends ApiRequestParams {
     BANK_ACCOUNT("bank_account"),
 
     @SerializedName("card")
-    CARD("card");
+    CARD("card"),
+
+    @SerializedName("fpx")
+    FPX("fpx");
 
     @Getter(onMethod_ = {@Override})
     private final String value;

--- a/src/main/java/com/stripe/param/PlanCreateParams.java
+++ b/src/main/java/com/stripe/param/PlanCreateParams.java
@@ -17,10 +17,10 @@ public class PlanCreateParams extends ApiRequestParams {
 
   /**
    * Specifies a usage aggregation strategy for plans of {@code usage_type=metered}. Allowed values
-   * are {@code sum} for summing up all usage during a period, {@code last_during_period} for
-   * picking the last usage record reported within a period, {@code last_ever} for picking the last
-   * usage record ever (across period bounds) or {@code max} which picks the usage record with the
-   * maximum reported usage during a period. Defaults to {@code sum}.
+   * are {@code sum} for summing up all usage during a period, {@code last_during_period} for using
+   * the last usage record reported within a period, {@code last_ever} for using the last usage
+   * record ever (across period bounds) or {@code max} which uses the usage record with the maximum
+   * reported usage during a period. Defaults to {@code sum}.
    */
   @SerializedName("aggregate_usage")
   AggregateUsage aggregateUsage;
@@ -139,10 +139,10 @@ public class PlanCreateParams extends ApiRequestParams {
   Long trialPeriodDays;
 
   /**
-   * Configures how the quantity per period should be determined, can be either {@code metered} or
-   * {@code licensed}. {@code licensed} will automatically bill the {@code quantity} set for a plan
-   * when adding it to a subscription, {@code metered} will aggregate the total usage based on usage
-   * records. Defaults to {@code licensed}.
+   * Configures how the quantity per period should be determined. Can be either {@code metered} or
+   * {@code licensed}. {@code licensed} automatically bills the {@code quantity} set when adding it
+   * to a subscription. {@code metered} aggregates the total usage based on usage records. Defaults
+   * to {@code licensed}.
    */
   @SerializedName("usage_type")
   UsageType usageType;
@@ -264,9 +264,9 @@ public class PlanCreateParams extends ApiRequestParams {
     /**
      * Specifies a usage aggregation strategy for plans of {@code usage_type=metered}. Allowed
      * values are {@code sum} for summing up all usage during a period, {@code last_during_period}
-     * for picking the last usage record reported within a period, {@code last_ever} for picking the
-     * last usage record ever (across period bounds) or {@code max} which picks the usage record
-     * with the maximum reported usage during a period. Defaults to {@code sum}.
+     * for using the last usage record reported within a period, {@code last_ever} for using the
+     * last usage record ever (across period bounds) or {@code max} which uses the usage record with
+     * the maximum reported usage during a period. Defaults to {@code sum}.
      */
     public Builder setAggregateUsage(AggregateUsage aggregateUsage) {
       this.aggregateUsage = aggregateUsage;
@@ -492,10 +492,10 @@ public class PlanCreateParams extends ApiRequestParams {
     }
 
     /**
-     * Configures how the quantity per period should be determined, can be either {@code metered} or
-     * {@code licensed}. {@code licensed} will automatically bill the {@code quantity} set for a
-     * plan when adding it to a subscription, {@code metered} will aggregate the total usage based
-     * on usage records. Defaults to {@code licensed}.
+     * Configures how the quantity per period should be determined. Can be either {@code metered} or
+     * {@code licensed}. {@code licensed} automatically bills the {@code quantity} set when adding
+     * it to a subscription. {@code metered} aggregates the total usage based on usage records.
+     * Defaults to {@code licensed}.
      */
     public Builder setUsageType(UsageType usageType) {
       this.usageType = usageType;

--- a/src/main/java/com/stripe/param/SetupIntentUpdateParams.java
+++ b/src/main/java/com/stripe/param/SetupIntentUpdateParams.java
@@ -53,6 +53,10 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
   @SerializedName("payment_method")
   Object paymentMethod;
 
+  /** Payment-method-specific configuration for this SetupIntent. */
+  @SerializedName("payment_method_options")
+  PaymentMethodOptions paymentMethodOptions;
+
   /**
    * The list of payment method types (e.g. card) that this SetupIntent is allowed to set up. If
    * this is not provided, defaults to [&quot;card&quot;].
@@ -67,6 +71,7 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
       Map<String, Object> extraParams,
       Map<String, String> metadata,
       Object paymentMethod,
+      PaymentMethodOptions paymentMethodOptions,
       List<String> paymentMethodTypes) {
     this.customer = customer;
     this.description = description;
@@ -74,6 +79,7 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
     this.extraParams = extraParams;
     this.metadata = metadata;
     this.paymentMethod = paymentMethod;
+    this.paymentMethodOptions = paymentMethodOptions;
     this.paymentMethodTypes = paymentMethodTypes;
   }
 
@@ -94,6 +100,8 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
 
     private Object paymentMethod;
 
+    private PaymentMethodOptions paymentMethodOptions;
+
     private List<String> paymentMethodTypes;
 
     /** Finalize and obtain parameter instance from this builder. */
@@ -105,6 +113,7 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
           this.extraParams,
           this.metadata,
           this.paymentMethod,
+          this.paymentMethodOptions,
           this.paymentMethodTypes);
     }
 
@@ -240,6 +249,12 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
       return this;
     }
 
+    /** Payment-method-specific configuration for this SetupIntent. */
+    public Builder setPaymentMethodOptions(PaymentMethodOptions paymentMethodOptions) {
+      this.paymentMethodOptions = paymentMethodOptions;
+      return this;
+    }
+
     /**
      * Add an element to `paymentMethodTypes` list. A list is initialized for the first `add/addAll`
      * call, and subsequent calls adds additional elements to the original list. See {@link
@@ -264,6 +279,202 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
       }
       this.paymentMethodTypes.addAll(elements);
       return this;
+    }
+  }
+
+  @Getter
+  public static class PaymentMethodOptions {
+    /** Configuration for any card setup attempted on this SetupIntent. */
+    @SerializedName("card")
+    Card card;
+
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    private PaymentMethodOptions(Card card, Map<String, Object> extraParams) {
+      this.card = card;
+      this.extraParams = extraParams;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Card card;
+
+      private Map<String, Object> extraParams;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public PaymentMethodOptions build() {
+        return new PaymentMethodOptions(this.card, this.extraParams);
+      }
+
+      /** Configuration for any card setup attempted on this SetupIntent. */
+      public Builder setCard(Card card) {
+        this.card = card;
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * SetupIntentUpdateParams.PaymentMethodOptions#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link SetupIntentUpdateParams.PaymentMethodOptions#extraParams} for the field
+       * documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+    }
+
+    @Getter
+    public static class Card {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /**
+       * When specified, this parameter signals that a card has been collected as MOTO (Mail Order
+       * Telephone Order) and thus out of scope for SCA. This parameter can only be provided during
+       * confirmation.
+       */
+      @SerializedName("moto")
+      Boolean moto;
+
+      /**
+       * We strongly recommend that you rely on our SCA Engine to automatically prompt your
+       * customers for authentication based on risk level and <a
+       * href="https://stripe.com/docs/strong-customer-authentication">other requirements</a>.
+       * However, if you wish to request 3D Secure based on logic from your own fraud engine,
+       * provide this option. Permitted values include: {@code automatic} or {@code any}. If not
+       * provided, defaults to {@code automatic}. Read our guide on <a
+       * href="https://stripe.com/docs/payments/3d-secure#manual-three-ds">manually requesting 3D
+       * Secure</a> for more information on how this configuration interacts with Radar and our SCA
+       * Engine.
+       */
+      @SerializedName("request_three_d_secure")
+      RequestThreeDSecure requestThreeDSecure;
+
+      private Card(
+          Map<String, Object> extraParams, Boolean moto, RequestThreeDSecure requestThreeDSecure) {
+        this.extraParams = extraParams;
+        this.moto = moto;
+        this.requestThreeDSecure = requestThreeDSecure;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private Boolean moto;
+
+        private RequestThreeDSecure requestThreeDSecure;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Card build() {
+          return new Card(this.extraParams, this.moto, this.requestThreeDSecure);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link SetupIntentUpdateParams.PaymentMethodOptions.Card#extraParams} for the
+         * field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link SetupIntentUpdateParams.PaymentMethodOptions.Card#extraParams} for the
+         * field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /**
+         * When specified, this parameter signals that a card has been collected as MOTO (Mail Order
+         * Telephone Order) and thus out of scope for SCA. This parameter can only be provided
+         * during confirmation.
+         */
+        public Builder setMoto(Boolean moto) {
+          this.moto = moto;
+          return this;
+        }
+
+        /**
+         * We strongly recommend that you rely on our SCA Engine to automatically prompt your
+         * customers for authentication based on risk level and <a
+         * href="https://stripe.com/docs/strong-customer-authentication">other requirements</a>.
+         * However, if you wish to request 3D Secure based on logic from your own fraud engine,
+         * provide this option. Permitted values include: {@code automatic} or {@code any}. If not
+         * provided, defaults to {@code automatic}. Read our guide on <a
+         * href="https://stripe.com/docs/payments/3d-secure#manual-three-ds">manually requesting 3D
+         * Secure</a> for more information on how this configuration interacts with Radar and our
+         * SCA Engine.
+         */
+        public Builder setRequestThreeDSecure(RequestThreeDSecure requestThreeDSecure) {
+          this.requestThreeDSecure = requestThreeDSecure;
+          return this;
+        }
+      }
+
+      public enum RequestThreeDSecure implements ApiRequestParams.EnumParam {
+        @SerializedName("any")
+        ANY("any"),
+
+        @SerializedName("automatic")
+        AUTOMATIC("automatic");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        RequestThreeDSecure(String value) {
+          this.value = value;
+        }
+      }
     }
   }
 }

--- a/src/main/java/com/stripe/param/TransferCreateParams.java
+++ b/src/main/java/com/stripe/param/TransferCreateParams.java
@@ -63,8 +63,8 @@ public class TransferCreateParams extends ApiRequestParams {
   String sourceTransaction;
 
   /**
-   * The source balance to use for this transfer. One of {@code bank_account} or {@code card}. For
-   * most users, this will default to {@code card}.
+   * The source balance to use for this transfer. One of {@code bank_account}, {@code card}, or
+   * {@code fpx}. For most users, this will default to {@code card}.
    */
   @SerializedName("source_type")
   SourceType sourceType;
@@ -259,8 +259,8 @@ public class TransferCreateParams extends ApiRequestParams {
     }
 
     /**
-     * The source balance to use for this transfer. One of {@code bank_account} or {@code card}. For
-     * most users, this will default to {@code card}.
+     * The source balance to use for this transfer. One of {@code bank_account}, {@code card}, or
+     * {@code fpx}. For most users, this will default to {@code card}.
      */
     public Builder setSourceType(SourceType sourceType) {
       this.sourceType = sourceType;
@@ -283,7 +283,10 @@ public class TransferCreateParams extends ApiRequestParams {
     BANK_ACCOUNT("bank_account"),
 
     @SerializedName("card")
-    CARD("card");
+    CARD("card"),
+
+    @SerializedName("fpx")
+    FPX("fpx");
 
     @Getter(onMethod_ = {@Override})
     private final String value;

--- a/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
+++ b/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
@@ -1924,6 +1924,9 @@ public class SessionCreateParams extends ApiRequestParams {
     @SerializedName("card")
     CARD("card"),
 
+    @SerializedName("fpx")
+    FPX("fpx"),
+
     @SerializedName("ideal")
     IDEAL("ideal");
 


### PR DESCRIPTION
Multiple API changes
* Add `fpx` as a valid `source_type` on `Balance`, `Payout` and `Transfer`
* Add `fpx` support on Checkout `Session`
* Fields inside `verification_data` on Issuing `Authorization` are now enums
* Support updating `payment_method_options` on `PaymentIntent` and `SetupIntent`

Codegen for openapi 9f798bd

r? @ob-stripe 
cc @stripe/api-libraries 