### PR TITLE
Add support for `amount_total`, `amount_subtotal`, `currency` and `total_details` on Checkout `Session`

### DIFF
--- a/src/main/java/com/stripe/model/LineItem.java
+++ b/src/main/java/com/stripe/model/LineItem.java
@@ -81,7 +81,7 @@ public class LineItem extends StripeObject implements HasId {
   @Setter
   @EqualsAndHashCode(callSuper = false)
   public static class Discount extends StripeObject {
-    /** Discount amount for this line item. */
+    /** The amount discounted. */
     @SerializedName("amount")
     Long amount;
 
@@ -100,12 +100,16 @@ public class LineItem extends StripeObject implements HasId {
   @Setter
   @EqualsAndHashCode(callSuper = false)
   public static class Tax extends StripeObject {
-    /** Amount of tax for this line item. */
+    /** Amount of tax applied for this rate. */
     @SerializedName("amount")
     Long amount;
 
     /**
-     * Tax rates can be applied to invoices and subscriptions to collect tax.
+     * Tax rates can be applied to <a
+     * href="https://stripe.com/docs/billing/invoices/tax-rates">invoices</a>, <a
+     * href="https://stripe.com/docs/billing/subscriptions/taxes">subscriptions</a> and <a
+     * href="https://stripe.com/docs/payments/checkout/set-up-a-subscription#tax-rates">Checkout
+     * Sessions</a> to collect tax.
      *
      * <p>Related guide: <a href="https://stripe.com/docs/billing/taxes/tax-rates">Tax Rates</a>.
      */

--- a/src/main/java/com/stripe/model/PaymentIntent.java
+++ b/src/main/java/com/stripe/model/PaymentIntent.java
@@ -207,7 +207,11 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
   @SerializedName("payment_method_types")
   List<String> paymentMethodTypes;
 
-  /** Email address that the receipt for the resulting payment will be sent to. */
+  /**
+   * Email address that the receipt for the resulting payment will be sent to. If {@code
+   * receipt_email} is specified for a payment in live mode, a receipt will be sent regardless of
+   * your <a href="https://dashboard.stripe.com/account/emails">email settings</a>.
+   */
   @SerializedName("receipt_email")
   String receiptEmail;
 
@@ -858,7 +862,7 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
   /**
    * A PaymentIntent object can be canceled when it is in one of these statuses: <code>
    * requires_payment_method</code>, <code>requires_capture</code>, <code>requires_confirmation
-   * </code>, <code>requires_action</code>.
+   * </code>, or <code>requires_action</code>.
    *
    * <p>Once canceled, no additional charges will be made by the PaymentIntent and any operations on
    * the PaymentIntent will fail with an error. For PaymentIntents with <code>
@@ -872,7 +876,7 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
   /**
    * A PaymentIntent object can be canceled when it is in one of these statuses: <code>
    * requires_payment_method</code>, <code>requires_capture</code>, <code>requires_confirmation
-   * </code>, <code>requires_action</code>.
+   * </code>, or <code>requires_action</code>.
    *
    * <p>Once canceled, no additional charges will be made by the PaymentIntent and any operations on
    * the PaymentIntent will fail with an error. For PaymentIntents with <code>
@@ -886,7 +890,7 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
   /**
    * A PaymentIntent object can be canceled when it is in one of these statuses: <code>
    * requires_payment_method</code>, <code>requires_capture</code>, <code>requires_confirmation
-   * </code>, <code>requires_action</code>.
+   * </code>, or <code>requires_action</code>.
    *
    * <p>Once canceled, no additional charges will be made by the PaymentIntent and any operations on
    * the PaymentIntent will fail with an error. For PaymentIntents with <code>
@@ -900,7 +904,7 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
   /**
    * A PaymentIntent object can be canceled when it is in one of these statuses: <code>
    * requires_payment_method</code>, <code>requires_capture</code>, <code>requires_confirmation
-   * </code>, <code>requires_action</code>.
+   * </code>, or <code>requires_action</code>.
    *
    * <p>Once canceled, no additional charges will be made by the PaymentIntent and any operations on
    * the PaymentIntent will fail with an error. For PaymentIntents with <code>
@@ -921,7 +925,7 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
   /**
    * A PaymentIntent object can be canceled when it is in one of these statuses: <code>
    * requires_payment_method</code>, <code>requires_capture</code>, <code>requires_confirmation
-   * </code>, <code>requires_action</code>.
+   * </code>, or <code>requires_action</code>.
    *
    * <p>Once canceled, no additional charges will be made by the PaymentIntent and any operations on
    * the PaymentIntent will fail with an error. For PaymentIntents with <code>
@@ -935,7 +939,7 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
   /**
    * A PaymentIntent object can be canceled when it is in one of these statuses: <code>
    * requires_payment_method</code>, <code>requires_capture</code>, <code>requires_confirmation
-   * </code>, <code>requires_action</code>.
+   * </code>, or <code>requires_action</code>.
    *
    * <p>Once canceled, no additional charges will be made by the PaymentIntent and any operations on
    * the PaymentIntent will fail with an error. For PaymentIntents with <code>

--- a/src/main/java/com/stripe/model/SetupIntent.java
+++ b/src/main/java/com/stripe/model/SetupIntent.java
@@ -556,8 +556,8 @@ public class SetupIntent extends ApiResource implements HasId, MetadataStore<Set
 
   /**
    * A SetupIntent object can be canceled when it is in one of these statuses: <code>
-   * requires_payment_method</code>, <code>requires_capture</code>, <code>requires_confirmation
-   * </code>, <code>requires_action</code>.
+   * requires_payment_method</code>, <code>requires_confirmation</code>, or <code>requires_action
+   * </code>.
    *
    * <p>Once canceled, setup is abandoned and any operations on the SetupIntent will fail with an
    * error.
@@ -568,8 +568,8 @@ public class SetupIntent extends ApiResource implements HasId, MetadataStore<Set
 
   /**
    * A SetupIntent object can be canceled when it is in one of these statuses: <code>
-   * requires_payment_method</code>, <code>requires_capture</code>, <code>requires_confirmation
-   * </code>, <code>requires_action</code>.
+   * requires_payment_method</code>, <code>requires_confirmation</code>, or <code>requires_action
+   * </code>.
    *
    * <p>Once canceled, setup is abandoned and any operations on the SetupIntent will fail with an
    * error.
@@ -580,8 +580,8 @@ public class SetupIntent extends ApiResource implements HasId, MetadataStore<Set
 
   /**
    * A SetupIntent object can be canceled when it is in one of these statuses: <code>
-   * requires_payment_method</code>, <code>requires_capture</code>, <code>requires_confirmation
-   * </code>, <code>requires_action</code>.
+   * requires_payment_method</code>, <code>requires_confirmation</code>, or <code>requires_action
+   * </code>.
    *
    * <p>Once canceled, setup is abandoned and any operations on the SetupIntent will fail with an
    * error.
@@ -592,8 +592,8 @@ public class SetupIntent extends ApiResource implements HasId, MetadataStore<Set
 
   /**
    * A SetupIntent object can be canceled when it is in one of these statuses: <code>
-   * requires_payment_method</code>, <code>requires_capture</code>, <code>requires_confirmation
-   * </code>, <code>requires_action</code>.
+   * requires_payment_method</code>, <code>requires_confirmation</code>, or <code>requires_action
+   * </code>.
    *
    * <p>Once canceled, setup is abandoned and any operations on the SetupIntent will fail with an
    * error.
@@ -611,8 +611,8 @@ public class SetupIntent extends ApiResource implements HasId, MetadataStore<Set
 
   /**
    * A SetupIntent object can be canceled when it is in one of these statuses: <code>
-   * requires_payment_method</code>, <code>requires_capture</code>, <code>requires_confirmation
-   * </code>, <code>requires_action</code>.
+   * requires_payment_method</code>, <code>requires_confirmation</code>, or <code>requires_action
+   * </code>.
    *
    * <p>Once canceled, setup is abandoned and any operations on the SetupIntent will fail with an
    * error.
@@ -623,8 +623,8 @@ public class SetupIntent extends ApiResource implements HasId, MetadataStore<Set
 
   /**
    * A SetupIntent object can be canceled when it is in one of these statuses: <code>
-   * requires_payment_method</code>, <code>requires_capture</code>, <code>requires_confirmation
-   * </code>, <code>requires_action</code>.
+   * requires_payment_method</code>, <code>requires_confirmation</code>, or <code>requires_action
+   * </code>.
    *
    * <p>Once canceled, setup is abandoned and any operations on the SetupIntent will fail with an
    * error.

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -148,7 +148,7 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
   @SerializedName("id")
   String id;
 
-  /** List of subscription items, each with an attached plan. */
+  /** List of subscription items, each with an attached price. */
   @SerializedName("items")
   SubscriptionItemCollection items;
 

--- a/src/main/java/com/stripe/model/SubscriptionItem.java
+++ b/src/main/java/com/stripe/model/SubscriptionItem.java
@@ -308,7 +308,7 @@ public class SubscriptionItem extends ApiResource
   /**
    * For the specified subscription item, returns a list of summary objects. Each object in the list
    * provides usage information that’s been summarized from multiple usage records and over a
-   * subscription billing period (e.g., 15 usage records in the billing plan’s month of September).
+   * subscription billing period (e.g., 15 usage records in the month of September).
    *
    * <p>The list is sorted in reverse-chronological order (newest first). The first list item
    * represents the most current usage period that hasn’t ended yet. Since new usage records can
@@ -322,7 +322,7 @@ public class SubscriptionItem extends ApiResource
   /**
    * For the specified subscription item, returns a list of summary objects. Each object in the list
    * provides usage information that’s been summarized from multiple usage records and over a
-   * subscription billing period (e.g., 15 usage records in the billing plan’s month of September).
+   * subscription billing period (e.g., 15 usage records in the month of September).
    *
    * <p>The list is sorted in reverse-chronological order (newest first). The first list item
    * represents the most current usage period that hasn’t ended yet. Since new usage records can
@@ -337,7 +337,7 @@ public class SubscriptionItem extends ApiResource
   /**
    * For the specified subscription item, returns a list of summary objects. Each object in the list
    * provides usage information that’s been summarized from multiple usage records and over a
-   * subscription billing period (e.g., 15 usage records in the billing plan’s month of September).
+   * subscription billing period (e.g., 15 usage records in the month of September).
    *
    * <p>The list is sorted in reverse-chronological order (newest first). The first list item
    * represents the most current usage period that hasn’t ended yet. Since new usage records can
@@ -359,7 +359,7 @@ public class SubscriptionItem extends ApiResource
   /**
    * For the specified subscription item, returns a list of summary objects. Each object in the list
    * provides usage information that’s been summarized from multiple usage records and over a
-   * subscription billing period (e.g., 15 usage records in the billing plan’s month of September).
+   * subscription billing period (e.g., 15 usage records in the month of September).
    *
    * <p>The list is sorted in reverse-chronological order (newest first). The first list item
    * represents the most current usage period that hasn’t ended yet. Since new usage records can
@@ -374,7 +374,7 @@ public class SubscriptionItem extends ApiResource
   /**
    * For the specified subscription item, returns a list of summary objects. Each object in the list
    * provides usage information that’s been summarized from multiple usage records and over a
-   * subscription billing period (e.g., 15 usage records in the billing plan’s month of September).
+   * subscription billing period (e.g., 15 usage records in the month of September).
    *
    * <p>The list is sorted in reverse-chronological order (newest first). The first list item
    * represents the most current usage period that hasn’t ended yet. Since new usage records can

--- a/src/main/java/com/stripe/model/SubscriptionSchedule.java
+++ b/src/main/java/com/stripe/model/SubscriptionSchedule.java
@@ -57,7 +57,8 @@ public class SubscriptionSchedule extends ApiResource
   DefaultSettings defaultSettings;
 
   /**
-   * Behavior of the subscription schedule and underlying subscription when it ends.
+   * Behavior of the subscription schedule and underlying subscription when it ends. Possible values
+   * are {@code release} and {@code cancel}.
    *
    * <p>One of {@code cancel}, {@code none}, {@code release}, or {@code renew}.
    */
@@ -687,7 +688,7 @@ public class SubscriptionSchedule extends ApiResource
 
     /**
      * Controls whether or not the subscription schedule will prorate when transitioning to this
-     * phase. Values are {@code create_prorations} and {@code none}.
+     * phase. Possible values are {@code create_prorations} and {@code none}.
      *
      * <p>One of {@code always_invoice}, {@code create_prorations}, or {@code none}.
      */

--- a/src/main/java/com/stripe/model/TaxRate.java
+++ b/src/main/java/com/stripe/model/TaxRate.java
@@ -20,9 +20,9 @@ import lombok.Setter;
 @EqualsAndHashCode(callSuper = false)
 public class TaxRate extends ApiResource implements HasId, MetadataStore<TaxRate> {
   /**
-   * Defaults to {@code true}. When set to {@code false}, this tax rate is considered archived and
-   * cannot be applied to new applications or Checkout Sessions, but will still be applied to
-   * subscriptions and invoices that already have it set.
+   * Defaults to {@code true}. When set to {@code false}, this tax rate cannot be used with new
+   * applications or Checkout Sessions, but will still work for subscriptions and invoices that
+   * already have it set.
    */
   @SerializedName("active")
   Boolean active;

--- a/src/main/java/com/stripe/model/checkout/Session.java
+++ b/src/main/java/com/stripe/model/checkout/Session.java
@@ -6,6 +6,7 @@ import com.stripe.exception.StripeException;
 import com.stripe.model.Customer;
 import com.stripe.model.ExpandableField;
 import com.stripe.model.HasId;
+import com.stripe.model.LineItem;
 import com.stripe.model.LineItemCollection;
 import com.stripe.model.PaymentIntent;
 import com.stripe.model.Plan;
@@ -30,9 +31,18 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class Session extends ApiResource implements HasId {
+  /** Total of all items before discounts or taxes are applied. */
+  @SerializedName("amount_subtotal")
+  Long amountSubtotal;
+
+  /** Total of all items after discounts and taxes are applied. */
+  @SerializedName("amount_total")
+  Long amountTotal;
+
   /**
-   * The value ({@code auto} or {@code required}) for whether Checkout collected the customer's
-   * billing address.
+   * Describes whether Checkout should collect the customer's billing address.
+   *
+   * <p>One of {@code auto}, or {@code required}.
    */
   @SerializedName("billing_address_collection")
   String billingAddressCollection;
@@ -50,6 +60,13 @@ public class Session extends ApiResource implements HasId {
    */
   @SerializedName("client_reference_id")
   String clientReferenceId;
+
+  /**
+   * Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency code</a>,
+   * in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported currency</a>.
+   */
+  @SerializedName("currency")
+  String currency;
 
   /**
    * The ID of the customer for this session. For Checkout Sessions in {@code payment} or {@code
@@ -177,6 +194,10 @@ public class Session extends ApiResource implements HasId {
    */
   @SerializedName("success_url")
   String successUrl;
+
+  /** Tax and discount details for the computed total amount. */
+  @SerializedName("total_details")
+  TotalDetails totalDetails;
 
   /** Get ID of expandable {@code customer} object. */
   public String getCustomer() {
@@ -462,5 +483,34 @@ public class Session extends ApiResource implements HasId {
      */
     @SerializedName("allowed_countries")
     List<String> allowedCountries;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class TotalDetails extends StripeObject {
+    /** This is the sum of all the line item discounts. */
+    @SerializedName("amount_discount")
+    Long amountDiscount;
+
+    /** This is the sum of all the line item tax amounts. */
+    @SerializedName("amount_tax")
+    Long amountTax;
+
+    @SerializedName("breakdown")
+    Breakdown breakdown;
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class Breakdown extends StripeObject {
+      /** The aggregated line item discounts. */
+      @SerializedName("discounts")
+      List<LineItem.Discount> discounts;
+
+      /** The aggregated line item tax amounts by rate. */
+      @SerializedName("taxes")
+      List<LineItem.Tax> taxes;
+    }
   }
 }

--- a/src/main/java/com/stripe/param/InvoiceUpcomingParams.java
+++ b/src/main/java/com/stripe/param/InvoiceUpcomingParams.java
@@ -95,7 +95,7 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
   @SerializedName("subscription_default_tax_rates")
   Object subscriptionDefaultTaxRates;
 
-  /** List of subscription items, each with an attached plan. */
+  /** A list of up to 20 subscription items, each with an attached price. */
   @SerializedName("subscription_items")
   List<SubscriptionItem> subscriptionItems;
 

--- a/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
@@ -73,7 +73,11 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
   @SerializedName("payment_method_options")
   PaymentMethodOptions paymentMethodOptions;
 
-  /** Email address that the receipt for the resulting payment will be sent to. */
+  /**
+   * Email address that the receipt for the resulting payment will be sent to. If {@code
+   * receipt_email} is specified for a payment in live mode, a receipt will be sent regardless of
+   * your <a href="https://dashboard.stripe.com/account/emails">email settings</a>.
+   */
   @SerializedName("receipt_email")
   Object receiptEmail;
 
@@ -363,13 +367,21 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       return this;
     }
 
-    /** Email address that the receipt for the resulting payment will be sent to. */
+    /**
+     * Email address that the receipt for the resulting payment will be sent to. If {@code
+     * receipt_email} is specified for a payment in live mode, a receipt will be sent regardless of
+     * your <a href="https://dashboard.stripe.com/account/emails">email settings</a>.
+     */
     public Builder setReceiptEmail(String receiptEmail) {
       this.receiptEmail = receiptEmail;
       return this;
     }
 
-    /** Email address that the receipt for the resulting payment will be sent to. */
+    /**
+     * Email address that the receipt for the resulting payment will be sent to. If {@code
+     * receipt_email} is specified for a payment in live mode, a receipt will be sent regardless of
+     * your <a href="https://dashboard.stripe.com/account/emails">email settings</a>.
+     */
     public Builder setReceiptEmail(EmptyParam receiptEmail) {
       this.receiptEmail = receiptEmail;
       return this;

--- a/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
@@ -177,7 +177,11 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
   @SerializedName("payment_method_types")
   List<String> paymentMethodTypes;
 
-  /** Email address that the receipt for the resulting payment will be sent to. */
+  /**
+   * Email address that the receipt for the resulting payment will be sent to. If {@code
+   * receipt_email} is specified for a payment in live mode, a receipt will be sent regardless of
+   * your <a href="https://dashboard.stripe.com/account/emails">email settings</a>.
+   */
   @SerializedName("receipt_email")
   String receiptEmail;
 
@@ -740,7 +744,11 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       return this;
     }
 
-    /** Email address that the receipt for the resulting payment will be sent to. */
+    /**
+     * Email address that the receipt for the resulting payment will be sent to. If {@code
+     * receipt_email} is specified for a payment in live mode, a receipt will be sent regardless of
+     * your <a href="https://dashboard.stripe.com/account/emails">email settings</a>.
+     */
     public Builder setReceiptEmail(String receiptEmail) {
       this.receiptEmail = receiptEmail;
       return this;

--- a/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
@@ -104,7 +104,11 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
   @SerializedName("payment_method_types")
   List<String> paymentMethodTypes;
 
-  /** Email address that the receipt for the resulting payment will be sent to. */
+  /**
+   * Email address that the receipt for the resulting payment will be sent to. If {@code
+   * receipt_email} is specified for a payment in live mode, a receipt will be sent regardless of
+   * your <a href="https://dashboard.stripe.com/account/emails">email settings</a>.
+   */
   @SerializedName("receipt_email")
   Object receiptEmail;
 
@@ -575,13 +579,21 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       return this;
     }
 
-    /** Email address that the receipt for the resulting payment will be sent to. */
+    /**
+     * Email address that the receipt for the resulting payment will be sent to. If {@code
+     * receipt_email} is specified for a payment in live mode, a receipt will be sent regardless of
+     * your <a href="https://dashboard.stripe.com/account/emails">email settings</a>.
+     */
     public Builder setReceiptEmail(String receiptEmail) {
       this.receiptEmail = receiptEmail;
       return this;
     }
 
-    /** Email address that the receipt for the resulting payment will be sent to. */
+    /**
+     * Email address that the receipt for the resulting payment will be sent to. If {@code
+     * receipt_email} is specified for a payment in live mode, a receipt will be sent regardless of
+     * your <a href="https://dashboard.stripe.com/account/emails">email settings</a>.
+     */
     public Builder setReceiptEmail(EmptyParam receiptEmail) {
       this.receiptEmail = receiptEmail;
       return this;

--- a/src/main/java/com/stripe/param/SubscriptionItemCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionItemCreateParams.java
@@ -56,9 +56,9 @@ public class SubscriptionItemCreateParams extends ApiRequestParams {
    * by pending updates</a>.
    *
    * <p>Use {@code error_if_incomplete} if you want Stripe to return an HTTP 402 status code if a
-   * subscription's first invoice cannot be paid. For example, if a payment method requires 3DS
+   * subscription's invoice cannot be paid. For example, if a payment method requires 3DS
    * authentication due to SCA regulation and further user action is needed, this parameter does not
-   * create a subscription and returns an error instead. This was the default behavior for API
+   * update the subscription and returns an error instead. This was the default behavior for API
    * versions prior to 2019-03-14. See the <a
    * href="https://stripe.com/docs/upgrades#2019-03-14">changelog</a> to learn more.
    */
@@ -323,10 +323,10 @@ public class SubscriptionItemCreateParams extends ApiRequestParams {
      * by pending updates</a>.
      *
      * <p>Use {@code error_if_incomplete} if you want Stripe to return an HTTP 402 status code if a
-     * subscription's first invoice cannot be paid. For example, if a payment method requires 3DS
+     * subscription's invoice cannot be paid. For example, if a payment method requires 3DS
      * authentication due to SCA regulation and further user action is needed, this parameter does
-     * not create a subscription and returns an error instead. This was the default behavior for API
-     * versions prior to 2019-03-14. See the <a
+     * not update the subscription and returns an error instead. This was the default behavior for
+     * API versions prior to 2019-03-14. See the <a
      * href="https://stripe.com/docs/upgrades#2019-03-14">changelog</a> to learn more.
      */
     public Builder setPaymentBehavior(PaymentBehavior paymentBehavior) {

--- a/src/main/java/com/stripe/param/SubscriptionItemUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionItemUpdateParams.java
@@ -60,9 +60,9 @@ public class SubscriptionItemUpdateParams extends ApiRequestParams {
    * by pending updates</a>.
    *
    * <p>Use {@code error_if_incomplete} if you want Stripe to return an HTTP 402 status code if a
-   * subscription's first invoice cannot be paid. For example, if a payment method requires 3DS
+   * subscription's invoice cannot be paid. For example, if a payment method requires 3DS
    * authentication due to SCA regulation and further user action is needed, this parameter does not
-   * create a subscription and returns an error instead. This was the default behavior for API
+   * update the subscription and returns an error instead. This was the default behavior for API
    * versions prior to 2019-03-14. See the <a
    * href="https://stripe.com/docs/upgrades#2019-03-14">changelog</a> to learn more.
    */
@@ -353,10 +353,10 @@ public class SubscriptionItemUpdateParams extends ApiRequestParams {
      * by pending updates</a>.
      *
      * <p>Use {@code error_if_incomplete} if you want Stripe to return an HTTP 402 status code if a
-     * subscription's first invoice cannot be paid. For example, if a payment method requires 3DS
+     * subscription's invoice cannot be paid. For example, if a payment method requires 3DS
      * authentication due to SCA regulation and further user action is needed, this parameter does
-     * not create a subscription and returns an error instead. This was the default behavior for API
-     * versions prior to 2019-03-14. See the <a
+     * not update the subscription and returns an error instead. This was the default behavior for
+     * API versions prior to 2019-03-14. See the <a
      * href="https://stripe.com/docs/upgrades#2019-03-14">changelog</a> to learn more.
      */
     public Builder setPaymentBehavior(PaymentBehavior paymentBehavior) {

--- a/src/main/java/com/stripe/param/SubscriptionScheduleCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionScheduleCreateParams.java
@@ -934,8 +934,8 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
 
     /**
      * Controls whether or not a subscription schedule will create prorations when transitioning to
-     * this phase. Valid values are {@code create_prorations} or {@code none}, and the default value
-     * is {@code create_prorations}. See <a
+     * this phase. Possible values are {@code create_prorations} or {@code none}, and the default
+     * value is {@code create_prorations}. See <a
      * href="https://stripe.com/docs/billing/subscriptions/prorations">Prorations</a>.
      */
     @SerializedName("proration_behavior")
@@ -1308,8 +1308,8 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
 
       /**
        * Controls whether or not a subscription schedule will create prorations when transitioning
-       * to this phase. Valid values are {@code create_prorations} or {@code none}, and the default
-       * value is {@code create_prorations}. See <a
+       * to this phase. Possible values are {@code create_prorations} or {@code none}, and the
+       * default value is {@code create_prorations}. See <a
        * href="https://stripe.com/docs/billing/subscriptions/prorations">Prorations</a>.
        */
       public Builder setProrationBehavior(ProrationBehavior prorationBehavior) {

--- a/src/main/java/com/stripe/param/SubscriptionScheduleUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionScheduleUpdateParams.java
@@ -65,7 +65,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
   Boolean prorate;
 
   /**
-   * If the update changes the current phase, indicates if the changes should be prorated. Valid
+   * If the update changes the current phase, indicates if the changes should be prorated. Possible
    * values are {@code create_prorations} or {@code none}, and the default value is {@code
    * create_prorations}.
    */
@@ -281,9 +281,9 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
     }
 
     /**
-     * If the update changes the current phase, indicates if the changes should be prorated. Valid
-     * values are {@code create_prorations} or {@code none}, and the default value is {@code
-     * create_prorations}.
+     * If the update changes the current phase, indicates if the changes should be prorated.
+     * Possible values are {@code create_prorations} or {@code none}, and the default value is
+     * {@code create_prorations}.
      */
     public Builder setProrationBehavior(ProrationBehavior prorationBehavior) {
       this.prorationBehavior = prorationBehavior;
@@ -922,8 +922,8 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
 
     /**
      * Controls whether or not a subscription schedule will create prorations when transitioning to
-     * this phase. Valid values are {@code create_prorations} or {@code none}, and the default value
-     * is {@code create_prorations}. See <a
+     * this phase. Possible values are {@code create_prorations} or {@code none}, and the default
+     * value is {@code create_prorations}. See <a
      * href="https://stripe.com/docs/billing/subscriptions/prorations">Prorations</a>.
      */
     @SerializedName("proration_behavior")
@@ -1333,8 +1333,8 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
 
       /**
        * Controls whether or not a subscription schedule will create prorations when transitioning
-       * to this phase. Valid values are {@code create_prorations} or {@code none}, and the default
-       * value is {@code create_prorations}. See <a
+       * to this phase. Possible values are {@code create_prorations} or {@code none}, and the
+       * default value is {@code create_prorations}. See <a
        * href="https://stripe.com/docs/billing/subscriptions/prorations">Prorations</a>.
        */
       public Builder setProrationBehavior(ProrationBehavior prorationBehavior) {

--- a/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
@@ -120,7 +120,7 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
   @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
   Map<String, Object> extraParams;
 
-  /** List of subscription items, each with an attached plan. */
+  /** A list of up to 20 subscription items, each with an attached price. */
   @SerializedName("items")
   List<Item> items;
 
@@ -156,9 +156,9 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
    * by pending updates</a>.
    *
    * <p>Use {@code error_if_incomplete} if you want Stripe to return an HTTP 402 status code if a
-   * subscription's first invoice cannot be paid. For example, if a payment method requires 3DS
+   * subscription's invoice cannot be paid. For example, if a payment method requires 3DS
    * authentication due to SCA regulation and further user action is needed, this parameter does not
-   * create a subscription and returns an error instead. This was the default behavior for API
+   * update the subscription and returns an error instead. This was the default behavior for API
    * versions prior to 2019-03-14. See the <a
    * href="https://stripe.com/docs/upgrades#2019-03-14">changelog</a> to learn more.
    */
@@ -781,10 +781,10 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
      * by pending updates</a>.
      *
      * <p>Use {@code error_if_incomplete} if you want Stripe to return an HTTP 402 status code if a
-     * subscription's first invoice cannot be paid. For example, if a payment method requires 3DS
+     * subscription's invoice cannot be paid. For example, if a payment method requires 3DS
      * authentication due to SCA regulation and further user action is needed, this parameter does
-     * not create a subscription and returns an error instead. This was the default behavior for API
-     * versions prior to 2019-03-14. See the <a
+     * not update the subscription and returns an error instead. This was the default behavior for
+     * API versions prior to 2019-03-14. See the <a
      * href="https://stripe.com/docs/upgrades#2019-03-14">changelog</a> to learn more.
      */
     public Builder setPaymentBehavior(PaymentBehavior paymentBehavior) {

--- a/src/main/java/com/stripe/param/TaxRateCreateParams.java
+++ b/src/main/java/com/stripe/param/TaxRateCreateParams.java
@@ -13,8 +13,8 @@ import lombok.Getter;
 public class TaxRateCreateParams extends ApiRequestParams {
   /**
    * Flag determining whether the tax rate is active or inactive (archived). Inactive tax rates
-   * continue to work where they are currently applied however they cannot be used for new
-   * applications or Checkout Sessions.
+   * cannot be used with new applications or Checkout Sessions, but will still work for
+   * subscriptions and invoices that already have it set.
    */
   @SerializedName("active")
   Boolean active;
@@ -124,8 +124,8 @@ public class TaxRateCreateParams extends ApiRequestParams {
 
     /**
      * Flag determining whether the tax rate is active or inactive (archived). Inactive tax rates
-     * continue to work where they are currently applied however they cannot be used for new
-     * applications or Checkout Sessions.
+     * cannot be used with new applications or Checkout Sessions, but will still work for
+     * subscriptions and invoices that already have it set.
      */
     public Builder setActive(Boolean active) {
       this.active = active;

--- a/src/main/java/com/stripe/param/TaxRateUpdateParams.java
+++ b/src/main/java/com/stripe/param/TaxRateUpdateParams.java
@@ -13,8 +13,8 @@ import lombok.Getter;
 public class TaxRateUpdateParams extends ApiRequestParams {
   /**
    * Flag determining whether the tax rate is active or inactive (archived). Inactive tax rates
-   * continue to work where they are currently applied however they cannot be used for new
-   * applications or Checkout Sessions.
+   * cannot be used with new applications or Checkout Sessions, but will still work for
+   * subscriptions and invoices that already have it set.
    */
   @SerializedName("active")
   Boolean active;
@@ -106,8 +106,8 @@ public class TaxRateUpdateParams extends ApiRequestParams {
 
     /**
      * Flag determining whether the tax rate is active or inactive (archived). Inactive tax rates
-     * continue to work where they are currently applied however they cannot be used for new
-     * applications or Checkout Sessions.
+     * cannot be used with new applications or Checkout Sessions, but will still work for
+     * subscriptions and invoices that already have it set.
      */
     public Builder setActive(Boolean active) {
       this.active = active;

--- a/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
+++ b/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
@@ -1316,7 +1316,11 @@ public class SessionCreateParams extends ApiRequestParams {
     @SerializedName("on_behalf_of")
     String onBehalfOf;
 
-    /** Email address that the receipt for the resulting payment will be sent to. */
+    /**
+     * Email address that the receipt for the resulting payment will be sent to. If {@code
+     * receipt_email} is specified for a payment in live mode, a receipt will be sent regardless of
+     * your <a href="https://dashboard.stripe.com/account/emails">email settings</a>.
+     */
     @SerializedName("receipt_email")
     String receiptEmail;
 
@@ -1536,7 +1540,11 @@ public class SessionCreateParams extends ApiRequestParams {
         return this;
       }
 
-      /** Email address that the receipt for the resulting payment will be sent to. */
+      /**
+       * Email address that the receipt for the resulting payment will be sent to. If {@code
+       * receipt_email} is specified for a payment in live mode, a receipt will be sent regardless
+       * of your <a href="https://dashboard.stripe.com/account/emails">email settings</a>.
+       */
       public Builder setReceiptEmail(String receiptEmail) {
         this.receiptEmail = receiptEmail;
         return this;


### PR DESCRIPTION
Codegen for openapi de5f566

r? @cjavilla-stripe 
cc @stripe/api-libraries 