### PR TITLE
Multiple API changes

### DIFF
--- a/src/main/java/com/stripe/model/Account.java
+++ b/src/main/java/com/stripe/model/Account.java
@@ -956,8 +956,8 @@ public class Account extends ApiResource implements MetadataStore<Account>, Paym
     String disabledReason;
 
     /**
-     * The fields that need to be collected again because validation or verification failed for some
-     * reason.
+     * The fields that are {@code currently_due} and need to be collected again because validation
+     * or verification failed for some reason.
      */
     @SerializedName("errors")
     List<Account.Requirements.Errors> errors;

--- a/src/main/java/com/stripe/model/Capability.java
+++ b/src/main/java/com/stripe/model/Capability.java
@@ -137,8 +137,8 @@ public class Capability extends ApiResource implements HasId {
     String disabledReason;
 
     /**
-     * The fields that need to be collected again because validation or verification failed for some
-     * reason.
+     * The fields that are {@code currently_due} and need to be collected again because validation
+     * or verification failed for some reason.
      */
     @SerializedName("errors")
     List<Account.Requirements.Errors> errors;

--- a/src/main/java/com/stripe/model/Card.java
+++ b/src/main/java/com/stripe/model/Card.java
@@ -207,9 +207,8 @@ public class Card extends ApiResource
   ExpandableField<Recipient> recipient;
 
   /**
-   * If the card number is tokenized, this is the method that was used. Can be {@code
-   * amex_express_checkout}, {@code android_pay} (includes Google Pay), {@code apple_pay}, {@code
-   * masterpass}, {@code visa_checkout}, or null.
+   * If the card number is tokenized, this is the method that was used. Can be {@code android_pay}
+   * (includes Google Pay), {@code apple_pay}, {@code masterpass}, {@code visa_checkout}, or null.
    */
   @SerializedName("tokenization_method")
   String tokenizationMethod;

--- a/src/main/java/com/stripe/model/Person.java
+++ b/src/main/java/com/stripe/model/Person.java
@@ -324,8 +324,8 @@ public class Person extends ApiResource implements HasId, MetadataStore<Person> 
     List<String> currentlyDue;
 
     /**
-     * The fields that need to be collected again because validation or verification failed for some
-     * reason.
+     * The fields that are {@code currently_due} and need to be collected again because validation
+     * or verification failed for some reason.
      */
     @SerializedName("errors")
     List<Account.Requirements.Errors> errors;

--- a/src/main/java/com/stripe/model/SubscriptionSchedule.java
+++ b/src/main/java/com/stripe/model/SubscriptionSchedule.java
@@ -519,6 +519,18 @@ public class SubscriptionSchedule extends ApiResource
   @EqualsAndHashCode(callSuper = false)
   public static class DefaultSettings extends StripeObject {
     /**
+     * Possible values are {@code phase_start} or {@code automatic}. If {@code phase_start} then
+     * billing cycle anchor of the subscription is set to the start of the phase when entering the
+     * phase. If {@code automatic} then the billing cycle anchor is automatically modified as needed
+     * when entering the phase. For more information, see the billing cycle <a
+     * href="https://stripe.com/docs/billing/subscriptions/billing-cycle">documentation</a>.
+     *
+     * <p>One of {@code automatic}, or {@code phase_start}.
+     */
+    @SerializedName("billing_cycle_anchor")
+    String billingCycleAnchor;
+
+    /**
      * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
      * billing period.
      */
@@ -607,6 +619,18 @@ public class SubscriptionSchedule extends ApiResource
      */
     @SerializedName("application_fee_percent")
     BigDecimal applicationFeePercent;
+
+    /**
+     * Possible values are {@code phase_start} or {@code automatic}. If {@code phase_start} then
+     * billing cycle anchor of the subscription is set to the start of the phase when entering the
+     * phase. If {@code automatic} then the billing cycle anchor is automatically modified as needed
+     * when entering the phase. For more information, see the billing cycle <a
+     * href="https://stripe.com/docs/billing/subscriptions/billing-cycle">documentation</a>.
+     *
+     * <p>One of {@code automatic}, or {@code phase_start}.
+     */
+    @SerializedName("billing_cycle_anchor")
+    String billingCycleAnchor;
 
     /**
      * Define thresholds at which an invoice will be sent, and the subscription advanced to a new

--- a/src/main/java/com/stripe/model/TaxRate.java
+++ b/src/main/java/com/stripe/model/TaxRate.java
@@ -20,8 +20,9 @@ import lombok.Setter;
 @EqualsAndHashCode(callSuper = false)
 public class TaxRate extends ApiResource implements HasId, MetadataStore<TaxRate> {
   /**
-   * Defaults to {@code true}. When set to {@code false}, this tax rate cannot be applied to objects
-   * in the API, but will still be applied to subscriptions and invoices that already have it set.
+   * Defaults to {@code true}. When set to {@code false}, this tax rate is considered archived and
+   * cannot be applied to new applications or Checkout Sessions, but will still be applied to
+   * subscriptions and invoices that already have it set.
    */
   @SerializedName("active")
   Boolean active;

--- a/src/main/java/com/stripe/model/checkout/Session.java
+++ b/src/main/java/com/stripe/model/checkout/Session.java
@@ -95,9 +95,10 @@ public class Session extends ApiResource implements HasId {
    * browser's locale is used.
    *
    * <p>One of {@code auto}, {@code bg}, {@code cs}, {@code da}, {@code de}, {@code el}, {@code en},
-   * {@code es}, {@code et}, {@code fi}, {@code fr}, {@code hu}, {@code it}, {@code ja}, {@code lt},
-   * {@code lv}, {@code ms}, {@code mt}, {@code nb}, {@code nl}, {@code pl}, {@code pt}, {@code
-   * pt-BR}, {@code ro}, {@code ru}, {@code sk}, {@code sl}, {@code sv}, {@code tr}, or {@code zh}.
+   * {@code es}, {@code es-419}, {@code et}, {@code fi}, {@code fr}, {@code hu}, {@code it}, {@code
+   * ja}, {@code lt}, {@code lv}, {@code ms}, {@code mt}, {@code nb}, {@code nl}, {@code pl}, {@code
+   * pt}, {@code pt-BR}, {@code ro}, {@code ru}, {@code sk}, {@code sl}, {@code sv}, {@code tr}, or
+   * {@code zh}.
    */
   @SerializedName("locale")
   String locale;

--- a/src/main/java/com/stripe/model/issuing/Transaction.java
+++ b/src/main/java/com/stripe/model/issuing/Transaction.java
@@ -411,7 +411,7 @@ public class Transaction extends ApiResource
       @SerializedName("type")
       String type;
 
-      /** The units for {@code volume}. One of {@code us_gallon} or {@code liter}. */
+      /** The units for {@code volume_decimal}. One of {@code us_gallon} or {@code liter}. */
       @SerializedName("unit")
       String unit;
 

--- a/src/main/java/com/stripe/param/SubscriptionScheduleCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionScheduleCreateParams.java
@@ -322,6 +322,15 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
   @Getter
   public static class DefaultSettings {
     /**
+     * Can be set to {@code phase_start} to set the anchor to the start of the phase or {@code
+     * automatic} to automatically change it if needed. Cannot be set to {@code phase_start} if this
+     * phase specifies a trial. For more information, see the billing cycle <a
+     * href="https://stripe.com/docs/billing/subscriptions/billing-cycle">documentation</a>.
+     */
+    @SerializedName("billing_cycle_anchor")
+    BillingCycleAnchor billingCycleAnchor;
+
+    /**
      * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
      * billing period. Pass an empty string to remove previously-defined thresholds.
      */
@@ -367,12 +376,14 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
     Object transferData;
 
     private DefaultSettings(
+        BillingCycleAnchor billingCycleAnchor,
         Object billingThresholds,
         CollectionMethod collectionMethod,
         String defaultPaymentMethod,
         Map<String, Object> extraParams,
         InvoiceSettings invoiceSettings,
         Object transferData) {
+      this.billingCycleAnchor = billingCycleAnchor;
       this.billingThresholds = billingThresholds;
       this.collectionMethod = collectionMethod;
       this.defaultPaymentMethod = defaultPaymentMethod;
@@ -386,6 +397,8 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
     }
 
     public static class Builder {
+      private BillingCycleAnchor billingCycleAnchor;
+
       private Object billingThresholds;
 
       private CollectionMethod collectionMethod;
@@ -401,12 +414,24 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
       /** Finalize and obtain parameter instance from this builder. */
       public DefaultSettings build() {
         return new DefaultSettings(
+            this.billingCycleAnchor,
             this.billingThresholds,
             this.collectionMethod,
             this.defaultPaymentMethod,
             this.extraParams,
             this.invoiceSettings,
             this.transferData);
+      }
+
+      /**
+       * Can be set to {@code phase_start} to set the anchor to the start of the phase or {@code
+       * automatic} to automatically change it if needed. Cannot be set to {@code phase_start} if
+       * this phase specifies a trial. For more information, see the billing cycle <a
+       * href="https://stripe.com/docs/billing/subscriptions/billing-cycle">documentation</a>.
+       */
+      public Builder setBillingCycleAnchor(BillingCycleAnchor billingCycleAnchor) {
+        this.billingCycleAnchor = billingCycleAnchor;
+        return this;
       }
 
       /**
@@ -771,6 +796,21 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
       }
     }
 
+    public enum BillingCycleAnchor implements ApiRequestParams.EnumParam {
+      @SerializedName("automatic")
+      AUTOMATIC("automatic"),
+
+      @SerializedName("phase_start")
+      PHASE_START("phase_start");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      BillingCycleAnchor(String value) {
+        this.value = value;
+      }
+    }
+
     public enum CollectionMethod implements ApiRequestParams.EnumParam {
       @SerializedName("charge_automatically")
       CHARGE_AUTOMATICALLY("charge_automatically"),
@@ -806,6 +846,15 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
      */
     @SerializedName("application_fee_percent")
     BigDecimal applicationFeePercent;
+
+    /**
+     * Can be set to {@code phase_start} to set the anchor to the start of the phase or {@code
+     * automatic} to automatically change it if needed. Cannot be set to {@code phase_start} if this
+     * phase specifies a trial. For more information, see the billing cycle <a
+     * href="https://stripe.com/docs/billing/subscriptions/billing-cycle">documentation</a>.
+     */
+    @SerializedName("billing_cycle_anchor")
+    BillingCycleAnchor billingCycleAnchor;
 
     /**
      * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
@@ -929,6 +978,7 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
     private Phase(
         List<AddInvoiceItem> addInvoiceItems,
         BigDecimal applicationFeePercent,
+        BillingCycleAnchor billingCycleAnchor,
         Object billingThresholds,
         CollectionMethod collectionMethod,
         String coupon,
@@ -946,6 +996,7 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
         Long trialEnd) {
       this.addInvoiceItems = addInvoiceItems;
       this.applicationFeePercent = applicationFeePercent;
+      this.billingCycleAnchor = billingCycleAnchor;
       this.billingThresholds = billingThresholds;
       this.collectionMethod = collectionMethod;
       this.coupon = coupon;
@@ -971,6 +1022,8 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
       private List<AddInvoiceItem> addInvoiceItems;
 
       private BigDecimal applicationFeePercent;
+
+      private BillingCycleAnchor billingCycleAnchor;
 
       private Object billingThresholds;
 
@@ -1007,6 +1060,7 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
         return new Phase(
             this.addInvoiceItems,
             this.applicationFeePercent,
+            this.billingCycleAnchor,
             this.billingThresholds,
             this.collectionMethod,
             this.coupon,
@@ -1060,6 +1114,17 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
        */
       public Builder setApplicationFeePercent(BigDecimal applicationFeePercent) {
         this.applicationFeePercent = applicationFeePercent;
+        return this;
+      }
+
+      /**
+       * Can be set to {@code phase_start} to set the anchor to the start of the phase or {@code
+       * automatic} to automatically change it if needed. Cannot be set to {@code phase_start} if
+       * this phase specifies a trial. For more information, see the billing cycle <a
+       * href="https://stripe.com/docs/billing/subscriptions/billing-cycle">documentation</a>.
+       */
+      public Builder setBillingCycleAnchor(BillingCycleAnchor billingCycleAnchor) {
+        this.billingCycleAnchor = billingCycleAnchor;
         return this;
       }
 
@@ -2365,6 +2430,21 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
           this.extraParams.putAll(map);
           return this;
         }
+      }
+    }
+
+    public enum BillingCycleAnchor implements ApiRequestParams.EnumParam {
+      @SerializedName("automatic")
+      AUTOMATIC("automatic"),
+
+      @SerializedName("phase_start")
+      PHASE_START("phase_start");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      BillingCycleAnchor(String value) {
+        this.value = value;
       }
     }
 

--- a/src/main/java/com/stripe/param/SubscriptionScheduleUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionScheduleUpdateParams.java
@@ -294,6 +294,15 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
   @Getter
   public static class DefaultSettings {
     /**
+     * Can be set to {@code phase_start} to set the anchor to the start of the phase or {@code
+     * automatic} to automatically change it if needed. Cannot be set to {@code phase_start} if this
+     * phase specifies a trial. For more information, see the billing cycle <a
+     * href="https://stripe.com/docs/billing/subscriptions/billing-cycle">documentation</a>.
+     */
+    @SerializedName("billing_cycle_anchor")
+    BillingCycleAnchor billingCycleAnchor;
+
+    /**
      * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
      * billing period. Pass an empty string to remove previously-defined thresholds.
      */
@@ -339,12 +348,14 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
     Object transferData;
 
     private DefaultSettings(
+        BillingCycleAnchor billingCycleAnchor,
         Object billingThresholds,
         CollectionMethod collectionMethod,
         Object defaultPaymentMethod,
         Map<String, Object> extraParams,
         InvoiceSettings invoiceSettings,
         Object transferData) {
+      this.billingCycleAnchor = billingCycleAnchor;
       this.billingThresholds = billingThresholds;
       this.collectionMethod = collectionMethod;
       this.defaultPaymentMethod = defaultPaymentMethod;
@@ -358,6 +369,8 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
     }
 
     public static class Builder {
+      private BillingCycleAnchor billingCycleAnchor;
+
       private Object billingThresholds;
 
       private CollectionMethod collectionMethod;
@@ -373,12 +386,24 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
       /** Finalize and obtain parameter instance from this builder. */
       public DefaultSettings build() {
         return new DefaultSettings(
+            this.billingCycleAnchor,
             this.billingThresholds,
             this.collectionMethod,
             this.defaultPaymentMethod,
             this.extraParams,
             this.invoiceSettings,
             this.transferData);
+      }
+
+      /**
+       * Can be set to {@code phase_start} to set the anchor to the start of the phase or {@code
+       * automatic} to automatically change it if needed. Cannot be set to {@code phase_start} if
+       * this phase specifies a trial. For more information, see the billing cycle <a
+       * href="https://stripe.com/docs/billing/subscriptions/billing-cycle">documentation</a>.
+       */
+      public Builder setBillingCycleAnchor(BillingCycleAnchor billingCycleAnchor) {
+        this.billingCycleAnchor = billingCycleAnchor;
+        return this;
       }
 
       /**
@@ -759,6 +784,21 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
       }
     }
 
+    public enum BillingCycleAnchor implements ApiRequestParams.EnumParam {
+      @SerializedName("automatic")
+      AUTOMATIC("automatic"),
+
+      @SerializedName("phase_start")
+      PHASE_START("phase_start");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      BillingCycleAnchor(String value) {
+        this.value = value;
+      }
+    }
+
     public enum CollectionMethod implements ApiRequestParams.EnumParam {
       @SerializedName("charge_automatically")
       CHARGE_AUTOMATICALLY("charge_automatically"),
@@ -794,6 +834,15 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
      */
     @SerializedName("application_fee_percent")
     BigDecimal applicationFeePercent;
+
+    /**
+     * Can be set to {@code phase_start} to set the anchor to the start of the phase or {@code
+     * automatic} to automatically change it if needed. Cannot be set to {@code phase_start} if this
+     * phase specifies a trial. For more information, see the billing cycle <a
+     * href="https://stripe.com/docs/billing/subscriptions/billing-cycle">documentation</a>.
+     */
+    @SerializedName("billing_cycle_anchor")
+    BillingCycleAnchor billingCycleAnchor;
 
     /**
      * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
@@ -924,6 +973,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
     private Phase(
         List<AddInvoiceItem> addInvoiceItems,
         BigDecimal applicationFeePercent,
+        BillingCycleAnchor billingCycleAnchor,
         Object billingThresholds,
         CollectionMethod collectionMethod,
         Object coupon,
@@ -942,6 +992,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
         Object trialEnd) {
       this.addInvoiceItems = addInvoiceItems;
       this.applicationFeePercent = applicationFeePercent;
+      this.billingCycleAnchor = billingCycleAnchor;
       this.billingThresholds = billingThresholds;
       this.collectionMethod = collectionMethod;
       this.coupon = coupon;
@@ -968,6 +1019,8 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
       private List<AddInvoiceItem> addInvoiceItems;
 
       private BigDecimal applicationFeePercent;
+
+      private BillingCycleAnchor billingCycleAnchor;
 
       private Object billingThresholds;
 
@@ -1006,6 +1059,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
         return new Phase(
             this.addInvoiceItems,
             this.applicationFeePercent,
+            this.billingCycleAnchor,
             this.billingThresholds,
             this.collectionMethod,
             this.coupon,
@@ -1060,6 +1114,17 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
        */
       public Builder setApplicationFeePercent(BigDecimal applicationFeePercent) {
         this.applicationFeePercent = applicationFeePercent;
+        return this;
+      }
+
+      /**
+       * Can be set to {@code phase_start} to set the anchor to the start of the phase or {@code
+       * automatic} to automatically change it if needed. Cannot be set to {@code phase_start} if
+       * this phase specifies a trial. For more information, see the billing cycle <a
+       * href="https://stripe.com/docs/billing/subscriptions/billing-cycle">documentation</a>.
+       */
+      public Builder setBillingCycleAnchor(BillingCycleAnchor billingCycleAnchor) {
+        this.billingCycleAnchor = billingCycleAnchor;
         return this;
       }
 
@@ -2494,6 +2559,21 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
           this.extraParams.putAll(map);
           return this;
         }
+      }
+    }
+
+    public enum BillingCycleAnchor implements ApiRequestParams.EnumParam {
+      @SerializedName("automatic")
+      AUTOMATIC("automatic"),
+
+      @SerializedName("phase_start")
+      PHASE_START("phase_start");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      BillingCycleAnchor(String value) {
+        this.value = value;
       }
     }
 

--- a/src/main/java/com/stripe/param/TaxRateCreateParams.java
+++ b/src/main/java/com/stripe/param/TaxRateCreateParams.java
@@ -12,8 +12,9 @@ import lombok.Getter;
 @Getter
 public class TaxRateCreateParams extends ApiRequestParams {
   /**
-   * Flag determining whether the tax rate is active or inactive. Inactive tax rates continue to
-   * work where they are currently applied however they cannot be used for new applications.
+   * Flag determining whether the tax rate is active or inactive (archived). Inactive tax rates
+   * continue to work where they are currently applied however they cannot be used for new
+   * applications or Checkout Sessions.
    */
   @SerializedName("active")
   Boolean active;
@@ -122,8 +123,9 @@ public class TaxRateCreateParams extends ApiRequestParams {
     }
 
     /**
-     * Flag determining whether the tax rate is active or inactive. Inactive tax rates continue to
-     * work where they are currently applied however they cannot be used for new applications.
+     * Flag determining whether the tax rate is active or inactive (archived). Inactive tax rates
+     * continue to work where they are currently applied however they cannot be used for new
+     * applications or Checkout Sessions.
      */
     public Builder setActive(Boolean active) {
       this.active = active;

--- a/src/main/java/com/stripe/param/TaxRateListParams.java
+++ b/src/main/java/com/stripe/param/TaxRateListParams.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 
 @Getter
 public class TaxRateListParams extends ApiRequestParams {
-  /** Optional flag to filter by tax rates that are either active or not active (archived). */
+  /** Optional flag to filter by tax rates that are either active or inactive (archived). */
   @SerializedName("active")
   Boolean active;
 
@@ -113,7 +113,7 @@ public class TaxRateListParams extends ApiRequestParams {
           this.startingAfter);
     }
 
-    /** Optional flag to filter by tax rates that are either active or not active (archived). */
+    /** Optional flag to filter by tax rates that are either active or inactive (archived). */
     public Builder setActive(Boolean active) {
       this.active = active;
       return this;

--- a/src/main/java/com/stripe/param/TaxRateUpdateParams.java
+++ b/src/main/java/com/stripe/param/TaxRateUpdateParams.java
@@ -12,8 +12,9 @@ import lombok.Getter;
 @Getter
 public class TaxRateUpdateParams extends ApiRequestParams {
   /**
-   * Flag determining whether the tax rate is active or inactive. Inactive tax rates continue to
-   * work where they are currently applied however they cannot be used for new applications.
+   * Flag determining whether the tax rate is active or inactive (archived). Inactive tax rates
+   * continue to work where they are currently applied however they cannot be used for new
+   * applications or Checkout Sessions.
    */
   @SerializedName("active")
   Boolean active;
@@ -104,8 +105,9 @@ public class TaxRateUpdateParams extends ApiRequestParams {
     }
 
     /**
-     * Flag determining whether the tax rate is active or inactive. Inactive tax rates continue to
-     * work where they are currently applied however they cannot be used for new applications.
+     * Flag determining whether the tax rate is active or inactive (archived). Inactive tax rates
+     * continue to work where they are currently applied however they cannot be used for new
+     * applications or Checkout Sessions.
      */
     public Builder setActive(Boolean active) {
       this.active = active;

--- a/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
+++ b/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
@@ -581,7 +581,10 @@ public class SessionCreateParams extends ApiRequestParams {
     @SerializedName("quantity")
     Long quantity;
 
-    /** The tax rates which apply to this line item. This is only allowed in subscription mode. */
+    /**
+     * The <a href="https://stripe.com/docs/api/tax_rates">tax rates</a> which apply to this line
+     * item. This is only allowed in subscription mode.
+     */
     @SerializedName("tax_rates")
     List<String> taxRates;
 
@@ -3412,6 +3415,9 @@ public class SessionCreateParams extends ApiRequestParams {
 
     @SerializedName("es")
     ES("es"),
+
+    @SerializedName("es-419")
+    ES_419("es-419"),
 
     @SerializedName("et")
     ET("et"),


### PR DESCRIPTION
Multiple API changes:
  * Adds `es-419` as a `locale` to Checkout `Session`
  * Adds `billing_cycle_anchor` to `default_settings` and `phases` for `SubscriptionSchedule`

Codegen for openapi 19ea774

r? @remi-stripe 
cc @stripe/api-libraries 