### PR TITLE
Add support for `ThreeDSecure` on Issuing `Authorization`

### DIFF
--- a/src/main/java/com/stripe/model/Product.java
+++ b/src/main/java/com/stripe/model/Product.java
@@ -65,10 +65,7 @@ public class Product extends ApiResource implements HasId, MetadataStore<Product
   @SerializedName("id")
   String id;
 
-  /**
-   * A list of up to 8 URLs of images for this product, meant to be displayable to the customer.
-   * Only applicable to products of {@code type=good}.
-   */
+  /** A list of up to 8 URLs of images for this product, meant to be displayable to the customer. */
   @SerializedName("images")
   List<String> images;
 

--- a/src/main/java/com/stripe/model/StripeError.java
+++ b/src/main/java/com/stripe/model/StripeError.java
@@ -60,9 +60,8 @@ public class StripeError extends StripeObject {
    * throughout its lifetime as it interfaces with Stripe.js to perform authentication flows and
    * ultimately creates at most one successful charge.
    *
-   * <p>Related guide: <a
-   * href="https://stripe.com/docs/payments/payment-intents/creating-payment-intents">Payment
-   * Intents API</a>.
+   * <p>Related guide: <a href="https://stripe.com/docs/payments/payment-intents">Payment Intents
+   * API</a>.
    */
   @SerializedName("payment_intent")
   PaymentIntent paymentIntent;
@@ -101,6 +100,9 @@ public class StripeError extends StripeObject {
    *
    * <p>By using SetupIntents, you ensure that your customers experience the minimum set of required
    * friction, even as regulations change over time.
+   *
+   * <p>Related guide: <a href="https://stripe.com/docs/payments/setup-intents">Setup Intents
+   * API</a>.
    */
   @SerializedName("setup_intent")
   SetupIntent setupIntent;

--- a/src/main/java/com/stripe/model/issuing/Authorization.java
+++ b/src/main/java/com/stripe/model/issuing/Authorization.java
@@ -494,6 +494,19 @@ public class Authorization extends ApiResource
   @Getter
   @Setter
   @EqualsAndHashCode(callSuper = false)
+  public static class ThreeDSecure extends StripeObject {
+    /**
+     * The outcome of the 3D Secure authentication request.
+     *
+     * <p>One of {@code attempt_acknowledged}, {@code authenticated}, or {@code failed}.
+     */
+    @SerializedName("result")
+    String result;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
   public static class VerificationData extends StripeObject {
     /**
      * Whether the cardholder provided an address first line and if it matched the cardholder’s
@@ -514,7 +527,7 @@ public class Authorization extends ApiResource
     String addressZipCheck;
 
     /**
-     * Whether 3DS authentication was performed.
+     * [DEPRECATED] Whether 3DS authentication was performed.
      *
      * <p>One of {@code failure}, {@code none}, or {@code success}.
      */
@@ -536,5 +549,9 @@ public class Authorization extends ApiResource
      */
     @SerializedName("expiry_check")
     String expiryCheck;
+
+    /** 3D Secure details on this authorization. */
+    @SerializedName("three_d_secure")
+    ThreeDSecure threeDSecure;
   }
 }

--- a/src/main/java/com/stripe/param/issuing/DisputeListParams.java
+++ b/src/main/java/com/stripe/param/issuing/DisputeListParams.java
@@ -10,11 +10,11 @@ import lombok.Getter;
 
 @Getter
 public class DisputeListParams extends ApiRequestParams {
-  /** Only return issuing disputes that were created during the given date interval. */
+  /** Select issuing disputes that were created during the given date interval. */
   @SerializedName("created")
   Object created;
 
-  /** Only return issuing disputes for the given transaction. */
+  /** Select the issuing dispute for the given transaction. */
   @SerializedName("disputed_transaction")
   String disputedTransaction;
 
@@ -104,19 +104,19 @@ public class DisputeListParams extends ApiRequestParams {
           this.startingAfter);
     }
 
-    /** Only return issuing disputes that were created during the given date interval. */
+    /** Select issuing disputes that were created during the given date interval. */
     public Builder setCreated(Created created) {
       this.created = created;
       return this;
     }
 
-    /** Only return issuing disputes that were created during the given date interval. */
+    /** Select issuing disputes that were created during the given date interval. */
     public Builder setCreated(Long created) {
       this.created = created;
       return this;
     }
 
-    /** Only return issuing disputes for the given transaction. */
+    /** Select the issuing dispute for the given transaction. */
     public Builder setDisputedTransaction(String disputedTransaction) {
       this.disputedTransaction = disputedTransaction;
       return this;


### PR DESCRIPTION
Codegen for openapi f8c0941

Docs: https://stripe.com/docs/api/issuing/authorizations/object#issuing_authorization_object-verification_data-three_d_secure

r? @ob-stripe 
cc @stripe/api-libraries 