### PR TITLE
Add support for `purchase_details` on Issuing `Transaction`

### DIFF
--- a/src/main/java/com/stripe/model/issuing/Transaction.java
+++ b/src/main/java/com/stripe/model/issuing/Transaction.java
@@ -7,11 +7,14 @@ import com.stripe.model.BalanceTransaction;
 import com.stripe.model.BalanceTransactionSource;
 import com.stripe.model.ExpandableField;
 import com.stripe.model.MetadataStore;
+import com.stripe.model.StripeObject;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 import com.stripe.param.issuing.TransactionListParams;
 import com.stripe.param.issuing.TransactionRetrieveParams;
 import com.stripe.param.issuing.TransactionUpdateParams;
+import java.math.BigDecimal;
+import java.util.List;
 import java.util.Map;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -110,6 +113,10 @@ public class Transaction extends ApiResource
    */
   @SerializedName("object")
   String object;
+
+  /** Additional purchase information that is optionally provided by the merchant. */
+  @SerializedName("purchase_details")
+  PurchaseDetails purchaseDetails;
 
   /**
    * The nature of the transaction.
@@ -312,5 +319,148 @@ public class Transaction extends ApiResource
             String.format("/v1/issuing/transactions/%s", ApiResource.urlEncodeId(this.getId())));
     return ApiResource.request(
         ApiResource.RequestMethod.POST, url, params, Transaction.class, options);
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class PurchaseDetails extends StripeObject {
+    /** Information about the flight that was purchased with this transaction. */
+    @SerializedName("flight")
+    Flight flight;
+
+    /** Information about fuel that was purchased with this transaction. */
+    @SerializedName("fuel")
+    Fuel fuel;
+
+    /** Information about lodging that was purchased with this transaction. */
+    @SerializedName("lodging")
+    Lodging lodging;
+
+    /** The line items in the purchase. */
+    @SerializedName("receipt")
+    List<Transaction.PurchaseDetails.Receipt> receipt;
+
+    /** A merchant-specific order number. */
+    @SerializedName("reference")
+    String reference;
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class Flight extends StripeObject {
+      /** The time that the flight departed. */
+      @SerializedName("departure_at")
+      Long departureAt;
+
+      /** The name of the passenger. */
+      @SerializedName("passenger_name")
+      String passengerName;
+
+      /** Whether the ticket is refundable. */
+      @SerializedName("refundable")
+      Boolean refundable;
+
+      /** The legs of the trip. */
+      @SerializedName("segments")
+      List<Transaction.PurchaseDetails.Flight.Segments> segments;
+
+      /** The travel agency that issued the ticket. */
+      @SerializedName("travel_agency")
+      String travelAgency;
+
+      @Getter
+      @Setter
+      @EqualsAndHashCode(callSuper = false)
+      public static class Segments extends StripeObject {
+        /** The flight's destination airport code. */
+        @SerializedName("arrival_airport_code")
+        String arrivalAirportCode;
+
+        /** The airline carrier code. */
+        @SerializedName("carrier")
+        String carrier;
+
+        /** The airport code that the flight departed from. */
+        @SerializedName("departure_airport_code")
+        String departureAirportCode;
+
+        /** The flight number. */
+        @SerializedName("flight_number")
+        String flightNumber;
+
+        /** The flight's service class. */
+        @SerializedName("service_class")
+        String serviceClass;
+
+        /** Whether a stopover is allowed on this flight. */
+        @SerializedName("stopover_allowed")
+        Boolean stopoverAllowed;
+      }
+    }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class Fuel extends StripeObject {
+      /**
+       * The type of fuel that was purchased. One of {@code diesel}, {@code unleaded_plus}, {@code
+       * unleaded_regular}, {@code unleaded_super}, or {@code other}.
+       */
+      @SerializedName("type")
+      String type;
+
+      /** The units for {@code volume}. One of {@code us_gallon} or {@code liter}. */
+      @SerializedName("unit")
+      String unit;
+
+      /**
+       * The cost in cents per each unit of fuel, represented as a decimal string with at most 12
+       * decimal places.
+       */
+      @SerializedName("unit_cost_decimal")
+      BigDecimal unitCostDecimal;
+
+      /**
+       * The volume of the fuel that was pumped, represented as a decimal string with at most 12
+       * decimal places.
+       */
+      @SerializedName("volume_decimal")
+      BigDecimal volumeDecimal;
+    }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class Lodging extends StripeObject {
+      /** The time of checking into the lodging. */
+      @SerializedName("check_in_at")
+      Long checkInAt;
+
+      /** The number of nights stayed at the lodging. */
+      @SerializedName("nights")
+      Long nights;
+    }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class Receipt extends StripeObject {
+      /** The description of the item. The maximum length of this field is 26 characters. */
+      @SerializedName("description")
+      String description;
+
+      /** The quantity of the item. */
+      @SerializedName("quantity")
+      BigDecimal quantity;
+
+      /** The total for this line item in cents. */
+      @SerializedName("total")
+      Long total;
+
+      /** The unit cost of the item in cents. */
+      @SerializedName("unit_cost")
+      Long unitCost;
+    }
   }
 }

--- a/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
+++ b/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
@@ -62,9 +62,14 @@ public class SessionCreateParams extends ApiRequestParams {
   Map<String, Object> extraParams;
 
   /**
-   * A list of items the customer is purchasing. Use this parameter for one-time payments or adding
-   * invoice line items to a subscription (used in conjunction with {@code subscription_data}).
-   * There is a maximum of 100 line items, however it is recommended to consolidate line items if
+   * A list of items the customer is purchasing. Use this parameter to pass one-time or recurring <a
+   * href="https://stripe.com/docs/api/prices">prices</a>.
+   *
+   * <p>Alternatively, if not using recurring prices, this parameter is for one-time payments or
+   * adding invoice line items to a subscription (used in conjunction with {@code
+   * subscription_data.items}).
+   *
+   * <p>There is a maximum of 100 line items, however it is recommended to consolidate line items if
    * there are more than a few dozen.
    */
   @SerializedName("line_items")
@@ -88,7 +93,8 @@ public class SessionCreateParams extends ApiRequestParams {
 
   /**
    * The mode of the Checkout Session, one of {@code payment}, {@code setup}, or {@code
-   * subscription}.
+   * subscription}. Required when using prices or {@code setup} mode. Pass {@code subscription} if
+   * Checkout session includes at least one recurring item.
    */
   @SerializedName("mode")
   Mode mode;
@@ -407,7 +413,8 @@ public class SessionCreateParams extends ApiRequestParams {
 
     /**
      * The mode of the Checkout Session, one of {@code payment}, {@code setup}, or {@code
-     * subscription}.
+     * subscription}. Required when using prices or {@code setup} mode. Pass {@code subscription} if
+     * Checkout session includes at least one recurring item.
      */
     public Builder setMode(Mode mode) {
       this.mode = mode;
@@ -501,19 +508,27 @@ public class SessionCreateParams extends ApiRequestParams {
 
   @Getter
   public static class LineItem {
-    /** The amount to be collected per unit of the line item. */
+    /**
+     * The amount to be collected per unit of the line item. If specified, must also pass {@code
+     * currency} and {@code name}.
+     */
     @SerializedName("amount")
     Long amount;
 
     /**
      * Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency
      * code</a>, in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported
-     * currency</a>.
+     * currency</a>. Required if {@code amount} is passed.
      */
     @SerializedName("currency")
     String currency;
 
-    /** The description for the line item, to be displayed on the Checkout page. */
+    /**
+     * The description for the line item, to be displayed on the Checkout page.
+     *
+     * <p>If using {@code price} or {@code price_data}, will default to the name of the associated
+     * product.
+     */
     @SerializedName("description")
     String description;
 
@@ -526,19 +541,32 @@ public class SessionCreateParams extends ApiRequestParams {
     @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
     Map<String, Object> extraParams;
 
-    /** A list of images representing this line item. Each image can be up to 5 MB in size. */
+    /**
+     * A list of image URLs representing this line item. Each image can be up to 5 MB in size. If
+     * passing {@code price} or {@code price_data}, specify images on the associated product
+     * instead.
+     */
     @SerializedName("images")
     List<String> images;
 
-    /** The name for the line item. */
+    /**
+     * The name for the item to be displayed on the Checkout page. Required if {@code amount} is
+     * passed.
+     */
     @SerializedName("name")
     String name;
 
-    /** The ID of the price object. */
+    /**
+     * The ID of the price object. One of {@code price}, {@code price_data} or {@code amount} is
+     * required.
+     */
     @SerializedName("price")
     String price;
 
-    /** Data used to generate a new price object inline. */
+    /**
+     * Data used to generate a new price object inline. One of {@code price}, {@code price_data} or
+     * {@code amount} is required.
+     */
     @SerializedName("price_data")
     PriceData priceData;
 
@@ -613,7 +641,10 @@ public class SessionCreateParams extends ApiRequestParams {
             this.taxRates);
       }
 
-      /** The amount to be collected per unit of the line item. */
+      /**
+       * The amount to be collected per unit of the line item. If specified, must also pass {@code
+       * currency} and {@code name}.
+       */
       public Builder setAmount(Long amount) {
         this.amount = amount;
         return this;
@@ -622,14 +653,19 @@ public class SessionCreateParams extends ApiRequestParams {
       /**
        * Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency
        * code</a>, in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported
-       * currency</a>.
+       * currency</a>. Required if {@code amount} is passed.
        */
       public Builder setCurrency(String currency) {
         this.currency = currency;
         return this;
       }
 
-      /** The description for the line item, to be displayed on the Checkout page. */
+      /**
+       * The description for the line item, to be displayed on the Checkout page.
+       *
+       * <p>If using {@code price} or {@code price_data}, will default to the name of the associated
+       * product.
+       */
       public Builder setDescription(String description) {
         this.description = description;
         return this;
@@ -687,19 +723,28 @@ public class SessionCreateParams extends ApiRequestParams {
         return this;
       }
 
-      /** The name for the line item. */
+      /**
+       * The name for the item to be displayed on the Checkout page. Required if {@code amount} is
+       * passed.
+       */
       public Builder setName(String name) {
         this.name = name;
         return this;
       }
 
-      /** The ID of the price object. */
+      /**
+       * The ID of the price object. One of {@code price}, {@code price_data} or {@code amount} is
+       * required.
+       */
       public Builder setPrice(String price) {
         this.price = price;
         return this;
       }
 
-      /** Data used to generate a new price object inline. */
+      /**
+       * Data used to generate a new price object inline. One of {@code price}, {@code price_data}
+       * or {@code amount} is required.
+       */
       public Builder setPriceData(PriceData priceData) {
         this.priceData = priceData;
         return this;


### PR DESCRIPTION
Codegen for openapi 6579724

r? @richardm-stripe 
cc @stripe/api-libraries 