### PR TITLE
Move the library to the latest API version `2020-03-02` and related changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 env:
   global:
     # If changing this number, please also change it in `BaseStripeTest.java`.
-  - STRIPE_MOCK_VERSION=0.79.0
+  - STRIPE_MOCK_VERSION=0.83.0
 
 matrix:
   include:

--- a/src/main/java/com/stripe/Stripe.java
+++ b/src/main/java/com/stripe/Stripe.java
@@ -9,7 +9,7 @@ public abstract class Stripe {
   public static final int DEFAULT_CONNECT_TIMEOUT = 30 * 1000;
   public static final int DEFAULT_READ_TIMEOUT = 80 * 1000;
 
-  public static final String API_VERSION = "2019-12-03";
+  public static final String API_VERSION = "2020-03-02";
   public static final String CONNECT_API_BASE = "https://connect.stripe.com";
   public static final String LIVE_API_BASE = "https://api.stripe.com";
   public static final String UPLOAD_API_BASE = "https://files.stripe.com";

--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -1632,7 +1632,7 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
        * ambank}, {@code bank_islam}, {@code bank_muamalat}, {@code bank_rakyat}, {@code bsn},
        * {@code cimb}, {@code hong_leong_bank}, {@code hsbc}, {@code kfh}, {@code maybank2u}, {@code
        * ocbc}, {@code public_bank}, {@code rhb}, {@code standard_chartered}, {@code uob}, {@code
-       * deutsche_bank}, {@code maybank2e}, {@code pb_enterprise}, or {@code uob_regional}.
+       * deutsche_bank}, {@code maybank2e}, or {@code pb_enterprise}.
        */
       @SerializedName("bank")
       String bank;

--- a/src/main/java/com/stripe/model/Customer.java
+++ b/src/main/java/com/stripe/model/Customer.java
@@ -112,6 +112,10 @@ public class Customer extends ApiResource implements HasId, MetadataStore<Custom
   @SerializedName("name")
   String name;
 
+  /** The suffix of the customer's next invoice number, e.g., 0001. */
+  @SerializedName("next_invoice_sequence")
+  Long nextInvoiceSequence;
+
   /**
    * String representing the object's type. Objects of the same type share the same value.
    *

--- a/src/main/java/com/stripe/model/PaymentMethod.java
+++ b/src/main/java/com/stripe/model/PaymentMethod.java
@@ -649,7 +649,7 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
      * {@code ambank}, {@code bank_islam}, {@code bank_muamalat}, {@code bank_rakyat}, {@code bsn},
      * {@code cimb}, {@code hong_leong_bank}, {@code hsbc}, {@code kfh}, {@code maybank2u}, {@code
      * ocbc}, {@code public_bank}, {@code rhb}, {@code standard_chartered}, {@code uob}, {@code
-     * deutsche_bank}, {@code maybank2e}, {@code pb_enterprise}, or {@code uob_regional}.
+     * deutsche_bank}, {@code maybank2e}, or {@code pb_enterprise}.
      */
     @SerializedName("bank")
     String bank;

--- a/src/main/java/com/stripe/param/CustomerCreateParams.java
+++ b/src/main/java/com/stripe/param/CustomerCreateParams.java
@@ -78,6 +78,10 @@ public class CustomerCreateParams extends ApiRequestParams {
   @SerializedName("name")
   String name;
 
+  /** The sequence to be used on the customer's next invoice. Defaults to 1. */
+  @SerializedName("next_invoice_sequence")
+  Long nextInvoiceSequence;
+
   @SerializedName("payment_method")
   String paymentMethod;
 
@@ -116,6 +120,7 @@ public class CustomerCreateParams extends ApiRequestParams {
       InvoiceSettings invoiceSettings,
       Map<String, String> metadata,
       String name,
+      Long nextInvoiceSequence,
       String paymentMethod,
       String phone,
       List<String> preferredLocales,
@@ -134,6 +139,7 @@ public class CustomerCreateParams extends ApiRequestParams {
     this.invoiceSettings = invoiceSettings;
     this.metadata = metadata;
     this.name = name;
+    this.nextInvoiceSequence = nextInvoiceSequence;
     this.paymentMethod = paymentMethod;
     this.phone = phone;
     this.preferredLocales = preferredLocales;
@@ -170,6 +176,8 @@ public class CustomerCreateParams extends ApiRequestParams {
 
     private String name;
 
+    private Long nextInvoiceSequence;
+
     private String paymentMethod;
 
     private String phone;
@@ -198,6 +206,7 @@ public class CustomerCreateParams extends ApiRequestParams {
           this.invoiceSettings,
           this.metadata,
           this.name,
+          this.nextInvoiceSequence,
           this.paymentMethod,
           this.phone,
           this.preferredLocales,
@@ -348,6 +357,12 @@ public class CustomerCreateParams extends ApiRequestParams {
     /** The customer's full name or business name. */
     public Builder setName(String name) {
       this.name = name;
+      return this;
+    }
+
+    /** The sequence to be used on the customer's next invoice. Defaults to 1. */
+    public Builder setNextInvoiceSequence(Long nextInvoiceSequence) {
+      this.nextInvoiceSequence = nextInvoiceSequence;
       return this;
     }
 

--- a/src/main/java/com/stripe/param/CustomerUpdateParams.java
+++ b/src/main/java/com/stripe/param/CustomerUpdateParams.java
@@ -92,6 +92,10 @@ public class CustomerUpdateParams extends ApiRequestParams {
   @SerializedName("name")
   Object name;
 
+  /** The sequence to be used on the customer's next invoice. Defaults to 1. */
+  @SerializedName("next_invoice_sequence")
+  Long nextInvoiceSequence;
+
   /** The customer's phone number. */
   @SerializedName("phone")
   Object phone;
@@ -134,6 +138,7 @@ public class CustomerUpdateParams extends ApiRequestParams {
       InvoiceSettings invoiceSettings,
       Map<String, String> metadata,
       Object name,
+      Long nextInvoiceSequence,
       Object phone,
       List<String> preferredLocales,
       Object shipping,
@@ -152,6 +157,7 @@ public class CustomerUpdateParams extends ApiRequestParams {
     this.invoiceSettings = invoiceSettings;
     this.metadata = metadata;
     this.name = name;
+    this.nextInvoiceSequence = nextInvoiceSequence;
     this.phone = phone;
     this.preferredLocales = preferredLocales;
     this.shipping = shipping;
@@ -189,6 +195,8 @@ public class CustomerUpdateParams extends ApiRequestParams {
 
     private Object name;
 
+    private Long nextInvoiceSequence;
+
     private Object phone;
 
     private List<String> preferredLocales;
@@ -216,6 +224,7 @@ public class CustomerUpdateParams extends ApiRequestParams {
           this.invoiceSettings,
           this.metadata,
           this.name,
+          this.nextInvoiceSequence,
           this.phone,
           this.preferredLocales,
           this.shipping,
@@ -437,6 +446,12 @@ public class CustomerUpdateParams extends ApiRequestParams {
     /** The customer's full name or business name. */
     public Builder setName(EmptyParam name) {
       this.name = name;
+      return this;
+    }
+
+    /** The sequence to be used on the customer's next invoice. Defaults to 1. */
+    public Builder setNextInvoiceSequence(Long nextInvoiceSequence) {
+      this.nextInvoiceSequence = nextInvoiceSequence;
       return this;
     }
 

--- a/src/main/java/com/stripe/param/PaymentMethodCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentMethodCreateParams.java
@@ -1014,10 +1014,7 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
       STANDARD_CHARTERED("standard_chartered"),
 
       @SerializedName("uob")
-      UOB("uob"),
-
-      @SerializedName("uob_regional")
-      UOB_REGIONAL("uob_regional");
+      UOB("uob");
 
       @Getter(onMethod_ = {@Override})
       private final String value;

--- a/src/main/java/com/stripe/param/SubscriptionItemCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionItemCreateParams.java
@@ -69,11 +69,9 @@ public class SubscriptionItemCreateParams extends ApiRequestParams {
   String plan;
 
   /**
-   * Flag indicating whether to <a
-   * href="https://stripe.com/docs/billing/subscriptions/prorations">prorate</a> switching plans
-   * during a billing cycle. This field has been deprecated and will be removed in a future API
-   * version. Use {@code proration_behavior=create_prorations} as a replacement for {@code
-   * prorate=true} and {@code proration_behavior=none} for {@code prorate=false}.
+   * This field has been renamed to {@code proration_behavior}. {@code prorate=true} can be replaced
+   * with {@code proration_behavior=create_prorations} and {@code prorate=false} can be replaced
+   * with {@code proration_behavior=none}.
    */
   @SerializedName("prorate")
   Boolean prorate;
@@ -324,11 +322,9 @@ public class SubscriptionItemCreateParams extends ApiRequestParams {
     }
 
     /**
-     * Flag indicating whether to <a
-     * href="https://stripe.com/docs/billing/subscriptions/prorations">prorate</a> switching plans
-     * during a billing cycle. This field has been deprecated and will be removed in a future API
-     * version. Use {@code proration_behavior=create_prorations} as a replacement for {@code
-     * prorate=true} and {@code proration_behavior=none} for {@code prorate=false}.
+     * This field has been renamed to {@code proration_behavior}. {@code prorate=true} can be
+     * replaced with {@code proration_behavior=create_prorations} and {@code prorate=false} can be
+     * replaced with {@code proration_behavior=none}.
      */
     public Builder setProrate(Boolean prorate) {
       this.prorate = prorate;

--- a/src/main/java/com/stripe/param/SubscriptionItemDeleteParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionItemDeleteParams.java
@@ -25,12 +25,30 @@ public class SubscriptionItemDeleteParams extends ApiRequestParams {
   Map<String, Object> extraParams;
 
   /**
-   * Flag indicating whether to <a
-   * href="https://stripe.com/docs/billing/subscriptions/prorations">prorate</a> switching plans
-   * during a billing cycle.
+   * This field has been renamed to {@code proration_behavior}. {@code prorate=true} can be replaced
+   * with {@code proration_behavior=create_prorations} and {@code prorate=false} can be replaced
+   * with {@code proration_behavior=none}.
    */
   @SerializedName("prorate")
   Boolean prorate;
+
+  /**
+   * Determines how to handle <a
+   * href="https://stripe.com/docs/subscriptions/billing-cycle#prorations">prorations</a> when the
+   * billing cycle changes (e.g., when switching plans, resetting {@code billing_cycle_anchor=now},
+   * or starting a trial), or if an item's {@code quantity} changes. Valid values are {@code
+   * create_prorations}, {@code none}, or {@code always_invoice}.
+   *
+   * <p>Passing {@code create_prorations} will cause proration invoice items to be created when
+   * applicable. These proration items will only be invoiced immediately under <a
+   * href="https://stripe.com/docs/subscriptions/upgrading-downgrading#immediate-payment">certain
+   * conditions</a>. In order to always invoice immediately for prorations, pass {@code
+   * always_invoice}.
+   *
+   * <p>Prorations can be disabled by passing {@code none}.
+   */
+  @SerializedName("proration_behavior")
+  ProrationBehavior prorationBehavior;
 
   /**
    * If set, the proration will be calculated as though the subscription was updated at the given
@@ -41,10 +59,15 @@ public class SubscriptionItemDeleteParams extends ApiRequestParams {
   Long prorationDate;
 
   private SubscriptionItemDeleteParams(
-      Boolean clearUsage, Map<String, Object> extraParams, Boolean prorate, Long prorationDate) {
+      Boolean clearUsage,
+      Map<String, Object> extraParams,
+      Boolean prorate,
+      ProrationBehavior prorationBehavior,
+      Long prorationDate) {
     this.clearUsage = clearUsage;
     this.extraParams = extraParams;
     this.prorate = prorate;
+    this.prorationBehavior = prorationBehavior;
     this.prorationDate = prorationDate;
   }
 
@@ -59,12 +82,18 @@ public class SubscriptionItemDeleteParams extends ApiRequestParams {
 
     private Boolean prorate;
 
+    private ProrationBehavior prorationBehavior;
+
     private Long prorationDate;
 
     /** Finalize and obtain parameter instance from this builder. */
     public SubscriptionItemDeleteParams build() {
       return new SubscriptionItemDeleteParams(
-          this.clearUsage, this.extraParams, this.prorate, this.prorationDate);
+          this.clearUsage,
+          this.extraParams,
+          this.prorate,
+          this.prorationBehavior,
+          this.prorationDate);
     }
 
     /**
@@ -103,12 +132,32 @@ public class SubscriptionItemDeleteParams extends ApiRequestParams {
     }
 
     /**
-     * Flag indicating whether to <a
-     * href="https://stripe.com/docs/billing/subscriptions/prorations">prorate</a> switching plans
-     * during a billing cycle.
+     * This field has been renamed to {@code proration_behavior}. {@code prorate=true} can be
+     * replaced with {@code proration_behavior=create_prorations} and {@code prorate=false} can be
+     * replaced with {@code proration_behavior=none}.
      */
     public Builder setProrate(Boolean prorate) {
       this.prorate = prorate;
+      return this;
+    }
+
+    /**
+     * Determines how to handle <a
+     * href="https://stripe.com/docs/subscriptions/billing-cycle#prorations">prorations</a> when the
+     * billing cycle changes (e.g., when switching plans, resetting {@code
+     * billing_cycle_anchor=now}, or starting a trial), or if an item's {@code quantity} changes.
+     * Valid values are {@code create_prorations}, {@code none}, or {@code always_invoice}.
+     *
+     * <p>Passing {@code create_prorations} will cause proration invoice items to be created when
+     * applicable. These proration items will only be invoiced immediately under <a
+     * href="https://stripe.com/docs/subscriptions/upgrading-downgrading#immediate-payment">certain
+     * conditions</a>. In order to always invoice immediately for prorations, pass {@code
+     * always_invoice}.
+     *
+     * <p>Prorations can be disabled by passing {@code none}.
+     */
+    public Builder setProrationBehavior(ProrationBehavior prorationBehavior) {
+      this.prorationBehavior = prorationBehavior;
       return this;
     }
 
@@ -120,6 +169,24 @@ public class SubscriptionItemDeleteParams extends ApiRequestParams {
     public Builder setProrationDate(Long prorationDate) {
       this.prorationDate = prorationDate;
       return this;
+    }
+  }
+
+  public enum ProrationBehavior implements ApiRequestParams.EnumParam {
+    @SerializedName("always_invoice")
+    ALWAYS_INVOICE("always_invoice"),
+
+    @SerializedName("create_prorations")
+    CREATE_PRORATIONS("create_prorations"),
+
+    @SerializedName("none")
+    NONE("none");
+
+    @Getter(onMethod_ = {@Override})
+    private final String value;
+
+    ProrationBehavior(String value) {
+      this.value = value;
     }
   }
 }

--- a/src/main/java/com/stripe/param/SubscriptionItemUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionItemUpdateParams.java
@@ -73,11 +73,9 @@ public class SubscriptionItemUpdateParams extends ApiRequestParams {
   Object plan;
 
   /**
-   * Flag indicating whether to <a
-   * href="https://stripe.com/docs/billing/subscriptions/prorations">prorate</a> switching plans
-   * during a billing cycle. This field has been deprecated and will be removed in a future API
-   * version. Use {@code proration_behavior=create_prorations} as a replacement for {@code
-   * prorate=true} and {@code proration_behavior=none} for {@code prorate=false}.
+   * This field has been renamed to {@code proration_behavior}. {@code prorate=true} can be replaced
+   * with {@code proration_behavior=create_prorations} and {@code prorate=false} can be replaced
+   * with {@code proration_behavior=none}.
    */
   @SerializedName("prorate")
   Boolean prorate;
@@ -336,11 +334,9 @@ public class SubscriptionItemUpdateParams extends ApiRequestParams {
     }
 
     /**
-     * Flag indicating whether to <a
-     * href="https://stripe.com/docs/billing/subscriptions/prorations">prorate</a> switching plans
-     * during a billing cycle. This field has been deprecated and will be removed in a future API
-     * version. Use {@code proration_behavior=create_prorations} as a replacement for {@code
-     * prorate=true} and {@code proration_behavior=none} for {@code prorate=false}.
+     * This field has been renamed to {@code proration_behavior}. {@code prorate=true} can be
+     * replaced with {@code proration_behavior=create_prorations} and {@code prorate=false} can be
+     * replaced with {@code proration_behavior=none}.
      */
     public Builder setProrate(Boolean prorate) {
       this.prorate = prorate;

--- a/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
+++ b/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
@@ -475,7 +475,10 @@ public class WebhookEndpointCreateParams extends ApiRequestParams {
     VERSION_2019_11_05("2019-11-05"),
 
     @SerializedName("2019-12-03")
-    VERSION_2019_12_03("2019-12-03");
+    VERSION_2019_12_03("2019-12-03"),
+
+    @SerializedName("2020-03-02")
+    VERSION_2020_03_02("2020-03-02");
 
     @Getter(onMethod_ = {@Override})
     private final String value;

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -33,7 +33,7 @@ import org.mockito.Mockito;
 
 public class BaseStripeTest {
   // If changing this number, please also change it in `.travis.yml`.
-  private static final String MOCK_MINIMUM_VERSION = "0.79.0";
+  private static final String MOCK_MINIMUM_VERSION = "0.83.0";
 
   private static String port;
 


### PR DESCRIPTION
Multiple API changes:
* Types are now for the API version `2020-03-02`
* Remove `uob_regional` as a value on `bank` for FPX as this is deprecated and was never used
* Add support for `next_invoice_sequence` on `Customer`
* Add support for `proration_behavior` on `SubscriptionItem` delete

r? @ob-stripe 
cc @stripe/api-libraries 
