### PR TITLE
Multiple API changes

### DIFF
--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -1387,7 +1387,11 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
         @SerializedName("succeeded")
         Boolean succeeded;
 
-        /** The version of 3D Secure that was used for this payment. */
+        /**
+         * The version of 3D Secure that was used for this payment.
+         *
+         * <p>One of {@code 1.0.2}, {@code 2.1.0}, or {@code 2.2.0}.
+         */
         @SerializedName("version")
         String version;
       }

--- a/src/main/java/com/stripe/param/AccountCreateParams.java
+++ b/src/main/java/com/stripe/param/AccountCreateParams.java
@@ -496,6 +496,10 @@ public class AccountCreateParams extends ApiRequestParams {
     @SerializedName("product_description")
     String productDescription;
 
+    /** A publicly available mailing address for sending support issues to. */
+    @SerializedName("support_address")
+    SupportAddress supportAddress;
+
     /** A publicly available email address for sending support issues to. */
     @SerializedName("support_email")
     String supportEmail;
@@ -517,6 +521,7 @@ public class AccountCreateParams extends ApiRequestParams {
         String mcc,
         String name,
         String productDescription,
+        SupportAddress supportAddress,
         String supportEmail,
         String supportPhone,
         String supportUrl,
@@ -525,6 +530,7 @@ public class AccountCreateParams extends ApiRequestParams {
       this.mcc = mcc;
       this.name = name;
       this.productDescription = productDescription;
+      this.supportAddress = supportAddress;
       this.supportEmail = supportEmail;
       this.supportPhone = supportPhone;
       this.supportUrl = supportUrl;
@@ -544,6 +550,8 @@ public class AccountCreateParams extends ApiRequestParams {
 
       private String productDescription;
 
+      private SupportAddress supportAddress;
+
       private String supportEmail;
 
       private String supportPhone;
@@ -559,6 +567,7 @@ public class AccountCreateParams extends ApiRequestParams {
             this.mcc,
             this.name,
             this.productDescription,
+            this.supportAddress,
             this.supportEmail,
             this.supportPhone,
             this.supportUrl,
@@ -616,6 +625,12 @@ public class AccountCreateParams extends ApiRequestParams {
         return this;
       }
 
+      /** A publicly available mailing address for sending support issues to. */
+      public Builder setSupportAddress(SupportAddress supportAddress) {
+        this.supportAddress = supportAddress;
+        return this;
+      }
+
       /** A publicly available email address for sending support issues to. */
       public Builder setSupportEmail(String supportEmail) {
         this.supportEmail = supportEmail;
@@ -638,6 +653,161 @@ public class AccountCreateParams extends ApiRequestParams {
       public Builder setUrl(String url) {
         this.url = url;
         return this;
+      }
+    }
+
+    @Getter
+    public static class SupportAddress {
+      /** City, district, suburb, town, or village. */
+      @SerializedName("city")
+      String city;
+
+      /**
+       * Two-letter country code (<a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO
+       * 3166-1 alpha-2</a>).
+       */
+      @SerializedName("country")
+      String country;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Address line 1 (e.g., street, PO Box, or company name). */
+      @SerializedName("line1")
+      String line1;
+
+      /** Address line 2 (e.g., apartment, suite, unit, or building). */
+      @SerializedName("line2")
+      String line2;
+
+      /** ZIP or postal code. */
+      @SerializedName("postal_code")
+      String postalCode;
+
+      /** State, county, province, or region. */
+      @SerializedName("state")
+      String state;
+
+      private SupportAddress(
+          String city,
+          String country,
+          Map<String, Object> extraParams,
+          String line1,
+          String line2,
+          String postalCode,
+          String state) {
+        this.city = city;
+        this.country = country;
+        this.extraParams = extraParams;
+        this.line1 = line1;
+        this.line2 = line2;
+        this.postalCode = postalCode;
+        this.state = state;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private String city;
+
+        private String country;
+
+        private Map<String, Object> extraParams;
+
+        private String line1;
+
+        private String line2;
+
+        private String postalCode;
+
+        private String state;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public SupportAddress build() {
+          return new SupportAddress(
+              this.city,
+              this.country,
+              this.extraParams,
+              this.line1,
+              this.line2,
+              this.postalCode,
+              this.state);
+        }
+
+        /** City, district, suburb, town, or village. */
+        public Builder setCity(String city) {
+          this.city = city;
+          return this;
+        }
+
+        /**
+         * Two-letter country code (<a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO
+         * 3166-1 alpha-2</a>).
+         */
+        public Builder setCountry(String country) {
+          this.country = country;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link AccountCreateParams.BusinessProfile.SupportAddress#extraParams} for the
+         * field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link AccountCreateParams.BusinessProfile.SupportAddress#extraParams} for the
+         * field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Address line 1 (e.g., street, PO Box, or company name). */
+        public Builder setLine1(String line1) {
+          this.line1 = line1;
+          return this;
+        }
+
+        /** Address line 2 (e.g., apartment, suite, unit, or building). */
+        public Builder setLine2(String line2) {
+          this.line2 = line2;
+          return this;
+        }
+
+        /** ZIP or postal code. */
+        public Builder setPostalCode(String postalCode) {
+          this.postalCode = postalCode;
+          return this;
+        }
+
+        /** State, county, province, or region. */
+        public Builder setState(String state) {
+          this.state = state;
+          return this;
+        }
       }
     }
   }

--- a/src/main/java/com/stripe/param/AccountUpdateParams.java
+++ b/src/main/java/com/stripe/param/AccountUpdateParams.java
@@ -500,6 +500,10 @@ public class AccountUpdateParams extends ApiRequestParams {
     @SerializedName("product_description")
     Object productDescription;
 
+    /** A publicly available mailing address for sending support issues to. */
+    @SerializedName("support_address")
+    SupportAddress supportAddress;
+
     /** A publicly available email address for sending support issues to. */
     @SerializedName("support_email")
     Object supportEmail;
@@ -521,6 +525,7 @@ public class AccountUpdateParams extends ApiRequestParams {
         Object mcc,
         Object name,
         Object productDescription,
+        SupportAddress supportAddress,
         Object supportEmail,
         Object supportPhone,
         Object supportUrl,
@@ -529,6 +534,7 @@ public class AccountUpdateParams extends ApiRequestParams {
       this.mcc = mcc;
       this.name = name;
       this.productDescription = productDescription;
+      this.supportAddress = supportAddress;
       this.supportEmail = supportEmail;
       this.supportPhone = supportPhone;
       this.supportUrl = supportUrl;
@@ -548,6 +554,8 @@ public class AccountUpdateParams extends ApiRequestParams {
 
       private Object productDescription;
 
+      private SupportAddress supportAddress;
+
       private Object supportEmail;
 
       private Object supportPhone;
@@ -563,6 +571,7 @@ public class AccountUpdateParams extends ApiRequestParams {
             this.mcc,
             this.name,
             this.productDescription,
+            this.supportAddress,
             this.supportEmail,
             this.supportPhone,
             this.supportUrl,
@@ -645,6 +654,12 @@ public class AccountUpdateParams extends ApiRequestParams {
         return this;
       }
 
+      /** A publicly available mailing address for sending support issues to. */
+      public Builder setSupportAddress(SupportAddress supportAddress) {
+        this.supportAddress = supportAddress;
+        return this;
+      }
+
       /** A publicly available email address for sending support issues to. */
       public Builder setSupportEmail(String supportEmail) {
         this.supportEmail = supportEmail;
@@ -691,6 +706,200 @@ public class AccountUpdateParams extends ApiRequestParams {
       public Builder setUrl(EmptyParam url) {
         this.url = url;
         return this;
+      }
+    }
+
+    @Getter
+    public static class SupportAddress {
+      /** City, district, suburb, town, or village. */
+      @SerializedName("city")
+      Object city;
+
+      /**
+       * Two-letter country code (<a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO
+       * 3166-1 alpha-2</a>).
+       */
+      @SerializedName("country")
+      Object country;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Address line 1 (e.g., street, PO Box, or company name). */
+      @SerializedName("line1")
+      Object line1;
+
+      /** Address line 2 (e.g., apartment, suite, unit, or building). */
+      @SerializedName("line2")
+      Object line2;
+
+      /** ZIP or postal code. */
+      @SerializedName("postal_code")
+      Object postalCode;
+
+      /** State, county, province, or region. */
+      @SerializedName("state")
+      Object state;
+
+      private SupportAddress(
+          Object city,
+          Object country,
+          Map<String, Object> extraParams,
+          Object line1,
+          Object line2,
+          Object postalCode,
+          Object state) {
+        this.city = city;
+        this.country = country;
+        this.extraParams = extraParams;
+        this.line1 = line1;
+        this.line2 = line2;
+        this.postalCode = postalCode;
+        this.state = state;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Object city;
+
+        private Object country;
+
+        private Map<String, Object> extraParams;
+
+        private Object line1;
+
+        private Object line2;
+
+        private Object postalCode;
+
+        private Object state;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public SupportAddress build() {
+          return new SupportAddress(
+              this.city,
+              this.country,
+              this.extraParams,
+              this.line1,
+              this.line2,
+              this.postalCode,
+              this.state);
+        }
+
+        /** City, district, suburb, town, or village. */
+        public Builder setCity(String city) {
+          this.city = city;
+          return this;
+        }
+
+        /** City, district, suburb, town, or village. */
+        public Builder setCity(EmptyParam city) {
+          this.city = city;
+          return this;
+        }
+
+        /**
+         * Two-letter country code (<a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO
+         * 3166-1 alpha-2</a>).
+         */
+        public Builder setCountry(String country) {
+          this.country = country;
+          return this;
+        }
+
+        /**
+         * Two-letter country code (<a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO
+         * 3166-1 alpha-2</a>).
+         */
+        public Builder setCountry(EmptyParam country) {
+          this.country = country;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link AccountUpdateParams.BusinessProfile.SupportAddress#extraParams} for the
+         * field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link AccountUpdateParams.BusinessProfile.SupportAddress#extraParams} for the
+         * field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Address line 1 (e.g., street, PO Box, or company name). */
+        public Builder setLine1(String line1) {
+          this.line1 = line1;
+          return this;
+        }
+
+        /** Address line 1 (e.g., street, PO Box, or company name). */
+        public Builder setLine1(EmptyParam line1) {
+          this.line1 = line1;
+          return this;
+        }
+
+        /** Address line 2 (e.g., apartment, suite, unit, or building). */
+        public Builder setLine2(String line2) {
+          this.line2 = line2;
+          return this;
+        }
+
+        /** Address line 2 (e.g., apartment, suite, unit, or building). */
+        public Builder setLine2(EmptyParam line2) {
+          this.line2 = line2;
+          return this;
+        }
+
+        /** ZIP or postal code. */
+        public Builder setPostalCode(String postalCode) {
+          this.postalCode = postalCode;
+          return this;
+        }
+
+        /** ZIP or postal code. */
+        public Builder setPostalCode(EmptyParam postalCode) {
+          this.postalCode = postalCode;
+          return this;
+        }
+
+        /** State, county, province, or region. */
+        public Builder setState(String state) {
+          this.state = state;
+          return this;
+        }
+
+        /** State, county, province, or region. */
+        public Builder setState(EmptyParam state) {
+          this.state = state;
+          return this;
+        }
       }
     }
   }

--- a/src/main/java/com/stripe/param/InvoiceUpcomingParams.java
+++ b/src/main/java/com/stripe/param/InvoiceUpcomingParams.java
@@ -1761,17 +1761,6 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
       @Getter
       public static class Recurring {
         /**
-         * Specifies a usage aggregation strategy for prices of {@code usage_type=metered}. Allowed
-         * values are {@code sum} for summing up all usage during a period, {@code
-         * last_during_period} for using the last usage record reported within a period, {@code
-         * last_ever} for using the last usage record ever (across period bounds) or {@code max}
-         * which uses the usage record with the maximum reported usage during a period. Defaults to
-         * {@code sum}.
-         */
-        @SerializedName("aggregate_usage")
-        AggregateUsage aggregateUsage;
-
-        /**
          * Map of extra parameters for custom features not available in this client library. The
          * content in this map is not serialized under this field's {@code @SerializedName} value.
          * Instead, each key/value pair is serialized as if the key is a root-level field
@@ -1796,36 +1785,10 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
         @SerializedName("interval_count")
         Long intervalCount;
 
-        /**
-         * Default number of trial days when subscribing a customer to this price using <a
-         * href="https://stripe.com/docs/api#create_subscription-trial_from_plan">{@code
-         * trial_from_plan=true}</a>.
-         */
-        @SerializedName("trial_period_days")
-        Long trialPeriodDays;
-
-        /**
-         * Configures how the quantity per period should be determined. Can be either {@code
-         * metered} or {@code licensed}. {@code licensed} automatically bills the {@code quantity}
-         * set when adding it to a subscription. {@code metered} aggregates the total usage based on
-         * usage records. Defaults to {@code licensed}.
-         */
-        @SerializedName("usage_type")
-        UsageType usageType;
-
-        private Recurring(
-            AggregateUsage aggregateUsage,
-            Map<String, Object> extraParams,
-            Interval interval,
-            Long intervalCount,
-            Long trialPeriodDays,
-            UsageType usageType) {
-          this.aggregateUsage = aggregateUsage;
+        private Recurring(Map<String, Object> extraParams, Interval interval, Long intervalCount) {
           this.extraParams = extraParams;
           this.interval = interval;
           this.intervalCount = intervalCount;
-          this.trialPeriodDays = trialPeriodDays;
-          this.usageType = usageType;
         }
 
         public static Builder builder() {
@@ -1833,40 +1796,15 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
         }
 
         public static class Builder {
-          private AggregateUsage aggregateUsage;
-
           private Map<String, Object> extraParams;
 
           private Interval interval;
 
           private Long intervalCount;
 
-          private Long trialPeriodDays;
-
-          private UsageType usageType;
-
           /** Finalize and obtain parameter instance from this builder. */
           public Recurring build() {
-            return new Recurring(
-                this.aggregateUsage,
-                this.extraParams,
-                this.interval,
-                this.intervalCount,
-                this.trialPeriodDays,
-                this.usageType);
-          }
-
-          /**
-           * Specifies a usage aggregation strategy for prices of {@code usage_type=metered}.
-           * Allowed values are {@code sum} for summing up all usage during a period, {@code
-           * last_during_period} for using the last usage record reported within a period, {@code
-           * last_ever} for using the last usage record ever (across period bounds) or {@code max}
-           * which uses the usage record with the maximum reported usage during a period. Defaults
-           * to {@code sum}.
-           */
-          public Builder setAggregateUsage(AggregateUsage aggregateUsage) {
-            this.aggregateUsage = aggregateUsage;
-            return this;
+            return new Recurring(this.extraParams, this.interval, this.intervalCount);
           }
 
           /**
@@ -1915,48 +1853,6 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
             this.intervalCount = intervalCount;
             return this;
           }
-
-          /**
-           * Default number of trial days when subscribing a customer to this price using <a
-           * href="https://stripe.com/docs/api#create_subscription-trial_from_plan">{@code
-           * trial_from_plan=true}</a>.
-           */
-          public Builder setTrialPeriodDays(Long trialPeriodDays) {
-            this.trialPeriodDays = trialPeriodDays;
-            return this;
-          }
-
-          /**
-           * Configures how the quantity per period should be determined. Can be either {@code
-           * metered} or {@code licensed}. {@code licensed} automatically bills the {@code quantity}
-           * set when adding it to a subscription. {@code metered} aggregates the total usage based
-           * on usage records. Defaults to {@code licensed}.
-           */
-          public Builder setUsageType(UsageType usageType) {
-            this.usageType = usageType;
-            return this;
-          }
-        }
-
-        public enum AggregateUsage implements ApiRequestParams.EnumParam {
-          @SerializedName("last_during_period")
-          LAST_DURING_PERIOD("last_during_period"),
-
-          @SerializedName("last_ever")
-          LAST_EVER("last_ever"),
-
-          @SerializedName("max")
-          MAX("max"),
-
-          @SerializedName("sum")
-          SUM("sum");
-
-          @Getter(onMethod_ = {@Override})
-          private final String value;
-
-          AggregateUsage(String value) {
-            this.value = value;
-          }
         }
 
         public enum Interval implements ApiRequestParams.EnumParam {
@@ -1976,21 +1872,6 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
           private final String value;
 
           Interval(String value) {
-            this.value = value;
-          }
-        }
-
-        public enum UsageType implements ApiRequestParams.EnumParam {
-          @SerializedName("licensed")
-          LICENSED("licensed"),
-
-          @SerializedName("metered")
-          METERED("metered");
-
-          @Getter(onMethod_ = {@Override})
-          private final String value;
-
-          UsageType(String value) {
             this.value = value;
           }
         }

--- a/src/main/java/com/stripe/param/PaymentMethodUpdateParams.java
+++ b/src/main/java/com/stripe/param/PaymentMethodUpdateParams.java
@@ -12,6 +12,13 @@ import lombok.Getter;
 @Getter
 public class PaymentMethodUpdateParams extends ApiRequestParams {
   /**
+   * If this is an {@code au_becs_debit} PaymentMethod, this hash contains details about the bank
+   * account.
+   */
+  @SerializedName("au_becs_debit")
+  AuBecsDebit auBecsDebit;
+
+  /**
    * Billing information associated with the PaymentMethod that may be used or required by
    * particular types of payment methods.
    */
@@ -52,12 +59,14 @@ public class PaymentMethodUpdateParams extends ApiRequestParams {
   SepaDebit sepaDebit;
 
   private PaymentMethodUpdateParams(
+      AuBecsDebit auBecsDebit,
       BillingDetails billingDetails,
       Card card,
       List<String> expand,
       Map<String, Object> extraParams,
       Object metadata,
       SepaDebit sepaDebit) {
+    this.auBecsDebit = auBecsDebit;
     this.billingDetails = billingDetails;
     this.card = card;
     this.expand = expand;
@@ -71,6 +80,8 @@ public class PaymentMethodUpdateParams extends ApiRequestParams {
   }
 
   public static class Builder {
+    private AuBecsDebit auBecsDebit;
+
     private BillingDetails billingDetails;
 
     private Card card;
@@ -86,12 +97,22 @@ public class PaymentMethodUpdateParams extends ApiRequestParams {
     /** Finalize and obtain parameter instance from this builder. */
     public PaymentMethodUpdateParams build() {
       return new PaymentMethodUpdateParams(
+          this.auBecsDebit,
           this.billingDetails,
           this.card,
           this.expand,
           this.extraParams,
           this.metadata,
           this.sepaDebit);
+    }
+
+    /**
+     * If this is an {@code au_becs_debit} PaymentMethod, this hash contains details about the bank
+     * account.
+     */
+    public Builder setAuBecsDebit(AuBecsDebit auBecsDebit) {
+      this.auBecsDebit = auBecsDebit;
+      return this;
     }
 
     /**
@@ -218,6 +239,61 @@ public class PaymentMethodUpdateParams extends ApiRequestParams {
     public Builder setSepaDebit(SepaDebit sepaDebit) {
       this.sepaDebit = sepaDebit;
       return this;
+    }
+  }
+
+  @Getter
+  public static class AuBecsDebit {
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    private AuBecsDebit(Map<String, Object> extraParams) {
+      this.extraParams = extraParams;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Map<String, Object> extraParams;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public AuBecsDebit build() {
+        return new AuBecsDebit(this.extraParams);
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * PaymentMethodUpdateParams.AuBecsDebit#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link PaymentMethodUpdateParams.AuBecsDebit#extraParams} for the field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
     }
   }
 

--- a/src/main/java/com/stripe/param/SubscriptionCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionCreateParams.java
@@ -1680,17 +1680,6 @@ public class SubscriptionCreateParams extends ApiRequestParams {
       @Getter
       public static class Recurring {
         /**
-         * Specifies a usage aggregation strategy for prices of {@code usage_type=metered}. Allowed
-         * values are {@code sum} for summing up all usage during a period, {@code
-         * last_during_period} for using the last usage record reported within a period, {@code
-         * last_ever} for using the last usage record ever (across period bounds) or {@code max}
-         * which uses the usage record with the maximum reported usage during a period. Defaults to
-         * {@code sum}.
-         */
-        @SerializedName("aggregate_usage")
-        AggregateUsage aggregateUsage;
-
-        /**
          * Map of extra parameters for custom features not available in this client library. The
          * content in this map is not serialized under this field's {@code @SerializedName} value.
          * Instead, each key/value pair is serialized as if the key is a root-level field
@@ -1715,36 +1704,10 @@ public class SubscriptionCreateParams extends ApiRequestParams {
         @SerializedName("interval_count")
         Long intervalCount;
 
-        /**
-         * Default number of trial days when subscribing a customer to this price using <a
-         * href="https://stripe.com/docs/api#create_subscription-trial_from_plan">{@code
-         * trial_from_plan=true}</a>.
-         */
-        @SerializedName("trial_period_days")
-        Long trialPeriodDays;
-
-        /**
-         * Configures how the quantity per period should be determined. Can be either {@code
-         * metered} or {@code licensed}. {@code licensed} automatically bills the {@code quantity}
-         * set when adding it to a subscription. {@code metered} aggregates the total usage based on
-         * usage records. Defaults to {@code licensed}.
-         */
-        @SerializedName("usage_type")
-        UsageType usageType;
-
-        private Recurring(
-            AggregateUsage aggregateUsage,
-            Map<String, Object> extraParams,
-            Interval interval,
-            Long intervalCount,
-            Long trialPeriodDays,
-            UsageType usageType) {
-          this.aggregateUsage = aggregateUsage;
+        private Recurring(Map<String, Object> extraParams, Interval interval, Long intervalCount) {
           this.extraParams = extraParams;
           this.interval = interval;
           this.intervalCount = intervalCount;
-          this.trialPeriodDays = trialPeriodDays;
-          this.usageType = usageType;
         }
 
         public static Builder builder() {
@@ -1752,40 +1715,15 @@ public class SubscriptionCreateParams extends ApiRequestParams {
         }
 
         public static class Builder {
-          private AggregateUsage aggregateUsage;
-
           private Map<String, Object> extraParams;
 
           private Interval interval;
 
           private Long intervalCount;
 
-          private Long trialPeriodDays;
-
-          private UsageType usageType;
-
           /** Finalize and obtain parameter instance from this builder. */
           public Recurring build() {
-            return new Recurring(
-                this.aggregateUsage,
-                this.extraParams,
-                this.interval,
-                this.intervalCount,
-                this.trialPeriodDays,
-                this.usageType);
-          }
-
-          /**
-           * Specifies a usage aggregation strategy for prices of {@code usage_type=metered}.
-           * Allowed values are {@code sum} for summing up all usage during a period, {@code
-           * last_during_period} for using the last usage record reported within a period, {@code
-           * last_ever} for using the last usage record ever (across period bounds) or {@code max}
-           * which uses the usage record with the maximum reported usage during a period. Defaults
-           * to {@code sum}.
-           */
-          public Builder setAggregateUsage(AggregateUsage aggregateUsage) {
-            this.aggregateUsage = aggregateUsage;
-            return this;
+            return new Recurring(this.extraParams, this.interval, this.intervalCount);
           }
 
           /**
@@ -1834,48 +1772,6 @@ public class SubscriptionCreateParams extends ApiRequestParams {
             this.intervalCount = intervalCount;
             return this;
           }
-
-          /**
-           * Default number of trial days when subscribing a customer to this price using <a
-           * href="https://stripe.com/docs/api#create_subscription-trial_from_plan">{@code
-           * trial_from_plan=true}</a>.
-           */
-          public Builder setTrialPeriodDays(Long trialPeriodDays) {
-            this.trialPeriodDays = trialPeriodDays;
-            return this;
-          }
-
-          /**
-           * Configures how the quantity per period should be determined. Can be either {@code
-           * metered} or {@code licensed}. {@code licensed} automatically bills the {@code quantity}
-           * set when adding it to a subscription. {@code metered} aggregates the total usage based
-           * on usage records. Defaults to {@code licensed}.
-           */
-          public Builder setUsageType(UsageType usageType) {
-            this.usageType = usageType;
-            return this;
-          }
-        }
-
-        public enum AggregateUsage implements ApiRequestParams.EnumParam {
-          @SerializedName("last_during_period")
-          LAST_DURING_PERIOD("last_during_period"),
-
-          @SerializedName("last_ever")
-          LAST_EVER("last_ever"),
-
-          @SerializedName("max")
-          MAX("max"),
-
-          @SerializedName("sum")
-          SUM("sum");
-
-          @Getter(onMethod_ = {@Override})
-          private final String value;
-
-          AggregateUsage(String value) {
-            this.value = value;
-          }
         }
 
         public enum Interval implements ApiRequestParams.EnumParam {
@@ -1895,21 +1791,6 @@ public class SubscriptionCreateParams extends ApiRequestParams {
           private final String value;
 
           Interval(String value) {
-            this.value = value;
-          }
-        }
-
-        public enum UsageType implements ApiRequestParams.EnumParam {
-          @SerializedName("licensed")
-          LICENSED("licensed"),
-
-          @SerializedName("metered")
-          METERED("metered");
-
-          @Getter(onMethod_ = {@Override})
-          private final String value;
-
-          UsageType(String value) {
             this.value = value;
           }
         }

--- a/src/main/java/com/stripe/param/SubscriptionItemCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionItemCreateParams.java
@@ -674,16 +674,6 @@ public class SubscriptionItemCreateParams extends ApiRequestParams {
     @Getter
     public static class Recurring {
       /**
-       * Specifies a usage aggregation strategy for prices of {@code usage_type=metered}. Allowed
-       * values are {@code sum} for summing up all usage during a period, {@code last_during_period}
-       * for using the last usage record reported within a period, {@code last_ever} for using the
-       * last usage record ever (across period bounds) or {@code max} which uses the usage record
-       * with the maximum reported usage during a period. Defaults to {@code sum}.
-       */
-      @SerializedName("aggregate_usage")
-      AggregateUsage aggregateUsage;
-
-      /**
        * Map of extra parameters for custom features not available in this client library. The
        * content in this map is not serialized under this field's {@code @SerializedName} value.
        * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
@@ -707,36 +697,10 @@ public class SubscriptionItemCreateParams extends ApiRequestParams {
       @SerializedName("interval_count")
       Long intervalCount;
 
-      /**
-       * Default number of trial days when subscribing a customer to this price using <a
-       * href="https://stripe.com/docs/api#create_subscription-trial_from_plan">{@code
-       * trial_from_plan=true}</a>.
-       */
-      @SerializedName("trial_period_days")
-      Long trialPeriodDays;
-
-      /**
-       * Configures how the quantity per period should be determined. Can be either {@code metered}
-       * or {@code licensed}. {@code licensed} automatically bills the {@code quantity} set when
-       * adding it to a subscription. {@code metered} aggregates the total usage based on usage
-       * records. Defaults to {@code licensed}.
-       */
-      @SerializedName("usage_type")
-      UsageType usageType;
-
-      private Recurring(
-          AggregateUsage aggregateUsage,
-          Map<String, Object> extraParams,
-          Interval interval,
-          Long intervalCount,
-          Long trialPeriodDays,
-          UsageType usageType) {
-        this.aggregateUsage = aggregateUsage;
+      private Recurring(Map<String, Object> extraParams, Interval interval, Long intervalCount) {
         this.extraParams = extraParams;
         this.interval = interval;
         this.intervalCount = intervalCount;
-        this.trialPeriodDays = trialPeriodDays;
-        this.usageType = usageType;
       }
 
       public static Builder builder() {
@@ -744,40 +708,15 @@ public class SubscriptionItemCreateParams extends ApiRequestParams {
       }
 
       public static class Builder {
-        private AggregateUsage aggregateUsage;
-
         private Map<String, Object> extraParams;
 
         private Interval interval;
 
         private Long intervalCount;
 
-        private Long trialPeriodDays;
-
-        private UsageType usageType;
-
         /** Finalize and obtain parameter instance from this builder. */
         public Recurring build() {
-          return new Recurring(
-              this.aggregateUsage,
-              this.extraParams,
-              this.interval,
-              this.intervalCount,
-              this.trialPeriodDays,
-              this.usageType);
-        }
-
-        /**
-         * Specifies a usage aggregation strategy for prices of {@code usage_type=metered}. Allowed
-         * values are {@code sum} for summing up all usage during a period, {@code
-         * last_during_period} for using the last usage record reported within a period, {@code
-         * last_ever} for using the last usage record ever (across period bounds) or {@code max}
-         * which uses the usage record with the maximum reported usage during a period. Defaults to
-         * {@code sum}.
-         */
-        public Builder setAggregateUsage(AggregateUsage aggregateUsage) {
-          this.aggregateUsage = aggregateUsage;
-          return this;
+          return new Recurring(this.extraParams, this.interval, this.intervalCount);
         }
 
         /**
@@ -826,48 +765,6 @@ public class SubscriptionItemCreateParams extends ApiRequestParams {
           this.intervalCount = intervalCount;
           return this;
         }
-
-        /**
-         * Default number of trial days when subscribing a customer to this price using <a
-         * href="https://stripe.com/docs/api#create_subscription-trial_from_plan">{@code
-         * trial_from_plan=true}</a>.
-         */
-        public Builder setTrialPeriodDays(Long trialPeriodDays) {
-          this.trialPeriodDays = trialPeriodDays;
-          return this;
-        }
-
-        /**
-         * Configures how the quantity per period should be determined. Can be either {@code
-         * metered} or {@code licensed}. {@code licensed} automatically bills the {@code quantity}
-         * set when adding it to a subscription. {@code metered} aggregates the total usage based on
-         * usage records. Defaults to {@code licensed}.
-         */
-        public Builder setUsageType(UsageType usageType) {
-          this.usageType = usageType;
-          return this;
-        }
-      }
-
-      public enum AggregateUsage implements ApiRequestParams.EnumParam {
-        @SerializedName("last_during_period")
-        LAST_DURING_PERIOD("last_during_period"),
-
-        @SerializedName("last_ever")
-        LAST_EVER("last_ever"),
-
-        @SerializedName("max")
-        MAX("max"),
-
-        @SerializedName("sum")
-        SUM("sum");
-
-        @Getter(onMethod_ = {@Override})
-        private final String value;
-
-        AggregateUsage(String value) {
-          this.value = value;
-        }
       }
 
       public enum Interval implements ApiRequestParams.EnumParam {
@@ -887,21 +784,6 @@ public class SubscriptionItemCreateParams extends ApiRequestParams {
         private final String value;
 
         Interval(String value) {
-          this.value = value;
-        }
-      }
-
-      public enum UsageType implements ApiRequestParams.EnumParam {
-        @SerializedName("licensed")
-        LICENSED("licensed"),
-
-        @SerializedName("metered")
-        METERED("metered");
-
-        @Getter(onMethod_ = {@Override})
-        private final String value;
-
-        UsageType(String value) {
           this.value = value;
         }
       }

--- a/src/main/java/com/stripe/param/SubscriptionItemUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionItemUpdateParams.java
@@ -735,16 +735,6 @@ public class SubscriptionItemUpdateParams extends ApiRequestParams {
     @Getter
     public static class Recurring {
       /**
-       * Specifies a usage aggregation strategy for prices of {@code usage_type=metered}. Allowed
-       * values are {@code sum} for summing up all usage during a period, {@code last_during_period}
-       * for using the last usage record reported within a period, {@code last_ever} for using the
-       * last usage record ever (across period bounds) or {@code max} which uses the usage record
-       * with the maximum reported usage during a period. Defaults to {@code sum}.
-       */
-      @SerializedName("aggregate_usage")
-      AggregateUsage aggregateUsage;
-
-      /**
        * Map of extra parameters for custom features not available in this client library. The
        * content in this map is not serialized under this field's {@code @SerializedName} value.
        * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
@@ -768,36 +758,10 @@ public class SubscriptionItemUpdateParams extends ApiRequestParams {
       @SerializedName("interval_count")
       Long intervalCount;
 
-      /**
-       * Default number of trial days when subscribing a customer to this price using <a
-       * href="https://stripe.com/docs/api#create_subscription-trial_from_plan">{@code
-       * trial_from_plan=true}</a>.
-       */
-      @SerializedName("trial_period_days")
-      Long trialPeriodDays;
-
-      /**
-       * Configures how the quantity per period should be determined. Can be either {@code metered}
-       * or {@code licensed}. {@code licensed} automatically bills the {@code quantity} set when
-       * adding it to a subscription. {@code metered} aggregates the total usage based on usage
-       * records. Defaults to {@code licensed}.
-       */
-      @SerializedName("usage_type")
-      UsageType usageType;
-
-      private Recurring(
-          AggregateUsage aggregateUsage,
-          Map<String, Object> extraParams,
-          Interval interval,
-          Long intervalCount,
-          Long trialPeriodDays,
-          UsageType usageType) {
-        this.aggregateUsage = aggregateUsage;
+      private Recurring(Map<String, Object> extraParams, Interval interval, Long intervalCount) {
         this.extraParams = extraParams;
         this.interval = interval;
         this.intervalCount = intervalCount;
-        this.trialPeriodDays = trialPeriodDays;
-        this.usageType = usageType;
       }
 
       public static Builder builder() {
@@ -805,40 +769,15 @@ public class SubscriptionItemUpdateParams extends ApiRequestParams {
       }
 
       public static class Builder {
-        private AggregateUsage aggregateUsage;
-
         private Map<String, Object> extraParams;
 
         private Interval interval;
 
         private Long intervalCount;
 
-        private Long trialPeriodDays;
-
-        private UsageType usageType;
-
         /** Finalize and obtain parameter instance from this builder. */
         public Recurring build() {
-          return new Recurring(
-              this.aggregateUsage,
-              this.extraParams,
-              this.interval,
-              this.intervalCount,
-              this.trialPeriodDays,
-              this.usageType);
-        }
-
-        /**
-         * Specifies a usage aggregation strategy for prices of {@code usage_type=metered}. Allowed
-         * values are {@code sum} for summing up all usage during a period, {@code
-         * last_during_period} for using the last usage record reported within a period, {@code
-         * last_ever} for using the last usage record ever (across period bounds) or {@code max}
-         * which uses the usage record with the maximum reported usage during a period. Defaults to
-         * {@code sum}.
-         */
-        public Builder setAggregateUsage(AggregateUsage aggregateUsage) {
-          this.aggregateUsage = aggregateUsage;
-          return this;
+          return new Recurring(this.extraParams, this.interval, this.intervalCount);
         }
 
         /**
@@ -887,48 +826,6 @@ public class SubscriptionItemUpdateParams extends ApiRequestParams {
           this.intervalCount = intervalCount;
           return this;
         }
-
-        /**
-         * Default number of trial days when subscribing a customer to this price using <a
-         * href="https://stripe.com/docs/api#create_subscription-trial_from_plan">{@code
-         * trial_from_plan=true}</a>.
-         */
-        public Builder setTrialPeriodDays(Long trialPeriodDays) {
-          this.trialPeriodDays = trialPeriodDays;
-          return this;
-        }
-
-        /**
-         * Configures how the quantity per period should be determined. Can be either {@code
-         * metered} or {@code licensed}. {@code licensed} automatically bills the {@code quantity}
-         * set when adding it to a subscription. {@code metered} aggregates the total usage based on
-         * usage records. Defaults to {@code licensed}.
-         */
-        public Builder setUsageType(UsageType usageType) {
-          this.usageType = usageType;
-          return this;
-        }
-      }
-
-      public enum AggregateUsage implements ApiRequestParams.EnumParam {
-        @SerializedName("last_during_period")
-        LAST_DURING_PERIOD("last_during_period"),
-
-        @SerializedName("last_ever")
-        LAST_EVER("last_ever"),
-
-        @SerializedName("max")
-        MAX("max"),
-
-        @SerializedName("sum")
-        SUM("sum");
-
-        @Getter(onMethod_ = {@Override})
-        private final String value;
-
-        AggregateUsage(String value) {
-          this.value = value;
-        }
       }
 
       public enum Interval implements ApiRequestParams.EnumParam {
@@ -948,21 +845,6 @@ public class SubscriptionItemUpdateParams extends ApiRequestParams {
         private final String value;
 
         Interval(String value) {
-          this.value = value;
-        }
-      }
-
-      public enum UsageType implements ApiRequestParams.EnumParam {
-        @SerializedName("licensed")
-        LICENSED("licensed"),
-
-        @SerializedName("metered")
-        METERED("metered");
-
-        @Getter(onMethod_ = {@Override})
-        private final String value;
-
-        UsageType(String value) {
           this.value = value;
         }
       }

--- a/src/main/java/com/stripe/param/SubscriptionScheduleCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionScheduleCreateParams.java
@@ -2003,17 +2003,6 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
         @Getter
         public static class Recurring {
           /**
-           * Specifies a usage aggregation strategy for prices of {@code usage_type=metered}.
-           * Allowed values are {@code sum} for summing up all usage during a period, {@code
-           * last_during_period} for using the last usage record reported within a period, {@code
-           * last_ever} for using the last usage record ever (across period bounds) or {@code max}
-           * which uses the usage record with the maximum reported usage during a period. Defaults
-           * to {@code sum}.
-           */
-          @SerializedName("aggregate_usage")
-          AggregateUsage aggregateUsage;
-
-          /**
            * Map of extra parameters for custom features not available in this client library. The
            * content in this map is not serialized under this field's {@code @SerializedName} value.
            * Instead, each key/value pair is serialized as if the key is a root-level field
@@ -2038,36 +2027,11 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
           @SerializedName("interval_count")
           Long intervalCount;
 
-          /**
-           * Default number of trial days when subscribing a customer to this price using <a
-           * href="https://stripe.com/docs/api#create_subscription-trial_from_plan">{@code
-           * trial_from_plan=true}</a>.
-           */
-          @SerializedName("trial_period_days")
-          Long trialPeriodDays;
-
-          /**
-           * Configures how the quantity per period should be determined. Can be either {@code
-           * metered} or {@code licensed}. {@code licensed} automatically bills the {@code quantity}
-           * set when adding it to a subscription. {@code metered} aggregates the total usage based
-           * on usage records. Defaults to {@code licensed}.
-           */
-          @SerializedName("usage_type")
-          UsageType usageType;
-
           private Recurring(
-              AggregateUsage aggregateUsage,
-              Map<String, Object> extraParams,
-              Interval interval,
-              Long intervalCount,
-              Long trialPeriodDays,
-              UsageType usageType) {
-            this.aggregateUsage = aggregateUsage;
+              Map<String, Object> extraParams, Interval interval, Long intervalCount) {
             this.extraParams = extraParams;
             this.interval = interval;
             this.intervalCount = intervalCount;
-            this.trialPeriodDays = trialPeriodDays;
-            this.usageType = usageType;
           }
 
           public static Builder builder() {
@@ -2075,40 +2039,15 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
           }
 
           public static class Builder {
-            private AggregateUsage aggregateUsage;
-
             private Map<String, Object> extraParams;
 
             private Interval interval;
 
             private Long intervalCount;
 
-            private Long trialPeriodDays;
-
-            private UsageType usageType;
-
             /** Finalize and obtain parameter instance from this builder. */
             public Recurring build() {
-              return new Recurring(
-                  this.aggregateUsage,
-                  this.extraParams,
-                  this.interval,
-                  this.intervalCount,
-                  this.trialPeriodDays,
-                  this.usageType);
-            }
-
-            /**
-             * Specifies a usage aggregation strategy for prices of {@code usage_type=metered}.
-             * Allowed values are {@code sum} for summing up all usage during a period, {@code
-             * last_during_period} for using the last usage record reported within a period, {@code
-             * last_ever} for using the last usage record ever (across period bounds) or {@code max}
-             * which uses the usage record with the maximum reported usage during a period. Defaults
-             * to {@code sum}.
-             */
-            public Builder setAggregateUsage(AggregateUsage aggregateUsage) {
-              this.aggregateUsage = aggregateUsage;
-              return this;
+              return new Recurring(this.extraParams, this.interval, this.intervalCount);
             }
 
             /**
@@ -2159,48 +2098,6 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
               this.intervalCount = intervalCount;
               return this;
             }
-
-            /**
-             * Default number of trial days when subscribing a customer to this price using <a
-             * href="https://stripe.com/docs/api#create_subscription-trial_from_plan">{@code
-             * trial_from_plan=true}</a>.
-             */
-            public Builder setTrialPeriodDays(Long trialPeriodDays) {
-              this.trialPeriodDays = trialPeriodDays;
-              return this;
-            }
-
-            /**
-             * Configures how the quantity per period should be determined. Can be either {@code
-             * metered} or {@code licensed}. {@code licensed} automatically bills the {@code
-             * quantity} set when adding it to a subscription. {@code metered} aggregates the total
-             * usage based on usage records. Defaults to {@code licensed}.
-             */
-            public Builder setUsageType(UsageType usageType) {
-              this.usageType = usageType;
-              return this;
-            }
-          }
-
-          public enum AggregateUsage implements ApiRequestParams.EnumParam {
-            @SerializedName("last_during_period")
-            LAST_DURING_PERIOD("last_during_period"),
-
-            @SerializedName("last_ever")
-            LAST_EVER("last_ever"),
-
-            @SerializedName("max")
-            MAX("max"),
-
-            @SerializedName("sum")
-            SUM("sum");
-
-            @Getter(onMethod_ = {@Override})
-            private final String value;
-
-            AggregateUsage(String value) {
-              this.value = value;
-            }
           }
 
           public enum Interval implements ApiRequestParams.EnumParam {
@@ -2220,21 +2117,6 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
             private final String value;
 
             Interval(String value) {
-              this.value = value;
-            }
-          }
-
-          public enum UsageType implements ApiRequestParams.EnumParam {
-            @SerializedName("licensed")
-            LICENSED("licensed"),
-
-            @SerializedName("metered")
-            METERED("metered");
-
-            @Getter(onMethod_ = {@Override})
-            private final String value;
-
-            UsageType(String value) {
               this.value = value;
             }
           }

--- a/src/main/java/com/stripe/param/SubscriptionScheduleUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionScheduleUpdateParams.java
@@ -2117,17 +2117,6 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
         @Getter
         public static class Recurring {
           /**
-           * Specifies a usage aggregation strategy for prices of {@code usage_type=metered}.
-           * Allowed values are {@code sum} for summing up all usage during a period, {@code
-           * last_during_period} for using the last usage record reported within a period, {@code
-           * last_ever} for using the last usage record ever (across period bounds) or {@code max}
-           * which uses the usage record with the maximum reported usage during a period. Defaults
-           * to {@code sum}.
-           */
-          @SerializedName("aggregate_usage")
-          AggregateUsage aggregateUsage;
-
-          /**
            * Map of extra parameters for custom features not available in this client library. The
            * content in this map is not serialized under this field's {@code @SerializedName} value.
            * Instead, each key/value pair is serialized as if the key is a root-level field
@@ -2152,36 +2141,11 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
           @SerializedName("interval_count")
           Long intervalCount;
 
-          /**
-           * Default number of trial days when subscribing a customer to this price using <a
-           * href="https://stripe.com/docs/api#create_subscription-trial_from_plan">{@code
-           * trial_from_plan=true}</a>.
-           */
-          @SerializedName("trial_period_days")
-          Long trialPeriodDays;
-
-          /**
-           * Configures how the quantity per period should be determined. Can be either {@code
-           * metered} or {@code licensed}. {@code licensed} automatically bills the {@code quantity}
-           * set when adding it to a subscription. {@code metered} aggregates the total usage based
-           * on usage records. Defaults to {@code licensed}.
-           */
-          @SerializedName("usage_type")
-          UsageType usageType;
-
           private Recurring(
-              AggregateUsage aggregateUsage,
-              Map<String, Object> extraParams,
-              Interval interval,
-              Long intervalCount,
-              Long trialPeriodDays,
-              UsageType usageType) {
-            this.aggregateUsage = aggregateUsage;
+              Map<String, Object> extraParams, Interval interval, Long intervalCount) {
             this.extraParams = extraParams;
             this.interval = interval;
             this.intervalCount = intervalCount;
-            this.trialPeriodDays = trialPeriodDays;
-            this.usageType = usageType;
           }
 
           public static Builder builder() {
@@ -2189,40 +2153,15 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
           }
 
           public static class Builder {
-            private AggregateUsage aggregateUsage;
-
             private Map<String, Object> extraParams;
 
             private Interval interval;
 
             private Long intervalCount;
 
-            private Long trialPeriodDays;
-
-            private UsageType usageType;
-
             /** Finalize and obtain parameter instance from this builder. */
             public Recurring build() {
-              return new Recurring(
-                  this.aggregateUsage,
-                  this.extraParams,
-                  this.interval,
-                  this.intervalCount,
-                  this.trialPeriodDays,
-                  this.usageType);
-            }
-
-            /**
-             * Specifies a usage aggregation strategy for prices of {@code usage_type=metered}.
-             * Allowed values are {@code sum} for summing up all usage during a period, {@code
-             * last_during_period} for using the last usage record reported within a period, {@code
-             * last_ever} for using the last usage record ever (across period bounds) or {@code max}
-             * which uses the usage record with the maximum reported usage during a period. Defaults
-             * to {@code sum}.
-             */
-            public Builder setAggregateUsage(AggregateUsage aggregateUsage) {
-              this.aggregateUsage = aggregateUsage;
-              return this;
+              return new Recurring(this.extraParams, this.interval, this.intervalCount);
             }
 
             /**
@@ -2273,48 +2212,6 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
               this.intervalCount = intervalCount;
               return this;
             }
-
-            /**
-             * Default number of trial days when subscribing a customer to this price using <a
-             * href="https://stripe.com/docs/api#create_subscription-trial_from_plan">{@code
-             * trial_from_plan=true}</a>.
-             */
-            public Builder setTrialPeriodDays(Long trialPeriodDays) {
-              this.trialPeriodDays = trialPeriodDays;
-              return this;
-            }
-
-            /**
-             * Configures how the quantity per period should be determined. Can be either {@code
-             * metered} or {@code licensed}. {@code licensed} automatically bills the {@code
-             * quantity} set when adding it to a subscription. {@code metered} aggregates the total
-             * usage based on usage records. Defaults to {@code licensed}.
-             */
-            public Builder setUsageType(UsageType usageType) {
-              this.usageType = usageType;
-              return this;
-            }
-          }
-
-          public enum AggregateUsage implements ApiRequestParams.EnumParam {
-            @SerializedName("last_during_period")
-            LAST_DURING_PERIOD("last_during_period"),
-
-            @SerializedName("last_ever")
-            LAST_EVER("last_ever"),
-
-            @SerializedName("max")
-            MAX("max"),
-
-            @SerializedName("sum")
-            SUM("sum");
-
-            @Getter(onMethod_ = {@Override})
-            private final String value;
-
-            AggregateUsage(String value) {
-              this.value = value;
-            }
           }
 
           public enum Interval implements ApiRequestParams.EnumParam {
@@ -2334,21 +2231,6 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
             private final String value;
 
             Interval(String value) {
-              this.value = value;
-            }
-          }
-
-          public enum UsageType implements ApiRequestParams.EnumParam {
-            @SerializedName("licensed")
-            LICENSED("licensed"),
-
-            @SerializedName("metered")
-            METERED("metered");
-
-            @Getter(onMethod_ = {@Override})
-            private final String value;
-
-            UsageType(String value) {
               this.value = value;
             }
           }

--- a/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
@@ -1885,17 +1885,6 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
       @Getter
       public static class Recurring {
         /**
-         * Specifies a usage aggregation strategy for prices of {@code usage_type=metered}. Allowed
-         * values are {@code sum} for summing up all usage during a period, {@code
-         * last_during_period} for using the last usage record reported within a period, {@code
-         * last_ever} for using the last usage record ever (across period bounds) or {@code max}
-         * which uses the usage record with the maximum reported usage during a period. Defaults to
-         * {@code sum}.
-         */
-        @SerializedName("aggregate_usage")
-        AggregateUsage aggregateUsage;
-
-        /**
          * Map of extra parameters for custom features not available in this client library. The
          * content in this map is not serialized under this field's {@code @SerializedName} value.
          * Instead, each key/value pair is serialized as if the key is a root-level field
@@ -1920,36 +1909,10 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
         @SerializedName("interval_count")
         Long intervalCount;
 
-        /**
-         * Default number of trial days when subscribing a customer to this price using <a
-         * href="https://stripe.com/docs/api#create_subscription-trial_from_plan">{@code
-         * trial_from_plan=true}</a>.
-         */
-        @SerializedName("trial_period_days")
-        Long trialPeriodDays;
-
-        /**
-         * Configures how the quantity per period should be determined. Can be either {@code
-         * metered} or {@code licensed}. {@code licensed} automatically bills the {@code quantity}
-         * set when adding it to a subscription. {@code metered} aggregates the total usage based on
-         * usage records. Defaults to {@code licensed}.
-         */
-        @SerializedName("usage_type")
-        UsageType usageType;
-
-        private Recurring(
-            AggregateUsage aggregateUsage,
-            Map<String, Object> extraParams,
-            Interval interval,
-            Long intervalCount,
-            Long trialPeriodDays,
-            UsageType usageType) {
-          this.aggregateUsage = aggregateUsage;
+        private Recurring(Map<String, Object> extraParams, Interval interval, Long intervalCount) {
           this.extraParams = extraParams;
           this.interval = interval;
           this.intervalCount = intervalCount;
-          this.trialPeriodDays = trialPeriodDays;
-          this.usageType = usageType;
         }
 
         public static Builder builder() {
@@ -1957,40 +1920,15 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
         }
 
         public static class Builder {
-          private AggregateUsage aggregateUsage;
-
           private Map<String, Object> extraParams;
 
           private Interval interval;
 
           private Long intervalCount;
 
-          private Long trialPeriodDays;
-
-          private UsageType usageType;
-
           /** Finalize and obtain parameter instance from this builder. */
           public Recurring build() {
-            return new Recurring(
-                this.aggregateUsage,
-                this.extraParams,
-                this.interval,
-                this.intervalCount,
-                this.trialPeriodDays,
-                this.usageType);
-          }
-
-          /**
-           * Specifies a usage aggregation strategy for prices of {@code usage_type=metered}.
-           * Allowed values are {@code sum} for summing up all usage during a period, {@code
-           * last_during_period} for using the last usage record reported within a period, {@code
-           * last_ever} for using the last usage record ever (across period bounds) or {@code max}
-           * which uses the usage record with the maximum reported usage during a period. Defaults
-           * to {@code sum}.
-           */
-          public Builder setAggregateUsage(AggregateUsage aggregateUsage) {
-            this.aggregateUsage = aggregateUsage;
-            return this;
+            return new Recurring(this.extraParams, this.interval, this.intervalCount);
           }
 
           /**
@@ -2039,48 +1977,6 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
             this.intervalCount = intervalCount;
             return this;
           }
-
-          /**
-           * Default number of trial days when subscribing a customer to this price using <a
-           * href="https://stripe.com/docs/api#create_subscription-trial_from_plan">{@code
-           * trial_from_plan=true}</a>.
-           */
-          public Builder setTrialPeriodDays(Long trialPeriodDays) {
-            this.trialPeriodDays = trialPeriodDays;
-            return this;
-          }
-
-          /**
-           * Configures how the quantity per period should be determined. Can be either {@code
-           * metered} or {@code licensed}. {@code licensed} automatically bills the {@code quantity}
-           * set when adding it to a subscription. {@code metered} aggregates the total usage based
-           * on usage records. Defaults to {@code licensed}.
-           */
-          public Builder setUsageType(UsageType usageType) {
-            this.usageType = usageType;
-            return this;
-          }
-        }
-
-        public enum AggregateUsage implements ApiRequestParams.EnumParam {
-          @SerializedName("last_during_period")
-          LAST_DURING_PERIOD("last_during_period"),
-
-          @SerializedName("last_ever")
-          LAST_EVER("last_ever"),
-
-          @SerializedName("max")
-          MAX("max"),
-
-          @SerializedName("sum")
-          SUM("sum");
-
-          @Getter(onMethod_ = {@Override})
-          private final String value;
-
-          AggregateUsage(String value) {
-            this.value = value;
-          }
         }
 
         public enum Interval implements ApiRequestParams.EnumParam {
@@ -2100,21 +1996,6 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
           private final String value;
 
           Interval(String value) {
-            this.value = value;
-          }
-        }
-
-        public enum UsageType implements ApiRequestParams.EnumParam {
-          @SerializedName("licensed")
-          LICENSED("licensed"),
-
-          @SerializedName("metered")
-          METERED("metered");
-
-          @Getter(onMethod_ = {@Override})
-          private final String value;
-
-          UsageType(String value) {
             this.value = value;
           }
         }


### PR DESCRIPTION
Multiple API changes
  * Remove parameters in `price_data[recurring]` across APIs as they were never supported
  * Move `payment_method_details[card][three_d_secure]` to a list of enum values on `Charge`
  * Add support for for `business_profile[support_adress]` on `Account` create and update

Codegen for openapi fd0d8ec

Flagging this is technically a breaking change but since the feature is new-ish, not yet live and those parameters never worked we will release as a minor.

r? @ob-stripe 
cc @stripe/api-libraries 