### PR TITLE
Multiple API changes

### DIFF
--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -219,7 +219,9 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
 
   /** ID of the PaymentIntent associated with this charge, if one exists. */
   @SerializedName("payment_intent")
-  String paymentIntent;
+  @Getter(lombok.AccessLevel.NONE)
+  @Setter(lombok.AccessLevel.NONE)
+  ExpandableField<PaymentIntent> paymentIntent;
 
   /** ID of the payment method used in this charge. */
   @SerializedName("payment_method")
@@ -494,6 +496,25 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
 
   public void setOrderObject(Order expandableObject) {
     this.order = new ExpandableField<Order>(expandableObject.getId(), expandableObject);
+  }
+
+  /** Get ID of expandable {@code paymentIntent} object. */
+  public String getPaymentIntent() {
+    return (this.paymentIntent != null) ? this.paymentIntent.getId() : null;
+  }
+
+  public void setPaymentIntent(String id) {
+    this.paymentIntent = ApiResource.setExpandableFieldId(id, this.paymentIntent);
+  }
+
+  /** Get expanded {@code paymentIntent}. */
+  public PaymentIntent getPaymentIntentObject() {
+    return (this.paymentIntent != null) ? this.paymentIntent.getExpanded() : null;
+  }
+
+  public void setPaymentIntentObject(PaymentIntent expandableObject) {
+    this.paymentIntent =
+        new ExpandableField<PaymentIntent>(expandableObject.getId(), expandableObject);
   }
 
   /** Get ID of expandable {@code review} object. */

--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -429,9 +429,11 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
   TransferData transferData;
 
   /**
-   * The time at which webhooks for this invoice were successfully delivered (if the invoice had no
-   * webhooks to deliver, this will match {@code created}). Invoice payment is delayed until
-   * webhooks are delivered, or until all webhook delivery attempts have been exhausted.
+   * Invoices are automatically paid or sent 1 hour after webhooks are delivered, or until all
+   * webhook delivery attempts have <a
+   * href="https://stripe.com/docs/billing/webhooks#understand">been exhausted</a>. This field
+   * tracks the time when webhooks for this invoice were successfully delivered. If the invoice had
+   * no webhooks to deliver, this will be set while the invoice is being created.
    */
   @SerializedName("webhooks_delivered_at")
   Long webhooksDeliveredAt;
@@ -1268,7 +1270,7 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
      * in_gst}, {@code no_vat}, {@code za_vat}, {@code ch_vat}, {@code mx_rfc}, {@code sg_uen},
      * {@code ru_inn}, {@code ca_bn}, {@code hk_br}, {@code es_cif}, {@code tw_vat}, {@code th_vat},
      * {@code jp_cn}, {@code li_uid}, {@code my_itn}, {@code us_ein}, {@code kr_brn}, {@code
-     * ca_qst}, {@code my_sst}, or {@code unknown}.
+     * ca_qst}, {@code my_sst}, {@code sg_gst}, or {@code unknown}.
      */
     @SerializedName("type")
     String type;
@@ -1366,10 +1368,7 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
   @Setter
   @EqualsAndHashCode(callSuper = false)
   public static class TransferData extends StripeObject {
-    /**
-     * The account (if any) where funds from the payment will be transferred to upon payment
-     * success.
-     */
+    /** The account where funds from the payment will be transferred to upon payment success. */
     @SerializedName("destination")
     @Getter(lombok.AccessLevel.NONE)
     @Setter(lombok.AccessLevel.NONE)

--- a/src/main/java/com/stripe/model/Mandate.java
+++ b/src/main/java/com/stripe/model/Mandate.java
@@ -54,13 +54,18 @@ public class Mandate extends ApiResource implements HasId {
   SingleUse singleUse;
 
   /**
-   * The status of the Mandate, one of {@code pending}, {@code inactive}, or {@code active}. The
-   * Mandate can be used to initiate a payment only if status=active.
+   * The status of the mandate, which indicates whether it can be used to initiate a payment.
+   *
+   * <p>One of {@code active}, {@code inactive}, or {@code pending}.
    */
   @SerializedName("status")
   String status;
 
-  /** The type of the mandate, one of {@code single_use} or {@code multi_use}. */
+  /**
+   * The type of the mandate.
+   *
+   * <p>One of {@code multi_use}, or {@code single_use}.
+   */
   @SerializedName("type")
   String type;
 

--- a/src/main/java/com/stripe/model/PaymentMethod.java
+++ b/src/main/java/com/stripe/model/PaymentMethod.java
@@ -253,6 +253,15 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
   /**
    * Attaches a PaymentMethod object to a Customer.
    *
+   * <p>To attach a new PaymentMethod to a customer for future payments, we recommend you use a <a
+   * href="https://stripe.com/docs/api/setup_intents">SetupIntent</a> or a PaymentIntent with <a
+   * href="https://stripe.com/docs/api/payment_intents/create#create_payment_intent-setup_future_usage">setup_future_usage</a>.
+   * These approaches will perform any necessary steps to ensure that the PaymentMethod can be used
+   * in a future payment. Using the <code>/v1/payment_methods/:id/attach</code> endpoint does not
+   * ensure that future payments can be made with the attached PaymentMethod. See <a
+   * href="https://stripe.com/docs/payments/payment-intents#future-usage">Optimizing cards for
+   * future payments</a> for more information about setting up future payments.
+   *
    * <p>To use this PaymentMethod as the default for invoice or subscription payments, set <a
    * href="https://stripe.com/docs/api/customers/update#update_customer-invoice_settings-default_payment_method">
    * <code>invoice_settings.default_payment_method</code></a>, on the Customer to the
@@ -264,6 +273,15 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
 
   /**
    * Attaches a PaymentMethod object to a Customer.
+   *
+   * <p>To attach a new PaymentMethod to a customer for future payments, we recommend you use a <a
+   * href="https://stripe.com/docs/api/setup_intents">SetupIntent</a> or a PaymentIntent with <a
+   * href="https://stripe.com/docs/api/payment_intents/create#create_payment_intent-setup_future_usage">setup_future_usage</a>.
+   * These approaches will perform any necessary steps to ensure that the PaymentMethod can be used
+   * in a future payment. Using the <code>/v1/payment_methods/:id/attach</code> endpoint does not
+   * ensure that future payments can be made with the attached PaymentMethod. See <a
+   * href="https://stripe.com/docs/payments/payment-intents#future-usage">Optimizing cards for
+   * future payments</a> for more information about setting up future payments.
    *
    * <p>To use this PaymentMethod as the default for invoice or subscription payments, set <a
    * href="https://stripe.com/docs/api/customers/update#update_customer-invoice_settings-default_payment_method">
@@ -284,6 +302,15 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
   /**
    * Attaches a PaymentMethod object to a Customer.
    *
+   * <p>To attach a new PaymentMethod to a customer for future payments, we recommend you use a <a
+   * href="https://stripe.com/docs/api/setup_intents">SetupIntent</a> or a PaymentIntent with <a
+   * href="https://stripe.com/docs/api/payment_intents/create#create_payment_intent-setup_future_usage">setup_future_usage</a>.
+   * These approaches will perform any necessary steps to ensure that the PaymentMethod can be used
+   * in a future payment. Using the <code>/v1/payment_methods/:id/attach</code> endpoint does not
+   * ensure that future payments can be made with the attached PaymentMethod. See <a
+   * href="https://stripe.com/docs/payments/payment-intents#future-usage">Optimizing cards for
+   * future payments</a> for more information about setting up future payments.
+   *
    * <p>To use this PaymentMethod as the default for invoice or subscription payments, set <a
    * href="https://stripe.com/docs/api/customers/update#update_customer-invoice_settings-default_payment_method">
    * <code>invoice_settings.default_payment_method</code></a>, on the Customer to the
@@ -295,6 +322,15 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
 
   /**
    * Attaches a PaymentMethod object to a Customer.
+   *
+   * <p>To attach a new PaymentMethod to a customer for future payments, we recommend you use a <a
+   * href="https://stripe.com/docs/api/setup_intents">SetupIntent</a> or a PaymentIntent with <a
+   * href="https://stripe.com/docs/api/payment_intents/create#create_payment_intent-setup_future_usage">setup_future_usage</a>.
+   * These approaches will perform any necessary steps to ensure that the PaymentMethod can be used
+   * in a future payment. Using the <code>/v1/payment_methods/:id/attach</code> endpoint does not
+   * ensure that future payments can be made with the attached PaymentMethod. See <a
+   * href="https://stripe.com/docs/payments/payment-intents#future-usage">Optimizing cards for
+   * future payments</a> for more information about setting up future payments.
    *
    * <p>To use this PaymentMethod as the default for invoice or subscription payments, set <a
    * href="https://stripe.com/docs/api/customers/update#update_customer-invoice_settings-default_payment_method">

--- a/src/main/java/com/stripe/model/TaxId.java
+++ b/src/main/java/com/stripe/model/TaxId.java
@@ -56,8 +56,8 @@ public class TaxId extends ApiResource implements HasId {
    * Type of the tax ID, one of {@code au_abn}, {@code ca_bn}, {@code ca_qst}, {@code ch_vat},
    * {@code es_cif}, {@code eu_vat}, {@code hk_br}, {@code in_gst}, {@code jp_cn}, {@code kr_brn},
    * {@code li_uid}, {@code mx_rfc}, {@code my_itn}, {@code my_sst}, {@code no_vat}, {@code nz_gst},
-   * {@code ru_inn}, {@code sg_uen}, {@code th_vat}, {@code tw_vat}, {@code us_ein}, or {@code
-   * za_vat}. Note that some legacy tax IDs have type {@code unknown}
+   * {@code ru_inn}, {@code sg_gst}, {@code sg_uen}, {@code th_vat}, {@code tw_vat}, {@code us_ein},
+   * or {@code za_vat}. Note that some legacy tax IDs have type {@code unknown}
    */
   @SerializedName("type")
   String type;

--- a/src/main/java/com/stripe/model/issuing/Authorization.java
+++ b/src/main/java/com/stripe/model/issuing/Authorization.java
@@ -26,7 +26,10 @@ import lombok.Setter;
 @EqualsAndHashCode(callSuper = false)
 public class Authorization extends ApiResource
     implements MetadataStore<Authorization>, BalanceTransactionSource {
-  /** The total amount in the card's currency that was authorized or rejected. */
+  /**
+   * The total amount that was authorized or rejected. This amount is in the card's currency and in
+   * the <a href="https://stripe.com/docs/currencies#zero-decimal">smallest currency unit</a>.
+   */
   @SerializedName("amount")
   Long amount;
 
@@ -124,7 +127,11 @@ public class Authorization extends ApiResource
   @SerializedName("livemode")
   Boolean livemode;
 
-  /** The total amount that was authorized or rejected in the local merchant_currency. */
+  /**
+   * The total amount that was authorized or rejected. This amount is in the {@code
+   * merchant_currency} and in the <a
+   * href="https://stripe.com/docs/currencies#zero-decimal">smallest currency unit</a>.
+   */
   @SerializedName("merchant_amount")
   Long merchantAmount;
 
@@ -359,22 +366,42 @@ public class Authorization extends ApiResource
         ApiResource.RequestMethod.POST, url, params, Authorization.class, options);
   }
 
-  /** Approves a pending Issuing <code>Authorization</code> object. */
+  /**
+   * Approves a pending Issuing <code>Authorization</code> object. This request should be made
+   * within the timeout window of the <a
+   * href="https://stripe.com/docs/issuing/controls/real-time-authorizations">real time
+   * authorization</a> flow.
+   */
   public Authorization approve() throws StripeException {
     return approve((Map<String, Object>) null, (RequestOptions) null);
   }
 
-  /** Approves a pending Issuing <code>Authorization</code> object. */
+  /**
+   * Approves a pending Issuing <code>Authorization</code> object. This request should be made
+   * within the timeout window of the <a
+   * href="https://stripe.com/docs/issuing/controls/real-time-authorizations">real time
+   * authorization</a> flow.
+   */
   public Authorization approve(RequestOptions options) throws StripeException {
     return approve((Map<String, Object>) null, options);
   }
 
-  /** Approves a pending Issuing <code>Authorization</code> object. */
+  /**
+   * Approves a pending Issuing <code>Authorization</code> object. This request should be made
+   * within the timeout window of the <a
+   * href="https://stripe.com/docs/issuing/controls/real-time-authorizations">real time
+   * authorization</a> flow.
+   */
   public Authorization approve(Map<String, Object> params) throws StripeException {
     return approve(params, (RequestOptions) null);
   }
 
-  /** Approves a pending Issuing <code>Authorization</code> object. */
+  /**
+   * Approves a pending Issuing <code>Authorization</code> object. This request should be made
+   * within the timeout window of the <a
+   * href="https://stripe.com/docs/issuing/controls/real-time-authorizations">real time
+   * authorization</a> flow.
+   */
   public Authorization approve(Map<String, Object> params, RequestOptions options)
       throws StripeException {
     String url =
@@ -387,12 +414,22 @@ public class Authorization extends ApiResource
         ApiResource.RequestMethod.POST, url, params, Authorization.class, options);
   }
 
-  /** Approves a pending Issuing <code>Authorization</code> object. */
+  /**
+   * Approves a pending Issuing <code>Authorization</code> object. This request should be made
+   * within the timeout window of the <a
+   * href="https://stripe.com/docs/issuing/controls/real-time-authorizations">real time
+   * authorization</a> flow.
+   */
   public Authorization approve(AuthorizationApproveParams params) throws StripeException {
     return approve(params, (RequestOptions) null);
   }
 
-  /** Approves a pending Issuing <code>Authorization</code> object. */
+  /**
+   * Approves a pending Issuing <code>Authorization</code> object. This request should be made
+   * within the timeout window of the <a
+   * href="https://stripe.com/docs/issuing/controls/real-time-authorizations">real time
+   * authorization</a> flow.
+   */
   public Authorization approve(AuthorizationApproveParams params, RequestOptions options)
       throws StripeException {
     String url =
@@ -405,22 +442,42 @@ public class Authorization extends ApiResource
         ApiResource.RequestMethod.POST, url, params, Authorization.class, options);
   }
 
-  /** Declines a pending Issuing <code>Authorization</code> object. */
+  /**
+   * Declines a pending Issuing <code>Authorization</code> object. This request should be made
+   * within the timeout window of the <a
+   * href="https://stripe.com/docs/issuing/controls/real-time-authorizations">real time
+   * authorization</a> flow.
+   */
   public Authorization decline() throws StripeException {
     return decline((Map<String, Object>) null, (RequestOptions) null);
   }
 
-  /** Declines a pending Issuing <code>Authorization</code> object. */
+  /**
+   * Declines a pending Issuing <code>Authorization</code> object. This request should be made
+   * within the timeout window of the <a
+   * href="https://stripe.com/docs/issuing/controls/real-time-authorizations">real time
+   * authorization</a> flow.
+   */
   public Authorization decline(RequestOptions options) throws StripeException {
     return decline((Map<String, Object>) null, options);
   }
 
-  /** Declines a pending Issuing <code>Authorization</code> object. */
+  /**
+   * Declines a pending Issuing <code>Authorization</code> object. This request should be made
+   * within the timeout window of the <a
+   * href="https://stripe.com/docs/issuing/controls/real-time-authorizations">real time
+   * authorization</a> flow.
+   */
   public Authorization decline(Map<String, Object> params) throws StripeException {
     return decline(params, (RequestOptions) null);
   }
 
-  /** Declines a pending Issuing <code>Authorization</code> object. */
+  /**
+   * Declines a pending Issuing <code>Authorization</code> object. This request should be made
+   * within the timeout window of the <a
+   * href="https://stripe.com/docs/issuing/controls/real-time-authorizations">real time
+   * authorization</a> flow.
+   */
   public Authorization decline(Map<String, Object> params, RequestOptions options)
       throws StripeException {
     String url =
@@ -433,12 +490,22 @@ public class Authorization extends ApiResource
         ApiResource.RequestMethod.POST, url, params, Authorization.class, options);
   }
 
-  /** Declines a pending Issuing <code>Authorization</code> object. */
+  /**
+   * Declines a pending Issuing <code>Authorization</code> object. This request should be made
+   * within the timeout window of the <a
+   * href="https://stripe.com/docs/issuing/controls/real-time-authorizations">real time
+   * authorization</a> flow.
+   */
   public Authorization decline(AuthorizationDeclineParams params) throws StripeException {
     return decline(params, (RequestOptions) null);
   }
 
-  /** Declines a pending Issuing <code>Authorization</code> object. */
+  /**
+   * Declines a pending Issuing <code>Authorization</code> object. This request should be made
+   * within the timeout window of the <a
+   * href="https://stripe.com/docs/issuing/controls/real-time-authorizations">real time
+   * authorization</a> flow.
+   */
   public Authorization decline(AuthorizationDeclineParams params, RequestOptions options)
       throws StripeException {
     String url =
@@ -456,9 +523,10 @@ public class Authorization extends ApiResource
   @EqualsAndHashCode(callSuper = false)
   public static class PendingRequest extends StripeObject {
     /**
-     * The additional amount Stripe will hold if the authorization is approved, in the <a
-     * href="https://stripe.com/docs/api#issuing_authorization_object-pending-request-currency">currency</a>,
-     * which is always the card's currency.
+     * The additional amount Stripe will hold if the authorization is approved, in the card's <a
+     * href="https://stripe.com/docs/api#issuing_authorization_object-pending-request-currency">currency</a>
+     * and in the <a href="https://stripe.com/docs/currencies#zero-decimal">smallest currency
+     * unit</a>.
      */
     @SerializedName("amount")
     Long amount;
@@ -479,7 +547,11 @@ public class Authorization extends ApiResource
     @SerializedName("is_amount_controllable")
     Boolean isAmountControllable;
 
-    /** The amount the merchant is requesting to be authorized in the {@code merchant_currency}. */
+    /**
+     * The amount the merchant is requesting to be authorized in the {@code merchant_currency}. The
+     * amount is in the <a href="https://stripe.com/docs/currencies#zero-decimal">smallest currency
+     * unit</a>.
+     */
     @SerializedName("merchant_amount")
     Long merchantAmount;
 
@@ -493,8 +565,9 @@ public class Authorization extends ApiResource
   @EqualsAndHashCode(callSuper = false)
   public static class RequestHistory extends StripeObject {
     /**
-     * The amount of the authorization in your card's currency. Stripe held this amount from your
-     * account to fund the authorization, if the request was approved.
+     * The authorization amount in your card's currency and in the <a
+     * href="https://stripe.com/docs/currencies#zero-decimal">smallest currency unit</a>. Stripe
+     * held this amount from your account to fund the authorization if the request was approved.
      */
     @SerializedName("amount")
     Long amount;
@@ -542,7 +615,11 @@ public class Authorization extends ApiResource
     @SerializedName("held_currency")
     String heldCurrency;
 
-    /** The amount that was authorized at the time of this request. */
+    /**
+     * The amount that was authorized at the time of this request. This amount is in the {@code
+     * merchant_currency} and in the <a
+     * href="https://stripe.com/docs/currencies#zero-decimal">smallest currency unit</a>.
+     */
     @SerializedName("merchant_amount")
     Long merchantAmount;
 

--- a/src/main/java/com/stripe/model/issuing/Card.java
+++ b/src/main/java/com/stripe/model/issuing/Card.java
@@ -33,6 +33,14 @@ public class Card extends ApiResource implements HasId, MetadataStore<Card> {
   String brand;
 
   /**
+   * The reason why the card was canceled.
+   *
+   * <p>One of {@code lost}, or {@code stolen}.
+   */
+  @SerializedName("cancellation_reason")
+  String cancellationReason;
+
+  /**
    * An Issuing {@code Cardholder} object represents an individual or business entity who is <a
    * href="https://stripe.com/docs/issuing">issued</a> cards.
    *
@@ -119,7 +127,8 @@ public class Card extends ApiResource implements HasId, MetadataStore<Card> {
   /**
    * The reason why the previous card needed to be replaced.
    *
-   * <p>One of {@code damage}, {@code expiration}, {@code loss}, or {@code theft}.
+   * <p>One of {@code damage}, {@code damaged}, {@code expiration}, {@code expired}, {@code loss},
+   * {@code lost}, {@code stolen}, or {@code theft}.
    */
   @SerializedName("replacement_reason")
   String replacementReason;

--- a/src/main/java/com/stripe/model/issuing/Cardholder.java
+++ b/src/main/java/com/stripe/model/issuing/Cardholder.java
@@ -435,8 +435,7 @@ public class Cardholder extends ApiResource implements HasId, MetadataStore<Card
     String disabledReason;
 
     /**
-     * If not empty, this field contains the list of fields that need to be collected in order to
-     * verify and re-enabled the cardholder.
+     * Array of fields that need to be collected in order to verify and re-enable the cardholder.
      */
     @SerializedName("past_due")
     List<String> pastDue;

--- a/src/main/java/com/stripe/model/issuing/Transaction.java
+++ b/src/main/java/com/stripe/model/issuing/Transaction.java
@@ -23,8 +23,9 @@ import lombok.Setter;
 public class Transaction extends ApiResource
     implements MetadataStore<Transaction>, BalanceTransactionSource {
   /**
-   * The amount of this transaction in your currency. This is the amount that your balance will be
-   * updated by.
+   * The transaction amount, which will be reflected in your balance. This amount is in your
+   * currency and in the <a href="https://stripe.com/docs/currencies#zero-decimal">smallest currency
+   * unit</a>.
    */
   @SerializedName("amount")
   Long amount;
@@ -86,8 +87,9 @@ public class Transaction extends ApiResource
   Boolean livemode;
 
   /**
-   * The amount that the merchant will receive, denominated in {@code merchant_currency}. It will be
-   * different from {@code amount} if the merchant is taking payment in a different currency.
+   * The amount that the merchant will receive, denominated in {@code merchant_currency} and in the
+   * <a href="https://stripe.com/docs/currencies#zero-decimal">smallest currency unit</a>. It will
+   * be different from {@code amount} if the merchant is taking payment in a different currency.
    */
   @SerializedName("merchant_amount")
   Long merchantAmount;

--- a/src/main/java/com/stripe/param/CustomerCreateParams.java
+++ b/src/main/java/com/stripe/param/CustomerCreateParams.java
@@ -1132,8 +1132,8 @@ public class CustomerCreateParams extends ApiRequestParams {
      * Type of the tax ID, one of {@code eu_vat}, {@code nz_gst}, {@code au_abn}, {@code in_gst},
      * {@code no_vat}, {@code za_vat}, {@code ch_vat}, {@code mx_rfc}, {@code sg_uen}, {@code
      * ru_inn}, {@code ca_bn}, {@code hk_br}, {@code es_cif}, {@code tw_vat}, {@code th_vat}, {@code
-     * jp_cn}, {@code li_uid}, {@code my_itn}, {@code us_ein}, {@code kr_brn}, {@code ca_qst}, or
-     * {@code my_sst}.
+     * jp_cn}, {@code li_uid}, {@code my_itn}, {@code us_ein}, {@code kr_brn}, {@code ca_qst},
+     * {@code my_sst}, or {@code sg_gst}.
      */
     @SerializedName("type")
     Type type;
@@ -1195,7 +1195,7 @@ public class CustomerCreateParams extends ApiRequestParams {
        * {@code no_vat}, {@code za_vat}, {@code ch_vat}, {@code mx_rfc}, {@code sg_uen}, {@code
        * ru_inn}, {@code ca_bn}, {@code hk_br}, {@code es_cif}, {@code tw_vat}, {@code th_vat},
        * {@code jp_cn}, {@code li_uid}, {@code my_itn}, {@code us_ein}, {@code kr_brn}, {@code
-       * ca_qst}, or {@code my_sst}.
+       * ca_qst}, {@code my_sst}, or {@code sg_gst}.
        */
       public Builder setType(Type type) {
         this.type = type;
@@ -1260,6 +1260,9 @@ public class CustomerCreateParams extends ApiRequestParams {
 
       @SerializedName("ru_inn")
       RU_INN("ru_inn"),
+
+      @SerializedName("sg_gst")
+      SG_GST("sg_gst"),
 
       @SerializedName("sg_uen")
       SG_UEN("sg_uen"),

--- a/src/main/java/com/stripe/param/InvoiceCreateParams.java
+++ b/src/main/java/com/stripe/param/InvoiceCreateParams.java
@@ -144,8 +144,7 @@ public class InvoiceCreateParams extends ApiRequestParams {
 
   /**
    * If specified, the funds from the invoice will be transferred to the destination and the ID of
-   * the resulting transfer will be found on the invoice's charge. This will be unset if you POST an
-   * empty value.
+   * the resulting transfer will be found on the invoice's charge.
    */
   @SerializedName("transfer_data")
   TransferData transferData;
@@ -554,8 +553,7 @@ public class InvoiceCreateParams extends ApiRequestParams {
 
     /**
      * If specified, the funds from the invoice will be transferred to the destination and the ID of
-     * the resulting transfer will be found on the invoice's charge. This will be unset if you POST
-     * an empty value.
+     * the resulting transfer will be found on the invoice's charge.
      */
     public Builder setTransferData(TransferData transferData) {
       this.transferData = transferData;

--- a/src/main/java/com/stripe/param/SubscriptionCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionCreateParams.java
@@ -208,8 +208,7 @@ public class SubscriptionCreateParams extends ApiRequestParams {
 
   /**
    * If specified, the funds from the subscription's invoices will be transferred to the destination
-   * and the ID of the resulting transfers will be found on the resulting charges. This will be
-   * unset if you POST an empty value.
+   * and the ID of the resulting transfers will be found on the resulting charges.
    */
   @SerializedName("transfer_data")
   TransferData transferData;
@@ -797,7 +796,6 @@ public class SubscriptionCreateParams extends ApiRequestParams {
     /**
      * If specified, the funds from the subscription's invoices will be transferred to the
      * destination and the ID of the resulting transfers will be found on the resulting charges.
-     * This will be unset if you POST an empty value.
      */
     public Builder setTransferData(TransferData transferData) {
       this.transferData = transferData;

--- a/src/main/java/com/stripe/param/SubscriptionScheduleCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionScheduleCreateParams.java
@@ -72,9 +72,7 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
   /**
    * When the subscription schedule starts. We recommend using {@code now} so that it starts the
    * subscription immediately. You can also use a Unix timestamp to backdate the subscription so
-   * that it starts on a past date, or set a future date for the subscription to start on. When you
-   * backdate, the {@code billing_cycle_anchor} of the subscription is equivalent to the {@code
-   * start_date}.
+   * that it starts on a past date, or set a future date for the subscription to start on.
    */
   @SerializedName("start_date")
   Object startDate;
@@ -303,9 +301,7 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
     /**
      * When the subscription schedule starts. We recommend using {@code now} so that it starts the
      * subscription immediately. You can also use a Unix timestamp to backdate the subscription so
-     * that it starts on a past date, or set a future date for the subscription to start on. When
-     * you backdate, the {@code billing_cycle_anchor} of the subscription is equivalent to the
-     * {@code start_date}.
+     * that it starts on a past date, or set a future date for the subscription to start on.
      */
     public Builder setStartDate(Long startDate) {
       this.startDate = startDate;
@@ -315,9 +311,7 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
     /**
      * When the subscription schedule starts. We recommend using {@code now} so that it starts the
      * subscription immediately. You can also use a Unix timestamp to backdate the subscription so
-     * that it starts on a past date, or set a future date for the subscription to start on. When
-     * you backdate, the {@code billing_cycle_anchor} of the subscription is equivalent to the
-     * {@code start_date}.
+     * that it starts on a past date, or set a future date for the subscription to start on.
      */
     public Builder setStartDate(StartDate startDate) {
       this.startDate = startDate;
@@ -716,8 +710,7 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
      * href="https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates">{@code
      * default_tax_rates}</a>, which means they will be the Invoice's <a
      * href="https://stripe.com/docs/api/invoices/create#create_invoice-default_tax_rates">{@code
-     * default_tax_rates}</a> for any Invoices issued by the Subscription during this Phase. When
-     * updating, pass an empty string to remove previously-defined tax rates.
+     * default_tax_rates}</a> for any Invoices issued by the Subscription during this Phase.
      */
     @SerializedName("default_tax_rates")
     Object defaultTaxRates;
@@ -975,8 +968,7 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
        * href="https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates">{@code
        * default_tax_rates}</a>, which means they will be the Invoice's <a
        * href="https://stripe.com/docs/api/invoices/create#create_invoice-default_tax_rates">{@code
-       * default_tax_rates}</a> for any Invoices issued by the Subscription during this Phase. When
-       * updating, pass an empty string to remove previously-defined tax rates.
+       * default_tax_rates}</a> for any Invoices issued by the Subscription during this Phase.
        */
       public Builder setDefaultTaxRates(EmptyParam defaultTaxRates) {
         this.defaultTaxRates = defaultTaxRates;
@@ -989,8 +981,7 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
        * href="https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates">{@code
        * default_tax_rates}</a>, which means they will be the Invoice's <a
        * href="https://stripe.com/docs/api/invoices/create#create_invoice-default_tax_rates">{@code
-       * default_tax_rates}</a> for any Invoices issued by the Subscription during this Phase. When
-       * updating, pass an empty string to remove previously-defined tax rates.
+       * default_tax_rates}</a> for any Invoices issued by the Subscription during this Phase.
        */
       public Builder setDefaultTaxRates(List<String> defaultTaxRates) {
         this.defaultTaxRates = defaultTaxRates;

--- a/src/main/java/com/stripe/param/SubscriptionScheduleUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionScheduleUpdateParams.java
@@ -692,8 +692,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
      * href="https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates">{@code
      * default_tax_rates}</a>, which means they will be the Invoice's <a
      * href="https://stripe.com/docs/api/invoices/create#create_invoice-default_tax_rates">{@code
-     * default_tax_rates}</a> for any Invoices issued by the Subscription during this Phase. When
-     * updating, pass an empty string to remove previously-defined tax rates.
+     * default_tax_rates}</a> for any Invoices issued by the Subscription during this Phase.
      */
     @SerializedName("default_tax_rates")
     Object defaultTaxRates;
@@ -979,8 +978,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
        * href="https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates">{@code
        * default_tax_rates}</a>, which means they will be the Invoice's <a
        * href="https://stripe.com/docs/api/invoices/create#create_invoice-default_tax_rates">{@code
-       * default_tax_rates}</a> for any Invoices issued by the Subscription during this Phase. When
-       * updating, pass an empty string to remove previously-defined tax rates.
+       * default_tax_rates}</a> for any Invoices issued by the Subscription during this Phase.
        */
       public Builder setDefaultTaxRates(EmptyParam defaultTaxRates) {
         this.defaultTaxRates = defaultTaxRates;
@@ -993,8 +991,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
        * href="https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates">{@code
        * default_tax_rates}</a>, which means they will be the Invoice's <a
        * href="https://stripe.com/docs/api/invoices/create#create_invoice-default_tax_rates">{@code
-       * default_tax_rates}</a> for any Invoices issued by the Subscription during this Phase. When
-       * updating, pass an empty string to remove previously-defined tax rates.
+       * default_tax_rates}</a> for any Invoices issued by the Subscription during this Phase.
        */
       public Builder setDefaultTaxRates(List<String> defaultTaxRates) {
         this.defaultTaxRates = defaultTaxRates;

--- a/src/main/java/com/stripe/param/TaxIdCollectionCreateParams.java
+++ b/src/main/java/com/stripe/param/TaxIdCollectionCreateParams.java
@@ -27,8 +27,8 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
    * Type of the tax ID, one of {@code eu_vat}, {@code nz_gst}, {@code au_abn}, {@code in_gst},
    * {@code no_vat}, {@code za_vat}, {@code ch_vat}, {@code mx_rfc}, {@code sg_uen}, {@code ru_inn},
    * {@code ca_bn}, {@code hk_br}, {@code es_cif}, {@code tw_vat}, {@code th_vat}, {@code jp_cn},
-   * {@code li_uid}, {@code my_itn}, {@code us_ein}, {@code kr_brn}, {@code ca_qst}, or {@code
-   * my_sst}.
+   * {@code li_uid}, {@code my_itn}, {@code us_ein}, {@code kr_brn}, {@code ca_qst}, {@code my_sst},
+   * or {@code sg_gst}.
    */
   @SerializedName("type")
   Type type;
@@ -119,8 +119,8 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
      * Type of the tax ID, one of {@code eu_vat}, {@code nz_gst}, {@code au_abn}, {@code in_gst},
      * {@code no_vat}, {@code za_vat}, {@code ch_vat}, {@code mx_rfc}, {@code sg_uen}, {@code
      * ru_inn}, {@code ca_bn}, {@code hk_br}, {@code es_cif}, {@code tw_vat}, {@code th_vat}, {@code
-     * jp_cn}, {@code li_uid}, {@code my_itn}, {@code us_ein}, {@code kr_brn}, {@code ca_qst}, or
-     * {@code my_sst}.
+     * jp_cn}, {@code li_uid}, {@code my_itn}, {@code us_ein}, {@code kr_brn}, {@code ca_qst},
+     * {@code my_sst}, or {@code sg_gst}.
      */
     public Builder setType(Type type) {
       this.type = type;
@@ -185,6 +185,9 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
 
     @SerializedName("ru_inn")
     RU_INN("ru_inn"),
+
+    @SerializedName("sg_gst")
+    SG_GST("sg_gst"),
 
     @SerializedName("sg_uen")
     SG_UEN("sg_uen"),

--- a/src/main/java/com/stripe/param/issuing/CardCreateParams.java
+++ b/src/main/java/com/stripe/param/issuing/CardCreateParams.java
@@ -6692,11 +6692,23 @@ public class CardCreateParams extends ApiRequestParams {
     @SerializedName("damage")
     DAMAGE("damage"),
 
+    @SerializedName("damaged")
+    DAMAGED("damaged"),
+
     @SerializedName("expiration")
     EXPIRATION("expiration"),
 
+    @SerializedName("expired")
+    EXPIRED("expired"),
+
     @SerializedName("loss")
     LOSS("loss"),
+
+    @SerializedName("lost")
+    LOST("lost"),
+
+    @SerializedName("stolen")
+    STOLEN("stolen"),
 
     @SerializedName("theft")
     THEFT("theft");

--- a/src/main/java/com/stripe/param/issuing/CardUpdateParams.java
+++ b/src/main/java/com/stripe/param/issuing/CardUpdateParams.java
@@ -19,6 +19,10 @@ public class CardUpdateParams extends ApiRequestParams {
   @SerializedName("authorization_controls")
   AuthorizationControls authorizationControls;
 
+  /** Reason why the {@code status} of this card is {@code canceled}. */
+  @SerializedName("cancellation_reason")
+  CancellationReason cancellationReason;
+
   /** Specifies which fields in the response should be expanded. */
   @SerializedName("expand")
   List<String> expand;
@@ -49,18 +53,24 @@ public class CardUpdateParams extends ApiRequestParams {
   @SerializedName("spending_controls")
   SpendingControls spendingControls;
 
-  /** Whether authorizations can be approved on this card. */
+  /**
+   * Dictates whether authorizations can be approved on this card. If this card is being canceled
+   * because it was lost or stolen, this information should be provided as {@code
+   * cancellation_reason}.
+   */
   @SerializedName("status")
   Status status;
 
   private CardUpdateParams(
       AuthorizationControls authorizationControls,
+      CancellationReason cancellationReason,
       List<String> expand,
       Map<String, Object> extraParams,
       Object metadata,
       SpendingControls spendingControls,
       Status status) {
     this.authorizationControls = authorizationControls;
+    this.cancellationReason = cancellationReason;
     this.expand = expand;
     this.extraParams = extraParams;
     this.metadata = metadata;
@@ -74,6 +84,8 @@ public class CardUpdateParams extends ApiRequestParams {
 
   public static class Builder {
     private AuthorizationControls authorizationControls;
+
+    private CancellationReason cancellationReason;
 
     private List<String> expand;
 
@@ -89,6 +101,7 @@ public class CardUpdateParams extends ApiRequestParams {
     public CardUpdateParams build() {
       return new CardUpdateParams(
           this.authorizationControls,
+          this.cancellationReason,
           this.expand,
           this.extraParams,
           this.metadata,
@@ -103,6 +116,12 @@ public class CardUpdateParams extends ApiRequestParams {
      */
     public Builder setAuthorizationControls(AuthorizationControls authorizationControls) {
       this.authorizationControls = authorizationControls;
+      return this;
+    }
+
+    /** Reason why the {@code status} of this card is {@code canceled}. */
+    public Builder setCancellationReason(CancellationReason cancellationReason) {
+      this.cancellationReason = cancellationReason;
       return this;
     }
 
@@ -218,7 +237,11 @@ public class CardUpdateParams extends ApiRequestParams {
       return this;
     }
 
-    /** Whether authorizations can be approved on this card. */
+    /**
+     * Dictates whether authorizations can be approved on this card. If this card is being canceled
+     * because it was lost or stolen, this information should be provided as {@code
+     * cancellation_reason}.
+     */
     public Builder setStatus(Status status) {
       this.status = status;
       return this;
@@ -6270,6 +6293,21 @@ public class CardUpdateParams extends ApiRequestParams {
       BlockedCategory(String value) {
         this.value = value;
       }
+    }
+  }
+
+  public enum CancellationReason implements ApiRequestParams.EnumParam {
+    @SerializedName("lost")
+    LOST("lost"),
+
+    @SerializedName("stolen")
+    STOLEN("stolen");
+
+    @Getter(onMethod_ = {@Override})
+    private final String value;
+
+    CancellationReason(String value) {
+      this.value = value;
     }
   }
 


### PR DESCRIPTION
Multiple API changes:
  * Make `payment_intent` expandable on `Charge`
  * Add support for `sg_gst` as a value for `type` on `TaxId` and related APIs
  * Add `cancellation_reason` and new enum values for `replacement_reason` on Issuing `Card`

Codegen for openapi 83431de

r? @ob-stripe 
cc @stripe/api-libraries 