### PR TITLE
Add support for `en-GB`, `fr-CA` and `id` as `locale` on Checkout `Session`

### DIFF
--- a/src/main/java/com/stripe/model/checkout/Session.java
+++ b/src/main/java/com/stripe/model/checkout/Session.java
@@ -112,10 +112,10 @@ public class Session extends ApiResource implements HasId {
    * browser's locale is used.
    *
    * <p>One of {@code auto}, {@code bg}, {@code cs}, {@code da}, {@code de}, {@code el}, {@code en},
-   * {@code es}, {@code es-419}, {@code et}, {@code fi}, {@code fr}, {@code hu}, {@code it}, {@code
-   * ja}, {@code lt}, {@code lv}, {@code ms}, {@code mt}, {@code nb}, {@code nl}, {@code pl}, {@code
-   * pt}, {@code pt-BR}, {@code ro}, {@code ru}, {@code sk}, {@code sl}, {@code sv}, {@code tr}, or
-   * {@code zh}.
+   * {@code en-GB}, {@code es}, {@code es-419}, {@code et}, {@code fi}, {@code fr}, {@code fr-CA},
+   * {@code hu}, {@code id}, {@code it}, {@code ja}, {@code lt}, {@code lv}, {@code ms}, {@code mt},
+   * {@code nb}, {@code nl}, {@code pl}, {@code pt}, {@code pt-BR}, {@code ro}, {@code ru}, {@code
+   * sk}, {@code sl}, {@code sv}, {@code tr}, or {@code zh}.
    */
   @SerializedName("locale")
   String locale;

--- a/src/main/java/com/stripe/param/SubscriptionCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionCreateParams.java
@@ -133,7 +133,7 @@ public class SubscriptionCreateParams extends ApiRequestParams {
   @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
   Map<String, Object> extraParams;
 
-  /** A list of up to 20 subscription items, each with an attached plan. */
+  /** A list of up to 20 subscription items, each with an attached price. */
   @SerializedName("items")
   List<Item> items;
 

--- a/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
+++ b/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
@@ -3421,6 +3421,9 @@ public class SessionCreateParams extends ApiRequestParams {
     @SerializedName("en")
     EN("en"),
 
+    @SerializedName("en-GB")
+    EN_GB("en-GB"),
+
     @SerializedName("es")
     ES("es"),
 
@@ -3436,8 +3439,14 @@ public class SessionCreateParams extends ApiRequestParams {
     @SerializedName("fr")
     FR("fr"),
 
+    @SerializedName("fr-CA")
+    FR_CA("fr-CA"),
+
     @SerializedName("hu")
     HU("hu"),
+
+    @SerializedName("id")
+    ID("id"),
 
     @SerializedName("it")
     IT("it"),


### PR DESCRIPTION
Codegen for openapi e925391

r? @paulasjes-stripe 
cc @stripe/api-libraries 