### PR TITLE
Multiple API changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 env:
   global:
     # If changing this number, please also change it in `BaseStripeTest.java`.
-  - STRIPE_MOCK_VERSION=0.94.0
+  - STRIPE_MOCK_VERSION=0.95.0
 
 matrix:
   include:

--- a/src/main/java/com/stripe/model/Coupon.java
+++ b/src/main/java/com/stripe/model/Coupon.java
@@ -10,6 +10,7 @@ import com.stripe.param.CouponListParams;
 import com.stripe.param.CouponRetrieveParams;
 import com.stripe.param.CouponUpdateParams;
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Map;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -25,6 +26,9 @@ public class Coupon extends ApiResource implements HasId, MetadataStore<Coupon> 
    */
   @SerializedName("amount_off")
   Long amountOff;
+
+  @SerializedName("applies_to")
+  Restrictions appliesTo;
 
   /** Time at which the object was created. Measured in seconds since the Unix epoch. */
   @SerializedName("created")
@@ -328,5 +332,14 @@ public class Coupon extends ApiResource implements HasId, MetadataStore<Coupon> 
             String.format("/v1/coupons/%s", ApiResource.urlEncodeId(this.getId())));
     return ApiResource.request(
         ApiResource.RequestMethod.DELETE, url, params, Coupon.class, options);
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class Restrictions extends StripeObject {
+    /** A list of product IDs this coupon applies to. */
+    @SerializedName("products")
+    List<String> products;
   }
 }

--- a/src/main/java/com/stripe/model/Coupon.java
+++ b/src/main/java/com/stripe/model/Coupon.java
@@ -28,7 +28,7 @@ public class Coupon extends ApiResource implements HasId, MetadataStore<Coupon> 
   Long amountOff;
 
   @SerializedName("applies_to")
-  Restrictions appliesTo;
+  AppliesTo appliesTo;
 
   /** Time at which the object was created. Measured in seconds since the Unix epoch. */
   @SerializedName("created")
@@ -337,7 +337,7 @@ public class Coupon extends ApiResource implements HasId, MetadataStore<Coupon> 
   @Getter
   @Setter
   @EqualsAndHashCode(callSuper = false)
-  public static class Restrictions extends StripeObject {
+  public static class AppliesTo extends StripeObject {
     /** A list of product IDs this coupon applies to. */
     @SerializedName("products")
     List<String> products;

--- a/src/main/java/com/stripe/model/Discount.java
+++ b/src/main/java/com/stripe/model/Discount.java
@@ -68,6 +68,12 @@ public class Discount extends StripeObject implements HasId {
   @SerializedName("object")
   String object;
 
+  /** The promotion code applied to create this discount. */
+  @SerializedName("promotion_code")
+  @Getter(lombok.AccessLevel.NONE)
+  @Setter(lombok.AccessLevel.NONE)
+  ExpandableField<PromotionCode> promotionCode;
+
   /** Date that the coupon was applied. */
   @SerializedName("start")
   Long start;
@@ -94,5 +100,24 @@ public class Discount extends StripeObject implements HasId {
 
   public void setCustomerObject(Customer expandableObject) {
     this.customer = new ExpandableField<Customer>(expandableObject.getId(), expandableObject);
+  }
+
+  /** Get ID of expandable {@code promotionCode} object. */
+  public String getPromotionCode() {
+    return (this.promotionCode != null) ? this.promotionCode.getId() : null;
+  }
+
+  public void setPromotionCode(String id) {
+    this.promotionCode = ApiResource.setExpandableFieldId(id, this.promotionCode);
+  }
+
+  /** Get expanded {@code promotionCode}. */
+  public PromotionCode getPromotionCodeObject() {
+    return (this.promotionCode != null) ? this.promotionCode.getExpanded() : null;
+  }
+
+  public void setPromotionCodeObject(PromotionCode expandableObject) {
+    this.promotionCode =
+        new ExpandableField<PromotionCode>(expandableObject.getId(), expandableObject);
   }
 }

--- a/src/main/java/com/stripe/model/EventDataClassLookup.java
+++ b/src/main/java/com/stripe/model/EventDataClassLookup.java
@@ -58,6 +58,7 @@ final class EventDataClassLookup {
     classLookup.put("platform_tax_fee", PlatformTaxFee.class);
     classLookup.put("price", Price.class);
     classLookup.put("product", Product.class);
+    classLookup.put("promotion_code", PromotionCode.class);
     classLookup.put("recipient", Recipient.class);
     classLookup.put("refund", Refund.class);
     classLookup.put("reserve_transaction", ReserveTransaction.class);

--- a/src/main/java/com/stripe/model/Plan.java
+++ b/src/main/java/com/stripe/model/Plan.java
@@ -213,16 +213,18 @@ public class Plan extends ApiResource implements HasId, MetadataStore<Plan> {
   }
 
   /**
-   * You can create plans using the API, or in the Stripe <a
-   * href="https://dashboard.stripe.com/products">Dashboard</a>.
+   * You can now model subscriptions more flexibly using the <a
+   * href="https://stripe.com/docs/api#prices">Prices API</a>. It replaces the Plans API and is
+   * backwards compatible to simplify your migration.
    */
   public static Plan create(Map<String, Object> params) throws StripeException {
     return create(params, (RequestOptions) null);
   }
 
   /**
-   * You can create plans using the API, or in the Stripe <a
-   * href="https://dashboard.stripe.com/products">Dashboard</a>.
+   * You can now model subscriptions more flexibly using the <a
+   * href="https://stripe.com/docs/api#prices">Prices API</a>. It replaces the Plans API and is
+   * backwards compatible to simplify your migration.
    */
   public static Plan create(Map<String, Object> params, RequestOptions options)
       throws StripeException {
@@ -231,16 +233,18 @@ public class Plan extends ApiResource implements HasId, MetadataStore<Plan> {
   }
 
   /**
-   * You can create plans using the API, or in the Stripe <a
-   * href="https://dashboard.stripe.com/products">Dashboard</a>.
+   * You can now model subscriptions more flexibly using the <a
+   * href="https://stripe.com/docs/api#prices">Prices API</a>. It replaces the Plans API and is
+   * backwards compatible to simplify your migration.
    */
   public static Plan create(PlanCreateParams params) throws StripeException {
     return create(params, (RequestOptions) null);
   }
 
   /**
-   * You can create plans using the API, or in the Stripe <a
-   * href="https://dashboard.stripe.com/products">Dashboard</a>.
+   * You can now model subscriptions more flexibly using the <a
+   * href="https://stripe.com/docs/api#prices">Prices API</a>. It replaces the Plans API and is
+   * backwards compatible to simplify your migration.
    */
   public static Plan create(PlanCreateParams params, RequestOptions options)
       throws StripeException {

--- a/src/main/java/com/stripe/model/PromotionCode.java
+++ b/src/main/java/com/stripe/model/PromotionCode.java
@@ -1,0 +1,287 @@
+package com.stripe.model;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.Stripe;
+import com.stripe.exception.StripeException;
+import com.stripe.net.ApiResource;
+import com.stripe.net.RequestOptions;
+import com.stripe.param.PromotionCodeCreateParams;
+import com.stripe.param.PromotionCodeListParams;
+import com.stripe.param.PromotionCodeRetrieveParams;
+import com.stripe.param.PromotionCodeUpdateParams;
+import java.util.Map;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
+public class PromotionCode extends ApiResource implements HasId, MetadataStore<PromotionCode> {
+  /**
+   * Whether the promotion code is currently active. A promotion code is only active if the coupon
+   * is also valid.
+   */
+  @SerializedName("active")
+  Boolean active;
+
+  /**
+   * The customer-facing code. Regardless of case, this code must be unique across all active
+   * promotion codes for each customer.
+   */
+  @SerializedName("code")
+  String code;
+
+  /**
+   * A coupon contains information about a percent-off or amount-off discount you might want to
+   * apply to a customer. Coupons may be applied to <a
+   * href="https://stripe.com/docs/api#invoices">invoices</a> or <a
+   * href="https://stripe.com/docs/api#create_order-coupon">orders</a>. Coupons do not work with
+   * conventional one-off <a href="https://stripe.com/docs/api#create_charge">charges</a>.
+   */
+  @SerializedName("coupon")
+  Coupon coupon;
+
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  @SerializedName("created")
+  Long created;
+
+  /** The customer that this promotion code can be used by. */
+  @SerializedName("customer")
+  @Getter(lombok.AccessLevel.NONE)
+  @Setter(lombok.AccessLevel.NONE)
+  ExpandableField<Customer> customer;
+
+  /** Date at which the promotion code can no longer be redeemed. */
+  @SerializedName("expires_at")
+  Long expiresAt;
+
+  /** Unique identifier for the object. */
+  @Getter(onMethod_ = {@Override})
+  @SerializedName("id")
+  String id;
+
+  /**
+   * Has the value {@code true} if the object exists in live mode or the value {@code false} if the
+   * object exists in test mode.
+   */
+  @SerializedName("livemode")
+  Boolean livemode;
+
+  /** Maximum number of times this promotion code can be redeemed. */
+  @SerializedName("max_redemptions")
+  Long maxRedemptions;
+
+  /**
+   * Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can attach
+   * to an object. This can be useful for storing additional information about the object in a
+   * structured format.
+   */
+  @Getter(onMethod_ = {@Override})
+  @SerializedName("metadata")
+  Map<String, String> metadata;
+
+  /**
+   * String representing the object's type. Objects of the same type share the same value.
+   *
+   * <p>Equal to {@code promotion_code}.
+   */
+  @SerializedName("object")
+  String object;
+
+  @SerializedName("restrictions")
+  Restrictions restrictions;
+
+  /** Number of times this promotion code has been used. */
+  @SerializedName("times_redeemed")
+  Long timesRedeemed;
+
+  /** Get ID of expandable {@code customer} object. */
+  public String getCustomer() {
+    return (this.customer != null) ? this.customer.getId() : null;
+  }
+
+  public void setCustomer(String id) {
+    this.customer = ApiResource.setExpandableFieldId(id, this.customer);
+  }
+
+  /** Get expanded {@code customer}. */
+  public Customer getCustomerObject() {
+    return (this.customer != null) ? this.customer.getExpanded() : null;
+  }
+
+  public void setCustomerObject(Customer expandableObject) {
+    this.customer = new ExpandableField<Customer>(expandableObject.getId(), expandableObject);
+  }
+
+  /** Retrieves the promotion code with the given ID. */
+  public static PromotionCode retrieve(String promotionCode) throws StripeException {
+    return retrieve(promotionCode, (Map<String, Object>) null, (RequestOptions) null);
+  }
+
+  /** Retrieves the promotion code with the given ID. */
+  public static PromotionCode retrieve(String promotionCode, RequestOptions options)
+      throws StripeException {
+    return retrieve(promotionCode, (Map<String, Object>) null, options);
+  }
+
+  /** Retrieves the promotion code with the given ID. */
+  public static PromotionCode retrieve(
+      String promotionCode, Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/promotion_codes/%s", ApiResource.urlEncodeId(promotionCode)));
+    return ApiResource.request(
+        ApiResource.RequestMethod.GET, url, params, PromotionCode.class, options);
+  }
+
+  /** Retrieves the promotion code with the given ID. */
+  public static PromotionCode retrieve(
+      String promotionCode, PromotionCodeRetrieveParams params, RequestOptions options)
+      throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/promotion_codes/%s", ApiResource.urlEncodeId(promotionCode)));
+    return ApiResource.request(
+        ApiResource.RequestMethod.GET, url, params, PromotionCode.class, options);
+  }
+
+  /**
+   * A promotion code points to a coupon. You can optionally restrict the code to a specific
+   * customer, redemption limit, and expiration date.
+   */
+  public static PromotionCode create(Map<String, Object> params) throws StripeException {
+    return create(params, (RequestOptions) null);
+  }
+
+  /**
+   * A promotion code points to a coupon. You can optionally restrict the code to a specific
+   * customer, redemption limit, and expiration date.
+   */
+  public static PromotionCode create(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/promotion_codes");
+    return ApiResource.request(
+        ApiResource.RequestMethod.POST, url, params, PromotionCode.class, options);
+  }
+
+  /**
+   * A promotion code points to a coupon. You can optionally restrict the code to a specific
+   * customer, redemption limit, and expiration date.
+   */
+  public static PromotionCode create(PromotionCodeCreateParams params) throws StripeException {
+    return create(params, (RequestOptions) null);
+  }
+
+  /**
+   * A promotion code points to a coupon. You can optionally restrict the code to a specific
+   * customer, redemption limit, and expiration date.
+   */
+  public static PromotionCode create(PromotionCodeCreateParams params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/promotion_codes");
+    return ApiResource.request(
+        ApiResource.RequestMethod.POST, url, params, PromotionCode.class, options);
+  }
+
+  /**
+   * Updates the specified promotion code by setting the values of the parameters passed. Most
+   * fields are, by design, not editable.
+   */
+  @Override
+  public PromotionCode update(Map<String, Object> params) throws StripeException {
+    return update(params, (RequestOptions) null);
+  }
+
+  /**
+   * Updates the specified promotion code by setting the values of the parameters passed. Most
+   * fields are, by design, not editable.
+   */
+  @Override
+  public PromotionCode update(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/promotion_codes/%s", ApiResource.urlEncodeId(this.getId())));
+    return ApiResource.request(
+        ApiResource.RequestMethod.POST, url, params, PromotionCode.class, options);
+  }
+
+  /**
+   * Updates the specified promotion code by setting the values of the parameters passed. Most
+   * fields are, by design, not editable.
+   */
+  public PromotionCode update(PromotionCodeUpdateParams params) throws StripeException {
+    return update(params, (RequestOptions) null);
+  }
+
+  /**
+   * Updates the specified promotion code by setting the values of the parameters passed. Most
+   * fields are, by design, not editable.
+   */
+  public PromotionCode update(PromotionCodeUpdateParams params, RequestOptions options)
+      throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/promotion_codes/%s", ApiResource.urlEncodeId(this.getId())));
+    return ApiResource.request(
+        ApiResource.RequestMethod.POST, url, params, PromotionCode.class, options);
+  }
+
+  /** Returns a list of your promotion codes. */
+  public static PromotionCodeCollection list(Map<String, Object> params) throws StripeException {
+    return list(params, (RequestOptions) null);
+  }
+
+  /** Returns a list of your promotion codes. */
+  public static PromotionCodeCollection list(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/promotion_codes");
+    return ApiResource.requestCollection(url, params, PromotionCodeCollection.class, options);
+  }
+
+  /** Returns a list of your promotion codes. */
+  public static PromotionCodeCollection list(PromotionCodeListParams params)
+      throws StripeException {
+    return list(params, (RequestOptions) null);
+  }
+
+  /** Returns a list of your promotion codes. */
+  public static PromotionCodeCollection list(PromotionCodeListParams params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/promotion_codes");
+    return ApiResource.requestCollection(url, params, PromotionCodeCollection.class, options);
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class Restrictions extends StripeObject {
+    /**
+     * A Boolean indicating if the Promotion Code should only be redeemed for Customers without any
+     * successful payments or invoices.
+     */
+    @SerializedName("first_time_transaction")
+    Boolean firstTimeTransaction;
+
+    /**
+     * Minimum amount required to redeem this Promotion Code into a Coupon (e.g., a purchase must be
+     * $100 or more to work).
+     */
+    @SerializedName("minimum_amount")
+    Long minimumAmount;
+
+    /** Three-letter <a href="https://stripe.com/docs/currencies">ISO code</a> for minimum_amount */
+    @SerializedName("minimum_amount_currency")
+    String minimumAmountCurrency;
+  }
+}

--- a/src/main/java/com/stripe/model/PromotionCodeCollection.java
+++ b/src/main/java/com/stripe/model/PromotionCodeCollection.java
@@ -1,0 +1,3 @@
+package com.stripe.model;
+
+public class PromotionCodeCollection extends StripeCollection<PromotionCode> {}

--- a/src/main/java/com/stripe/model/checkout/Session.java
+++ b/src/main/java/com/stripe/model/checkout/Session.java
@@ -31,6 +31,10 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class Session extends ApiResource implements HasId {
+  /** Enables user redeemable promotion codes. */
+  @SerializedName("allow_promotion_codes")
+  Boolean allowPromotionCodes;
+
   /** Total of all items before discounts or taxes are applied. */
   @SerializedName("amount_subtotal")
   Long amountSubtotal;

--- a/src/main/java/com/stripe/param/CouponCreateParams.java
+++ b/src/main/java/com/stripe/param/CouponCreateParams.java
@@ -19,6 +19,10 @@ public class CouponCreateParams extends ApiRequestParams {
   @SerializedName("amount_off")
   Long amountOff;
 
+  /** A hash containing directions for what this Coupon will apply discounts to. */
+  @SerializedName("applies_to")
+  AppliesTo appliesTo;
+
   /**
    * Three-letter <a href="https://stripe.com/docs/currencies">ISO code for the currency</a> of the
    * {@code amount_off} parameter (required if {@code amount_off} is passed).
@@ -101,6 +105,7 @@ public class CouponCreateParams extends ApiRequestParams {
 
   private CouponCreateParams(
       Long amountOff,
+      AppliesTo appliesTo,
       String currency,
       Duration duration,
       Long durationInMonths,
@@ -113,6 +118,7 @@ public class CouponCreateParams extends ApiRequestParams {
       BigDecimal percentOff,
       Long redeemBy) {
     this.amountOff = amountOff;
+    this.appliesTo = appliesTo;
     this.currency = currency;
     this.duration = duration;
     this.durationInMonths = durationInMonths;
@@ -132,6 +138,8 @@ public class CouponCreateParams extends ApiRequestParams {
 
   public static class Builder {
     private Long amountOff;
+
+    private AppliesTo appliesTo;
 
     private String currency;
 
@@ -159,6 +167,7 @@ public class CouponCreateParams extends ApiRequestParams {
     public CouponCreateParams build() {
       return new CouponCreateParams(
           this.amountOff,
+          this.appliesTo,
           this.currency,
           this.duration,
           this.durationInMonths,
@@ -178,6 +187,12 @@ public class CouponCreateParams extends ApiRequestParams {
      */
     public Builder setAmountOff(Long amountOff) {
       this.amountOff = amountOff;
+      return this;
+    }
+
+    /** A hash containing directions for what this Coupon will apply discounts to. */
+    public Builder setAppliesTo(AppliesTo appliesTo) {
+      this.appliesTo = appliesTo;
       return this;
     }
 
@@ -355,6 +370,94 @@ public class CouponCreateParams extends ApiRequestParams {
     public Builder setRedeemBy(Long redeemBy) {
       this.redeemBy = redeemBy;
       return this;
+    }
+  }
+
+  @Getter
+  public static class AppliesTo {
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /** An array of Product IDs that this Coupon will apply to. */
+    @SerializedName("products")
+    List<String> products;
+
+    private AppliesTo(Map<String, Object> extraParams, List<String> products) {
+      this.extraParams = extraParams;
+      this.products = products;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Map<String, Object> extraParams;
+
+      private List<String> products;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public AppliesTo build() {
+        return new AppliesTo(this.extraParams, this.products);
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * CouponCreateParams.AppliesTo#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link CouponCreateParams.AppliesTo#extraParams} for the field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /**
+       * Add an element to `products` list. A list is initialized for the first `add/addAll` call,
+       * and subsequent calls adds additional elements to the original list. See {@link
+       * CouponCreateParams.AppliesTo#products} for the field documentation.
+       */
+      public Builder addProduct(String element) {
+        if (this.products == null) {
+          this.products = new ArrayList<>();
+        }
+        this.products.add(element);
+        return this;
+      }
+
+      /**
+       * Add all elements to `products` list. A list is initialized for the first `add/addAll` call,
+       * and subsequent calls adds additional elements to the original list. See {@link
+       * CouponCreateParams.AppliesTo#products} for the field documentation.
+       */
+      public Builder addAllProduct(List<String> elements) {
+        if (this.products == null) {
+          this.products = new ArrayList<>();
+        }
+        this.products.addAll(elements);
+        return this;
+      }
     }
   }
 

--- a/src/main/java/com/stripe/param/CustomerCreateParams.java
+++ b/src/main/java/com/stripe/param/CustomerCreateParams.java
@@ -93,6 +93,14 @@ public class CustomerCreateParams extends ApiRequestParams {
   @SerializedName("preferred_locales")
   List<String> preferredLocales;
 
+  /**
+   * The API ID of a promotion code to apply to the customer. The customer will have a discount
+   * applied on all recurring payments. Charges you create through the API will not have the
+   * discount.
+   */
+  @SerializedName("promotion_code")
+  String promotionCode;
+
   /** The customer's shipping information. Appears on invoices emailed to this customer. */
   @SerializedName("shipping")
   Object shipping;
@@ -124,6 +132,7 @@ public class CustomerCreateParams extends ApiRequestParams {
       String paymentMethod,
       String phone,
       List<String> preferredLocales,
+      String promotionCode,
       Object shipping,
       String source,
       EnumParam taxExempt,
@@ -143,6 +152,7 @@ public class CustomerCreateParams extends ApiRequestParams {
     this.paymentMethod = paymentMethod;
     this.phone = phone;
     this.preferredLocales = preferredLocales;
+    this.promotionCode = promotionCode;
     this.shipping = shipping;
     this.source = source;
     this.taxExempt = taxExempt;
@@ -184,6 +194,8 @@ public class CustomerCreateParams extends ApiRequestParams {
 
     private List<String> preferredLocales;
 
+    private String promotionCode;
+
     private Object shipping;
 
     private String source;
@@ -210,6 +222,7 @@ public class CustomerCreateParams extends ApiRequestParams {
           this.paymentMethod,
           this.phone,
           this.preferredLocales,
+          this.promotionCode,
           this.shipping,
           this.source,
           this.taxExempt,
@@ -424,6 +437,16 @@ public class CustomerCreateParams extends ApiRequestParams {
         this.preferredLocales = new ArrayList<>();
       }
       this.preferredLocales.addAll(elements);
+      return this;
+    }
+
+    /**
+     * The API ID of a promotion code to apply to the customer. The customer will have a discount
+     * applied on all recurring payments. Charges you create through the API will not have the
+     * discount.
+     */
+    public Builder setPromotionCode(String promotionCode) {
+      this.promotionCode = promotionCode;
       return this;
     }
 

--- a/src/main/java/com/stripe/param/CustomerUpdateParams.java
+++ b/src/main/java/com/stripe/param/CustomerUpdateParams.java
@@ -104,6 +104,14 @@ public class CustomerUpdateParams extends ApiRequestParams {
   @SerializedName("preferred_locales")
   List<String> preferredLocales;
 
+  /**
+   * The API ID of a promotion code to apply to the customer. The customer will have a discount
+   * applied on all recurring payments. Charges you create through the API will not have the
+   * discount.
+   */
+  @SerializedName("promotion_code")
+  Object promotionCode;
+
   /** The customer's shipping information. Appears on invoices emailed to this customer. */
   @SerializedName("shipping")
   Object shipping;
@@ -141,6 +149,7 @@ public class CustomerUpdateParams extends ApiRequestParams {
       Long nextInvoiceSequence,
       Object phone,
       List<String> preferredLocales,
+      Object promotionCode,
       Object shipping,
       Object source,
       EnumParam taxExempt,
@@ -160,6 +169,7 @@ public class CustomerUpdateParams extends ApiRequestParams {
     this.nextInvoiceSequence = nextInvoiceSequence;
     this.phone = phone;
     this.preferredLocales = preferredLocales;
+    this.promotionCode = promotionCode;
     this.shipping = shipping;
     this.source = source;
     this.taxExempt = taxExempt;
@@ -201,6 +211,8 @@ public class CustomerUpdateParams extends ApiRequestParams {
 
     private List<String> preferredLocales;
 
+    private Object promotionCode;
+
     private Object shipping;
 
     private Object source;
@@ -227,6 +239,7 @@ public class CustomerUpdateParams extends ApiRequestParams {
           this.nextInvoiceSequence,
           this.phone,
           this.preferredLocales,
+          this.promotionCode,
           this.shipping,
           this.source,
           this.taxExempt,
@@ -514,6 +527,26 @@ public class CustomerUpdateParams extends ApiRequestParams {
         this.preferredLocales = new ArrayList<>();
       }
       this.preferredLocales.addAll(elements);
+      return this;
+    }
+
+    /**
+     * The API ID of a promotion code to apply to the customer. The customer will have a discount
+     * applied on all recurring payments. Charges you create through the API will not have the
+     * discount.
+     */
+    public Builder setPromotionCode(String promotionCode) {
+      this.promotionCode = promotionCode;
+      return this;
+    }
+
+    /**
+     * The API ID of a promotion code to apply to the customer. The customer will have a discount
+     * applied on all recurring payments. Charges you create through the API will not have the
+     * discount.
+     */
+    public Builder setPromotionCode(EmptyParam promotionCode) {
+      this.promotionCode = promotionCode;
       return this;
     }
 

--- a/src/main/java/com/stripe/param/PromotionCodeCreateParams.java
+++ b/src/main/java/com/stripe/param/PromotionCodeCreateParams.java
@@ -1,0 +1,388 @@
+package com.stripe.param;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class PromotionCodeCreateParams extends ApiRequestParams {
+  /** Whether the promotion code is currently active. */
+  @SerializedName("active")
+  Boolean active;
+
+  /**
+   * The customer-facing code. Regardless of case, this code must be unique across all active
+   * promotion codes for a specific customer. If left blank, we will generate one automatically.
+   */
+  @SerializedName("code")
+  String code;
+
+  /** The coupon for this promotion code. */
+  @SerializedName("coupon")
+  String coupon;
+
+  /**
+   * The customer that this promotion code can be used by. If not set, the promotion code can be
+   * used by all customers.
+   */
+  @SerializedName("customer")
+  String customer;
+
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * The timestamp at which this promotion code will expire. If the coupon has specified a {@code
+   * redeems_by}, then this value cannot be after the coupon's {@code redeems_by}.
+   */
+  @SerializedName("expires_at")
+  Long expiresAt;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  /**
+   * A positive integer specifying the number of times the promotion code can be redeemed. If the
+   * coupon has specified a {@code max_redemptions}, then this value cannot be greater than the
+   * coupon's {@code max_redemptions}.
+   */
+  @SerializedName("max_redemptions")
+  Long maxRedemptions;
+
+  /**
+   * Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can attach
+   * to an object. This can be useful for storing additional information about the object in a
+   * structured format. Individual keys can be unset by posting an empty value to them. All keys can
+   * be unset by posting an empty value to {@code metadata}.
+   */
+  @SerializedName("metadata")
+  Map<String, String> metadata;
+
+  /** Settings that restrict the redemption of the promotion code. */
+  @SerializedName("restrictions")
+  Restrictions restrictions;
+
+  private PromotionCodeCreateParams(
+      Boolean active,
+      String code,
+      String coupon,
+      String customer,
+      List<String> expand,
+      Long expiresAt,
+      Map<String, Object> extraParams,
+      Long maxRedemptions,
+      Map<String, String> metadata,
+      Restrictions restrictions) {
+    this.active = active;
+    this.code = code;
+    this.coupon = coupon;
+    this.customer = customer;
+    this.expand = expand;
+    this.expiresAt = expiresAt;
+    this.extraParams = extraParams;
+    this.maxRedemptions = maxRedemptions;
+    this.metadata = metadata;
+    this.restrictions = restrictions;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Boolean active;
+
+    private String code;
+
+    private String coupon;
+
+    private String customer;
+
+    private List<String> expand;
+
+    private Long expiresAt;
+
+    private Map<String, Object> extraParams;
+
+    private Long maxRedemptions;
+
+    private Map<String, String> metadata;
+
+    private Restrictions restrictions;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public PromotionCodeCreateParams build() {
+      return new PromotionCodeCreateParams(
+          this.active,
+          this.code,
+          this.coupon,
+          this.customer,
+          this.expand,
+          this.expiresAt,
+          this.extraParams,
+          this.maxRedemptions,
+          this.metadata,
+          this.restrictions);
+    }
+
+    /** Whether the promotion code is currently active. */
+    public Builder setActive(Boolean active) {
+      this.active = active;
+      return this;
+    }
+
+    /**
+     * The customer-facing code. Regardless of case, this code must be unique across all active
+     * promotion codes for a specific customer. If left blank, we will generate one automatically.
+     */
+    public Builder setCode(String code) {
+      this.code = code;
+      return this;
+    }
+
+    /** The coupon for this promotion code. */
+    public Builder setCoupon(String coupon) {
+      this.coupon = coupon;
+      return this;
+    }
+
+    /**
+     * The customer that this promotion code can be used by. If not set, the promotion code can be
+     * used by all customers.
+     */
+    public Builder setCustomer(String customer) {
+      this.customer = customer;
+      return this;
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * PromotionCodeCreateParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * PromotionCodeCreateParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * The timestamp at which this promotion code will expire. If the coupon has specified a {@code
+     * redeems_by}, then this value cannot be after the coupon's {@code redeems_by}.
+     */
+    public Builder setExpiresAt(Long expiresAt) {
+      this.expiresAt = expiresAt;
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * PromotionCodeCreateParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link PromotionCodeCreateParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /**
+     * A positive integer specifying the number of times the promotion code can be redeemed. If the
+     * coupon has specified a {@code max_redemptions}, then this value cannot be greater than the
+     * coupon's {@code max_redemptions}.
+     */
+    public Builder setMaxRedemptions(Long maxRedemptions) {
+      this.maxRedemptions = maxRedemptions;
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `metadata` map. A map is initialized for the first `put/putAll` call,
+     * and subsequent calls add additional key/value pairs to the original map. See {@link
+     * PromotionCodeCreateParams#metadata} for the field documentation.
+     */
+    public Builder putMetadata(String key, String value) {
+      if (this.metadata == null) {
+        this.metadata = new HashMap<>();
+      }
+      this.metadata.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `metadata` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link PromotionCodeCreateParams#metadata} for the field documentation.
+     */
+    public Builder putAllMetadata(Map<String, String> map) {
+      if (this.metadata == null) {
+        this.metadata = new HashMap<>();
+      }
+      this.metadata.putAll(map);
+      return this;
+    }
+
+    /** Settings that restrict the redemption of the promotion code. */
+    public Builder setRestrictions(Restrictions restrictions) {
+      this.restrictions = restrictions;
+      return this;
+    }
+  }
+
+  @Getter
+  public static class Restrictions {
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /**
+     * A Boolean indicating if the Promotion Code should only be redeemed for Customers without any
+     * successful payments or invoices.
+     */
+    @SerializedName("first_time_transaction")
+    Boolean firstTimeTransaction;
+
+    /**
+     * Minimum amount required to redeem this Promotion Code into a Coupon (e.g., a purchase must be
+     * $100 or more to work).
+     */
+    @SerializedName("minimum_amount")
+    Long minimumAmount;
+
+    /** Three-letter <a href="https://stripe.com/docs/currencies">ISO code</a> for minimum_amount */
+    @SerializedName("minimum_amount_currency")
+    String minimumAmountCurrency;
+
+    private Restrictions(
+        Map<String, Object> extraParams,
+        Boolean firstTimeTransaction,
+        Long minimumAmount,
+        String minimumAmountCurrency) {
+      this.extraParams = extraParams;
+      this.firstTimeTransaction = firstTimeTransaction;
+      this.minimumAmount = minimumAmount;
+      this.minimumAmountCurrency = minimumAmountCurrency;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Map<String, Object> extraParams;
+
+      private Boolean firstTimeTransaction;
+
+      private Long minimumAmount;
+
+      private String minimumAmountCurrency;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public Restrictions build() {
+        return new Restrictions(
+            this.extraParams,
+            this.firstTimeTransaction,
+            this.minimumAmount,
+            this.minimumAmountCurrency);
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * PromotionCodeCreateParams.Restrictions#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link PromotionCodeCreateParams.Restrictions#extraParams} for the field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /**
+       * A Boolean indicating if the Promotion Code should only be redeemed for Customers without
+       * any successful payments or invoices.
+       */
+      public Builder setFirstTimeTransaction(Boolean firstTimeTransaction) {
+        this.firstTimeTransaction = firstTimeTransaction;
+        return this;
+      }
+
+      /**
+       * Minimum amount required to redeem this Promotion Code into a Coupon (e.g., a purchase must
+       * be $100 or more to work).
+       */
+      public Builder setMinimumAmount(Long minimumAmount) {
+        this.minimumAmount = minimumAmount;
+        return this;
+      }
+
+      /**
+       * Three-letter <a href="https://stripe.com/docs/currencies">ISO code</a> for minimum_amount
+       */
+      public Builder setMinimumAmountCurrency(String minimumAmountCurrency) {
+        this.minimumAmountCurrency = minimumAmountCurrency;
+        return this;
+      }
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/PromotionCodeListParams.java
+++ b/src/main/java/com/stripe/param/PromotionCodeListParams.java
@@ -1,0 +1,371 @@
+package com.stripe.param;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class PromotionCodeListParams extends ApiRequestParams {
+  /** Filter promotion codes by whether they are active. */
+  @SerializedName("active")
+  Boolean active;
+
+  /** Only return promotion codes that have this case-insensitive code. */
+  @SerializedName("code")
+  String code;
+
+  /** Only return promotion codes for this coupon. */
+  @SerializedName("coupon")
+  String coupon;
+
+  /**
+   * A filter on the list, based on the object {@code created} field. The value can be a string with
+   * an integer Unix timestamp, or it can be a dictionary with a number of different query options.
+   */
+  @SerializedName("created")
+  Object created;
+
+  /** Only return promotion codes that are restricted to this customer. */
+  @SerializedName("customer")
+  String customer;
+
+  /**
+   * A cursor for use in pagination. {@code ending_before} is an object ID that defines your place
+   * in the list. For instance, if you make a list request and receive 100 objects, starting with
+   * {@code obj_bar}, your subsequent call can include {@code ending_before=obj_bar} in order to
+   * fetch the previous page of the list.
+   */
+  @SerializedName("ending_before")
+  String endingBefore;
+
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  /**
+   * A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+   * default is 10.
+   */
+  @SerializedName("limit")
+  Long limit;
+
+  /**
+   * A cursor for use in pagination. {@code starting_after} is an object ID that defines your place
+   * in the list. For instance, if you make a list request and receive 100 objects, ending with
+   * {@code obj_foo}, your subsequent call can include {@code starting_after=obj_foo} in order to
+   * fetch the next page of the list.
+   */
+  @SerializedName("starting_after")
+  String startingAfter;
+
+  private PromotionCodeListParams(
+      Boolean active,
+      String code,
+      String coupon,
+      Object created,
+      String customer,
+      String endingBefore,
+      List<String> expand,
+      Map<String, Object> extraParams,
+      Long limit,
+      String startingAfter) {
+    this.active = active;
+    this.code = code;
+    this.coupon = coupon;
+    this.created = created;
+    this.customer = customer;
+    this.endingBefore = endingBefore;
+    this.expand = expand;
+    this.extraParams = extraParams;
+    this.limit = limit;
+    this.startingAfter = startingAfter;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Boolean active;
+
+    private String code;
+
+    private String coupon;
+
+    private Object created;
+
+    private String customer;
+
+    private String endingBefore;
+
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    private Long limit;
+
+    private String startingAfter;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public PromotionCodeListParams build() {
+      return new PromotionCodeListParams(
+          this.active,
+          this.code,
+          this.coupon,
+          this.created,
+          this.customer,
+          this.endingBefore,
+          this.expand,
+          this.extraParams,
+          this.limit,
+          this.startingAfter);
+    }
+
+    /** Filter promotion codes by whether they are active. */
+    public Builder setActive(Boolean active) {
+      this.active = active;
+      return this;
+    }
+
+    /** Only return promotion codes that have this case-insensitive code. */
+    public Builder setCode(String code) {
+      this.code = code;
+      return this;
+    }
+
+    /** Only return promotion codes for this coupon. */
+    public Builder setCoupon(String coupon) {
+      this.coupon = coupon;
+      return this;
+    }
+
+    /**
+     * A filter on the list, based on the object {@code created} field. The value can be a string
+     * with an integer Unix timestamp, or it can be a dictionary with a number of different query
+     * options.
+     */
+    public Builder setCreated(Created created) {
+      this.created = created;
+      return this;
+    }
+
+    /**
+     * A filter on the list, based on the object {@code created} field. The value can be a string
+     * with an integer Unix timestamp, or it can be a dictionary with a number of different query
+     * options.
+     */
+    public Builder setCreated(Long created) {
+      this.created = created;
+      return this;
+    }
+
+    /** Only return promotion codes that are restricted to this customer. */
+    public Builder setCustomer(String customer) {
+      this.customer = customer;
+      return this;
+    }
+
+    /**
+     * A cursor for use in pagination. {@code ending_before} is an object ID that defines your place
+     * in the list. For instance, if you make a list request and receive 100 objects, starting with
+     * {@code obj_bar}, your subsequent call can include {@code ending_before=obj_bar} in order to
+     * fetch the previous page of the list.
+     */
+    public Builder setEndingBefore(String endingBefore) {
+      this.endingBefore = endingBefore;
+      return this;
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * PromotionCodeListParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * PromotionCodeListParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * PromotionCodeListParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link PromotionCodeListParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /**
+     * A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+     * default is 10.
+     */
+    public Builder setLimit(Long limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    /**
+     * A cursor for use in pagination. {@code starting_after} is an object ID that defines your
+     * place in the list. For instance, if you make a list request and receive 100 objects, ending
+     * with {@code obj_foo}, your subsequent call can include {@code starting_after=obj_foo} in
+     * order to fetch the next page of the list.
+     */
+    public Builder setStartingAfter(String startingAfter) {
+      this.startingAfter = startingAfter;
+      return this;
+    }
+  }
+
+  @Getter
+  public static class Created {
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /** Minimum value to filter by (exclusive). */
+    @SerializedName("gt")
+    Long gt;
+
+    /** Minimum value to filter by (inclusive). */
+    @SerializedName("gte")
+    Long gte;
+
+    /** Maximum value to filter by (exclusive). */
+    @SerializedName("lt")
+    Long lt;
+
+    /** Maximum value to filter by (inclusive). */
+    @SerializedName("lte")
+    Long lte;
+
+    private Created(Map<String, Object> extraParams, Long gt, Long gte, Long lt, Long lte) {
+      this.extraParams = extraParams;
+      this.gt = gt;
+      this.gte = gte;
+      this.lt = lt;
+      this.lte = lte;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Map<String, Object> extraParams;
+
+      private Long gt;
+
+      private Long gte;
+
+      private Long lt;
+
+      private Long lte;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public Created build() {
+        return new Created(this.extraParams, this.gt, this.gte, this.lt, this.lte);
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * PromotionCodeListParams.Created#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link PromotionCodeListParams.Created#extraParams} for the field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** Minimum value to filter by (exclusive). */
+      public Builder setGt(Long gt) {
+        this.gt = gt;
+        return this;
+      }
+
+      /** Minimum value to filter by (inclusive). */
+      public Builder setGte(Long gte) {
+        this.gte = gte;
+        return this;
+      }
+
+      /** Maximum value to filter by (exclusive). */
+      public Builder setLt(Long lt) {
+        this.lt = lt;
+        return this;
+      }
+
+      /** Maximum value to filter by (inclusive). */
+      public Builder setLte(Long lte) {
+        this.lte = lte;
+        return this;
+      }
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/PromotionCodeRetrieveParams.java
+++ b/src/main/java/com/stripe/param/PromotionCodeRetrieveParams.java
@@ -1,0 +1,97 @@
+package com.stripe.param;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class PromotionCodeRetrieveParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  private PromotionCodeRetrieveParams(List<String> expand, Map<String, Object> extraParams) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public PromotionCodeRetrieveParams build() {
+      return new PromotionCodeRetrieveParams(this.expand, this.extraParams);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * PromotionCodeRetrieveParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * PromotionCodeRetrieveParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * PromotionCodeRetrieveParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link PromotionCodeRetrieveParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/PromotionCodeUpdateParams.java
+++ b/src/main/java/com/stripe/param/PromotionCodeUpdateParams.java
@@ -1,0 +1,181 @@
+package com.stripe.param;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import com.stripe.param.common.EmptyParam;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class PromotionCodeUpdateParams extends ApiRequestParams {
+  /**
+   * Whether the promotion code is currently active. A promotion code can only be reactivated when
+   * the coupon is still valid and the promotion code is otherwise redeemable.
+   */
+  @SerializedName("active")
+  Boolean active;
+
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  /**
+   * Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can attach
+   * to an object. This can be useful for storing additional information about the object in a
+   * structured format. Individual keys can be unset by posting an empty value to them. All keys can
+   * be unset by posting an empty value to {@code metadata}.
+   */
+  @SerializedName("metadata")
+  Object metadata;
+
+  private PromotionCodeUpdateParams(
+      Boolean active, List<String> expand, Map<String, Object> extraParams, Object metadata) {
+    this.active = active;
+    this.expand = expand;
+    this.extraParams = extraParams;
+    this.metadata = metadata;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Boolean active;
+
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    private Object metadata;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public PromotionCodeUpdateParams build() {
+      return new PromotionCodeUpdateParams(
+          this.active, this.expand, this.extraParams, this.metadata);
+    }
+
+    /**
+     * Whether the promotion code is currently active. A promotion code can only be reactivated when
+     * the coupon is still valid and the promotion code is otherwise redeemable.
+     */
+    public Builder setActive(Boolean active) {
+      this.active = active;
+      return this;
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * PromotionCodeUpdateParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * PromotionCodeUpdateParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * PromotionCodeUpdateParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link PromotionCodeUpdateParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `metadata` map. A map is initialized for the first `put/putAll` call,
+     * and subsequent calls add additional key/value pairs to the original map. See {@link
+     * PromotionCodeUpdateParams#metadata} for the field documentation.
+     */
+    @SuppressWarnings("unchecked")
+    public Builder putMetadata(String key, String value) {
+      if (this.metadata == null || this.metadata instanceof EmptyParam) {
+        this.metadata = new HashMap<String, String>();
+      }
+      ((Map<String, String>) this.metadata).put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `metadata` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link PromotionCodeUpdateParams#metadata} for the field documentation.
+     */
+    @SuppressWarnings("unchecked")
+    public Builder putAllMetadata(Map<String, String> map) {
+      if (this.metadata == null || this.metadata instanceof EmptyParam) {
+        this.metadata = new HashMap<String, String>();
+      }
+      ((Map<String, String>) this.metadata).putAll(map);
+      return this;
+    }
+
+    /**
+     * Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can attach
+     * to an object. This can be useful for storing additional information about the object in a
+     * structured format. Individual keys can be unset by posting an empty value to them. All keys
+     * can be unset by posting an empty value to {@code metadata}.
+     */
+    public Builder setMetadata(EmptyParam metadata) {
+      this.metadata = metadata;
+      return this;
+    }
+
+    /**
+     * Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can attach
+     * to an object. This can be useful for storing additional information about the object in a
+     * structured format. Individual keys can be unset by posting an empty value to them. All keys
+     * can be unset by posting an empty value to {@code metadata}.
+     */
+    public Builder setMetadata(Map<String, String> metadata) {
+      this.metadata = metadata;
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/SubscriptionCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionCreateParams.java
@@ -180,6 +180,13 @@ public class SubscriptionCreateParams extends ApiRequestParams {
   Object pendingInvoiceItemInterval;
 
   /**
+   * The API ID of a promotion code to apply to this subscription. A promotion code applied to a
+   * subscription will only affect invoices created for that particular subscription.
+   */
+  @SerializedName("promotion_code")
+  String promotionCode;
+
+  /**
    * This field has been renamed to {@code proration_behavior}. {@code prorate=true} can be replaced
    * with {@code proration_behavior=create_prorations} and {@code prorate=false} can be replaced
    * with {@code proration_behavior=none}.
@@ -267,6 +274,7 @@ public class SubscriptionCreateParams extends ApiRequestParams {
       Boolean offSession,
       PaymentBehavior paymentBehavior,
       Object pendingInvoiceItemInterval,
+      String promotionCode,
       Boolean prorate,
       ProrationBehavior prorationBehavior,
       Object taxPercent,
@@ -295,6 +303,7 @@ public class SubscriptionCreateParams extends ApiRequestParams {
     this.offSession = offSession;
     this.paymentBehavior = paymentBehavior;
     this.pendingInvoiceItemInterval = pendingInvoiceItemInterval;
+    this.promotionCode = promotionCode;
     this.prorate = prorate;
     this.prorationBehavior = prorationBehavior;
     this.taxPercent = taxPercent;
@@ -351,6 +360,8 @@ public class SubscriptionCreateParams extends ApiRequestParams {
 
     private Object pendingInvoiceItemInterval;
 
+    private String promotionCode;
+
     private Boolean prorate;
 
     private ProrationBehavior prorationBehavior;
@@ -389,6 +400,7 @@ public class SubscriptionCreateParams extends ApiRequestParams {
           this.offSession,
           this.paymentBehavior,
           this.pendingInvoiceItemInterval,
+          this.promotionCode,
           this.prorate,
           this.prorationBehavior,
           this.taxPercent,
@@ -773,6 +785,15 @@ public class SubscriptionCreateParams extends ApiRequestParams {
      */
     public Builder setPendingInvoiceItemInterval(EmptyParam pendingInvoiceItemInterval) {
       this.pendingInvoiceItemInterval = pendingInvoiceItemInterval;
+      return this;
+    }
+
+    /**
+     * The API ID of a promotion code to apply to this subscription. A promotion code applied to a
+     * subscription will only affect invoices created for that particular subscription.
+     */
+    public Builder setPromotionCode(String promotionCode) {
+      this.promotionCode = promotionCode;
       return this;
     }
 

--- a/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
@@ -174,6 +174,13 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
   Object pendingInvoiceItemInterval;
 
   /**
+   * The promotion code to apply to this subscription. A promotion code applied to a subscription
+   * will only affect invoices created for that particular subscription.
+   */
+  @SerializedName("promotion_code")
+  Object promotionCode;
+
+  /**
    * This field has been renamed to {@code proration_behavior}. {@code prorate=true} can be replaced
    * with {@code proration_behavior=create_prorations} and {@code prorate=false} can be replaced
    * with {@code proration_behavior=none}.
@@ -269,6 +276,7 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
       Object pauseCollection,
       PaymentBehavior paymentBehavior,
       Object pendingInvoiceItemInterval,
+      Object promotionCode,
       Boolean prorate,
       ProrationBehavior prorationBehavior,
       Long prorationDate,
@@ -296,6 +304,7 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
     this.pauseCollection = pauseCollection;
     this.paymentBehavior = paymentBehavior;
     this.pendingInvoiceItemInterval = pendingInvoiceItemInterval;
+    this.promotionCode = promotionCode;
     this.prorate = prorate;
     this.prorationBehavior = prorationBehavior;
     this.prorationDate = prorationDate;
@@ -350,6 +359,8 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
 
     private Object pendingInvoiceItemInterval;
 
+    private Object promotionCode;
+
     private Boolean prorate;
 
     private ProrationBehavior prorationBehavior;
@@ -387,6 +398,7 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
           this.pauseCollection,
           this.paymentBehavior,
           this.pendingInvoiceItemInterval,
+          this.promotionCode,
           this.prorate,
           this.prorationBehavior,
           this.prorationDate,
@@ -810,6 +822,24 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
      */
     public Builder setPendingInvoiceItemInterval(EmptyParam pendingInvoiceItemInterval) {
       this.pendingInvoiceItemInterval = pendingInvoiceItemInterval;
+      return this;
+    }
+
+    /**
+     * The promotion code to apply to this subscription. A promotion code applied to a subscription
+     * will only affect invoices created for that particular subscription.
+     */
+    public Builder setPromotionCode(String promotionCode) {
+      this.promotionCode = promotionCode;
+      return this;
+    }
+
+    /**
+     * The promotion code to apply to this subscription. A promotion code applied to a subscription
+     * will only affect invoices created for that particular subscription.
+     */
+    public Builder setPromotionCode(EmptyParam promotionCode) {
+      this.promotionCode = promotionCode;
       return this;
     }
 

--- a/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
+++ b/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
@@ -11,6 +11,10 @@ import lombok.Getter;
 
 @Getter
 public class SessionCreateParams extends ApiRequestParams {
+  /** Enables user redeemable promotion codes. */
+  @SerializedName("allow_promotion_codes")
+  Boolean allowPromotionCodes;
+
   /** Specify whether Checkout should collect the customer's billing address. */
   @SerializedName("billing_address_collection")
   BillingAddressCollection billingAddressCollection;
@@ -155,6 +159,7 @@ public class SessionCreateParams extends ApiRequestParams {
   String successUrl;
 
   private SessionCreateParams(
+      Boolean allowPromotionCodes,
       BillingAddressCollection billingAddressCollection,
       String cancelUrl,
       String clientReferenceId,
@@ -173,6 +178,7 @@ public class SessionCreateParams extends ApiRequestParams {
       SubmitType submitType,
       SubscriptionData subscriptionData,
       String successUrl) {
+    this.allowPromotionCodes = allowPromotionCodes;
     this.billingAddressCollection = billingAddressCollection;
     this.cancelUrl = cancelUrl;
     this.clientReferenceId = clientReferenceId;
@@ -198,6 +204,8 @@ public class SessionCreateParams extends ApiRequestParams {
   }
 
   public static class Builder {
+    private Boolean allowPromotionCodes;
+
     private BillingAddressCollection billingAddressCollection;
 
     private String cancelUrl;
@@ -237,6 +245,7 @@ public class SessionCreateParams extends ApiRequestParams {
     /** Finalize and obtain parameter instance from this builder. */
     public SessionCreateParams build() {
       return new SessionCreateParams(
+          this.allowPromotionCodes,
           this.billingAddressCollection,
           this.cancelUrl,
           this.clientReferenceId,
@@ -255,6 +264,12 @@ public class SessionCreateParams extends ApiRequestParams {
           this.submitType,
           this.subscriptionData,
           this.successUrl);
+    }
+
+    /** Enables user redeemable promotion codes. */
+    public Builder setAllowPromotionCodes(Boolean allowPromotionCodes) {
+      this.allowPromotionCodes = allowPromotionCodes;
+      return this;
     }
 
     /** Specify whether Checkout should collect the customer's billing address. */

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -33,7 +33,7 @@ import org.mockito.Mockito;
 
 public class BaseStripeTest {
   // If changing this number, please also change it in `.travis.yml`.
-  private static final String MOCK_MINIMUM_VERSION = "0.94.0";
+  private static final String MOCK_MINIMUM_VERSION = "0.95.0";
 
   private static String port;
 

--- a/src/test/java/com/stripe/functional/PromotionCodeTest.java
+++ b/src/test/java/com/stripe/functional/PromotionCodeTest.java
@@ -1,0 +1,72 @@
+package com.stripe.functional;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.stripe.BaseStripeTest;
+import com.stripe.exception.StripeException;
+import com.stripe.model.PromotionCode;
+import com.stripe.model.PromotionCodeCollection;
+import com.stripe.net.ApiResource;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class PromotionCodeTest extends BaseStripeTest {
+  public static final String PROMOTION_CODE_ID = "promo_123";
+
+  private PromotionCode getPromotionCodeFixture() throws StripeException {
+    final PromotionCode promotionCode = PromotionCode.retrieve(PROMOTION_CODE_ID);
+    resetNetworkSpy();
+    return promotionCode;
+  }
+
+  @Test
+  public void testCreate() throws StripeException {
+    final Map<String, Object> params = new HashMap<>();
+    params.put("coupon", "co_123");
+    params.put("code", "MYCODE");
+
+    final PromotionCode promotionCode = PromotionCode.create(params);
+
+    assertNotNull(promotionCode);
+    verifyRequest(ApiResource.RequestMethod.POST, String.format("/v1/promotion_codes"), params);
+  }
+
+  @Test
+  public void testRetrieve() throws StripeException {
+    final PromotionCode promotionCode = PromotionCode.retrieve(PROMOTION_CODE_ID);
+
+    assertNotNull(promotionCode);
+    verifyRequest(
+        ApiResource.RequestMethod.GET, String.format("/v1/promotion_codes/%s", PROMOTION_CODE_ID));
+  }
+
+  @Test
+  public void testUpdate() throws StripeException {
+    final PromotionCode promotionCode = getPromotionCodeFixture();
+
+    final Map<String, String> metadata = new HashMap<>();
+    metadata.put("key", "value");
+    final Map<String, Object> params = new HashMap<>();
+    params.put("metadata", metadata);
+
+    final PromotionCode updatedPromotionCode = promotionCode.update(params);
+
+    assertNotNull(updatedPromotionCode);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        String.format("/v1/promotion_codes/%s", promotionCode.getId()),
+        params);
+  }
+
+  @Test
+  public void testList() throws StripeException {
+    final Map<String, Object> params = new HashMap<>();
+    params.put("limit", 1);
+
+    final PromotionCodeCollection promotionCodes = PromotionCode.list(params);
+
+    assertNotNull(promotionCodes);
+    verifyRequest(ApiResource.RequestMethod.GET, String.format("/v1/promotion_codes"));
+  }
+}

--- a/src/test/java/com/stripe/functional/StripeObjectTest.java
+++ b/src/test/java/com/stripe/functional/StripeObjectTest.java
@@ -22,15 +22,6 @@ public class StripeObjectTest extends BaseStripeTest {
         subscription.getCreated(),
         subscription.getRawJsonObject().getAsJsonPrimitive("created").getAsLong());
 
-    // Access `plan[id]`, a nested string element
-    assertEquals(
-        subscription.getPlan().getId(),
-        subscription
-            .getRawJsonObject()
-            .getAsJsonObject("plan")
-            .getAsJsonPrimitive("id")
-            .getAsString());
-
     // Access `items[data][0][id]`, a deeply nested string element
     assertEquals(
         subscription.getItems().getData().get(0).getId(),

--- a/src/test/java/com/stripe/functional/SubscriptionItemTest.java
+++ b/src/test/java/com/stripe/functional/SubscriptionItemTest.java
@@ -25,7 +25,7 @@ public class SubscriptionItemTest extends BaseStripeTest {
   @Test
   public void testCreate() throws StripeException {
     final Map<String, Object> params = new HashMap<>();
-    params.put("plan", "plan_123");
+    params.put("price", "price_123");
     params.put("subscription", "cus_123");
     params.put("quantity", 99);
 

--- a/src/test/java/com/stripe/model/PromotionCodeTest.java
+++ b/src/test/java/com/stripe/model/PromotionCodeTest.java
@@ -1,0 +1,34 @@
+package com.stripe.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.stripe.BaseStripeTest;
+import com.stripe.net.ApiResource;
+import org.junit.jupiter.api.Test;
+
+public class PromotionCodeTest extends BaseStripeTest {
+  @Test
+  public void testDeserialize() throws Exception {
+    final String data = getFixture("/v1/promotion_codes/co_123");
+    final PromotionCode resource = ApiResource.GSON.fromJson(data, PromotionCode.class);
+    assertNotNull(resource);
+    assertNotNull(resource.getId());
+  }
+
+  @Test
+  public void testDeserializeWithExpansions() throws Exception {
+    final String[] expansions = {
+      "customer",
+    };
+    final String data = getFixture("/v1/promotion_codes/co_123", expansions);
+    final PromotionCode resource = ApiResource.GSON.fromJson(data, PromotionCode.class);
+    assertNotNull(resource);
+    assertNotNull(resource.getId());
+
+    final Customer customer = resource.getCustomerObject();
+    assertNotNull(customer);
+    assertNotNull(customer.getId());
+    assertEquals(resource.getCustomer(), customer.getId());
+  }
+}


### PR DESCRIPTION
Multiple API changes:
  * Add support for the `PromotionCode` resource and APIs
  * Add support for `allow_promotion_codes` on Checkout `Session`
  * Add support for `applies_to[products]` on `Coupon`
  * Add support for `promotion_code` on `Customer` and `Subscription`
  * Add support for `promotion_code` on `Discount`

Codegen for openapi f71053e + an urgent change to fix the `AppliesTo` name which was `Restrictions` incorrectly

r? @cjavilla-stripe 
cc @stripe/api-libraries 