### PR TITLE
Multiple API changes for Issuing and other docstrings

### DIFF
--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -25,8 +25,8 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
   AlternateStatementDescriptors alternateStatementDescriptors;
 
   /**
-   * Amount intended to be collected by this PaymentIntent. A positive integer representing how much
-   * to charge in the <a href="https://stripe.com/docs/currencies#zero-decimal">smallest currency
+   * Amount intended to be collected by this payment. A positive integer representing how much to
+   * charge in the <a href="https://stripe.com/docs/currencies#zero-decimal">smallest currency
    * unit</a> (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency). The
    * minimum amount is $0.50 US or <a
    * href="https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts">equivalent in

--- a/src/main/java/com/stripe/model/IssuerFraudRecord.java
+++ b/src/main/java/com/stripe/model/IssuerFraudRecord.java
@@ -44,7 +44,7 @@ public class IssuerFraudRecord extends ApiResource implements HasId {
 
   /**
    * If true, the associated charge is subject to <a
-   * href="https://stripe.com/docs/sources/three-d-secure#disputed-payments">liability shift</a>.
+   * href="https://stripe.com/docs/payments/3d-secure#disputed-payments">liability shift</a>.
    */
   @SerializedName("has_liability_shift")
   Boolean hasLiabilityShift;

--- a/src/main/java/com/stripe/model/PaymentIntent.java
+++ b/src/main/java/com/stripe/model/PaymentIntent.java
@@ -117,9 +117,12 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
   /**
    * ID of the Customer this PaymentIntent belongs to, if one exists.
    *
-   * <p>If present, payment methods used with this PaymentIntent can only be attached to this
-   * Customer, and payment methods attached to other Customers cannot be used with this
-   * PaymentIntent.
+   * <p>Payment methods attached to other Customers cannot be used with this PaymentIntent.
+   *
+   * <p>If present in combination with <a
+   * href="https://stripe.com/docs/api#payment_intents/object#payment_intent_object-setup_future_usage">setup_future_usage</a>,
+   * this PaymentIntent's payment method will be attached to the Customer after the PaymentIntent
+   * has been confirmed and any required actions from the user are complete.
    */
   @SerializedName("customer")
   @Getter(lombok.AccessLevel.NONE)
@@ -217,9 +220,11 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
   /**
    * Indicates that you intend to make future payments with this PaymentIntent's payment method.
    *
-   * <p>If present, the payment method used with this PaymentIntent can be <a
-   * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer, even
-   * after the transaction completes.
+   * <p>Providing this parameter will attach the payment method to the PaymentIntent's Customer, if
+   * present, after the PaymentIntent is confirmed and any required actions from the user are
+   * complete. If no Customer was provided, the payment method can still be <a
+   * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer after the
+   * transaction completes.
    *
    * <p>For more, learn to <a href="https://stripe.com/docs/payments/save-during-payment">save card
    * details during payment</a>.

--- a/src/main/java/com/stripe/model/SetupIntent.java
+++ b/src/main/java/com/stripe/model/SetupIntent.java
@@ -51,8 +51,8 @@ public class SetupIntent extends ApiResource implements HasId, MetadataStore<Set
   /**
    * ID of the Customer this SetupIntent belongs to, if one exists.
    *
-   * <p>If present, payment methods used with this SetupIntent can only be attached to this
-   * Customer, and payment methods attached to other Customers cannot be used with this SetupIntent.
+   * <p>If present, the SetupIntent's payment method will be attached to the Customer on successful
+   * setup. Payment methods attached to other Customers cannot be used with this SetupIntent.
    */
   @SerializedName("customer")
   @Getter(lombok.AccessLevel.NONE)

--- a/src/main/java/com/stripe/model/StripeError.java
+++ b/src/main/java/com/stripe/model/StripeError.java
@@ -79,9 +79,9 @@ public class StripeError extends StripeObject {
   PaymentMethod paymentMethod;
 
   /**
-   * A SetupIntent guides you through the process of setting up a customer's payment credentials for
-   * future payments. For example, you could use a SetupIntent to set up your customer's card
-   * without immediately collecting a payment. Later, you can use <a
+   * A SetupIntent guides you through the process of setting up and saving a customer's payment
+   * credentials for future payments. For example, you could use a SetupIntent to set up and save
+   * your customer's card without immediately collecting a payment. Later, you can use <a
    * href="https://stripe.com/docs/api#payment_intents">PaymentIntents</a> to drive the payment
    * flow.
    *
@@ -96,7 +96,14 @@ public class StripeError extends StripeObject {
    * href="https://stripe.com/guides/strong-customer-authentication">certain regions</a> may need to
    * be run through <a href="https://stripe.com/docs/strong-customer-authentication">Strong Customer
    * Authentication</a> at the time of payment method collection in order to streamline later <a
-   * href="https://stripe.com/docs/payments/setup-intents">off-session payments</a>.
+   * href="https://stripe.com/docs/payments/setup-intents">off-session payments</a>. If the
+   * SetupIntent is used with a <a
+   * href="https://stripe.com/docs/api#setup_intents/object#setup_intent_object-customer">Customer</a>,
+   * upon success, it will automatically attach the resulting payment method to that Customer. We
+   * recommend using SetupIntents or <a
+   * href="https://stripe.com/docs/api#payment_intents/object#payment_intent_object-setup_future_usage">setup_future_usage</a>
+   * on PaymentIntents to save payment methods in order to prevent saving invalid or unoptimized
+   * payment methods.
    *
    * <p>By using SetupIntents, you ensure that your customers experience the minimum set of required
    * friction, even as regulations change over time.

--- a/src/main/java/com/stripe/model/issuing/Card.java
+++ b/src/main/java/com/stripe/model/issuing/Card.java
@@ -98,6 +98,12 @@ public class Card extends ApiResource implements HasId, MetadataStore<Card> {
   @SerializedName("pin")
   Pin pin;
 
+  /** The latest card that replaces this card, if any. */
+  @SerializedName("replaced_by")
+  @Getter(lombok.AccessLevel.NONE)
+  @Setter(lombok.AccessLevel.NONE)
+  ExpandableField<Card> replacedBy;
+
   /** The card this card replaces, if any. */
   @SerializedName("replacement_for")
   @Getter(lombok.AccessLevel.NONE)
@@ -131,6 +137,24 @@ public class Card extends ApiResource implements HasId, MetadataStore<Card> {
    */
   @SerializedName("type")
   String type;
+
+  /** Get ID of expandable {@code replacedBy} object. */
+  public String getReplacedBy() {
+    return (this.replacedBy != null) ? this.replacedBy.getId() : null;
+  }
+
+  public void setReplacedBy(String id) {
+    this.replacedBy = ApiResource.setExpandableFieldId(id, this.replacedBy);
+  }
+
+  /** Get expanded {@code replacedBy}. */
+  public Card getReplacedByObject() {
+    return (this.replacedBy != null) ? this.replacedBy.getExpanded() : null;
+  }
+
+  public void setReplacedByObject(Card expandableObject) {
+    this.replacedBy = new ExpandableField<Card>(expandableObject.getId(), expandableObject);
+  }
 
   /** Get ID of expandable {@code replacementFor} object. */
   public String getReplacementFor() {
@@ -288,7 +312,7 @@ public class Card extends ApiResource implements HasId, MetadataStore<Card> {
 
   /**
    * For virtual cards only. Retrieves an Issuing <code>card_details</code> object that contains <a
-   * href="https://stripe.com/docs/issuing/cards/management#virtual-card-info">the sensitive
+   * href="https://stripe.com/docs/issuing/cards/virtual#virtual-card-info">the sensitive
    * details</a> of a virtual card.
    */
   public CardDetails details() throws StripeException {
@@ -297,7 +321,7 @@ public class Card extends ApiResource implements HasId, MetadataStore<Card> {
 
   /**
    * For virtual cards only. Retrieves an Issuing <code>card_details</code> object that contains <a
-   * href="https://stripe.com/docs/issuing/cards/management#virtual-card-info">the sensitive
+   * href="https://stripe.com/docs/issuing/cards/virtual#virtual-card-info">the sensitive
    * details</a> of a virtual card.
    */
   public CardDetails details(Map<String, Object> params) throws StripeException {
@@ -306,7 +330,7 @@ public class Card extends ApiResource implements HasId, MetadataStore<Card> {
 
   /**
    * For virtual cards only. Retrieves an Issuing <code>card_details</code> object that contains <a
-   * href="https://stripe.com/docs/issuing/cards/management#virtual-card-info">the sensitive
+   * href="https://stripe.com/docs/issuing/cards/virtual#virtual-card-info">the sensitive
    * details</a> of a virtual card.
    */
   public CardDetails details(Map<String, Object> params, RequestOptions options)
@@ -322,7 +346,7 @@ public class Card extends ApiResource implements HasId, MetadataStore<Card> {
 
   /**
    * For virtual cards only. Retrieves an Issuing <code>card_details</code> object that contains <a
-   * href="https://stripe.com/docs/issuing/cards/management#virtual-card-info">the sensitive
+   * href="https://stripe.com/docs/issuing/cards/virtual#virtual-card-info">the sensitive
    * details</a> of a virtual card.
    */
   public CardDetails details(CardDetailsParams params) throws StripeException {
@@ -331,7 +355,7 @@ public class Card extends ApiResource implements HasId, MetadataStore<Card> {
 
   /**
    * For virtual cards only. Retrieves an Issuing <code>card_details</code> object that contains <a
-   * href="https://stripe.com/docs/issuing/cards/management#virtual-card-info">the sensitive
+   * href="https://stripe.com/docs/issuing/cards/virtual#virtual-card-info">the sensitive
    * details</a> of a virtual card.
    */
   public CardDetails details(CardDetailsParams params, RequestOptions options)

--- a/src/main/java/com/stripe/model/issuing/Cardholder.java
+++ b/src/main/java/com/stripe/model/issuing/Cardholder.java
@@ -27,7 +27,7 @@ import lombok.Setter;
 public class Cardholder extends ApiResource implements HasId, MetadataStore<Cardholder> {
   /**
    * Spending rules that give you some control over how this cardholder's cards can be used. Refer
-   * to our <a href="https://stripe.com/docs/issuing/authorizations">authorizations</a>
+   * to our <a href="https://stripe.com/docs/issuing/purchases/authorizations">authorizations</a>
    * documentation for more details.
    */
   @SerializedName("authorization_controls")

--- a/src/main/java/com/stripe/param/ChargeCreateParams.java
+++ b/src/main/java/com/stripe/param/ChargeCreateParams.java
@@ -12,8 +12,8 @@ import lombok.Getter;
 @Getter
 public class ChargeCreateParams extends ApiRequestParams {
   /**
-   * Amount intended to be collected by this PaymentIntent. A positive integer representing how much
-   * to charge in the <a href="https://stripe.com/docs/currencies#zero-decimal">smallest currency
+   * Amount intended to be collected by this payment. A positive integer representing how much to
+   * charge in the <a href="https://stripe.com/docs/currencies#zero-decimal">smallest currency
    * unit</a> (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency). The
    * minimum amount is $0.50 US or <a
    * href="https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts">equivalent in
@@ -273,10 +273,10 @@ public class ChargeCreateParams extends ApiRequestParams {
     }
 
     /**
-     * Amount intended to be collected by this PaymentIntent. A positive integer representing how
-     * much to charge in the <a href="https://stripe.com/docs/currencies#zero-decimal">smallest
-     * currency unit</a> (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal
-     * currency). The minimum amount is $0.50 US or <a
+     * Amount intended to be collected by this payment. A positive integer representing how much to
+     * charge in the <a href="https://stripe.com/docs/currencies#zero-decimal">smallest currency
+     * unit</a> (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency).
+     * The minimum amount is $0.50 US or <a
      * href="https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts">equivalent in
      * charge currency</a>. The amount value supports up to eight digits (e.g., a value of 99999999
      * for a USD charge of $999,999.99).

--- a/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
@@ -80,19 +80,17 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
   /**
    * If the PaymentIntent has a {@code payment_method} and a {@code customer} or if you're attaching
    * a payment method to the PaymentIntent in this request, you can pass {@code
-   * save_payment_method=true} to save the payment method to the customer. Defaults to {@code
-   * false}.
+   * save_payment_method=true} to save the payment method to the customer immediately.
    *
-   * <p>If the payment method is already saved to a customer, this does nothing. If this type of
-   * payment method cannot be saved to a customer, the request will error.
+   * <p>If the payment method is already saved to a customer, this parameter does nothing. If this
+   * type of payment method cannot be saved to a customer, the request will error.
    *
-   * <p><em>Note that saving a payment method using this parameter does not guarantee that the
-   * payment method can be charged.</em> To ensure that only payment methods which can be charged
-   * are saved to a customer, you can <a
-   * href="https://stripe.com/docs/api/customers/create#create_customer-source">manually save</a>
-   * the payment method in response to the <a
-   * href="https://stripe.com/docs/api/events/types#event_types-payment_intent.succeeded">{@code
-   * payment_intent.succeeded} webhook</a>.
+   * <p>Saving a payment method using this parameter is <em>not recommended</em> because it will
+   * save the payment method even if it cannot be charged (e.g. the user made a typo). To ensure
+   * that only payment methods which are likely to be chargeable are saved to a customer, use the
+   * (setup_future_usage)[#payment_intents/object#payment_intent_object-setup_future_usage]
+   * property, which saves the payment method after the PaymentIntent has been confirmed and all
+   * required actions by the customer are complete.
    */
   @SerializedName("save_payment_method")
   Boolean savePaymentMethod;
@@ -100,13 +98,14 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
   /**
    * Indicates that you intend to make future payments with this PaymentIntent's payment method.
    *
-   * <p>If present, the payment method used with this PaymentIntent can be <a
-   * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer, even
-   * after the transaction completes.
+   * <p>Providing this parameter will attach the payment method to the PaymentIntent's Customer, if
+   * present, after the PaymentIntent is confirmed and any required actions from the user are
+   * complete. If no Customer was provided, the payment method can still be <a
+   * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer after the
+   * transaction completes.
    *
-   * <p>Use {@code on_session} if you intend to only reuse the payment method when your customer is
-   * present in your checkout flow. Use {@code off_session} if your customer may or may not be in
-   * your checkout flow.
+   * <p>For more, learn to <a href="https://stripe.com/docs/payments/save-during-payment">save card
+   * details during payment</a>.
    *
    * <p>Stripe uses {@code setup_future_usage} to dynamically optimize your payment flow and comply
    * with regional legislation and network rules. For example, if your customer is impacted by <a
@@ -371,19 +370,17 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
     /**
      * If the PaymentIntent has a {@code payment_method} and a {@code customer} or if you're
      * attaching a payment method to the PaymentIntent in this request, you can pass {@code
-     * save_payment_method=true} to save the payment method to the customer. Defaults to {@code
-     * false}.
+     * save_payment_method=true} to save the payment method to the customer immediately.
      *
-     * <p>If the payment method is already saved to a customer, this does nothing. If this type of
-     * payment method cannot be saved to a customer, the request will error.
+     * <p>If the payment method is already saved to a customer, this parameter does nothing. If this
+     * type of payment method cannot be saved to a customer, the request will error.
      *
-     * <p><em>Note that saving a payment method using this parameter does not guarantee that the
-     * payment method can be charged.</em> To ensure that only payment methods which can be charged
-     * are saved to a customer, you can <a
-     * href="https://stripe.com/docs/api/customers/create#create_customer-source">manually save</a>
-     * the payment method in response to the <a
-     * href="https://stripe.com/docs/api/events/types#event_types-payment_intent.succeeded">{@code
-     * payment_intent.succeeded} webhook</a>.
+     * <p>Saving a payment method using this parameter is <em>not recommended</em> because it will
+     * save the payment method even if it cannot be charged (e.g. the user made a typo). To ensure
+     * that only payment methods which are likely to be chargeable are saved to a customer, use the
+     * (setup_future_usage)[#payment_intents/object#payment_intent_object-setup_future_usage]
+     * property, which saves the payment method after the PaymentIntent has been confirmed and all
+     * required actions by the customer are complete.
      */
     public Builder setSavePaymentMethod(Boolean savePaymentMethod) {
       this.savePaymentMethod = savePaymentMethod;
@@ -393,13 +390,14 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
     /**
      * Indicates that you intend to make future payments with this PaymentIntent's payment method.
      *
-     * <p>If present, the payment method used with this PaymentIntent can be <a
-     * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer, even
-     * after the transaction completes.
+     * <p>Providing this parameter will attach the payment method to the PaymentIntent's Customer,
+     * if present, after the PaymentIntent is confirmed and any required actions from the user are
+     * complete. If no Customer was provided, the payment method can still be <a
+     * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer after
+     * the transaction completes.
      *
-     * <p>Use {@code on_session} if you intend to only reuse the payment method when your customer
-     * is present in your checkout flow. Use {@code off_session} if your customer may or may not be
-     * in your checkout flow.
+     * <p>For more, learn to <a href="https://stripe.com/docs/payments/save-during-payment">save
+     * card details during payment</a>.
      *
      * <p>Stripe uses {@code setup_future_usage} to dynamically optimize your payment flow and
      * comply with regional legislation and network rules. For example, if your customer is impacted
@@ -421,13 +419,14 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
     /**
      * Indicates that you intend to make future payments with this PaymentIntent's payment method.
      *
-     * <p>If present, the payment method used with this PaymentIntent can be <a
-     * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer, even
-     * after the transaction completes.
+     * <p>Providing this parameter will attach the payment method to the PaymentIntent's Customer,
+     * if present, after the PaymentIntent is confirmed and any required actions from the user are
+     * complete. If no Customer was provided, the payment method can still be <a
+     * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer after
+     * the transaction completes.
      *
-     * <p>Use {@code on_session} if you intend to only reuse the payment method when your customer
-     * is present in your checkout flow. Use {@code off_session} if your customer may or may not be
-     * in your checkout flow.
+     * <p>For more, learn to <a href="https://stripe.com/docs/payments/save-during-payment">save
+     * card details during payment</a>.
      *
      * <p>Stripe uses {@code setup_future_usage} to dynamically optimize your payment flow and
      * comply with regional legislation and network rules. For example, if your customer is impacted

--- a/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
@@ -59,9 +59,12 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
   /**
    * ID of the Customer this PaymentIntent belongs to, if one exists.
    *
-   * <p>If present, payment methods used with this PaymentIntent can only be attached to this
-   * Customer, and payment methods attached to other Customers cannot be used with this
-   * PaymentIntent.
+   * <p>Payment methods attached to other Customers cannot be used with this PaymentIntent.
+   *
+   * <p>If present in combination with <a
+   * href="https://stripe.com/docs/api#payment_intents/object#payment_intent_object-setup_future_usage">setup_future_usage</a>,
+   * this PaymentIntent's payment method will be attached to the Customer after the PaymentIntent
+   * has been confirmed and any required actions from the user are complete.
    */
   @SerializedName("customer")
   String customer;
@@ -181,19 +184,17 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
   /**
    * If the PaymentIntent has a {@code payment_method} and a {@code customer} or if you're attaching
    * a payment method to the PaymentIntent in this request, you can pass {@code
-   * save_payment_method=true} to save the payment method to the customer. Defaults to {@code
-   * false}.
+   * save_payment_method=true} to save the payment method to the customer immediately.
    *
-   * <p>If the payment method is already saved to a customer, this does nothing. If this type of
-   * payment method cannot be saved to a customer, the request will error.
+   * <p>If the payment method is already saved to a customer, this parameter does nothing. If this
+   * type of payment method cannot be saved to a customer, the request will error.
    *
-   * <p><em>Note that saving a payment method using this parameter does not guarantee that the
-   * payment method can be charged.</em> To ensure that only payment methods which can be charged
-   * are saved to a customer, you can <a
-   * href="https://stripe.com/docs/api/customers/create#create_customer-source">manually save</a>
-   * the payment method in response to the <a
-   * href="https://stripe.com/docs/api/events/types#event_types-payment_intent.succeeded">{@code
-   * payment_intent.succeeded} webhook</a>.
+   * <p>Saving a payment method using this parameter is <em>not recommended</em> because it will
+   * save the payment method even if it cannot be charged (e.g. the user made a typo). To ensure
+   * that only payment methods which are likely to be chargeable are saved to a customer, use the
+   * (setup_future_usage)[#payment_intents/object#payment_intent_object-setup_future_usage]
+   * property, which saves the payment method after the PaymentIntent has been confirmed and all
+   * required actions by the customer are complete.
    */
   @SerializedName("save_payment_method")
   Boolean savePaymentMethod;
@@ -201,9 +202,11 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
   /**
    * Indicates that you intend to make future payments with this PaymentIntent's payment method.
    *
-   * <p>If present, the payment method used with this PaymentIntent can be <a
-   * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer, even
-   * after the transaction completes.
+   * <p>Providing this parameter will attach the payment method to the PaymentIntent's Customer, if
+   * present, after the PaymentIntent is confirmed and any required actions from the user are
+   * complete. If no Customer was provided, the payment method can still be <a
+   * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer after the
+   * transaction completes.
    *
    * <p>For more, learn to <a href="https://stripe.com/docs/payments/save-during-payment">save card
    * details during payment</a>.
@@ -500,9 +503,12 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     /**
      * ID of the Customer this PaymentIntent belongs to, if one exists.
      *
-     * <p>If present, payment methods used with this PaymentIntent can only be attached to this
-     * Customer, and payment methods attached to other Customers cannot be used with this
-     * PaymentIntent.
+     * <p>Payment methods attached to other Customers cannot be used with this PaymentIntent.
+     *
+     * <p>If present in combination with <a
+     * href="https://stripe.com/docs/api#payment_intents/object#payment_intent_object-setup_future_usage">setup_future_usage</a>,
+     * this PaymentIntent's payment method will be attached to the Customer after the PaymentIntent
+     * has been confirmed and any required actions from the user are complete.
      */
     public Builder setCustomer(String customer) {
       this.customer = customer;
@@ -734,19 +740,17 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     /**
      * If the PaymentIntent has a {@code payment_method} and a {@code customer} or if you're
      * attaching a payment method to the PaymentIntent in this request, you can pass {@code
-     * save_payment_method=true} to save the payment method to the customer. Defaults to {@code
-     * false}.
+     * save_payment_method=true} to save the payment method to the customer immediately.
      *
-     * <p>If the payment method is already saved to a customer, this does nothing. If this type of
-     * payment method cannot be saved to a customer, the request will error.
+     * <p>If the payment method is already saved to a customer, this parameter does nothing. If this
+     * type of payment method cannot be saved to a customer, the request will error.
      *
-     * <p><em>Note that saving a payment method using this parameter does not guarantee that the
-     * payment method can be charged.</em> To ensure that only payment methods which can be charged
-     * are saved to a customer, you can <a
-     * href="https://stripe.com/docs/api/customers/create#create_customer-source">manually save</a>
-     * the payment method in response to the <a
-     * href="https://stripe.com/docs/api/events/types#event_types-payment_intent.succeeded">{@code
-     * payment_intent.succeeded} webhook</a>.
+     * <p>Saving a payment method using this parameter is <em>not recommended</em> because it will
+     * save the payment method even if it cannot be charged (e.g. the user made a typo). To ensure
+     * that only payment methods which are likely to be chargeable are saved to a customer, use the
+     * (setup_future_usage)[#payment_intents/object#payment_intent_object-setup_future_usage]
+     * property, which saves the payment method after the PaymentIntent has been confirmed and all
+     * required actions by the customer are complete.
      */
     public Builder setSavePaymentMethod(Boolean savePaymentMethod) {
       this.savePaymentMethod = savePaymentMethod;
@@ -756,9 +760,11 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     /**
      * Indicates that you intend to make future payments with this PaymentIntent's payment method.
      *
-     * <p>If present, the payment method used with this PaymentIntent can be <a
-     * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer, even
-     * after the transaction completes.
+     * <p>Providing this parameter will attach the payment method to the PaymentIntent's Customer,
+     * if present, after the PaymentIntent is confirmed and any required actions from the user are
+     * complete. If no Customer was provided, the payment method can still be <a
+     * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer after
+     * the transaction completes.
      *
      * <p>For more, learn to <a href="https://stripe.com/docs/payments/save-during-payment">save
      * card details during payment</a>.

--- a/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
@@ -42,9 +42,12 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
   /**
    * ID of the Customer this PaymentIntent belongs to, if one exists.
    *
-   * <p>If present, payment methods used with this PaymentIntent can only be attached to this
-   * Customer, and payment methods attached to other Customers cannot be used with this
-   * PaymentIntent.
+   * <p>Payment methods attached to other Customers cannot be used with this PaymentIntent.
+   *
+   * <p>If present in combination with <a
+   * href="https://stripe.com/docs/api#payment_intents/object#payment_intent_object-setup_future_usage">setup_future_usage</a>,
+   * this PaymentIntent's payment method will be attached to the Customer after the PaymentIntent
+   * has been confirmed and any required actions from the user are complete.
    */
   @SerializedName("customer")
   Object customer;
@@ -98,19 +101,17 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
   /**
    * If the PaymentIntent has a {@code payment_method} and a {@code customer} or if you're attaching
    * a payment method to the PaymentIntent in this request, you can pass {@code
-   * save_payment_method=true} to save the payment method to the customer. Defaults to {@code
-   * false}.
+   * save_payment_method=true} to save the payment method to the customer immediately.
    *
-   * <p>If the payment method is already saved to a customer, this does nothing. If this type of
-   * payment method cannot be saved to a customer, the request will error.
+   * <p>If the payment method is already saved to a customer, this parameter does nothing. If this
+   * type of payment method cannot be saved to a customer, the request will error.
    *
-   * <p><em>Note that saving a payment method using this parameter does not guarantee that the
-   * payment method can be charged.</em> To ensure that only payment methods which can be charged
-   * are saved to a customer, you can <a
-   * href="https://stripe.com/docs/api/customers/create#create_customer-source">manually save</a>
-   * the payment method in response to the <a
-   * href="https://stripe.com/docs/api/events/types#event_types-payment_intent.succeeded">{@code
-   * payment_intent.succeeded} webhook</a>.
+   * <p>Saving a payment method using this parameter is <em>not recommended</em> because it will
+   * save the payment method even if it cannot be charged (e.g. the user made a typo). To ensure
+   * that only payment methods which are likely to be chargeable are saved to a customer, use the
+   * (setup_future_usage)[#payment_intents/object#payment_intent_object-setup_future_usage]
+   * property, which saves the payment method after the PaymentIntent has been confirmed and all
+   * required actions by the customer are complete.
    */
   @SerializedName("save_payment_method")
   Boolean savePaymentMethod;
@@ -118,13 +119,14 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
   /**
    * Indicates that you intend to make future payments with this PaymentIntent's payment method.
    *
-   * <p>If present, the payment method used with this PaymentIntent can be <a
-   * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer, even
-   * after the transaction completes.
+   * <p>Providing this parameter will attach the payment method to the PaymentIntent's Customer, if
+   * present, after the PaymentIntent is confirmed and any required actions from the user are
+   * complete. If no Customer was provided, the payment method can still be <a
+   * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer after the
+   * transaction completes.
    *
-   * <p>Use {@code on_session} if you intend to only reuse the payment method when your customer is
-   * present in your checkout flow. Use {@code off_session} if your customer may or may not be in
-   * your checkout flow.
+   * <p>For more, learn to <a href="https://stripe.com/docs/payments/save-during-payment">save card
+   * details during payment</a>.
    *
    * <p>Stripe uses {@code setup_future_usage} to dynamically optimize your payment flow and comply
    * with regional legislation and network rules. For example, if your customer is impacted by <a
@@ -356,9 +358,12 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     /**
      * ID of the Customer this PaymentIntent belongs to, if one exists.
      *
-     * <p>If present, payment methods used with this PaymentIntent can only be attached to this
-     * Customer, and payment methods attached to other Customers cannot be used with this
-     * PaymentIntent.
+     * <p>Payment methods attached to other Customers cannot be used with this PaymentIntent.
+     *
+     * <p>If present in combination with <a
+     * href="https://stripe.com/docs/api#payment_intents/object#payment_intent_object-setup_future_usage">setup_future_usage</a>,
+     * this PaymentIntent's payment method will be attached to the Customer after the PaymentIntent
+     * has been confirmed and any required actions from the user are complete.
      */
     public Builder setCustomer(String customer) {
       this.customer = customer;
@@ -368,9 +373,12 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     /**
      * ID of the Customer this PaymentIntent belongs to, if one exists.
      *
-     * <p>If present, payment methods used with this PaymentIntent can only be attached to this
-     * Customer, and payment methods attached to other Customers cannot be used with this
-     * PaymentIntent.
+     * <p>Payment methods attached to other Customers cannot be used with this PaymentIntent.
+     *
+     * <p>If present in combination with <a
+     * href="https://stripe.com/docs/api#payment_intents/object#payment_intent_object-setup_future_usage">setup_future_usage</a>,
+     * this PaymentIntent's payment method will be attached to the Customer after the PaymentIntent
+     * has been confirmed and any required actions from the user are complete.
      */
     public Builder setCustomer(EmptyParam customer) {
       this.customer = customer;
@@ -534,19 +542,17 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     /**
      * If the PaymentIntent has a {@code payment_method} and a {@code customer} or if you're
      * attaching a payment method to the PaymentIntent in this request, you can pass {@code
-     * save_payment_method=true} to save the payment method to the customer. Defaults to {@code
-     * false}.
+     * save_payment_method=true} to save the payment method to the customer immediately.
      *
-     * <p>If the payment method is already saved to a customer, this does nothing. If this type of
-     * payment method cannot be saved to a customer, the request will error.
+     * <p>If the payment method is already saved to a customer, this parameter does nothing. If this
+     * type of payment method cannot be saved to a customer, the request will error.
      *
-     * <p><em>Note that saving a payment method using this parameter does not guarantee that the
-     * payment method can be charged.</em> To ensure that only payment methods which can be charged
-     * are saved to a customer, you can <a
-     * href="https://stripe.com/docs/api/customers/create#create_customer-source">manually save</a>
-     * the payment method in response to the <a
-     * href="https://stripe.com/docs/api/events/types#event_types-payment_intent.succeeded">{@code
-     * payment_intent.succeeded} webhook</a>.
+     * <p>Saving a payment method using this parameter is <em>not recommended</em> because it will
+     * save the payment method even if it cannot be charged (e.g. the user made a typo). To ensure
+     * that only payment methods which are likely to be chargeable are saved to a customer, use the
+     * (setup_future_usage)[#payment_intents/object#payment_intent_object-setup_future_usage]
+     * property, which saves the payment method after the PaymentIntent has been confirmed and all
+     * required actions by the customer are complete.
      */
     public Builder setSavePaymentMethod(Boolean savePaymentMethod) {
       this.savePaymentMethod = savePaymentMethod;
@@ -556,13 +562,14 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     /**
      * Indicates that you intend to make future payments with this PaymentIntent's payment method.
      *
-     * <p>If present, the payment method used with this PaymentIntent can be <a
-     * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer, even
-     * after the transaction completes.
+     * <p>Providing this parameter will attach the payment method to the PaymentIntent's Customer,
+     * if present, after the PaymentIntent is confirmed and any required actions from the user are
+     * complete. If no Customer was provided, the payment method can still be <a
+     * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer after
+     * the transaction completes.
      *
-     * <p>Use {@code on_session} if you intend to only reuse the payment method when your customer
-     * is present in your checkout flow. Use {@code off_session} if your customer may or may not be
-     * in your checkout flow.
+     * <p>For more, learn to <a href="https://stripe.com/docs/payments/save-during-payment">save
+     * card details during payment</a>.
      *
      * <p>Stripe uses {@code setup_future_usage} to dynamically optimize your payment flow and
      * comply with regional legislation and network rules. For example, if your customer is impacted
@@ -584,13 +591,14 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     /**
      * Indicates that you intend to make future payments with this PaymentIntent's payment method.
      *
-     * <p>If present, the payment method used with this PaymentIntent can be <a
-     * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer, even
-     * after the transaction completes.
+     * <p>Providing this parameter will attach the payment method to the PaymentIntent's Customer,
+     * if present, after the PaymentIntent is confirmed and any required actions from the user are
+     * complete. If no Customer was provided, the payment method can still be <a
+     * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer after
+     * the transaction completes.
      *
-     * <p>Use {@code on_session} if you intend to only reuse the payment method when your customer
-     * is present in your checkout flow. Use {@code off_session} if your customer may or may not be
-     * in your checkout flow.
+     * <p>For more, learn to <a href="https://stripe.com/docs/payments/save-during-payment">save
+     * card details during payment</a>.
      *
      * <p>Stripe uses {@code setup_future_usage} to dynamically optimize your payment flow and
      * comply with regional legislation and network rules. For example, if your customer is impacted

--- a/src/main/java/com/stripe/param/SetupIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/SetupIntentCreateParams.java
@@ -21,8 +21,8 @@ public class SetupIntentCreateParams extends ApiRequestParams {
   /**
    * ID of the Customer this SetupIntent belongs to, if one exists.
    *
-   * <p>If present, payment methods used with this SetupIntent can only be attached to this
-   * Customer, and payment methods attached to other Customers cannot be used with this SetupIntent.
+   * <p>If present, the SetupIntent's payment method will be attached to the Customer on successful
+   * setup. Payment methods attached to other Customers cannot be used with this SetupIntent.
    */
   @SerializedName("customer")
   String customer;
@@ -200,8 +200,8 @@ public class SetupIntentCreateParams extends ApiRequestParams {
     /**
      * ID of the Customer this SetupIntent belongs to, if one exists.
      *
-     * <p>If present, payment methods used with this SetupIntent can only be attached to this
-     * Customer, and payment methods attached to other Customers cannot be used with this
+     * <p>If present, the SetupIntent's payment method will be attached to the Customer on
+     * successful setup. Payment methods attached to other Customers cannot be used with this
      * SetupIntent.
      */
     public Builder setCustomer(String customer) {
@@ -941,8 +941,8 @@ public class SetupIntentCreateParams extends ApiRequestParams {
   @Getter
   public static class SingleUse {
     /**
-     * Amount intended to be collected by this PaymentIntent. A positive integer representing how
-     * much to charge in the <a href="https://stripe.com/docs/currencies#zero-decimal">smallest
+     * Amount the customer is granting permission to collect later. A positive integer representing
+     * how much to charge in the <a href="https://stripe.com/docs/currencies#zero-decimal">smallest
      * currency unit</a> (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal
      * currency). The minimum amount is $0.50 US or <a
      * href="https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts">equivalent in
@@ -992,10 +992,11 @@ public class SetupIntentCreateParams extends ApiRequestParams {
       }
 
       /**
-       * Amount intended to be collected by this PaymentIntent. A positive integer representing how
-       * much to charge in the <a href="https://stripe.com/docs/currencies#zero-decimal">smallest
-       * currency unit</a> (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal
-       * currency). The minimum amount is $0.50 US or <a
+       * Amount the customer is granting permission to collect later. A positive integer
+       * representing how much to charge in the <a
+       * href="https://stripe.com/docs/currencies#zero-decimal">smallest currency unit</a> (e.g.,
+       * 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency). The minimum
+       * amount is $0.50 US or <a
        * href="https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts">equivalent in
        * charge currency</a>. The amount value supports up to eight digits (e.g., a value of
        * 99999999 for a USD charge of $999,999.99).

--- a/src/main/java/com/stripe/param/SetupIntentUpdateParams.java
+++ b/src/main/java/com/stripe/param/SetupIntentUpdateParams.java
@@ -14,8 +14,8 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
   /**
    * ID of the Customer this SetupIntent belongs to, if one exists.
    *
-   * <p>If present, payment methods used with this SetupIntent can only be attached to this
-   * Customer, and payment methods attached to other Customers cannot be used with this SetupIntent.
+   * <p>If present, the SetupIntent's payment method will be attached to the Customer on successful
+   * setup. Payment methods attached to other Customers cannot be used with this SetupIntent.
    */
   @SerializedName("customer")
   Object customer;
@@ -120,8 +120,8 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
     /**
      * ID of the Customer this SetupIntent belongs to, if one exists.
      *
-     * <p>If present, payment methods used with this SetupIntent can only be attached to this
-     * Customer, and payment methods attached to other Customers cannot be used with this
+     * <p>If present, the SetupIntent's payment method will be attached to the Customer on
+     * successful setup. Payment methods attached to other Customers cannot be used with this
      * SetupIntent.
      */
     public Builder setCustomer(String customer) {
@@ -132,8 +132,8 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
     /**
      * ID of the Customer this SetupIntent belongs to, if one exists.
      *
-     * <p>If present, payment methods used with this SetupIntent can only be attached to this
-     * Customer, and payment methods attached to other Customers cannot be used with this
+     * <p>If present, the SetupIntent's payment method will be attached to the Customer on
+     * successful setup. Payment methods attached to other Customers cannot be used with this
      * SetupIntent.
      */
     public Builder setCustomer(EmptyParam customer) {

--- a/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
+++ b/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
@@ -30,12 +30,11 @@ public class SessionCreateParams extends ApiRequestParams {
   String clientReferenceId;
 
   /**
-   * ID of an existing customer, if one exists. Only supported for Checkout Sessions in {@code
-   * payment} or {@code subscription} mode, but not Checkout Sessions in {@code setup} mode. The
-   * email stored on the customer will be used to prefill the email field on the Checkout page. If
-   * the customer changes their email on the Checkout page, the Customer object will be updated with
-   * the new email. If blank for Checkout Sessions in {@code payment} or {@code subscription} mode,
-   * Checkout will create a new customer object based on information provided during the session.
+   * ID of an existing customer, if one exists. The email stored on the customer will be used to
+   * prefill the email field on the Checkout page. If the customer changes their email on the
+   * Checkout page, the Customer object will be updated with the new email. If blank for Checkout
+   * Sessions in {@code payment} or {@code subscription} mode, Checkout will create a new customer
+   * object based on information provided during the session.
    */
   @SerializedName("customer")
   String customer;
@@ -269,13 +268,11 @@ public class SessionCreateParams extends ApiRequestParams {
     }
 
     /**
-     * ID of an existing customer, if one exists. Only supported for Checkout Sessions in {@code
-     * payment} or {@code subscription} mode, but not Checkout Sessions in {@code setup} mode. The
-     * email stored on the customer will be used to prefill the email field on the Checkout page. If
-     * the customer changes their email on the Checkout page, the Customer object will be updated
-     * with the new email. If blank for Checkout Sessions in {@code payment} or {@code subscription}
-     * mode, Checkout will create a new customer object based on information provided during the
-     * session.
+     * ID of an existing customer, if one exists. The email stored on the customer will be used to
+     * prefill the email field on the Checkout page. If the customer changes their email on the
+     * Checkout page, the Customer object will be updated with the new email. If blank for Checkout
+     * Sessions in {@code payment} or {@code subscription} mode, Checkout will create a new customer
+     * object based on information provided during the session.
      */
     public Builder setCustomer(String customer) {
       this.customer = customer;
@@ -514,7 +511,7 @@ public class SessionCreateParams extends ApiRequestParams {
     @SerializedName("currency")
     String currency;
 
-    /** The description for the line item. */
+    /** The description for the line item, to be displayed on the Checkout page. */
     @SerializedName("description")
     String description;
 
@@ -612,7 +609,7 @@ public class SessionCreateParams extends ApiRequestParams {
         return this;
       }
 
-      /** The description for the line item. */
+      /** The description for the line item, to be displayed on the Checkout page. */
       public Builder setDescription(String description) {
         this.description = description;
         return this;
@@ -764,9 +761,11 @@ public class SessionCreateParams extends ApiRequestParams {
     /**
      * Indicates that you intend to make future payments with this PaymentIntent's payment method.
      *
-     * <p>If present, the payment method used with this PaymentIntent can be <a
-     * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer, even
-     * after the transaction completes.
+     * <p>Providing this parameter will attach the payment method to the PaymentIntent's Customer,
+     * if present, after the PaymentIntent is confirmed and any required actions from the user are
+     * complete. If no Customer was provided, the payment method can still be <a
+     * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer after
+     * the transaction completes.
      *
      * <p>For more, learn to <a href="https://stripe.com/docs/payments/save-during-payment">save
      * card details during payment</a>.
@@ -980,9 +979,11 @@ public class SessionCreateParams extends ApiRequestParams {
       /**
        * Indicates that you intend to make future payments with this PaymentIntent's payment method.
        *
-       * <p>If present, the payment method used with this PaymentIntent can be <a
-       * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer, even
-       * after the transaction completes.
+       * <p>Providing this parameter will attach the payment method to the PaymentIntent's Customer,
+       * if present, after the PaymentIntent is confirmed and any required actions from the user are
+       * complete. If no Customer was provided, the payment method can still be <a
+       * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer after
+       * the transaction completes.
        *
        * <p>For more, learn to <a href="https://stripe.com/docs/payments/save-during-payment">save
        * card details during payment</a>.

--- a/src/main/java/com/stripe/param/issuing/AuthorizationApproveParams.java
+++ b/src/main/java/com/stripe/param/issuing/AuthorizationApproveParams.java
@@ -11,6 +11,15 @@ import lombok.Getter;
 
 @Getter
 public class AuthorizationApproveParams extends ApiRequestParams {
+  /**
+   * If the authorization's {@code pending_request.is_amount_controllable} property is {@code true},
+   * you may provide this value to control how much to hold for the authorization. Must be positive
+   * (use <a href="https://stripe.com/docs/api/issuing/authorizations/decline">{@code decline}</a>
+   * to decline an authorization request).
+   */
+  @SerializedName("amount")
+  Long amount;
+
   /** Specifies which fields in the response should be expanded. */
   @SerializedName("expand")
   List<String> expand;
@@ -43,7 +52,12 @@ public class AuthorizationApproveParams extends ApiRequestParams {
   Object metadata;
 
   private AuthorizationApproveParams(
-      List<String> expand, Map<String, Object> extraParams, Long heldAmount, Object metadata) {
+      Long amount,
+      List<String> expand,
+      Map<String, Object> extraParams,
+      Long heldAmount,
+      Object metadata) {
+    this.amount = amount;
     this.expand = expand;
     this.extraParams = extraParams;
     this.heldAmount = heldAmount;
@@ -55,6 +69,8 @@ public class AuthorizationApproveParams extends ApiRequestParams {
   }
 
   public static class Builder {
+    private Long amount;
+
     private List<String> expand;
 
     private Map<String, Object> extraParams;
@@ -66,7 +82,18 @@ public class AuthorizationApproveParams extends ApiRequestParams {
     /** Finalize and obtain parameter instance from this builder. */
     public AuthorizationApproveParams build() {
       return new AuthorizationApproveParams(
-          this.expand, this.extraParams, this.heldAmount, this.metadata);
+          this.amount, this.expand, this.extraParams, this.heldAmount, this.metadata);
+    }
+
+    /**
+     * If the authorization's {@code pending_request.is_amount_controllable} property is {@code
+     * true}, you may provide this value to control how much to hold for the authorization. Must be
+     * positive (use <a href="https://stripe.com/docs/api/issuing/authorizations/decline">{@code
+     * decline}</a> to decline an authorization request).
+     */
+    public Builder setAmount(Long amount) {
+      this.amount = amount;
+      return this;
     }
 
     /**

--- a/src/main/java/com/stripe/param/issuing/CardCreateParams.java
+++ b/src/main/java/com/stripe/param/issuing/CardCreateParams.java
@@ -12,8 +12,8 @@ import lombok.Getter;
 public class CardCreateParams extends ApiRequestParams {
   /**
    * Spending rules that give you some control over how your cards can be used. Refer to our <a
-   * href="https://stripe.com/docs/issuing/authorizations">authorizations</a> documentation for more
-   * details.
+   * href="https://stripe.com/docs/issuing/purchases/authorizations">authorizations</a>
+   * documentation for more details.
    */
   @SerializedName("authorization_controls")
   AuthorizationControls authorizationControls;
@@ -143,8 +143,8 @@ public class CardCreateParams extends ApiRequestParams {
 
     /**
      * Spending rules that give you some control over how your cards can be used. Refer to our <a
-     * href="https://stripe.com/docs/issuing/authorizations">authorizations</a> documentation for
-     * more details.
+     * href="https://stripe.com/docs/issuing/purchases/authorizations">authorizations</a>
+     * documentation for more details.
      */
     public Builder setAuthorizationControls(AuthorizationControls authorizationControls) {
       this.authorizationControls = authorizationControls;

--- a/src/main/java/com/stripe/param/issuing/CardUpdateParams.java
+++ b/src/main/java/com/stripe/param/issuing/CardUpdateParams.java
@@ -13,8 +13,8 @@ import lombok.Getter;
 public class CardUpdateParams extends ApiRequestParams {
   /**
    * Spending rules that give you some control over how your cards can be used. Refer to our <a
-   * href="https://stripe.com/docs/issuing/authorizations">authorizations</a> documentation for more
-   * details.
+   * href="https://stripe.com/docs/issuing/purchases/authorizations">authorizations</a>
+   * documentation for more details.
    */
   @SerializedName("authorization_controls")
   AuthorizationControls authorizationControls;
@@ -81,8 +81,8 @@ public class CardUpdateParams extends ApiRequestParams {
 
     /**
      * Spending rules that give you some control over how your cards can be used. Refer to our <a
-     * href="https://stripe.com/docs/issuing/authorizations">authorizations</a> documentation for
-     * more details.
+     * href="https://stripe.com/docs/issuing/purchases/authorizations">authorizations</a>
+     * documentation for more details.
      */
     public Builder setAuthorizationControls(AuthorizationControls authorizationControls) {
       this.authorizationControls = authorizationControls;

--- a/src/main/java/com/stripe/param/issuing/CardholderCreateParams.java
+++ b/src/main/java/com/stripe/param/issuing/CardholderCreateParams.java
@@ -12,8 +12,8 @@ import lombok.Getter;
 public class CardholderCreateParams extends ApiRequestParams {
   /**
    * Spending rules that give you control over how your cardholders can make charges. Refer to our
-   * <a href="https://stripe.com/docs/issuing/authorizations">authorizations</a> documentation for
-   * more details.
+   * <a href="https://stripe.com/docs/issuing/purchases/authorizations">authorizations</a>
+   * documentation for more details.
    */
   @SerializedName("authorization_controls")
   AuthorizationControls authorizationControls;
@@ -163,8 +163,8 @@ public class CardholderCreateParams extends ApiRequestParams {
 
     /**
      * Spending rules that give you control over how your cardholders can make charges. Refer to our
-     * <a href="https://stripe.com/docs/issuing/authorizations">authorizations</a> documentation for
-     * more details.
+     * <a href="https://stripe.com/docs/issuing/purchases/authorizations">authorizations</a>
+     * documentation for more details.
      */
     public Builder setAuthorizationControls(AuthorizationControls authorizationControls) {
       this.authorizationControls = authorizationControls;

--- a/src/main/java/com/stripe/param/issuing/CardholderUpdateParams.java
+++ b/src/main/java/com/stripe/param/issuing/CardholderUpdateParams.java
@@ -13,8 +13,8 @@ import lombok.Getter;
 public class CardholderUpdateParams extends ApiRequestParams {
   /**
    * Spending rules that give you some control over how your cards can be used. Refer to our <a
-   * href="https://stripe.com/docs/issuing/authorizations">authorizations</a> documentation for more
-   * details.
+   * href="https://stripe.com/docs/issuing/purchases/authorizations">authorizations</a>
+   * documentation for more details.
    */
   @SerializedName("authorization_controls")
   AuthorizationControls authorizationControls;
@@ -139,8 +139,8 @@ public class CardholderUpdateParams extends ApiRequestParams {
 
     /**
      * Spending rules that give you some control over how your cards can be used. Refer to our <a
-     * href="https://stripe.com/docs/issuing/authorizations">authorizations</a> documentation for
-     * more details.
+     * href="https://stripe.com/docs/issuing/purchases/authorizations">authorizations</a>
+     * documentation for more details.
      */
     public Builder setAuthorizationControls(AuthorizationControls authorizationControls) {
       this.authorizationControls = authorizationControls;


### PR DESCRIPTION
Multiple API changes for Issuing:
  * Add `amount`, `currency`, `merchant_amount` and `merchant_currency` on `Authorization`
  * Add `amount`, `currency`, `merchant_amount` and `merchant_currency` inside `request_history` on `Authorization`
  * Add `pending_request` on `Authorization`
  * Add `amount` when approving an `Authorization`
  * Add `replaced_by` on `Card`.

Codegen for openapi dddc308

r? @ob-stripe 
cc @stripe/api-libraries 