### PR TITLE
Fix retrieval of upcoming Invoice line items

### DIFF
--- a/src/main/java/com/stripe/net/StripeRequest.java
+++ b/src/main/java/com/stripe/net/StripeRequest.java
@@ -109,10 +109,18 @@ public class StripeRequest {
 
     sb.append(spec);
 
+    URL specUrl = new URL(spec);
+    String specQueryString = specUrl.getQuery();
+
     if ((method != ApiResource.RequestMethod.POST) && (params != null)) {
       String queryString = FormEncoder.createQueryString(params);
+
       if (queryString != null && !queryString.isEmpty()) {
-        sb.append("?");
+        if (specQueryString != null && !specQueryString.isEmpty()) {
+          sb.append("&");
+        } else {
+          sb.append("?");
+        }
         sb.append(queryString);
       }
     }

--- a/src/test/java/com/stripe/net/StripeRequestTest.java
+++ b/src/test/java/com/stripe/net/StripeRequestTest.java
@@ -36,6 +36,26 @@ public class StripeRequestTest extends BaseStripeTest {
   }
 
   @Test
+  public void testCtorGetRequestWithQueryString() throws StripeException {
+    StripeRequest request =
+        new StripeRequest(
+            ApiResource.RequestMethod.GET,
+            "http://example.com/get?customer=cus_xxx",
+            ImmutableMap.of("string", "String!"),
+            null);
+
+    assertEquals(ApiResource.RequestMethod.GET, request.method());
+    assertEquals(
+        "http://example.com/get?customer=cus_xxx&string=String%21", request.url().toString());
+    assertEquals("Bearer sk_test_123", request.headers().firstValue("Authorization").orElse(null));
+    assertTrue(request.headers().firstValue("Stripe-Version").isPresent());
+    assertEquals(Stripe.API_VERSION, request.headers().firstValue("Stripe-Version").get());
+    assertFalse(request.headers().firstValue("Idempotency-Key").isPresent());
+    assertFalse(request.headers().firstValue("Stripe-Account").isPresent());
+    assertNull(request.content());
+  }
+
+  @Test
   public void testCtorPostRequest() throws StripeException {
     StripeRequest request =
         new StripeRequest(


### PR DESCRIPTION
Some endpoints receive the "root" object id as a query string parameter for example:

`/v1/invoices/upcoming/lines?customer=cus_xxx` if `invoice.getLines().list(linesParams)` is used. 

If, in `linesParams`, further options are passed (limit: 5 for example), these are appended to the URI using a question mark and not an ampersand, resulting in in a URI of the form `http://api.stripe.com/v1/invoices/upcoming/lines/?customer=cus_xxx?limit=5`.

This PR attempts to fix this by first checking whether the incoming `spec` URL has an existing query string. If it does, it appends any further params, specified in the incoming params hash, otherwise appends a new query string starting with ampersand.

