### PR TITLE
Retry after socket timeout exceptions, too

### DIFF
--- a/src/main/java/com/stripe/net/HttpClient.java
+++ b/src/main/java/com/stripe/net/HttpClient.java
@@ -5,6 +5,7 @@ import com.stripe.exception.ApiConnectionException;
 import com.stripe.exception.StripeException;
 import com.stripe.util.Stopwatch;
 import java.net.ConnectException;
+import java.net.SocketTimeoutException;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -174,7 +175,7 @@ public abstract class HttpClient {
     // Retry on connection error.
     if ((exception != null)
         && (exception.getCause() != null)
-        && (exception.getCause() instanceof ConnectException)) {
+        && (exception.getCause() instanceof ConnectException || exception.getCause() instanceof SocketTimeoutException)) {
       return true;
     }
 

--- a/src/main/java/com/stripe/net/HttpClient.java
+++ b/src/main/java/com/stripe/net/HttpClient.java
@@ -175,7 +175,8 @@ public abstract class HttpClient {
     // Retry on connection error.
     if ((exception != null)
         && (exception.getCause() != null)
-        && (exception.getCause() instanceof ConnectException || exception.getCause() instanceof SocketTimeoutException)) {
+        && (exception.getCause() instanceof ConnectException
+            || exception.getCause() instanceof SocketTimeoutException)) {
       return true;
     }
 

--- a/src/test/java/com/stripe/net/HttpClientTest.java
+++ b/src/test/java/com/stripe/net/HttpClientTest.java
@@ -77,7 +77,8 @@ public class HttpClientTest extends BaseStripeTest {
   @Test
   public void testRequestWithRetriesSocketTimeoutException() throws StripeException {
     Mockito.when(this.client.request(this.request))
-        .thenThrow(new ApiConnectionException("foo", new SocketTimeoutException("timeout or something")))
+        .thenThrow(
+            new ApiConnectionException("foo", new SocketTimeoutException("timeout or something")))
         .thenReturn(new StripeResponse(200, emptyHeaders, "{}"));
 
     StripeResponse response = this.client.requestWithRetries(this.request);

--- a/src/test/java/com/stripe/net/HttpClientTest.java
+++ b/src/test/java/com/stripe/net/HttpClientTest.java
@@ -12,6 +12,7 @@ import com.stripe.BaseStripeTest;
 import com.stripe.exception.ApiConnectionException;
 import com.stripe.exception.StripeException;
 import java.net.ConnectException;
+import java.net.SocketTimeoutException;
 import java.util.Collections;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -70,6 +71,39 @@ public class HttpClientTest extends BaseStripeTest {
     assertEquals("3", e.getMessage());
     assertNotNull(e.getCause());
     assertTrue(e.getCause() instanceof ConnectException);
+    assertEquals("timeout 3", e.getCause().getMessage());
+  }
+
+  @Test
+  public void testRequestWithRetriesSocketTimeoutException() throws StripeException {
+    Mockito.when(this.client.request(this.request))
+        .thenThrow(new ApiConnectionException("foo", new SocketTimeoutException("timeout or something")))
+        .thenReturn(new StripeResponse(200, emptyHeaders, "{}"));
+
+    StripeResponse response = this.client.requestWithRetries(this.request);
+
+    assertNotNull(response);
+    assertEquals(200, response.code());
+    assertEquals(1, response.numRetries());
+  }
+
+  @Test
+  public void testRequestWithRetriesSocketTimeoutExceptionRethrowAfterAllAttempts()
+      throws StripeException {
+    Mockito.when(this.client.request(this.request))
+        .thenThrow(new ApiConnectionException("1", new SocketTimeoutException("timeout 1")))
+        .thenThrow(new ApiConnectionException("2", new SocketTimeoutException("timeout 2")))
+        .thenThrow(new ApiConnectionException("3", new SocketTimeoutException("timeout 3")));
+
+    ApiConnectionException e =
+        assertThrows(
+            ApiConnectionException.class,
+            () -> {
+              this.client.requestWithRetries(this.request);
+            });
+    assertEquals("3", e.getMessage());
+    assertNotNull(e.getCause());
+    assertTrue(e.getCause() instanceof SocketTimeoutException);
     assertEquals("timeout 3", e.getCause().getMessage());
   }
 


### PR DESCRIPTION
Fixes #1071

Causes HttpClient to retry after both ConnectException and SocketTimeoutException (previously it only retried after ConnectException).

My impression is that `SocketTimeoutException` occurs if a socket has successfully been established, but too much time has elapsed without any bytes being written through it. Whereas 'ConnectException' includes timeouts for the socket becoming established in the first place.

r? @ob-stripe
cc @remi-stripe @cjavilla-stripe @stripe/api-libraries 