### PR TITLE
Add support for BACS Debit as a `PaymentMethod`

### DIFF
--- a/src/main/java/com/stripe/model/Account.java
+++ b/src/main/java/com/stripe/model/Account.java
@@ -1025,6 +1025,9 @@ public class Account extends ApiResource implements MetadataStore<Account>, Paym
   @Setter
   @EqualsAndHashCode(callSuper = false)
   public static class Settings extends StripeObject {
+    @SerializedName("bacs_debit_payments")
+    BacsDebitPayments bacsDebitPayments;
+
     @SerializedName("branding")
     SettingsBranding branding;
 
@@ -1039,6 +1042,18 @@ public class Account extends ApiResource implements MetadataStore<Account>, Paym
 
     @SerializedName("payouts")
     SettingsPayouts payouts;
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class BacsDebitPayments extends StripeObject {
+      /**
+       * The Bacs Direct Debit Display Name for this account. For payments made with Bacs Direct
+       * Debit, this will appear on the mandate, and as the statement descriptor.
+       */
+      @SerializedName("display_name")
+      String displayName;
+    }
   }
 
   @Getter

--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -1008,6 +1008,9 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
     @SerializedName("au_becs_debit")
     AuBecsDebit auBecsDebit;
 
+    @SerializedName("bacs_debit")
+    BacsDebit bacsDebit;
+
     @SerializedName("bancontact")
     Bancontact bancontact;
 
@@ -1191,6 +1194,30 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
       /** ID of the mandate used to make this payment. */
       @SerializedName("mandate")
       String mandate;
+    }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class BacsDebit extends StripeObject {
+      /**
+       * Uniquely identifies this particular bank account. You can use this attribute to check
+       * whether two bank accounts are the same.
+       */
+      @SerializedName("fingerprint")
+      String fingerprint;
+
+      /** Last four digits of the bank account number. */
+      @SerializedName("last4")
+      String last4;
+
+      /** ID of the mandate used to make this payment. */
+      @SerializedName("mandate")
+      String mandate;
+
+      /** Sort code of the bank account. (e.g., {@code 10-20-30}) */
+      @SerializedName("sort_code")
+      String sortCode;
     }
 
     @Getter
@@ -1398,8 +1425,7 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
         Boolean authenticated;
 
         /**
-         * For authenticated transactions: whether issuing bank authenticated the cardholder with a
-         * traditional challenge screen, or with device data via the 3DS2 frictionless flow.
+         * For authenticated transactions: how the customer was authenticated by the issuing bank.
          *
          * <p>One of {@code challenge}, or {@code frictionless}.
          */
@@ -1416,7 +1442,8 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
         String result;
 
         /**
-         * Additional information about why 3D Secure succeeded or failed.
+         * Additional information about why 3D Secure succeeded or failed based on the {@code
+         * result}.
          *
          * <p>One of {@code abandoned}, {@code bypassed}, {@code canceled}, {@code
          * card_not_enrolled}, {@code network_not_supported}, {@code protocol_error}, or {@code

--- a/src/main/java/com/stripe/model/Mandate.java
+++ b/src/main/java/com/stripe/model/Mandate.java
@@ -135,6 +135,20 @@ public class Mandate extends ApiResource implements HasId {
   @Getter
   @Setter
   @EqualsAndHashCode(callSuper = false)
+  public static class BacsDebit extends StripeObject {
+    @SerializedName("network_status")
+    String networkStatus;
+
+    @SerializedName("reference")
+    String reference;
+
+    @SerializedName("url")
+    String url;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
   public static class CustomerAcceptance extends StripeObject {
     /** The time at which the customer accepted the Mandate. */
     @SerializedName("accepted_at")
@@ -183,6 +197,9 @@ public class Mandate extends ApiResource implements HasId {
   public static class PaymentMethodDetails extends StripeObject {
     @SerializedName("au_becs_debit")
     AuBecsDebit auBecsDebit;
+
+    @SerializedName("bacs_debit")
+    BacsDebit bacsDebit;
 
     @SerializedName("card")
     Card card;

--- a/src/main/java/com/stripe/model/PaymentMethod.java
+++ b/src/main/java/com/stripe/model/PaymentMethod.java
@@ -23,6 +23,9 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
   @SerializedName("au_becs_debit")
   AuBecsDebit auBecsDebit;
 
+  @SerializedName("bacs_debit")
+  BacsDebit bacsDebit;
+
   @SerializedName("billing_details")
   BillingDetails billingDetails;
 
@@ -89,8 +92,8 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
    * The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a name
    * matching this value. It contains additional information specific to the PaymentMethod type.
    *
-   * <p>One of {@code au_becs_debit}, {@code card}, {@code card_present}, {@code fpx}, {@code
-   * ideal}, or {@code sepa_debit}.
+   * <p>One of {@code au_becs_debit}, {@code bacs_debit}, {@code card}, {@code card_present}, {@code
+   * fpx}, {@code ideal}, or {@code sepa_debit}.
    */
   @SerializedName("type")
   String type;
@@ -413,6 +416,26 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
     /** Last four digits of the bank account number. */
     @SerializedName("last4")
     String last4;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class BacsDebit extends StripeObject {
+    /**
+     * Uniquely identifies this particular bank account. You can use this attribute to check whether
+     * two bank accounts are the same.
+     */
+    @SerializedName("fingerprint")
+    String fingerprint;
+
+    /** Last four digits of the bank account number. */
+    @SerializedName("last4")
+    String last4;
+
+    /** Sort code of the bank account. (e.g., {@code 10-20-30}) */
+    @SerializedName("sort_code")
+    String sortCode;
   }
 
   @Getter

--- a/src/main/java/com/stripe/model/Person.java
+++ b/src/main/java/com/stripe/model/Person.java
@@ -121,7 +121,10 @@ public class Person extends ApiResource implements HasId, MetadataStore<Person> 
   @SerializedName("requirements")
   Requirements requirements;
 
-  /** Whether the last 4 digits of this person's SSN have been provided. */
+  /**
+   * Whether the last four digits of the person's Social Security number have been provided (U.S.
+   * only).
+   */
   @SerializedName("ssn_last_4_provided")
   Boolean ssnLast4Provided;
 

--- a/src/main/java/com/stripe/model/Plan.java
+++ b/src/main/java/com/stripe/model/Plan.java
@@ -213,7 +213,7 @@ public class Plan extends ApiResource implements HasId, MetadataStore<Plan> {
 
   /**
    * You can create plans using the API, or in the Stripe <a
-   * href="https://dashboard.stripe.com/subscriptions/products">Dashboard</a>.
+   * href="https://dashboard.stripe.com/products">Dashboard</a>.
    */
   public static Plan create(Map<String, Object> params) throws StripeException {
     return create(params, (RequestOptions) null);
@@ -221,7 +221,7 @@ public class Plan extends ApiResource implements HasId, MetadataStore<Plan> {
 
   /**
    * You can create plans using the API, or in the Stripe <a
-   * href="https://dashboard.stripe.com/subscriptions/products">Dashboard</a>.
+   * href="https://dashboard.stripe.com/products">Dashboard</a>.
    */
   public static Plan create(Map<String, Object> params, RequestOptions options)
       throws StripeException {
@@ -231,7 +231,7 @@ public class Plan extends ApiResource implements HasId, MetadataStore<Plan> {
 
   /**
    * You can create plans using the API, or in the Stripe <a
-   * href="https://dashboard.stripe.com/subscriptions/products">Dashboard</a>.
+   * href="https://dashboard.stripe.com/products">Dashboard</a>.
    */
   public static Plan create(PlanCreateParams params) throws StripeException {
     return create(params, (RequestOptions) null);
@@ -239,7 +239,7 @@ public class Plan extends ApiResource implements HasId, MetadataStore<Plan> {
 
   /**
    * You can create plans using the API, or in the Stripe <a
-   * href="https://dashboard.stripe.com/subscriptions/products">Dashboard</a>.
+   * href="https://dashboard.stripe.com/products">Dashboard</a>.
    */
   public static Plan create(PlanCreateParams params, RequestOptions options)
       throws StripeException {

--- a/src/main/java/com/stripe/model/checkout/Session.java
+++ b/src/main/java/com/stripe/model/checkout/Session.java
@@ -65,12 +65,12 @@ public class Session extends ApiResource implements HasId {
    * If provided, this value will be used when the Customer object is created. If not provided,
    * customers will be asked to enter their email address. Use this parameter to prefill customer
    * data if you already have an email on file. To access information about the customer once a
-   * session is complete, use the {@code customer} field.
+   * session is complete, use the {@code customer} attribute.
    */
   @SerializedName("customer_email")
   String customerEmail;
 
-  /** The line items, plans, or SKUs purchased by the customer. */
+  /** The line items, plans, or SKUs purchased by the customer. Prefer using {@code line_items}. */
   @SerializedName("display_items")
   List<Session.DisplayItem> displayItems;
 

--- a/src/main/java/com/stripe/param/PaymentMethodCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentMethodCreateParams.java
@@ -18,6 +18,13 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
   AuBecsDebit auBecsDebit;
 
   /**
+   * If this is a {@code bacs_debit} PaymentMethod, this hash contains details about the Bacs Direct
+   * Debit bank account.
+   */
+  @SerializedName("bacs_debit")
+  BacsDebit bacsDebit;
+
+  /**
    * Billing information associated with the PaymentMethod that may be used or required by
    * particular types of payment methods.
    */
@@ -105,6 +112,7 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
 
   private PaymentMethodCreateParams(
       AuBecsDebit auBecsDebit,
+      BacsDebit bacsDebit,
       BillingDetails billingDetails,
       Object card,
       String customer,
@@ -118,6 +126,7 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
       SepaDebit sepaDebit,
       Type type) {
     this.auBecsDebit = auBecsDebit;
+    this.bacsDebit = bacsDebit;
     this.billingDetails = billingDetails;
     this.card = card;
     this.customer = customer;
@@ -138,6 +147,8 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
 
   public static class Builder {
     private AuBecsDebit auBecsDebit;
+
+    private BacsDebit bacsDebit;
 
     private BillingDetails billingDetails;
 
@@ -167,6 +178,7 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
     public PaymentMethodCreateParams build() {
       return new PaymentMethodCreateParams(
           this.auBecsDebit,
+          this.bacsDebit,
           this.billingDetails,
           this.card,
           this.customer,
@@ -187,6 +199,15 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
      */
     public Builder setAuBecsDebit(AuBecsDebit auBecsDebit) {
       this.auBecsDebit = auBecsDebit;
+      return this;
+    }
+
+    /**
+     * If this is a {@code bacs_debit} PaymentMethod, this hash contains details about the Bacs
+     * Direct Debit bank account.
+     */
+    public Builder setBacsDebit(BacsDebit bacsDebit) {
+      this.bacsDebit = bacsDebit;
       return this;
     }
 
@@ -440,6 +461,87 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
           this.extraParams = new HashMap<>();
         }
         this.extraParams.putAll(map);
+        return this;
+      }
+    }
+  }
+
+  @Getter
+  public static class BacsDebit {
+    /** Account number of the bank account that the funds will be debited from. */
+    @SerializedName("account_number")
+    String accountNumber;
+
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /** Sort code of the bank account. (e.g., {@code 10-20-30}) */
+    @SerializedName("sort_code")
+    String sortCode;
+
+    private BacsDebit(String accountNumber, Map<String, Object> extraParams, String sortCode) {
+      this.accountNumber = accountNumber;
+      this.extraParams = extraParams;
+      this.sortCode = sortCode;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private String accountNumber;
+
+      private Map<String, Object> extraParams;
+
+      private String sortCode;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public BacsDebit build() {
+        return new BacsDebit(this.accountNumber, this.extraParams, this.sortCode);
+      }
+
+      /** Account number of the bank account that the funds will be debited from. */
+      public Builder setAccountNumber(String accountNumber) {
+        this.accountNumber = accountNumber;
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * PaymentMethodCreateParams.BacsDebit#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link PaymentMethodCreateParams.BacsDebit#extraParams} for the field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** Sort code of the bank account. (e.g., {@code 10-20-30}) */
+      public Builder setSortCode(String sortCode) {
+        this.sortCode = sortCode;
         return this;
       }
     }
@@ -1290,6 +1392,9 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
   public enum Type implements ApiRequestParams.EnumParam {
     @SerializedName("au_becs_debit")
     AU_BECS_DEBIT("au_becs_debit"),
+
+    @SerializedName("bacs_debit")
+    BACS_DEBIT("bacs_debit"),
 
     @SerializedName("card")
     CARD("card"),

--- a/src/main/java/com/stripe/param/PersonCollectionCreateParams.java
+++ b/src/main/java/com/stripe/param/PersonCollectionCreateParams.java
@@ -113,7 +113,7 @@ public class PersonCollectionCreateParams extends ApiRequestParams {
   @SerializedName("relationship")
   Relationship relationship;
 
-  /** The last 4 digits of the person's social security number. */
+  /** The last four digits of the person's Social Security number (U.S. only). */
   @SerializedName("ssn_last_4")
   String ssnLast4;
 
@@ -465,7 +465,7 @@ public class PersonCollectionCreateParams extends ApiRequestParams {
       return this;
     }
 
-    /** The last 4 digits of the person's social security number. */
+    /** The last four digits of the person's Social Security number (U.S. only). */
     public Builder setSsnLast4(String ssnLast4) {
       this.ssnLast4 = ssnLast4;
       return this;

--- a/src/main/java/com/stripe/param/PersonUpdateParams.java
+++ b/src/main/java/com/stripe/param/PersonUpdateParams.java
@@ -113,7 +113,7 @@ public class PersonUpdateParams extends ApiRequestParams {
   @SerializedName("relationship")
   Relationship relationship;
 
-  /** The last 4 digits of the person's social security number. */
+  /** The last four digits of the person's Social Security number (U.S. only). */
   @SerializedName("ssn_last_4")
   Object ssnLast4;
 
@@ -548,13 +548,13 @@ public class PersonUpdateParams extends ApiRequestParams {
       return this;
     }
 
-    /** The last 4 digits of the person's social security number. */
+    /** The last four digits of the person's Social Security number (U.S. only). */
     public Builder setSsnLast4(String ssnLast4) {
       this.ssnLast4 = ssnLast4;
       return this;
     }
 
-    /** The last 4 digits of the person's social security number. */
+    /** The last four digits of the person's Social Security number (U.S. only). */
     public Builder setSsnLast4(EmptyParam ssnLast4) {
       this.ssnLast4 = ssnLast4;
       return this;

--- a/src/main/java/com/stripe/param/TokenCreateParams.java
+++ b/src/main/java/com/stripe/param/TokenCreateParams.java
@@ -3237,7 +3237,7 @@ public class TokenCreateParams extends ApiRequestParams {
     @SerializedName("relationship")
     Relationship relationship;
 
-    /** The last 4 digits of the person's social security number. */
+    /** The last four digits of the person's Social Security number (U.S. only). */
     @SerializedName("ssn_last_4")
     String ssnLast4;
 
@@ -3544,7 +3544,7 @@ public class TokenCreateParams extends ApiRequestParams {
         return this;
       }
 
-      /** The last 4 digits of the person's social security number. */
+      /** The last four digits of the person's Social Security number (U.S. only). */
       public Builder setSsnLast4(String ssnLast4) {
         this.ssnLast4 = ssnLast4;
         return this;

--- a/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
+++ b/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
@@ -65,9 +65,8 @@ public class SessionCreateParams extends ApiRequestParams {
    * A list of items the customer is purchasing. Use this parameter to pass one-time or recurring <a
    * href="https://stripe.com/docs/api/prices">prices</a>.
    *
-   * <p>Alternatively, if not using recurring prices, this parameter is for one-time payments or
-   * adding invoice line items to a subscription (used in conjunction with {@code
-   * subscription_data.items}).
+   * <p>If not using recurring prices, this parameter is for one-time payments or adding invoice
+   * line items to a subscription (used in conjunction with {@code subscription_data.items}).
    *
    * <p>There is a maximum of 100 line items, however it is recommended to consolidate line items if
    * there are more than a few dozen.
@@ -558,8 +557,8 @@ public class SessionCreateParams extends ApiRequestParams {
     String name;
 
     /**
-     * The ID of the price object. One of {@code price}, {@code price_data} or {@code amount} is
-     * required.
+     * The ID of the price or plan object. One of {@code price}, {@code price_data} or {@code
+     * amount} is required.
      */
     @SerializedName("price")
     String price;
@@ -734,8 +733,8 @@ public class SessionCreateParams extends ApiRequestParams {
       }
 
       /**
-       * The ID of the price object. One of {@code price}, {@code price_data} or {@code amount} is
-       * required.
+       * The ID of the price or plan object. One of {@code price}, {@code price_data} or {@code
+       * amount} is required.
        */
       public Builder setPrice(String price) {
         this.price = price;
@@ -2980,8 +2979,8 @@ public class SessionCreateParams extends ApiRequestParams {
     Map<String, Object> extraParams;
 
     /**
-     * A list of items, each with an attached plan, that the customer is subscribing to. Use this
-     * parameter for subscriptions. To create one-time payments, use {@code line_items}.
+     * A list of items, each with an attached plan, that the customer is subscribing to. Prefer
+     * using {@code line_items}.
      */
     @SerializedName("items")
     List<Item> items;


### PR DESCRIPTION
Add support for BACS Debit as a `PaymentMethod`
  * Add `settings[bacs_debit_payments]` on `Account`
  * Add `bacs_debit` as a `type` on `PaymentMethod` 
  * Add `payment_method_details[bacs_debit]` on `Charge`
  * Add `bacs_debit` on `Mandate`

Codegen for openapi 7a853ce

r? @cjavilla-stripe 
cc @stripe/api-libraries 