### PR TITLE
Fix Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ notifications:
 script:
   - ./gradlew --version
   - ./gradlew clean
-  - if [ "$TRAVIS_JDK_VERSION" == "openjdk8" ]; then ./gradlew check; fi
+  - ./gradlew check
   - ./gradlew -Djdk.tls.client.protocols="TLSv1.2" jacocoTestReport coveralls
 
 before_cache:


### PR DESCRIPTION
r? @ob-stripe 
cc @brandur-stripe @richardm-stripe @remi-stripe 

I think I broke CI back in #891 🤦‍♂

The `cobertura` command implied `test`, but the `jacocoTestReport` command doesn't. So tests were only run with JDK8 (because `check` does imply `test`). Because just running the test is so fast compared to the rest of the build process, Travis build times weren't significantly affected.
