### PR TITLE
Feature proxy foreach request

### DIFF
--- a/src/main/java/com/stripe/net/HttpURLConnectionClient.java
+++ b/src/main/java/com/stripe/net/HttpURLConnectionClient.java
@@ -39,9 +39,9 @@ public class HttpURLConnectionClient extends HttpClient {
       final HttpHeaders headers = HttpHeaders.of(conn.getHeaderFields());
 
       final InputStream responseStream =
-          (responseCode >= 200 && responseCode < 300)
-              ? conn.getInputStream()
-              : conn.getErrorStream();
+        (responseCode >= 200 && responseCode < 300)
+          ? conn.getInputStream()
+          : conn.getErrorStream();
 
       final String responseBody = StreamUtils.readToEnd(responseStream, ApiResource.CHARSET);
 
@@ -51,13 +51,13 @@ public class HttpURLConnectionClient extends HttpClient {
 
     } catch (IOException e) {
       throw new ApiConnectionException(
-          String.format(
-              "IOException during API request to Stripe (%s): %s "
-                  + "Please check your internet connection and try again. If this problem persists,"
-                  + "you should check Stripe's service status at https://twitter.com/stripestatus,"
-                  + " or let us know at support@stripe.com.",
-              Stripe.getApiBase(), e.getMessage()),
-          e);
+        String.format(
+          "IOException during API request to Stripe (%s): %s "
+            + "Please check your internet connection and try again. If this problem persists,"
+            + "you should check Stripe's service status at https://twitter.com/stripestatus,"
+            + " or let us know at support@stripe.com.",
+          Stripe.getApiBase(), e.getMessage()),
+        e);
     }
   }
 
@@ -66,24 +66,24 @@ public class HttpURLConnectionClient extends HttpClient {
 
     userAgentHeadersMap.put("User-Agent", Arrays.asList(buildUserAgentString()));
     userAgentHeadersMap.put(
-        "X-Stripe-Client-User-Agent", Arrays.asList(buildXStripeClientUserAgentString()));
+      "X-Stripe-Client-User-Agent", Arrays.asList(buildXStripeClientUserAgentString()));
 
     return request.headers().withAdditionalHeaders(userAgentHeadersMap);
   }
 
   private static HttpURLConnection createStripeConnection(StripeRequest request)
-      throws IOException, ApiConnectionException {
+    throws IOException, ApiConnectionException {
     HttpURLConnection conn = null;
 
-    if (Stripe.getConnectionProxy() != null) {
-      conn = (HttpURLConnection) request.url().openConnection(Stripe.getConnectionProxy());
+    if (request.options().getConnectionProxy() != null) {
+      conn = (HttpURLConnection) request.url().openConnection(request.options().getConnectionProxy());
       Authenticator.setDefault(
-          new Authenticator() {
-            @Override
-            protected PasswordAuthentication getPasswordAuthentication() {
-              return Stripe.getProxyCredential();
-            }
-          });
+        new Authenticator() {
+          @Override
+          protected PasswordAuthentication getPasswordAuthentication() {
+            return request.options().getProxyCredential();
+          }
+        });
     } else {
       conn = (HttpURLConnection) request.url().openConnection();
     }

--- a/src/main/java/com/stripe/net/HttpURLConnectionClient.java
+++ b/src/main/java/com/stripe/net/HttpURLConnectionClient.java
@@ -39,9 +39,9 @@ public class HttpURLConnectionClient extends HttpClient {
       final HttpHeaders headers = HttpHeaders.of(conn.getHeaderFields());
 
       final InputStream responseStream =
-        (responseCode >= 200 && responseCode < 300)
-          ? conn.getInputStream()
-          : conn.getErrorStream();
+          (responseCode >= 200 && responseCode < 300)
+              ? conn.getInputStream()
+              : conn.getErrorStream();
 
       final String responseBody = StreamUtils.readToEnd(responseStream, ApiResource.CHARSET);
 
@@ -51,13 +51,13 @@ public class HttpURLConnectionClient extends HttpClient {
 
     } catch (IOException e) {
       throw new ApiConnectionException(
-        String.format(
-          "IOException during API request to Stripe (%s): %s "
-            + "Please check your internet connection and try again. If this problem persists,"
-            + "you should check Stripe's service status at https://twitter.com/stripestatus,"
-            + " or let us know at support@stripe.com.",
-          Stripe.getApiBase(), e.getMessage()),
-        e);
+          String.format(
+              "IOException during API request to Stripe (%s): %s "
+                  + "Please check your internet connection and try again. If this problem persists,"
+                  + "you should check Stripe's service status at https://twitter.com/stripestatus,"
+                  + " or let us know at support@stripe.com.",
+              Stripe.getApiBase(), e.getMessage()),
+          e);
     }
   }
 
@@ -66,13 +66,13 @@ public class HttpURLConnectionClient extends HttpClient {
 
     userAgentHeadersMap.put("User-Agent", Arrays.asList(buildUserAgentString()));
     userAgentHeadersMap.put(
-      "X-Stripe-Client-User-Agent", Arrays.asList(buildXStripeClientUserAgentString()));
+        "X-Stripe-Client-User-Agent", Arrays.asList(buildXStripeClientUserAgentString()));
 
     return request.headers().withAdditionalHeaders(userAgentHeadersMap);
   }
 
   private static HttpURLConnection createStripeConnection(StripeRequest request)
-    throws IOException, ApiConnectionException {
+      throws IOException, ApiConnectionException {
     HttpURLConnection conn = null;
 
     if (request.options().getConnectionProxy() != null) {

--- a/src/main/java/com/stripe/net/RequestOptions.java
+++ b/src/main/java/com/stripe/net/RequestOptions.java
@@ -31,29 +31,29 @@ public class RequestOptions {
 
   public static RequestOptions getDefault() {
     return new RequestOptions(
-      Stripe.apiKey,
-      Stripe.clientId,
-      null,
-      null,
-      null,
-      Stripe.getConnectTimeout(),
-      Stripe.getReadTimeout(),
-      Stripe.getMaxNetworkRetries(),
-      Stripe.getConnectionProxy(),
-      Stripe.getProxyCredential());
+        Stripe.apiKey,
+        Stripe.clientId,
+        null,
+        null,
+        null,
+        Stripe.getConnectTimeout(),
+        Stripe.getReadTimeout(),
+        Stripe.getMaxNetworkRetries(),
+        Stripe.getConnectionProxy(),
+        Stripe.getProxyCredential());
   }
 
   private RequestOptions(
-    String apiKey,
-    String clientId,
-    String idempotencyKey,
-    String stripeAccount,
-    String stripeVersionOverride,
-    int connectTimeout,
-    int readTimeout,
-    int maxNetworkRetries,
-    Proxy connectionProxy,
-    PasswordAuthentication proxyCredential) {
+      String apiKey,
+      String clientId,
+      String idempotencyKey,
+      String stripeAccount,
+      String stripeVersionOverride,
+      int connectTimeout,
+      int readTimeout,
+      int maxNetworkRetries,
+      Proxy connectionProxy,
+      PasswordAuthentication proxyCredential) {
     this.apiKey = apiKey;
     this.clientId = clientId;
     this.idempotencyKey = idempotencyKey;
@@ -307,16 +307,14 @@ public class RequestOptions {
     /** Constructs a {@link RequestOptions} with the specified values. */
     public RequestOptions build() {
       return new RequestOptions(
-        normalizeApiKey(this.apiKey),
-        normalizeClientId(this.clientId),
-        normalizeIdempotencyKey(this.idempotencyKey),
-        normalizeStripeAccount(this.stripeAccount),
-        normalizeStripeVersion(this.stripeVersionOverride),
-        connectTimeout,
-        readTimeout,
-        maxNetworkRetries,
-        connectionProxy,
-        proxyCredential);
+          normalizeApiKey(this.apiKey),
+          normalizeClientId(this.clientId),
+          normalizeIdempotencyKey(this.idempotencyKey),
+          normalizeStripeAccount(this.stripeAccount),
+          normalizeStripeVersion(this.stripeVersionOverride),
+          connectTimeout,
+          readTimeout,
+          maxNetworkRetries);
     }
   }
 
@@ -366,9 +364,9 @@ public class RequestOptions {
     }
     if (normalized.length() > 255) {
       throw new InvalidRequestOptionsException(
-        String.format(
-          "Idempotency Key length was %d, which is larger than the 255 character " + "maximum!",
-          normalized.length()));
+          String.format(
+              "Idempotency Key length was %d, which is larger than the 255 character " + "maximum!",
+              normalized.length()));
     }
     return normalized;
   }


### PR DESCRIPTION
Added an option to set different proxy for each request individually.
It is now possible by doing:
```Java
Stripe.apiKey = "sk_test_...";

RequestOptions requestOptions = RequestOptions.builder()
        .setConnectionProxy(<java.net.Proxy>)
        .setProxyCredential(<java.net.PasswordAuthentication>)
        .build();

Balance.retrieve(requestOptions);
```