### PR TITLE
Multiple API changes

### DIFF
--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -1397,12 +1397,31 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
         @SerializedName("authenticated")
         Boolean authenticated;
 
+        /**
+         * Indicates the outcome of 3D Secure authentication.
+         *
+         * <p>One of {@code attempt_acknowledged}, {@code authenticated}, {@code failed}, {@code
+         * not_supported}, or {@code processing_error}.
+         */
+        @SerializedName("result")
+        String result;
+
+        /**
+         * Additional information about why 3D Secure succeeded or failed.
+         *
+         * <p>One of {@code abandoned}, {@code bypassed}, {@code canceled}, {@code
+         * card_not_enrolled}, {@code network_not_supported}, {@code protocol_error}, or {@code
+         * rejected}.
+         */
+        @SerializedName("result_reason")
+        String resultReason;
+
         /** Whether or not 3D Secure succeeded. */
         @SerializedName("succeeded")
         Boolean succeeded;
 
         /**
-         * The version of 3D Secure that was used for this payment.
+         * The version of 3D Secure that was used.
          *
          * <p>One of {@code 1.0.2}, {@code 2.1.0}, or {@code 2.2.0}.
          */

--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -1274,7 +1274,8 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
      * nz_gst}, {@code au_abn}, {@code in_gst}, {@code no_vat}, {@code za_vat}, {@code ch_vat},
      * {@code mx_rfc}, {@code sg_uen}, {@code ru_inn}, {@code ca_bn}, {@code hk_br}, {@code es_cif},
      * {@code tw_vat}, {@code th_vat}, {@code jp_cn}, {@code li_uid}, {@code my_itn}, {@code
-     * us_ein}, {@code kr_brn}, {@code ca_qst}, {@code my_sst}, {@code sg_gst}, or {@code unknown}.
+     * us_ein}, {@code kr_brn}, {@code ca_qst}, {@code my_sst}, {@code sg_gst}, {@code ae_trn},
+     * {@code cl_tin}, {@code sa_vat}, or {@code unknown}.
      */
     @SerializedName("type")
     String type;

--- a/src/main/java/com/stripe/model/SourceMandateNotification.java
+++ b/src/main/java/com/stripe/model/SourceMandateNotification.java
@@ -9,6 +9,9 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class SourceMandateNotification extends StripeObject implements HasId {
+  @SerializedName("acss_debit")
+  AcssDebitData acssDebit;
+
   /**
    * A positive integer in the smallest currency unit (that is, 100 cents for $1.00, or 1 for ¥1,
    * Japanese Yen being a zero-decimal currency) representing the amount associated with the mandate
@@ -79,6 +82,15 @@ public class SourceMandateNotification extends StripeObject implements HasId {
    */
   @SerializedName("type")
   String type;
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class AcssDebitData extends StripeObject {
+    /** The statement descriptor associate with the debit. */
+    @SerializedName("statement_descriptor")
+    String statementDescriptor;
+  }
 
   @Getter
   @Setter

--- a/src/main/java/com/stripe/model/TaxId.java
+++ b/src/main/java/com/stripe/model/TaxId.java
@@ -53,12 +53,12 @@ public class TaxId extends ApiResource implements HasId {
   String object;
 
   /**
-   * Type of the tax ID, one of {@code au_abn}, {@code br_cnpj}, {@code br_cpf}, {@code ca_bn},
-   * {@code ca_qst}, {@code ch_vat}, {@code es_cif}, {@code eu_vat}, {@code hk_br}, {@code in_gst},
-   * {@code jp_cn}, {@code kr_brn}, {@code li_uid}, {@code mx_rfc}, {@code my_itn}, {@code my_sst},
-   * {@code no_vat}, {@code nz_gst}, {@code ru_inn}, {@code sg_gst}, {@code sg_uen}, {@code th_vat},
-   * {@code tw_vat}, {@code us_ein}, or {@code za_vat}. Note that some legacy tax IDs have type
-   * {@code unknown}
+   * Type of the tax ID, one of {@code ae_trn}, {@code au_abn}, {@code br_cnpj}, {@code br_cpf},
+   * {@code ca_bn}, {@code ca_qst}, {@code ch_vat}, {@code cl_tin}, {@code es_cif}, {@code eu_vat},
+   * {@code hk_br}, {@code in_gst}, {@code jp_cn}, {@code kr_brn}, {@code li_uid}, {@code mx_rfc},
+   * {@code my_itn}, {@code my_sst}, {@code no_vat}, {@code nz_gst}, {@code ru_inn}, {@code sa_vat},
+   * {@code sg_gst}, {@code sg_uen}, {@code th_vat}, {@code tw_vat}, {@code us_ein}, or {@code
+   * za_vat}. Note that some legacy tax IDs have type {@code unknown}
    */
   @SerializedName("type")
   String type;

--- a/src/main/java/com/stripe/param/CustomerCreateParams.java
+++ b/src/main/java/com/stripe/param/CustomerCreateParams.java
@@ -1133,7 +1133,8 @@ public class CustomerCreateParams extends ApiRequestParams {
      * {@code au_abn}, {@code in_gst}, {@code no_vat}, {@code za_vat}, {@code ch_vat}, {@code
      * mx_rfc}, {@code sg_uen}, {@code ru_inn}, {@code ca_bn}, {@code hk_br}, {@code es_cif}, {@code
      * tw_vat}, {@code th_vat}, {@code jp_cn}, {@code li_uid}, {@code my_itn}, {@code us_ein},
-     * {@code kr_brn}, {@code ca_qst}, {@code my_sst}, or {@code sg_gst}.
+     * {@code kr_brn}, {@code ca_qst}, {@code my_sst}, {@code sg_gst}, {@code ae_trn}, {@code
+     * cl_tin}, or {@code sa_vat}.
      */
     @SerializedName("type")
     Type type;
@@ -1195,7 +1196,8 @@ public class CustomerCreateParams extends ApiRequestParams {
        * {@code au_abn}, {@code in_gst}, {@code no_vat}, {@code za_vat}, {@code ch_vat}, {@code
        * mx_rfc}, {@code sg_uen}, {@code ru_inn}, {@code ca_bn}, {@code hk_br}, {@code es_cif},
        * {@code tw_vat}, {@code th_vat}, {@code jp_cn}, {@code li_uid}, {@code my_itn}, {@code
-       * us_ein}, {@code kr_brn}, {@code ca_qst}, {@code my_sst}, or {@code sg_gst}.
+       * us_ein}, {@code kr_brn}, {@code ca_qst}, {@code my_sst}, {@code sg_gst}, {@code ae_trn},
+       * {@code cl_tin}, or {@code sa_vat}.
        */
       public Builder setType(Type type) {
         this.type = type;
@@ -1210,6 +1212,9 @@ public class CustomerCreateParams extends ApiRequestParams {
     }
 
     public enum Type implements ApiRequestParams.EnumParam {
+      @SerializedName("ae_trn")
+      AE_TRN("ae_trn"),
+
       @SerializedName("au_abn")
       AU_ABN("au_abn"),
 
@@ -1227,6 +1232,9 @@ public class CustomerCreateParams extends ApiRequestParams {
 
       @SerializedName("ch_vat")
       CH_VAT("ch_vat"),
+
+      @SerializedName("cl_tin")
+      CL_TIN("cl_tin"),
 
       @SerializedName("es_cif")
       ES_CIF("es_cif"),
@@ -1266,6 +1274,9 @@ public class CustomerCreateParams extends ApiRequestParams {
 
       @SerializedName("ru_inn")
       RU_INN("ru_inn"),
+
+      @SerializedName("sa_vat")
+      SA_VAT("sa_vat"),
 
       @SerializedName("sg_gst")
       SG_GST("sg_gst"),

--- a/src/main/java/com/stripe/param/TaxIdCollectionCreateParams.java
+++ b/src/main/java/com/stripe/param/TaxIdCollectionCreateParams.java
@@ -28,7 +28,8 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
    * {@code au_abn}, {@code in_gst}, {@code no_vat}, {@code za_vat}, {@code ch_vat}, {@code mx_rfc},
    * {@code sg_uen}, {@code ru_inn}, {@code ca_bn}, {@code hk_br}, {@code es_cif}, {@code tw_vat},
    * {@code th_vat}, {@code jp_cn}, {@code li_uid}, {@code my_itn}, {@code us_ein}, {@code kr_brn},
-   * {@code ca_qst}, {@code my_sst}, or {@code sg_gst}.
+   * {@code ca_qst}, {@code my_sst}, {@code sg_gst}, {@code ae_trn}, {@code cl_tin}, or {@code
+   * sa_vat}.
    */
   @SerializedName("type")
   Type type;
@@ -120,7 +121,8 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
      * {@code au_abn}, {@code in_gst}, {@code no_vat}, {@code za_vat}, {@code ch_vat}, {@code
      * mx_rfc}, {@code sg_uen}, {@code ru_inn}, {@code ca_bn}, {@code hk_br}, {@code es_cif}, {@code
      * tw_vat}, {@code th_vat}, {@code jp_cn}, {@code li_uid}, {@code my_itn}, {@code us_ein},
-     * {@code kr_brn}, {@code ca_qst}, {@code my_sst}, or {@code sg_gst}.
+     * {@code kr_brn}, {@code ca_qst}, {@code my_sst}, {@code sg_gst}, {@code ae_trn}, {@code
+     * cl_tin}, or {@code sa_vat}.
      */
     public Builder setType(Type type) {
       this.type = type;
@@ -135,6 +137,9 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
   }
 
   public enum Type implements ApiRequestParams.EnumParam {
+    @SerializedName("ae_trn")
+    AE_TRN("ae_trn"),
+
     @SerializedName("au_abn")
     AU_ABN("au_abn"),
 
@@ -152,6 +157,9 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
 
     @SerializedName("ch_vat")
     CH_VAT("ch_vat"),
+
+    @SerializedName("cl_tin")
+    CL_TIN("cl_tin"),
 
     @SerializedName("es_cif")
     ES_CIF("es_cif"),
@@ -191,6 +199,9 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
 
     @SerializedName("ru_inn")
     RU_INN("ru_inn"),
+
+    @SerializedName("sa_vat")
+    SA_VAT("sa_vat"),
 
     @SerializedName("sg_gst")
     SG_GST("sg_gst"),


### PR DESCRIPTION
Multiple API changes:
  * Add support for `ae_trn`, `cl_tin` and `sa_vat` as `type` on `TaxId`
  * Add `result` and `result_reason` inside `payment_method_details[card][three_d_secure]` on `Charge`

Codegen for openapi cd33b40

r? @cjavilla-stripe 
cc @stripe/api-libraries 