### PR TITLE
Add support for `br_cpf` and `br_cnpj` as `type` on `TaxId`

### DIFF
--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -1266,11 +1266,11 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
   @EqualsAndHashCode(callSuper = false)
   public static class CustomerTaxId extends StripeObject {
     /**
-     * The type of the tax ID, one of {@code eu_vat}, {@code nz_gst}, {@code au_abn}, {@code
-     * in_gst}, {@code no_vat}, {@code za_vat}, {@code ch_vat}, {@code mx_rfc}, {@code sg_uen},
-     * {@code ru_inn}, {@code ca_bn}, {@code hk_br}, {@code es_cif}, {@code tw_vat}, {@code th_vat},
-     * {@code jp_cn}, {@code li_uid}, {@code my_itn}, {@code us_ein}, {@code kr_brn}, {@code
-     * ca_qst}, {@code my_sst}, {@code sg_gst}, or {@code unknown}.
+     * The type of the tax ID, one of {@code eu_vat}, {@code br_cnpj}, {@code br_cpf}, {@code
+     * nz_gst}, {@code au_abn}, {@code in_gst}, {@code no_vat}, {@code za_vat}, {@code ch_vat},
+     * {@code mx_rfc}, {@code sg_uen}, {@code ru_inn}, {@code ca_bn}, {@code hk_br}, {@code es_cif},
+     * {@code tw_vat}, {@code th_vat}, {@code jp_cn}, {@code li_uid}, {@code my_itn}, {@code
+     * us_ein}, {@code kr_brn}, {@code ca_qst}, {@code my_sst}, {@code sg_gst}, or {@code unknown}.
      */
     @SerializedName("type")
     String type;

--- a/src/main/java/com/stripe/model/TaxId.java
+++ b/src/main/java/com/stripe/model/TaxId.java
@@ -53,11 +53,12 @@ public class TaxId extends ApiResource implements HasId {
   String object;
 
   /**
-   * Type of the tax ID, one of {@code au_abn}, {@code ca_bn}, {@code ca_qst}, {@code ch_vat},
-   * {@code es_cif}, {@code eu_vat}, {@code hk_br}, {@code in_gst}, {@code jp_cn}, {@code kr_brn},
-   * {@code li_uid}, {@code mx_rfc}, {@code my_itn}, {@code my_sst}, {@code no_vat}, {@code nz_gst},
-   * {@code ru_inn}, {@code sg_gst}, {@code sg_uen}, {@code th_vat}, {@code tw_vat}, {@code us_ein},
-   * or {@code za_vat}. Note that some legacy tax IDs have type {@code unknown}
+   * Type of the tax ID, one of {@code au_abn}, {@code br_cnpj}, {@code br_cpf}, {@code ca_bn},
+   * {@code ca_qst}, {@code ch_vat}, {@code es_cif}, {@code eu_vat}, {@code hk_br}, {@code in_gst},
+   * {@code jp_cn}, {@code kr_brn}, {@code li_uid}, {@code mx_rfc}, {@code my_itn}, {@code my_sst},
+   * {@code no_vat}, {@code nz_gst}, {@code ru_inn}, {@code sg_gst}, {@code sg_uen}, {@code th_vat},
+   * {@code tw_vat}, {@code us_ein}, or {@code za_vat}. Note that some legacy tax IDs have type
+   * {@code unknown}
    */
   @SerializedName("type")
   String type;

--- a/src/main/java/com/stripe/param/CustomerCreateParams.java
+++ b/src/main/java/com/stripe/param/CustomerCreateParams.java
@@ -1129,11 +1129,11 @@ public class CustomerCreateParams extends ApiRequestParams {
     Map<String, Object> extraParams;
 
     /**
-     * Type of the tax ID, one of {@code eu_vat}, {@code nz_gst}, {@code au_abn}, {@code in_gst},
-     * {@code no_vat}, {@code za_vat}, {@code ch_vat}, {@code mx_rfc}, {@code sg_uen}, {@code
-     * ru_inn}, {@code ca_bn}, {@code hk_br}, {@code es_cif}, {@code tw_vat}, {@code th_vat}, {@code
-     * jp_cn}, {@code li_uid}, {@code my_itn}, {@code us_ein}, {@code kr_brn}, {@code ca_qst},
-     * {@code my_sst}, or {@code sg_gst}.
+     * Type of the tax ID, one of {@code eu_vat}, {@code br_cnpj}, {@code br_cpf}, {@code nz_gst},
+     * {@code au_abn}, {@code in_gst}, {@code no_vat}, {@code za_vat}, {@code ch_vat}, {@code
+     * mx_rfc}, {@code sg_uen}, {@code ru_inn}, {@code ca_bn}, {@code hk_br}, {@code es_cif}, {@code
+     * tw_vat}, {@code th_vat}, {@code jp_cn}, {@code li_uid}, {@code my_itn}, {@code us_ein},
+     * {@code kr_brn}, {@code ca_qst}, {@code my_sst}, or {@code sg_gst}.
      */
     @SerializedName("type")
     Type type;
@@ -1191,11 +1191,11 @@ public class CustomerCreateParams extends ApiRequestParams {
       }
 
       /**
-       * Type of the tax ID, one of {@code eu_vat}, {@code nz_gst}, {@code au_abn}, {@code in_gst},
-       * {@code no_vat}, {@code za_vat}, {@code ch_vat}, {@code mx_rfc}, {@code sg_uen}, {@code
-       * ru_inn}, {@code ca_bn}, {@code hk_br}, {@code es_cif}, {@code tw_vat}, {@code th_vat},
-       * {@code jp_cn}, {@code li_uid}, {@code my_itn}, {@code us_ein}, {@code kr_brn}, {@code
-       * ca_qst}, {@code my_sst}, or {@code sg_gst}.
+       * Type of the tax ID, one of {@code eu_vat}, {@code br_cnpj}, {@code br_cpf}, {@code nz_gst},
+       * {@code au_abn}, {@code in_gst}, {@code no_vat}, {@code za_vat}, {@code ch_vat}, {@code
+       * mx_rfc}, {@code sg_uen}, {@code ru_inn}, {@code ca_bn}, {@code hk_br}, {@code es_cif},
+       * {@code tw_vat}, {@code th_vat}, {@code jp_cn}, {@code li_uid}, {@code my_itn}, {@code
+       * us_ein}, {@code kr_brn}, {@code ca_qst}, {@code my_sst}, or {@code sg_gst}.
        */
       public Builder setType(Type type) {
         this.type = type;
@@ -1212,6 +1212,12 @@ public class CustomerCreateParams extends ApiRequestParams {
     public enum Type implements ApiRequestParams.EnumParam {
       @SerializedName("au_abn")
       AU_ABN("au_abn"),
+
+      @SerializedName("br_cnpj")
+      BR_CNPJ("br_cnpj"),
+
+      @SerializedName("br_cpf")
+      BR_CPF("br_cpf"),
 
       @SerializedName("ca_bn")
       CA_BN("ca_bn"),

--- a/src/main/java/com/stripe/param/TaxIdCollectionCreateParams.java
+++ b/src/main/java/com/stripe/param/TaxIdCollectionCreateParams.java
@@ -24,11 +24,11 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
   Map<String, Object> extraParams;
 
   /**
-   * Type of the tax ID, one of {@code eu_vat}, {@code nz_gst}, {@code au_abn}, {@code in_gst},
-   * {@code no_vat}, {@code za_vat}, {@code ch_vat}, {@code mx_rfc}, {@code sg_uen}, {@code ru_inn},
-   * {@code ca_bn}, {@code hk_br}, {@code es_cif}, {@code tw_vat}, {@code th_vat}, {@code jp_cn},
-   * {@code li_uid}, {@code my_itn}, {@code us_ein}, {@code kr_brn}, {@code ca_qst}, {@code my_sst},
-   * or {@code sg_gst}.
+   * Type of the tax ID, one of {@code eu_vat}, {@code br_cnpj}, {@code br_cpf}, {@code nz_gst},
+   * {@code au_abn}, {@code in_gst}, {@code no_vat}, {@code za_vat}, {@code ch_vat}, {@code mx_rfc},
+   * {@code sg_uen}, {@code ru_inn}, {@code ca_bn}, {@code hk_br}, {@code es_cif}, {@code tw_vat},
+   * {@code th_vat}, {@code jp_cn}, {@code li_uid}, {@code my_itn}, {@code us_ein}, {@code kr_brn},
+   * {@code ca_qst}, {@code my_sst}, or {@code sg_gst}.
    */
   @SerializedName("type")
   Type type;
@@ -116,11 +116,11 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
     }
 
     /**
-     * Type of the tax ID, one of {@code eu_vat}, {@code nz_gst}, {@code au_abn}, {@code in_gst},
-     * {@code no_vat}, {@code za_vat}, {@code ch_vat}, {@code mx_rfc}, {@code sg_uen}, {@code
-     * ru_inn}, {@code ca_bn}, {@code hk_br}, {@code es_cif}, {@code tw_vat}, {@code th_vat}, {@code
-     * jp_cn}, {@code li_uid}, {@code my_itn}, {@code us_ein}, {@code kr_brn}, {@code ca_qst},
-     * {@code my_sst}, or {@code sg_gst}.
+     * Type of the tax ID, one of {@code eu_vat}, {@code br_cnpj}, {@code br_cpf}, {@code nz_gst},
+     * {@code au_abn}, {@code in_gst}, {@code no_vat}, {@code za_vat}, {@code ch_vat}, {@code
+     * mx_rfc}, {@code sg_uen}, {@code ru_inn}, {@code ca_bn}, {@code hk_br}, {@code es_cif}, {@code
+     * tw_vat}, {@code th_vat}, {@code jp_cn}, {@code li_uid}, {@code my_itn}, {@code us_ein},
+     * {@code kr_brn}, {@code ca_qst}, {@code my_sst}, or {@code sg_gst}.
      */
     public Builder setType(Type type) {
       this.type = type;
@@ -137,6 +137,12 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
   public enum Type implements ApiRequestParams.EnumParam {
     @SerializedName("au_abn")
     AU_ABN("au_abn"),
+
+    @SerializedName("br_cnpj")
+    BR_CNPJ("br_cnpj"),
+
+    @SerializedName("br_cpf")
+    BR_CPF("br_cpf"),
 
     @SerializedName("ca_bn")
     CA_BN("ca_bn"),


### PR DESCRIPTION
Codegen for openapi 76b55df

r? @ob-stripe 
cc @stripe/api-libraries 