### PR TITLE
Add support for `Coupon` when for subscriptions on Checkout

### DIFF
--- a/src/main/java/com/stripe/model/billingportal/Session.java
+++ b/src/main/java/com/stripe/model/billingportal/Session.java
@@ -55,24 +55,24 @@ public class Session extends ApiResource implements HasId {
   @SerializedName("url")
   String url;
 
-  /** Creates a session of the Self-service Portal. */
+  /** Creates a session of the self-serve Portal. */
   public static Session create(Map<String, Object> params) throws StripeException {
     return create(params, (RequestOptions) null);
   }
 
-  /** Creates a session of the Self-service Portal. */
+  /** Creates a session of the self-serve Portal. */
   public static Session create(Map<String, Object> params, RequestOptions options)
       throws StripeException {
     String url = String.format("%s%s", Stripe.getApiBase(), "/v1/billing_portal/sessions");
     return ApiResource.request(ApiResource.RequestMethod.POST, url, params, Session.class, options);
   }
 
-  /** Creates a session of the Self-service Portal. */
+  /** Creates a session of the self-serve Portal. */
   public static Session create(SessionCreateParams params) throws StripeException {
     return create(params, (RequestOptions) null);
   }
 
-  /** Creates a session of the Self-service Portal. */
+  /** Creates a session of the self-serve Portal. */
   public static Session create(SessionCreateParams params, RequestOptions options)
       throws StripeException {
     String url = String.format("%s%s", Stripe.getApiBase(), "/v1/billing_portal/sessions");

--- a/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
+++ b/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
@@ -2403,6 +2403,13 @@ public class SessionCreateParams extends ApiRequestParams {
     BigDecimal applicationFeePercent;
 
     /**
+     * The code of the coupon to apply to this subscription. A coupon applied to a subscription will
+     * only affect invoices created for that particular subscription.
+     */
+    @SerializedName("coupon")
+    String coupon;
+
+    /**
      * The tax rates that will apply to any subscription item that does not have {@code tax_rates}
      * set. Invoices created will have their {@code default_tax_rates} populated from the
      * subscription.
@@ -2459,6 +2466,7 @@ public class SessionCreateParams extends ApiRequestParams {
 
     private SubscriptionData(
         BigDecimal applicationFeePercent,
+        String coupon,
         List<String> defaultTaxRates,
         Map<String, Object> extraParams,
         List<Item> items,
@@ -2467,6 +2475,7 @@ public class SessionCreateParams extends ApiRequestParams {
         Boolean trialFromPlan,
         Long trialPeriodDays) {
       this.applicationFeePercent = applicationFeePercent;
+      this.coupon = coupon;
       this.defaultTaxRates = defaultTaxRates;
       this.extraParams = extraParams;
       this.items = items;
@@ -2482,6 +2491,8 @@ public class SessionCreateParams extends ApiRequestParams {
 
     public static class Builder {
       private BigDecimal applicationFeePercent;
+
+      private String coupon;
 
       private List<String> defaultTaxRates;
 
@@ -2501,6 +2512,7 @@ public class SessionCreateParams extends ApiRequestParams {
       public SubscriptionData build() {
         return new SubscriptionData(
             this.applicationFeePercent,
+            this.coupon,
             this.defaultTaxRates,
             this.extraParams,
             this.items,
@@ -2520,6 +2532,15 @@ public class SessionCreateParams extends ApiRequestParams {
        */
       public Builder setApplicationFeePercent(BigDecimal applicationFeePercent) {
         this.applicationFeePercent = applicationFeePercent;
+        return this;
+      }
+
+      /**
+       * The code of the coupon to apply to this subscription. A coupon applied to a subscription
+       * will only affect invoices created for that particular subscription.
+       */
+      public Builder setCoupon(String coupon) {
+        this.coupon = coupon;
         return this;
       }
 


### PR DESCRIPTION
Codegen for openapi 6bc6b0c

r? @cjavilla-stripe 
cc @stripe/api-libraries 