### PR TITLE
Multiple API changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 env:
   global:
     # If changing this number, please also change it in `BaseStripeTest.java`.
-  - STRIPE_MOCK_VERSION=0.95.0
+  - STRIPE_MOCK_VERSION=0.96.0
 
 matrix:
   include:

--- a/src/main/java/com/stripe/Stripe.java
+++ b/src/main/java/com/stripe/Stripe.java
@@ -9,7 +9,7 @@ public abstract class Stripe {
   public static final int DEFAULT_CONNECT_TIMEOUT = 30 * 1000;
   public static final int DEFAULT_READ_TIMEOUT = 80 * 1000;
 
-  public static final String API_VERSION = "2020-03-02";
+  public static final String API_VERSION = "2020-08-27";
   public static final String CONNECT_API_BASE = "https://connect.stripe.com";
   public static final String LIVE_API_BASE = "https://api.stripe.com";
   public static final String UPLOAD_API_BASE = "https://files.stripe.com";

--- a/src/main/java/com/stripe/model/Account.java
+++ b/src/main/java/com/stripe/model/Account.java
@@ -1019,16 +1019,19 @@ public class Account extends ApiResource implements MetadataStore<Account>, Paym
        * verification_document_failed_other}, {@code verification_document_failed_test_mode}, {@code
        * verification_document_fraudulent}, {@code verification_document_id_number_mismatch}, {@code
        * verification_document_id_number_missing}, {@code verification_document_incomplete}, {@code
-       * verification_document_invalid}, {@code verification_document_manipulated}, {@code
-       * verification_document_missing_back}, {@code verification_document_missing_front}, {@code
-       * verification_document_name_mismatch}, {@code verification_document_name_missing}, {@code
+       * verification_document_invalid}, {@code verification_document_issue_or_expiry_date_missing},
+       * {@code verification_document_manipulated}, {@code verification_document_missing_back},
+       * {@code verification_document_missing_front}, {@code verification_document_name_mismatch},
+       * {@code verification_document_name_missing}, {@code
        * verification_document_nationality_mismatch}, {@code verification_document_not_readable},
-       * {@code verification_document_not_uploaded}, {@code verification_document_photo_mismatch},
-       * {@code verification_document_too_large}, {@code verification_document_type_not_supported},
-       * {@code verification_failed_address_match}, {@code verification_failed_business_iec_number},
-       * {@code verification_failed_document_match}, {@code verification_failed_id_number_match},
-       * {@code verification_failed_keyed_identity}, {@code verification_failed_keyed_match}, {@code
-       * verification_failed_name_match}, or {@code verification_failed_other}.
+       * {@code verification_document_not_signed}, {@code verification_document_not_uploaded},
+       * {@code verification_document_photo_mismatch}, {@code verification_document_too_large},
+       * {@code verification_document_type_not_supported}, {@code
+       * verification_failed_address_match}, {@code verification_failed_business_iec_number}, {@code
+       * verification_failed_document_match}, {@code verification_failed_id_number_match}, {@code
+       * verification_failed_keyed_identity}, {@code verification_failed_keyed_match}, {@code
+       * verification_failed_name_match}, {@code verification_failed_other}, {@code
+       * verification_failed_tax_id_match}, or {@code verification_failed_tax_id_not_issued}.
        */
       @SerializedName("code")
       String code;

--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -1427,13 +1427,6 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
       @EqualsAndHashCode(callSuper = false)
       public static class ThreeDSecure extends StripeObject {
         /**
-         * Whether or not authentication was performed. 3D Secure will succeed without
-         * authentication when the card is not enrolled.
-         */
-        @SerializedName("authenticated")
-        Boolean authenticated;
-
-        /**
          * For authenticated transactions: how the customer was authenticated by the issuing bank.
          *
          * <p>One of {@code challenge}, or {@code frictionless}.
@@ -1460,10 +1453,6 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
          */
         @SerializedName("result_reason")
         String resultReason;
-
-        /** Whether or not 3D Secure succeeded. */
-        @SerializedName("succeeded")
-        Boolean succeeded;
 
         /**
          * The version of 3D Secure that was used.
@@ -1676,8 +1665,10 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
       String network;
 
       /**
-       * How were card details read in this transaction. Can be contact_emv, contactless_emv,
-       * magnetic_stripe_fallback, magnetic_stripe_track2, or contactless_magstripe_mode
+       * How card details were read in this transaction.
+       *
+       * <p>One of {@code contact_emv}, {@code contactless_emv}, {@code contactless_magstripe_mode},
+       * {@code magnetic_stripe_fallback}, or {@code magnetic_stripe_track2}.
        */
       @SerializedName("read_method")
       String readMethod;
@@ -1904,8 +1895,10 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
       String network;
 
       /**
-       * How were card details read in this transaction. Can be contact_emv, contactless_emv,
-       * magnetic_stripe_fallback, magnetic_stripe_track2, or contactless_magstripe_mode
+       * How card details were read in this transaction.
+       *
+       * <p>One of {@code contact_emv}, {@code contactless_emv}, {@code contactless_magstripe_mode},
+       * {@code magnetic_stripe_fallback}, or {@code magnetic_stripe_track2}.
        */
       @SerializedName("read_method")
       String readMethod;

--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -1015,9 +1015,6 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
     @SerializedName("bancontact")
     Bancontact bancontact;
 
-    @SerializedName("bitcoin")
-    Bitcoin bitcoin;
-
     @SerializedName("card")
     Card card;
 
@@ -1262,29 +1259,6 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
        */
       @SerializedName("verified_name")
       String verifiedName;
-    }
-
-    @Getter
-    @Setter
-    @EqualsAndHashCode(callSuper = false)
-    public static class Bitcoin extends StripeObject {
-      @SerializedName("address")
-      String address;
-
-      @SerializedName("amount")
-      Long amount;
-
-      @SerializedName("amount_charged")
-      Long amountCharged;
-
-      @SerializedName("amount_received")
-      Long amountReceived;
-
-      @SerializedName("amount_returned")
-      Long amountReturned;
-
-      @SerializedName("refund_address")
-      String refundAddress;
     }
 
     @Getter

--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -15,7 +15,6 @@ import com.stripe.param.InvoiceSendInvoiceParams;
 import com.stripe.param.InvoiceUpcomingParams;
 import com.stripe.param.InvoiceUpdateParams;
 import com.stripe.param.InvoiceVoidInvoiceParams;
-import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -410,14 +409,6 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
   /** The amount of tax on this invoice. This is the sum of all the tax amounts on this invoice. */
   @SerializedName("tax")
   Long tax;
-
-  /**
-   * This percentage of the subtotal has been added to the total amount of the invoice, including
-   * invoice line items and discounts. This field is inherited from the subscription's {@code
-   * tax_percent} field, but can be changed before the invoice is paid. This field defaults to null.
-   */
-  @SerializedName("tax_percent")
-  BigDecimal taxPercent;
 
   @SerializedName("threshold_reason")
   ThresholdReason thresholdReason;

--- a/src/main/java/com/stripe/model/InvoiceItem.java
+++ b/src/main/java/com/stripe/model/InvoiceItem.java
@@ -144,13 +144,6 @@ public class InvoiceItem extends ApiResource implements HasId, MetadataStore<Inv
   @SerializedName("tax_rates")
   List<TaxRate> taxRates;
 
-  /**
-   * For prorations this indicates whether Stripe automatically grouped multiple related debit and
-   * credit line items into a single combined line item.
-   */
-  @SerializedName("unified_proration")
-  Boolean unifiedProration;
-
   /** Unit Amount (in the {@code currency} specified) of the invoice item. */
   @SerializedName("unit_amount")
   Long unitAmount;

--- a/src/main/java/com/stripe/model/InvoiceItem.java
+++ b/src/main/java/com/stripe/model/InvoiceItem.java
@@ -291,16 +291,16 @@ public class InvoiceItem extends ApiResource implements HasId, MetadataStore<Inv
   }
 
   /**
-   * Creates an item to be added to a draft invoice. If no invoice is specified, the item will be on
-   * the next invoice created for the customer specified.
+   * Creates an item to be added to a draft invoice (up to 250 items per invoice). If no invoice is
+   * specified, the item will be on the next invoice created for the customer specified.
    */
   public static InvoiceItem create(Map<String, Object> params) throws StripeException {
     return create(params, (RequestOptions) null);
   }
 
   /**
-   * Creates an item to be added to a draft invoice. If no invoice is specified, the item will be on
-   * the next invoice created for the customer specified.
+   * Creates an item to be added to a draft invoice (up to 250 items per invoice). If no invoice is
+   * specified, the item will be on the next invoice created for the customer specified.
    */
   public static InvoiceItem create(Map<String, Object> params, RequestOptions options)
       throws StripeException {
@@ -310,16 +310,16 @@ public class InvoiceItem extends ApiResource implements HasId, MetadataStore<Inv
   }
 
   /**
-   * Creates an item to be added to a draft invoice. If no invoice is specified, the item will be on
-   * the next invoice created for the customer specified.
+   * Creates an item to be added to a draft invoice (up to 250 items per invoice). If no invoice is
+   * specified, the item will be on the next invoice created for the customer specified.
    */
   public static InvoiceItem create(InvoiceItemCreateParams params) throws StripeException {
     return create(params, (RequestOptions) null);
   }
 
   /**
-   * Creates an item to be added to a draft invoice. If no invoice is specified, the item will be on
-   * the next invoice created for the customer specified.
+   * Creates an item to be added to a draft invoice (up to 250 items per invoice). If no invoice is
+   * specified, the item will be on the next invoice created for the customer specified.
    */
   public static InvoiceItem create(InvoiceItemCreateParams params, RequestOptions options)
       throws StripeException {

--- a/src/main/java/com/stripe/model/InvoiceLineItem.java
+++ b/src/main/java/com/stripe/model/InvoiceLineItem.java
@@ -126,13 +126,6 @@ public class InvoiceLineItem extends StripeObject implements HasId {
   @SerializedName("type")
   String type;
 
-  /**
-   * For prorations this indicates whether Stripe automatically grouped multiple related debit and
-   * credit line items into a single combined line item.
-   */
-  @SerializedName("unified_proration")
-  Boolean unifiedProration;
-
   /** Get IDs of expandable {@code discounts} object list. */
   public List<String> getDiscounts() {
     return (this.discounts != null)

--- a/src/main/java/com/stripe/model/PaymentMethod.java
+++ b/src/main/java/com/stripe/model/PaymentMethod.java
@@ -110,8 +110,8 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
    * matching this value. It contains additional information specific to the PaymentMethod type.
    *
    * <p>One of {@code alipay}, {@code au_becs_debit}, {@code bacs_debit}, {@code bancontact}, {@code
-   * card}, {@code card_present}, {@code eps}, {@code fpx}, {@code giropay}, {@code ideal}, {@code
-   * p24}, or {@code sepa_debit}.
+   * card}, {@code eps}, {@code fpx}, {@code giropay}, {@code ideal}, {@code p24}, or {@code
+   * sepa_debit}.
    */
   @SerializedName("type")
   String type;

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -282,13 +282,6 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
   String status;
 
   /**
-   * If provided, each invoice created by this subscription will apply the tax rate, increasing the
-   * amount billed to the customer.
-   */
-  @SerializedName("tax_percent")
-  BigDecimal taxPercent;
-
-  /**
    * The account (if any) the subscription's payments will be attributed to for tax reporting, and
    * where funds from each payment will be transferred to for each of the subscription's invoices.
    */

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -222,21 +222,6 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
   @SerializedName("pending_update")
   PendingUpdate pendingUpdate;
 
-  /**
-   * Hash describing the plan the customer is subscribed to. Only set if the subscription contains a
-   * single plan.
-   */
-  @SerializedName("plan")
-  Plan plan;
-
-  /**
-   * The quantity of the plan to which the customer is subscribed. For example, if your plan is
-   * $10/user/month, and your customer has 5 users, you could pass 5 as the quantity to have the
-   * customer charged $50 (5 x $10) monthly. Only set if the subscription contains a single plan.
-   */
-  @SerializedName("quantity")
-  Long quantity;
-
   /** The schedule attached to the subscription. */
   @SerializedName("schedule")
   @Getter(lombok.AccessLevel.NONE)

--- a/src/main/java/com/stripe/model/SubscriptionSchedule.java
+++ b/src/main/java/com/stripe/model/SubscriptionSchedule.java
@@ -563,8 +563,9 @@ public class SubscriptionSchedule extends ApiResource
     InvoiceSettings invoiceSettings;
 
     /**
-     * The account (if any) the subscription's payments will be attributed to for tax reporting, and
-     * where funds from each payment will be transferred to for each of the subscription's invoices.
+     * The account (if any) the associated subscription's payments will be attributed to for tax
+     * reporting, and where funds from each payment will be transferred to for each of the
+     * subscription's invoices.
      */
     @SerializedName("transfer_data")
     Subscription.TransferData transferData;
@@ -682,9 +683,12 @@ public class SubscriptionSchedule extends ApiResource
     @SerializedName("invoice_settings")
     InvoiceSettings invoiceSettings;
 
-    /** Plans to subscribe during this phase of the subscription schedule. */
-    @SerializedName("plans")
-    List<SubscriptionSchedule.PhaseItem> plans;
+    /**
+     * Subscription items to configure the subscription to during this phase of the subscription
+     * schedule.
+     */
+    @SerializedName("items")
+    List<SubscriptionSchedule.PhaseItem> items;
 
     /**
      * If the subscription schedule will prorate when transitioning to this phase. Possible values
@@ -700,15 +704,9 @@ public class SubscriptionSchedule extends ApiResource
     Long startDate;
 
     /**
-     * If provided, each invoice created during this phase of the subscription schedule will apply
-     * the tax rate, increasing the amount billed to the customer.
-     */
-    @SerializedName("tax_percent")
-    BigDecimal taxPercent;
-
-    /**
-     * The account (if any) the subscription's payments will be attributed to for tax reporting, and
-     * where funds from each payment will be transferred to for each of the subscription's invoices.
+     * The account (if any) the associated subscription's payments will be attributed to for tax
+     * reporting, and where funds from each payment will be transferred to for each of the
+     * subscription's invoices.
      */
     @SerializedName("transfer_data")
     Subscription.TransferData transferData;

--- a/src/main/java/com/stripe/model/checkout/Session.java
+++ b/src/main/java/com/stripe/model/checkout/Session.java
@@ -9,10 +9,8 @@ import com.stripe.model.HasId;
 import com.stripe.model.LineItem;
 import com.stripe.model.LineItemCollection;
 import com.stripe.model.PaymentIntent;
-import com.stripe.model.Plan;
 import com.stripe.model.SetupIntent;
 import com.stripe.model.ShippingDetails;
-import com.stripe.model.Sku;
 import com.stripe.model.StripeObject;
 import com.stripe.model.Subscription;
 import com.stripe.net.ApiResource;
@@ -90,10 +88,6 @@ public class Session extends ApiResource implements HasId {
    */
   @SerializedName("customer_email")
   String customerEmail;
-
-  /** The line items, plans, or SKUs purchased by the customer. Prefer using {@code line_items}. */
-  @SerializedName("display_items")
-  List<Session.DisplayItem> displayItems;
 
   /** Unique identifier for the object. Used to pass to {@code redirectToCheckout} in Stripe.js. */
   @Getter(onMethod_ = {@Override})
@@ -392,88 +386,6 @@ public class Session extends ApiResource implements HasId {
                 "/v1/checkout/sessions/%s/line_items", ApiResource.urlEncodeId(this.getId())));
 
     return ApiResource.requestCollection(url, params, LineItemCollection.class, options);
-  }
-
-  @Getter
-  @Setter
-  @EqualsAndHashCode(callSuper = false)
-  public static class DisplayItem extends StripeObject {
-    /** Amount for the display item. */
-    @SerializedName("amount")
-    Long amount;
-
-    /**
-     * Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency
-     * code</a>, in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported
-     * currency</a>.
-     */
-    @SerializedName("currency")
-    String currency;
-
-    @SerializedName("custom")
-    Custom custom;
-
-    /**
-     * You can now model subscriptions more flexibly using the <a
-     * href="https://stripe.com/docs/api#prices">Prices API</a>. It replaces the Plans API and is
-     * backwards compatible to simplify your migration.
-     *
-     * <p>Plans define the base price, currency, and billing cycle for recurring purchases of
-     * products. <a href="https://stripe.com/docs/api#products">Products</a> help you track
-     * inventory or provisioning, and plans help you track pricing. Different physical goods or
-     * levels of service should be represented by products, and pricing options should be
-     * represented by plans. This approach lets you change prices without having to change your
-     * provisioning scheme.
-     *
-     * <p>For example, you might have a single &quot;gold&quot; product that has plans for
-     * $10/month, $100/year, €9/month, and €90/year.
-     *
-     * <p>Related guides: <a
-     * href="https://stripe.com/docs/billing/subscriptions/set-up-subscription">Set up a
-     * subscription</a> and more about <a
-     * href="https://stripe.com/docs/billing/prices-guide">products and prices</a>.
-     */
-    @SerializedName("plan")
-    Plan plan;
-
-    /** Quantity of the display item being purchased. */
-    @SerializedName("quantity")
-    Long quantity;
-
-    /**
-     * Stores representations of <a href="http://en.wikipedia.org/wiki/Stock_keeping_unit">stock
-     * keeping units</a>. SKUs describe specific product variations, taking into account any
-     * combination of: attributes, currency, and cost. For example, a product may be a T-shirt,
-     * whereas a specific SKU represents the {@code size: large}, {@code color: red} version of that
-     * shirt.
-     *
-     * <p>Can also be used to manage inventory.
-     *
-     * <p>Related guide: <a href="https://stripe.com/docs/orders">Tax, Shipping, and Inventory</a>.
-     */
-    @SerializedName("sku")
-    Sku sku;
-
-    /** The type of display item. One of {@code custom}, {@code plan} or {@code sku} */
-    @SerializedName("type")
-    String type;
-
-    @Getter
-    @Setter
-    @EqualsAndHashCode(callSuper = false)
-    public static class Custom extends StripeObject {
-      /** The description of the line item. */
-      @SerializedName("description")
-      String description;
-
-      /** The images of the line item. */
-      @SerializedName("images")
-      List<String> images;
-
-      /** The name of the line item. */
-      @SerializedName("name")
-      String name;
-    }
   }
 
   @Getter

--- a/src/main/java/com/stripe/model/issuing/Dispute.java
+++ b/src/main/java/com/stripe/model/issuing/Dispute.java
@@ -132,7 +132,8 @@ public class Dispute extends ApiResource implements HasId {
 
   /**
    * Updates the specified Issuing <code>Dispute</code> object by setting the values of the
-   * parameters passed. Any parameters not provided will be left unchanged.
+   * parameters passed. Any parameters not provided will be left unchanged. Properties on the <code>
+   * evidence</code> object can be unset by passing in an empty string.
    */
   public Dispute update(Map<String, Object> params) throws StripeException {
     return update(params, (RequestOptions) null);
@@ -140,7 +141,8 @@ public class Dispute extends ApiResource implements HasId {
 
   /**
    * Updates the specified Issuing <code>Dispute</code> object by setting the values of the
-   * parameters passed. Any parameters not provided will be left unchanged.
+   * parameters passed. Any parameters not provided will be left unchanged. Properties on the <code>
+   * evidence</code> object can be unset by passing in an empty string.
    */
   public Dispute update(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
@@ -153,7 +155,8 @@ public class Dispute extends ApiResource implements HasId {
 
   /**
    * Updates the specified Issuing <code>Dispute</code> object by setting the values of the
-   * parameters passed. Any parameters not provided will be left unchanged.
+   * parameters passed. Any parameters not provided will be left unchanged. Properties on the <code>
+   * evidence</code> object can be unset by passing in an empty string.
    */
   public Dispute update(DisputeUpdateParams params) throws StripeException {
     return update(params, (RequestOptions) null);
@@ -161,7 +164,8 @@ public class Dispute extends ApiResource implements HasId {
 
   /**
    * Updates the specified Issuing <code>Dispute</code> object by setting the values of the
-   * parameters passed. Any parameters not provided will be left unchanged.
+   * parameters passed. Any parameters not provided will be left unchanged. Properties on the <code>
+   * evidence</code> object can be unset by passing in an empty string.
    */
   public Dispute update(DisputeUpdateParams params, RequestOptions options) throws StripeException {
     String url =

--- a/src/main/java/com/stripe/model/issuing/Dispute.java
+++ b/src/main/java/com/stripe/model/issuing/Dispute.java
@@ -22,7 +22,7 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class Dispute extends ApiResource implements HasId {
-  /** List of balance transactions associated with this dispute. */
+  /** List of balance transactions associated with the dispute. */
   @SerializedName("balance_transactions")
   List<BalanceTransaction> balanceTransactions;
 
@@ -106,24 +106,48 @@ public class Dispute extends ApiResource implements HasId {
     return ApiResource.requestCollection(url, params, DisputeCollection.class, options);
   }
 
-  /** Creates an Issuing <code>Dispute</code> object. */
+  /**
+   * Creates an Issuing <code>Dispute</code> object. Individual pieces of evidence within the <code>
+   * evidence</code> object are optional at this point. Stripe only validates that required evidence
+   * is present during submission. Refer to <a
+   * href="https://stripe.com/docs/issuing/purchases/disputes#dispute-reasons-and-evidence">Dispute
+   * reasons and evidence</a> for more details about evidence requirements.
+   */
   public static Dispute create(Map<String, Object> params) throws StripeException {
     return create(params, (RequestOptions) null);
   }
 
-  /** Creates an Issuing <code>Dispute</code> object. */
+  /**
+   * Creates an Issuing <code>Dispute</code> object. Individual pieces of evidence within the <code>
+   * evidence</code> object are optional at this point. Stripe only validates that required evidence
+   * is present during submission. Refer to <a
+   * href="https://stripe.com/docs/issuing/purchases/disputes#dispute-reasons-and-evidence">Dispute
+   * reasons and evidence</a> for more details about evidence requirements.
+   */
   public static Dispute create(Map<String, Object> params, RequestOptions options)
       throws StripeException {
     String url = String.format("%s%s", Stripe.getApiBase(), "/v1/issuing/disputes");
     return ApiResource.request(ApiResource.RequestMethod.POST, url, params, Dispute.class, options);
   }
 
-  /** Creates an Issuing <code>Dispute</code> object. */
+  /**
+   * Creates an Issuing <code>Dispute</code> object. Individual pieces of evidence within the <code>
+   * evidence</code> object are optional at this point. Stripe only validates that required evidence
+   * is present during submission. Refer to <a
+   * href="https://stripe.com/docs/issuing/purchases/disputes#dispute-reasons-and-evidence">Dispute
+   * reasons and evidence</a> for more details about evidence requirements.
+   */
   public static Dispute create(DisputeCreateParams params) throws StripeException {
     return create(params, (RequestOptions) null);
   }
 
-  /** Creates an Issuing <code>Dispute</code> object. */
+  /**
+   * Creates an Issuing <code>Dispute</code> object. Individual pieces of evidence within the <code>
+   * evidence</code> object are optional at this point. Stripe only validates that required evidence
+   * is present during submission. Refer to <a
+   * href="https://stripe.com/docs/issuing/purchases/disputes#dispute-reasons-and-evidence">Dispute
+   * reasons and evidence</a> for more details about evidence requirements.
+   */
   public static Dispute create(DisputeCreateParams params, RequestOptions options)
       throws StripeException {
     String url = String.format("%s%s", Stripe.getApiBase(), "/v1/issuing/disputes");

--- a/src/main/java/com/stripe/param/AccountCreateParams.java
+++ b/src/main/java/com/stripe/param/AccountCreateParams.java
@@ -111,15 +111,6 @@ public class AccountCreateParams extends ApiRequestParams {
   @SerializedName("metadata")
   Object metadata;
 
-  /**
-   * (Deprecated) Alternative to {@code capabilities}. The set of capabilities you want to unlock
-   * for this account. Each capability will be inactive until you have provided its specific
-   * requirements and Stripe has verified them. An account may have some of its requested
-   * capabilities be active and some be inactive.
-   */
-  @SerializedName("requested_capabilities")
-  List<RequestedCapability> requestedCapabilities;
-
   /** Options for customizing how the account functions within Stripe. */
   @SerializedName("settings")
   Settings settings;
@@ -153,7 +144,6 @@ public class AccountCreateParams extends ApiRequestParams {
       Map<String, Object> extraParams,
       Individual individual,
       Object metadata,
-      List<RequestedCapability> requestedCapabilities,
       Settings settings,
       TosAcceptance tosAcceptance,
       Type type) {
@@ -170,7 +160,6 @@ public class AccountCreateParams extends ApiRequestParams {
     this.extraParams = extraParams;
     this.individual = individual;
     this.metadata = metadata;
-    this.requestedCapabilities = requestedCapabilities;
     this.settings = settings;
     this.tosAcceptance = tosAcceptance;
     this.type = type;
@@ -207,8 +196,6 @@ public class AccountCreateParams extends ApiRequestParams {
 
     private Object metadata;
 
-    private List<RequestedCapability> requestedCapabilities;
-
     private Settings settings;
 
     private TosAcceptance tosAcceptance;
@@ -231,7 +218,6 @@ public class AccountCreateParams extends ApiRequestParams {
           this.extraParams,
           this.individual,
           this.metadata,
-          this.requestedCapabilities,
           this.settings,
           this.tosAcceptance,
           this.type);
@@ -439,32 +425,6 @@ public class AccountCreateParams extends ApiRequestParams {
      */
     public Builder setMetadata(Map<String, String> metadata) {
       this.metadata = metadata;
-      return this;
-    }
-
-    /**
-     * Add an element to `requestedCapabilities` list. A list is initialized for the first
-     * `add/addAll` call, and subsequent calls adds additional elements to the original list. See
-     * {@link AccountCreateParams#requestedCapabilities} for the field documentation.
-     */
-    public Builder addRequestedCapability(RequestedCapability element) {
-      if (this.requestedCapabilities == null) {
-        this.requestedCapabilities = new ArrayList<>();
-      }
-      this.requestedCapabilities.add(element);
-      return this;
-    }
-
-    /**
-     * Add all elements to `requestedCapabilities` list. A list is initialized for the first
-     * `add/addAll` call, and subsequent calls adds additional elements to the original list. See
-     * {@link AccountCreateParams#requestedCapabilities} for the field documentation.
-     */
-    public Builder addAllRequestedCapability(List<RequestedCapability> elements) {
-      if (this.requestedCapabilities == null) {
-        this.requestedCapabilities = new ArrayList<>();
-      }
-      this.requestedCapabilities.addAll(elements);
       return this;
     }
 
@@ -5373,48 +5333,6 @@ public class AccountCreateParams extends ApiRequestParams {
     private final String value;
 
     BusinessType(String value) {
-      this.value = value;
-    }
-  }
-
-  public enum RequestedCapability implements ApiRequestParams.EnumParam {
-    @SerializedName("au_becs_debit_payments")
-    AU_BECS_DEBIT_PAYMENTS("au_becs_debit_payments"),
-
-    @SerializedName("bacs_debit_payments")
-    BACS_DEBIT_PAYMENTS("bacs_debit_payments"),
-
-    @SerializedName("card_issuing")
-    CARD_ISSUING("card_issuing"),
-
-    @SerializedName("card_payments")
-    CARD_PAYMENTS("card_payments"),
-
-    @SerializedName("cartes_bancaires_payments")
-    CARTES_BANCAIRES_PAYMENTS("cartes_bancaires_payments"),
-
-    @SerializedName("fpx_payments")
-    FPX_PAYMENTS("fpx_payments"),
-
-    @SerializedName("jcb_payments")
-    JCB_PAYMENTS("jcb_payments"),
-
-    @SerializedName("legacy_payments")
-    LEGACY_PAYMENTS("legacy_payments"),
-
-    @SerializedName("tax_reporting_us_1099_k")
-    TAX_REPORTING_US_1099_K("tax_reporting_us_1099_k"),
-
-    @SerializedName("tax_reporting_us_1099_misc")
-    TAX_REPORTING_US_1099_MISC("tax_reporting_us_1099_misc"),
-
-    @SerializedName("transfers")
-    TRANSFERS("transfers");
-
-    @Getter(onMethod_ = {@Override})
-    private final String value;
-
-    RequestedCapability(String value) {
       this.value = value;
     }
   }

--- a/src/main/java/com/stripe/param/AccountCreateParams.java
+++ b/src/main/java/com/stripe/param/AccountCreateParams.java
@@ -37,8 +37,8 @@ public class AccountCreateParams extends ApiRequestParams {
   Capabilities capabilities;
 
   /**
-   * Information about the company or business. This field is null unless {@code business_type} is
-   * set to {@code company}, {@code government_entity}, or {@code non_profit}.
+   * Information about the company or business. This field is available for any {@code
+   * business_type}.
    */
   @SerializedName("company")
   Company company;
@@ -276,8 +276,8 @@ public class AccountCreateParams extends ApiRequestParams {
     }
 
     /**
-     * Information about the company or business. This field is null unless {@code business_type} is
-     * set to {@code company}, {@code government_entity}, or {@code non_profit}.
+     * Information about the company or business. This field is available for any {@code
+     * business_type}.
      */
     public Builder setCompany(Company company) {
       this.company = company;

--- a/src/main/java/com/stripe/param/AccountLinkCreateParams.java
+++ b/src/main/java/com/stripe/param/AccountLinkCreateParams.java
@@ -34,10 +34,6 @@ public class AccountLinkCreateParams extends ApiRequestParams {
   @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
   Map<String, Object> extraParams;
 
-  /** Alternate name for refresh_url to ensure backwards compatibility. */
-  @SerializedName("failure_url")
-  String failureUrl;
-
   /**
    * The URL that the user will be redirected to if the account link is no longer valid. Your {@code
    * refresh_url} should trigger a method on your server to create a new account link using this
@@ -49,10 +45,6 @@ public class AccountLinkCreateParams extends ApiRequestParams {
   /** The URL that the user will be redirected to upon leaving or completing the linked flow. */
   @SerializedName("return_url")
   String returnUrl;
-
-  /** Alternate name for return_url to ensure backwards compatibility. */
-  @SerializedName("success_url")
-  String successUrl;
 
   /**
    * The type of account link the user is requesting. Possible values are {@code account_onboarding}
@@ -66,19 +58,15 @@ public class AccountLinkCreateParams extends ApiRequestParams {
       Collect collect,
       List<String> expand,
       Map<String, Object> extraParams,
-      String failureUrl,
       String refreshUrl,
       String returnUrl,
-      String successUrl,
       Type type) {
     this.account = account;
     this.collect = collect;
     this.expand = expand;
     this.extraParams = extraParams;
-    this.failureUrl = failureUrl;
     this.refreshUrl = refreshUrl;
     this.returnUrl = returnUrl;
-    this.successUrl = successUrl;
     this.type = type;
   }
 
@@ -95,13 +83,9 @@ public class AccountLinkCreateParams extends ApiRequestParams {
 
     private Map<String, Object> extraParams;
 
-    private String failureUrl;
-
     private String refreshUrl;
 
     private String returnUrl;
-
-    private String successUrl;
 
     private Type type;
 
@@ -112,10 +96,8 @@ public class AccountLinkCreateParams extends ApiRequestParams {
           this.collect,
           this.expand,
           this.extraParams,
-          this.failureUrl,
           this.refreshUrl,
           this.returnUrl,
-          this.successUrl,
           this.type);
     }
 
@@ -186,12 +168,6 @@ public class AccountLinkCreateParams extends ApiRequestParams {
       return this;
     }
 
-    /** Alternate name for refresh_url to ensure backwards compatibility. */
-    public Builder setFailureUrl(String failureUrl) {
-      this.failureUrl = failureUrl;
-      return this;
-    }
-
     /**
      * The URL that the user will be redirected to if the account link is no longer valid. Your
      * {@code refresh_url} should trigger a method on your server to create a new account link using
@@ -205,12 +181,6 @@ public class AccountLinkCreateParams extends ApiRequestParams {
     /** The URL that the user will be redirected to upon leaving or completing the linked flow. */
     public Builder setReturnUrl(String returnUrl) {
       this.returnUrl = returnUrl;
-      return this;
-    }
-
-    /** Alternate name for return_url to ensure backwards compatibility. */
-    public Builder setSuccessUrl(String successUrl) {
-      this.successUrl = successUrl;
       return this;
     }
 

--- a/src/main/java/com/stripe/param/AccountUpdateParams.java
+++ b/src/main/java/com/stripe/param/AccountUpdateParams.java
@@ -37,8 +37,8 @@ public class AccountUpdateParams extends ApiRequestParams {
   Capabilities capabilities;
 
   /**
-   * Information about the company or business. This field is null unless {@code business_type} is
-   * set to {@code company}, {@code government_entity}, or {@code non_profit}.
+   * Information about the company or business. This field is available for any {@code
+   * business_type}.
    */
   @SerializedName("company")
   Company company;
@@ -265,8 +265,8 @@ public class AccountUpdateParams extends ApiRequestParams {
     }
 
     /**
-     * Information about the company or business. This field is null unless {@code business_type} is
-     * set to {@code company}, {@code government_entity}, or {@code non_profit}.
+     * Information about the company or business. This field is available for any {@code
+     * business_type}.
      */
     public Builder setCompany(Company company) {
       this.company = company;

--- a/src/main/java/com/stripe/param/AccountUpdateParams.java
+++ b/src/main/java/com/stripe/param/AccountUpdateParams.java
@@ -102,15 +102,6 @@ public class AccountUpdateParams extends ApiRequestParams {
   @SerializedName("metadata")
   Object metadata;
 
-  /**
-   * (Deprecated) Alternative to {@code capabilities}. The set of capabilities you want to unlock
-   * for this account. Each capability will be inactive until you have provided its specific
-   * requirements and Stripe has verified them. An account may have some of its requested
-   * capabilities be active and some be inactive.
-   */
-  @SerializedName("requested_capabilities")
-  List<RequestedCapability> requestedCapabilities;
-
   /** Options for customizing how the account functions within Stripe. */
   @SerializedName("settings")
   Settings settings;
@@ -136,7 +127,6 @@ public class AccountUpdateParams extends ApiRequestParams {
       Map<String, Object> extraParams,
       Individual individual,
       Object metadata,
-      List<RequestedCapability> requestedCapabilities,
       Settings settings,
       TosAcceptance tosAcceptance) {
     this.accountToken = accountToken;
@@ -151,7 +141,6 @@ public class AccountUpdateParams extends ApiRequestParams {
     this.extraParams = extraParams;
     this.individual = individual;
     this.metadata = metadata;
-    this.requestedCapabilities = requestedCapabilities;
     this.settings = settings;
     this.tosAcceptance = tosAcceptance;
   }
@@ -185,8 +174,6 @@ public class AccountUpdateParams extends ApiRequestParams {
 
     private Object metadata;
 
-    private List<RequestedCapability> requestedCapabilities;
-
     private Settings settings;
 
     private TosAcceptance tosAcceptance;
@@ -206,7 +193,6 @@ public class AccountUpdateParams extends ApiRequestParams {
           this.extraParams,
           this.individual,
           this.metadata,
-          this.requestedCapabilities,
           this.settings,
           this.tosAcceptance);
     }
@@ -453,32 +439,6 @@ public class AccountUpdateParams extends ApiRequestParams {
      */
     public Builder setMetadata(Map<String, String> metadata) {
       this.metadata = metadata;
-      return this;
-    }
-
-    /**
-     * Add an element to `requestedCapabilities` list. A list is initialized for the first
-     * `add/addAll` call, and subsequent calls adds additional elements to the original list. See
-     * {@link AccountUpdateParams#requestedCapabilities} for the field documentation.
-     */
-    public Builder addRequestedCapability(RequestedCapability element) {
-      if (this.requestedCapabilities == null) {
-        this.requestedCapabilities = new ArrayList<>();
-      }
-      this.requestedCapabilities.add(element);
-      return this;
-    }
-
-    /**
-     * Add all elements to `requestedCapabilities` list. A list is initialized for the first
-     * `add/addAll` call, and subsequent calls adds additional elements to the original list. See
-     * {@link AccountUpdateParams#requestedCapabilities} for the field documentation.
-     */
-    public Builder addAllRequestedCapability(List<RequestedCapability> elements) {
-      if (this.requestedCapabilities == null) {
-        this.requestedCapabilities = new ArrayList<>();
-      }
-      this.requestedCapabilities.addAll(elements);
       return this;
     }
 
@@ -6017,48 +5977,6 @@ public class AccountUpdateParams extends ApiRequestParams {
     private final String value;
 
     BusinessType(String value) {
-      this.value = value;
-    }
-  }
-
-  public enum RequestedCapability implements ApiRequestParams.EnumParam {
-    @SerializedName("au_becs_debit_payments")
-    AU_BECS_DEBIT_PAYMENTS("au_becs_debit_payments"),
-
-    @SerializedName("bacs_debit_payments")
-    BACS_DEBIT_PAYMENTS("bacs_debit_payments"),
-
-    @SerializedName("card_issuing")
-    CARD_ISSUING("card_issuing"),
-
-    @SerializedName("card_payments")
-    CARD_PAYMENTS("card_payments"),
-
-    @SerializedName("cartes_bancaires_payments")
-    CARTES_BANCAIRES_PAYMENTS("cartes_bancaires_payments"),
-
-    @SerializedName("fpx_payments")
-    FPX_PAYMENTS("fpx_payments"),
-
-    @SerializedName("jcb_payments")
-    JCB_PAYMENTS("jcb_payments"),
-
-    @SerializedName("legacy_payments")
-    LEGACY_PAYMENTS("legacy_payments"),
-
-    @SerializedName("tax_reporting_us_1099_k")
-    TAX_REPORTING_US_1099_K("tax_reporting_us_1099_k"),
-
-    @SerializedName("tax_reporting_us_1099_misc")
-    TAX_REPORTING_US_1099_MISC("tax_reporting_us_1099_misc"),
-
-    @SerializedName("transfers")
-    TRANSFERS("transfers");
-
-    @Getter(onMethod_ = {@Override})
-    private final String value;
-
-    RequestedCapability(String value) {
       this.value = value;
     }
   }

--- a/src/main/java/com/stripe/param/InvoiceCreateParams.java
+++ b/src/main/java/com/stripe/param/InvoiceCreateParams.java
@@ -3,7 +3,6 @@ package com.stripe.param;
 import com.google.gson.annotations.SerializedName;
 import com.stripe.net.ApiRequestParams;
 import com.stripe.param.common.EmptyParam;
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -141,15 +140,6 @@ public class InvoiceCreateParams extends ApiRequestParams {
   String subscription;
 
   /**
-   * The percent tax rate applied to the invoice, represented as a decimal number. This field has
-   * been deprecated and will be removed in a future API version, for further information view the
-   * <a href="https://stripe.com/docs/billing/migration/taxes">migration docs</a> for {@code
-   * tax_rates}.
-   */
-  @SerializedName("tax_percent")
-  BigDecimal taxPercent;
-
-  /**
    * If specified, the funds from the invoice will be transferred to the destination and the ID of
    * the resulting transfer will be found on the invoice's charge.
    */
@@ -175,7 +165,6 @@ public class InvoiceCreateParams extends ApiRequestParams {
       Object metadata,
       String statementDescriptor,
       String subscription,
-      BigDecimal taxPercent,
       TransferData transferData) {
     this.applicationFeeAmount = applicationFeeAmount;
     this.autoAdvance = autoAdvance;
@@ -195,7 +184,6 @@ public class InvoiceCreateParams extends ApiRequestParams {
     this.metadata = metadata;
     this.statementDescriptor = statementDescriptor;
     this.subscription = subscription;
-    this.taxPercent = taxPercent;
     this.transferData = transferData;
   }
 
@@ -240,8 +228,6 @@ public class InvoiceCreateParams extends ApiRequestParams {
 
     private String subscription;
 
-    private BigDecimal taxPercent;
-
     private TransferData transferData;
 
     /** Finalize and obtain parameter instance from this builder. */
@@ -265,7 +251,6 @@ public class InvoiceCreateParams extends ApiRequestParams {
           this.metadata,
           this.statementDescriptor,
           this.subscription,
-          this.taxPercent,
           this.transferData);
     }
 
@@ -595,17 +580,6 @@ public class InvoiceCreateParams extends ApiRequestParams {
      */
     public Builder setSubscription(String subscription) {
       this.subscription = subscription;
-      return this;
-    }
-
-    /**
-     * The percent tax rate applied to the invoice, represented as a decimal number. This field has
-     * been deprecated and will be removed in a future API version, for further information view the
-     * <a href="https://stripe.com/docs/billing/migration/taxes">migration docs</a> for {@code
-     * tax_rates}.
-     */
-    public Builder setTaxPercent(BigDecimal taxPercent) {
-      this.taxPercent = taxPercent;
       return this;
     }
 

--- a/src/main/java/com/stripe/param/InvoiceItemCreateParams.java
+++ b/src/main/java/com/stripe/param/InvoiceItemCreateParams.java
@@ -64,7 +64,8 @@ public class InvoiceItemCreateParams extends ApiRequestParams {
   /**
    * The ID of an existing invoice to add this invoice item to. When left blank, the invoice item
    * will be added to the next upcoming scheduled invoice. This is useful when adding invoice items
-   * in response to an invoice.created webhook. You can only add invoice items to draft invoices.
+   * in response to an invoice.created webhook. You can only add invoice items to draft invoices and
+   * there is a maximum of 250 items per invoice.
    */
   @SerializedName("invoice")
   String invoice;
@@ -371,7 +372,7 @@ public class InvoiceItemCreateParams extends ApiRequestParams {
      * The ID of an existing invoice to add this invoice item to. When left blank, the invoice item
      * will be added to the next upcoming scheduled invoice. This is useful when adding invoice
      * items in response to an invoice.created webhook. You can only add invoice items to draft
-     * invoices.
+     * invoices and there is a maximum of 250 items per invoice.
      */
     public Builder setInvoice(String invoice) {
       this.invoice = invoice;

--- a/src/main/java/com/stripe/param/InvoicePayParams.java
+++ b/src/main/java/com/stripe/param/InvoicePayParams.java
@@ -32,18 +32,21 @@ public class InvoicePayParams extends ApiRequestParams {
    * <p>Passing {@code forgive=false} will fail the charge if the source hasn't been pre-funded with
    * the right amount. An example for this case is with ACH Credit Transfers and wires: if the
    * amount wired is less than the amount due by a small amount, you might want to forgive the
-   * difference.
+   * difference. Defaults to {@code false}.
    */
   @SerializedName("forgive")
   Boolean forgive;
 
-  /** Indicates if a customer is on or off-session while an invoice payment is attempted. */
+  /**
+   * Indicates if a customer is on or off-session while an invoice payment is attempted. Defaults to
+   * {@code true} (off-session).
+   */
   @SerializedName("off_session")
   Boolean offSession;
 
   /**
    * Boolean representing whether an invoice is paid outside of Stripe. This will result in no
-   * charge being made.
+   * charge being made. Defaults to {@code false}.
    */
   @SerializedName("paid_out_of_band")
   Boolean paidOutOfBand;
@@ -171,14 +174,17 @@ public class InvoicePayParams extends ApiRequestParams {
      * <p>Passing {@code forgive=false} will fail the charge if the source hasn't been pre-funded
      * with the right amount. An example for this case is with ACH Credit Transfers and wires: if
      * the amount wired is less than the amount due by a small amount, you might want to forgive the
-     * difference.
+     * difference. Defaults to {@code false}.
      */
     public Builder setForgive(Boolean forgive) {
       this.forgive = forgive;
       return this;
     }
 
-    /** Indicates if a customer is on or off-session while an invoice payment is attempted. */
+    /**
+     * Indicates if a customer is on or off-session while an invoice payment is attempted. Defaults
+     * to {@code true} (off-session).
+     */
     public Builder setOffSession(Boolean offSession) {
       this.offSession = offSession;
       return this;
@@ -186,7 +192,7 @@ public class InvoicePayParams extends ApiRequestParams {
 
     /**
      * Boolean representing whether an invoice is paid outside of Stripe. This will result in no
-     * charge being made.
+     * charge being made. Defaults to {@code false}.
      */
     public Builder setPaidOutOfBand(Boolean paidOutOfBand) {
       this.paidOutOfBand = paidOutOfBand;

--- a/src/main/java/com/stripe/param/InvoiceUpcomingParams.java
+++ b/src/main/java/com/stripe/param/InvoiceUpcomingParams.java
@@ -103,15 +103,6 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
   List<SubscriptionItem> subscriptionItems;
 
   /**
-   * This field has been renamed to {@code subscription_proration_behavior}. {@code
-   * subscription_prorate=true} can be replaced with {@code
-   * subscription_proration_behavior=create_prorations} and {@code subscription_prorate=false} can
-   * be replaced with {@code subscription_proration_behavior=none}.
-   */
-  @SerializedName("subscription_prorate")
-  Boolean subscriptionProrate;
-
-  /**
    * Determines how to handle <a
    * href="https://stripe.com/docs/subscriptions/billing-cycle#prorations">prorations</a> when the
    * billing cycle changes (e.g., when switching plans, resetting {@code billing_cycle_anchor=now},
@@ -185,7 +176,6 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
       Boolean subscriptionCancelNow,
       Object subscriptionDefaultTaxRates,
       List<SubscriptionItem> subscriptionItems,
-      Boolean subscriptionProrate,
       SubscriptionProrationBehavior subscriptionProrationBehavior,
       Long subscriptionProrationDate,
       Long subscriptionStartDate,
@@ -206,7 +196,6 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
     this.subscriptionCancelNow = subscriptionCancelNow;
     this.subscriptionDefaultTaxRates = subscriptionDefaultTaxRates;
     this.subscriptionItems = subscriptionItems;
-    this.subscriptionProrate = subscriptionProrate;
     this.subscriptionProrationBehavior = subscriptionProrationBehavior;
     this.subscriptionProrationDate = subscriptionProrationDate;
     this.subscriptionStartDate = subscriptionStartDate;
@@ -248,8 +237,6 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
 
     private List<SubscriptionItem> subscriptionItems;
 
-    private Boolean subscriptionProrate;
-
     private SubscriptionProrationBehavior subscriptionProrationBehavior;
 
     private Long subscriptionProrationDate;
@@ -279,7 +266,6 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
           this.subscriptionCancelNow,
           this.subscriptionDefaultTaxRates,
           this.subscriptionItems,
-          this.subscriptionProrate,
           this.subscriptionProrationBehavior,
           this.subscriptionProrationDate,
           this.subscriptionStartDate,
@@ -573,17 +559,6 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
         this.subscriptionItems = new ArrayList<>();
       }
       this.subscriptionItems.addAll(elements);
-      return this;
-    }
-
-    /**
-     * This field has been renamed to {@code subscription_proration_behavior}. {@code
-     * subscription_prorate=true} can be replaced with {@code
-     * subscription_proration_behavior=create_prorations} and {@code subscription_prorate=false} can
-     * be replaced with {@code subscription_proration_behavior=none}.
-     */
-    public Builder setSubscriptionProrate(Boolean subscriptionProrate) {
-      this.subscriptionProrate = subscriptionProrate;
       return this;
     }
 

--- a/src/main/java/com/stripe/param/InvoiceUpcomingParams.java
+++ b/src/main/java/com/stripe/param/InvoiceUpcomingParams.java
@@ -126,7 +126,7 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
    * done at the specified time. The time given must be within the current subscription period, and
    * cannot be before the subscription was on its current plan. If set, {@code subscription}, and
    * one of {@code subscription_items}, or {@code subscription_trial_end} are required. Also, {@code
-   * subscription_proration} cannot be set to false.
+   * subscription_proration_behavior} cannot be set to 'none'.
    */
   @SerializedName("subscription_proration_date")
   Long subscriptionProrationDate;
@@ -134,16 +134,6 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
   /** Date a subscription is intended to start (can be future or past). */
   @SerializedName("subscription_start_date")
   Long subscriptionStartDate;
-
-  /**
-   * If provided, the invoice returned will preview updating or creating a subscription with that
-   * tax percent. If set, one of {@code subscription_items} or {@code subscription} is required.
-   * This field has been deprecated and will be removed in a future API version, for further
-   * information view the <a href="https://stripe.com/docs/billing/migration/taxes">migration
-   * docs</a> for {@code tax_rates}.
-   */
-  @SerializedName("subscription_tax_percent")
-  BigDecimal subscriptionTaxPercent;
 
   /**
    * If provided, the invoice returned will preview updating or creating a subscription with that
@@ -179,7 +169,6 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
       SubscriptionProrationBehavior subscriptionProrationBehavior,
       Long subscriptionProrationDate,
       Long subscriptionStartDate,
-      BigDecimal subscriptionTaxPercent,
       Object subscriptionTrialEnd,
       Boolean subscriptionTrialFromPlan) {
     this.coupon = coupon;
@@ -199,7 +188,6 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
     this.subscriptionProrationBehavior = subscriptionProrationBehavior;
     this.subscriptionProrationDate = subscriptionProrationDate;
     this.subscriptionStartDate = subscriptionStartDate;
-    this.subscriptionTaxPercent = subscriptionTaxPercent;
     this.subscriptionTrialEnd = subscriptionTrialEnd;
     this.subscriptionTrialFromPlan = subscriptionTrialFromPlan;
   }
@@ -243,8 +231,6 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
 
     private Long subscriptionStartDate;
 
-    private BigDecimal subscriptionTaxPercent;
-
     private Object subscriptionTrialEnd;
 
     private Boolean subscriptionTrialFromPlan;
@@ -269,7 +255,6 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
           this.subscriptionProrationBehavior,
           this.subscriptionProrationDate,
           this.subscriptionStartDate,
-          this.subscriptionTaxPercent,
           this.subscriptionTrialEnd,
           this.subscriptionTrialFromPlan);
     }
@@ -589,7 +574,7 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
      * done at the specified time. The time given must be within the current subscription period,
      * and cannot be before the subscription was on its current plan. If set, {@code subscription},
      * and one of {@code subscription_items}, or {@code subscription_trial_end} are required. Also,
-     * {@code subscription_proration} cannot be set to false.
+     * {@code subscription_proration_behavior} cannot be set to 'none'.
      */
     public Builder setSubscriptionProrationDate(Long subscriptionProrationDate) {
       this.subscriptionProrationDate = subscriptionProrationDate;
@@ -599,18 +584,6 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
     /** Date a subscription is intended to start (can be future or past). */
     public Builder setSubscriptionStartDate(Long subscriptionStartDate) {
       this.subscriptionStartDate = subscriptionStartDate;
-      return this;
-    }
-
-    /**
-     * If provided, the invoice returned will preview updating or creating a subscription with that
-     * tax percent. If set, one of {@code subscription_items} or {@code subscription} is required.
-     * This field has been deprecated and will be removed in a future API version, for further
-     * information view the <a href="https://stripe.com/docs/billing/migration/taxes">migration
-     * docs</a> for {@code tax_rates}.
-     */
-    public Builder setSubscriptionTaxPercent(BigDecimal subscriptionTaxPercent) {
-      this.subscriptionTaxPercent = subscriptionTaxPercent;
       return this;
     }
 

--- a/src/main/java/com/stripe/param/InvoiceUpdateParams.java
+++ b/src/main/java/com/stripe/param/InvoiceUpdateParams.java
@@ -3,7 +3,6 @@ package com.stripe.param;
 import com.google.gson.annotations.SerializedName;
 import com.stripe.net.ApiRequestParams;
 import com.stripe.param.common.EmptyParam;
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -132,17 +131,6 @@ public class InvoiceUpdateParams extends ApiRequestParams {
   Object statementDescriptor;
 
   /**
-   * The percent tax rate applied to the invoice, represented as a non-negative decimal number (with
-   * at most four decimal places) between 0 and 100. To unset a previously-set value, pass an empty
-   * string. This field can be updated only on {@code draft} invoices. This field has been
-   * deprecated and will be removed in a future API version, for further information view the <a
-   * href="https://stripe.com/docs/billing/migration/taxes">migration docs</a> for {@code
-   * tax_rates}.
-   */
-  @SerializedName("tax_percent")
-  Object taxPercent;
-
-  /**
    * If specified, the funds from the invoice will be transferred to the destination and the ID of
    * the resulting transfer will be found on the invoice's charge. This will be unset if you POST an
    * empty value.
@@ -167,7 +155,6 @@ public class InvoiceUpdateParams extends ApiRequestParams {
       Object footer,
       Object metadata,
       Object statementDescriptor,
-      Object taxPercent,
       Object transferData) {
     this.applicationFeeAmount = applicationFeeAmount;
     this.autoAdvance = autoAdvance;
@@ -185,7 +172,6 @@ public class InvoiceUpdateParams extends ApiRequestParams {
     this.footer = footer;
     this.metadata = metadata;
     this.statementDescriptor = statementDescriptor;
-    this.taxPercent = taxPercent;
     this.transferData = transferData;
   }
 
@@ -226,8 +212,6 @@ public class InvoiceUpdateParams extends ApiRequestParams {
 
     private Object statementDescriptor;
 
-    private Object taxPercent;
-
     private Object transferData;
 
     /** Finalize and obtain parameter instance from this builder. */
@@ -249,7 +233,6 @@ public class InvoiceUpdateParams extends ApiRequestParams {
           this.footer,
           this.metadata,
           this.statementDescriptor,
-          this.taxPercent,
           this.transferData);
     }
 
@@ -633,32 +616,6 @@ public class InvoiceUpdateParams extends ApiRequestParams {
      */
     public Builder setStatementDescriptor(EmptyParam statementDescriptor) {
       this.statementDescriptor = statementDescriptor;
-      return this;
-    }
-
-    /**
-     * The percent tax rate applied to the invoice, represented as a non-negative decimal number
-     * (with at most four decimal places) between 0 and 100. To unset a previously-set value, pass
-     * an empty string. This field can be updated only on {@code draft} invoices. This field has
-     * been deprecated and will be removed in a future API version, for further information view the
-     * <a href="https://stripe.com/docs/billing/migration/taxes">migration docs</a> for {@code
-     * tax_rates}.
-     */
-    public Builder setTaxPercent(BigDecimal taxPercent) {
-      this.taxPercent = taxPercent;
-      return this;
-    }
-
-    /**
-     * The percent tax rate applied to the invoice, represented as a non-negative decimal number
-     * (with at most four decimal places) between 0 and 100. To unset a previously-set value, pass
-     * an empty string. This field can be updated only on {@code draft} invoices. This field has
-     * been deprecated and will be removed in a future API version, for further information view the
-     * <a href="https://stripe.com/docs/billing/migration/taxes">migration docs</a> for {@code
-     * tax_rates}.
-     */
-    public Builder setTaxPercent(EmptyParam taxPercent) {
-      this.taxPercent = taxPercent;
       return this;
     }
 

--- a/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
@@ -1517,7 +1517,7 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
     public static class BillingDetails {
       /** Billing address. */
       @SerializedName("address")
-      Address address;
+      Object address;
 
       /** Email address. */
       @SerializedName("email")
@@ -1541,7 +1541,7 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       String phone;
 
       private BillingDetails(
-          Address address,
+          Object address,
           String email,
           Map<String, Object> extraParams,
           String name,
@@ -1558,7 +1558,7 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       }
 
       public static class Builder {
-        private Address address;
+        private Object address;
 
         private String email;
 
@@ -1576,6 +1576,12 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
 
         /** Billing address. */
         public Builder setAddress(Address address) {
+          this.address = address;
+          return this;
+        }
+
+        /** Billing address. */
+        public Builder setAddress(EmptyParam address) {
           this.address = address;
           return this;
         }

--- a/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
@@ -91,24 +91,6 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
   String returnUrl;
 
   /**
-   * If the PaymentIntent has a {@code payment_method} and a {@code customer} or if you're attaching
-   * a payment method to the PaymentIntent in this request, you can pass {@code
-   * save_payment_method=true} to save the payment method to the customer immediately.
-   *
-   * <p>If the payment method is already saved to a customer, this parameter does nothing. If this
-   * type of payment method cannot be saved to a customer, the request will error.
-   *
-   * <p>Saving a payment method using this parameter is <em>not recommended</em> because it will
-   * save the payment method even if it cannot be charged (e.g. the user made a typo). To ensure
-   * that only payment methods which are likely to be chargeable are saved to a customer, use the
-   * (setup_future_usage)[#payment_intents/object#payment_intent_object-setup_future_usage]
-   * property, which saves the payment method after the PaymentIntent has been confirmed and all
-   * required actions by the customer are complete.
-   */
-  @SerializedName("save_payment_method")
-  Boolean savePaymentMethod;
-
-  /**
    * Indicates that you intend to make future payments with this PaymentIntent's payment method.
    *
    * <p>Providing this parameter will <a
@@ -133,16 +115,6 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
   Object shipping;
 
   /**
-   * This is a legacy field that will be removed in the future. It is the ID of the Source object to
-   * attach to this PaymentIntent. Please use the {@code payment_method} field instead, which also
-   * supports Cards and <a
-   * href="https://stripe.com/docs/payments/payment-methods#compatibility">compatible Source</a>
-   * objects.
-   */
-  @SerializedName("source")
-  String source;
-
-  /**
    * Set to {@code true} only when using manual confirmation and the iOS or Android SDKs to handle
    * additional authentication steps.
    */
@@ -161,10 +133,8 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       PaymentMethodOptions paymentMethodOptions,
       Object receiptEmail,
       String returnUrl,
-      Boolean savePaymentMethod,
       EnumParam setupFutureUsage,
       Object shipping,
-      String source,
       Boolean useStripeSdk) {
     this.errorOnRequiresAction = errorOnRequiresAction;
     this.expand = expand;
@@ -177,10 +147,8 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
     this.paymentMethodOptions = paymentMethodOptions;
     this.receiptEmail = receiptEmail;
     this.returnUrl = returnUrl;
-    this.savePaymentMethod = savePaymentMethod;
     this.setupFutureUsage = setupFutureUsage;
     this.shipping = shipping;
-    this.source = source;
     this.useStripeSdk = useStripeSdk;
   }
 
@@ -211,13 +179,9 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
 
     private String returnUrl;
 
-    private Boolean savePaymentMethod;
-
     private EnumParam setupFutureUsage;
 
     private Object shipping;
-
-    private String source;
 
     private Boolean useStripeSdk;
 
@@ -235,10 +199,8 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
           this.paymentMethodOptions,
           this.receiptEmail,
           this.returnUrl,
-          this.savePaymentMethod,
           this.setupFutureUsage,
           this.shipping,
-          this.source,
           this.useStripeSdk);
     }
 
@@ -399,26 +361,6 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
     }
 
     /**
-     * If the PaymentIntent has a {@code payment_method} and a {@code customer} or if you're
-     * attaching a payment method to the PaymentIntent in this request, you can pass {@code
-     * save_payment_method=true} to save the payment method to the customer immediately.
-     *
-     * <p>If the payment method is already saved to a customer, this parameter does nothing. If this
-     * type of payment method cannot be saved to a customer, the request will error.
-     *
-     * <p>Saving a payment method using this parameter is <em>not recommended</em> because it will
-     * save the payment method even if it cannot be charged (e.g. the user made a typo). To ensure
-     * that only payment methods which are likely to be chargeable are saved to a customer, use the
-     * (setup_future_usage)[#payment_intents/object#payment_intent_object-setup_future_usage]
-     * property, which saves the payment method after the PaymentIntent has been confirmed and all
-     * required actions by the customer are complete.
-     */
-    public Builder setSavePaymentMethod(Boolean savePaymentMethod) {
-      this.savePaymentMethod = savePaymentMethod;
-      return this;
-    }
-
-    /**
      * Indicates that you intend to make future payments with this PaymentIntent's payment method.
      *
      * <p>Providing this parameter will <a
@@ -473,18 +415,6 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
     /** Shipping information for this PaymentIntent. */
     public Builder setShipping(EmptyParam shipping) {
       this.shipping = shipping;
-      return this;
-    }
-
-    /**
-     * This is a legacy field that will be removed in the future. It is the ID of the Source object
-     * to attach to this PaymentIntent. Please use the {@code payment_method} field instead, which
-     * also supports Cards and <a
-     * href="https://stripe.com/docs/payments/payment-methods#compatibility">compatible Source</a>
-     * objects.
-     */
-    public Builder setSource(String source) {
-      this.source = source;
       return this;
     }
 
@@ -2384,9 +2314,6 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
 
       @SerializedName("bancontact")
       BANCONTACT("bancontact"),
-
-      @SerializedName("card_present")
-      CARD_PRESENT("card_present"),
 
       @SerializedName("eps")
       EPS("eps"),

--- a/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
@@ -196,24 +196,6 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
   String returnUrl;
 
   /**
-   * If the PaymentIntent has a {@code payment_method} and a {@code customer} or if you're attaching
-   * a payment method to the PaymentIntent in this request, you can pass {@code
-   * save_payment_method=true} to save the payment method to the customer immediately.
-   *
-   * <p>If the payment method is already saved to a customer, this parameter does nothing. If this
-   * type of payment method cannot be saved to a customer, the request will error.
-   *
-   * <p>Saving a payment method using this parameter is <em>not recommended</em> because it will
-   * save the payment method even if it cannot be charged (e.g. the user made a typo). To ensure
-   * that only payment methods which are likely to be chargeable are saved to a customer, use the
-   * (setup_future_usage)[#payment_intents/object#payment_intent_object-setup_future_usage]
-   * property, which saves the payment method after the PaymentIntent has been confirmed and all
-   * required actions by the customer are complete.
-   */
-  @SerializedName("save_payment_method")
-  Boolean savePaymentMethod;
-
-  /**
    * Indicates that you intend to make future payments with this PaymentIntent's payment method.
    *
    * <p>Providing this parameter will <a
@@ -233,20 +215,6 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
   /** Shipping information for this PaymentIntent. */
   @SerializedName("shipping")
   Shipping shipping;
-
-  /**
-   * This is a legacy field that will be removed in the future. It is the ID of the Source object to
-   * attach to this PaymentIntent. Please use the {@code payment_method} field instead, which also
-   * supports Cards and <a
-   * href="https://stripe.com/docs/payments/payment-methods#compatibility">compatible Source</a>
-   * objects.If neither the {@code payment_method} parameter nor the {@code source} parameter are
-   * provided with {@code confirm=true}, this field will be automatically populated with {@code
-   * customer.default_source} to improve the migration experience for users of the Charges API. We
-   * recommend that you explicitly provide the {@code source} or {@code payment_method} parameter
-   * going forward.
-   */
-  @SerializedName("source")
-  String source;
 
   /**
    * For non-card charges, you can use this value as the complete description that appears on your
@@ -309,10 +277,8 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       List<String> paymentMethodTypes,
       String receiptEmail,
       String returnUrl,
-      Boolean savePaymentMethod,
       SetupFutureUsage setupFutureUsage,
       Shipping shipping,
-      String source,
       String statementDescriptor,
       String statementDescriptorSuffix,
       TransferData transferData,
@@ -340,10 +306,8 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     this.paymentMethodTypes = paymentMethodTypes;
     this.receiptEmail = receiptEmail;
     this.returnUrl = returnUrl;
-    this.savePaymentMethod = savePaymentMethod;
     this.setupFutureUsage = setupFutureUsage;
     this.shipping = shipping;
-    this.source = source;
     this.statementDescriptor = statementDescriptor;
     this.statementDescriptorSuffix = statementDescriptorSuffix;
     this.transferData = transferData;
@@ -400,13 +364,9 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
 
     private String returnUrl;
 
-    private Boolean savePaymentMethod;
-
     private SetupFutureUsage setupFutureUsage;
 
     private Shipping shipping;
-
-    private String source;
 
     private String statementDescriptor;
 
@@ -443,10 +403,8 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
           this.paymentMethodTypes,
           this.receiptEmail,
           this.returnUrl,
-          this.savePaymentMethod,
           this.setupFutureUsage,
           this.shipping,
-          this.source,
           this.statementDescriptor,
           this.statementDescriptorSuffix,
           this.transferData,
@@ -767,26 +725,6 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     }
 
     /**
-     * If the PaymentIntent has a {@code payment_method} and a {@code customer} or if you're
-     * attaching a payment method to the PaymentIntent in this request, you can pass {@code
-     * save_payment_method=true} to save the payment method to the customer immediately.
-     *
-     * <p>If the payment method is already saved to a customer, this parameter does nothing. If this
-     * type of payment method cannot be saved to a customer, the request will error.
-     *
-     * <p>Saving a payment method using this parameter is <em>not recommended</em> because it will
-     * save the payment method even if it cannot be charged (e.g. the user made a typo). To ensure
-     * that only payment methods which are likely to be chargeable are saved to a customer, use the
-     * (setup_future_usage)[#payment_intents/object#payment_intent_object-setup_future_usage]
-     * property, which saves the payment method after the PaymentIntent has been confirmed and all
-     * required actions by the customer are complete.
-     */
-    public Builder setSavePaymentMethod(Boolean savePaymentMethod) {
-      this.savePaymentMethod = savePaymentMethod;
-      return this;
-    }
-
-    /**
      * Indicates that you intend to make future payments with this PaymentIntent's payment method.
      *
      * <p>Providing this parameter will <a
@@ -808,22 +746,6 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     /** Shipping information for this PaymentIntent. */
     public Builder setShipping(Shipping shipping) {
       this.shipping = shipping;
-      return this;
-    }
-
-    /**
-     * This is a legacy field that will be removed in the future. It is the ID of the Source object
-     * to attach to this PaymentIntent. Please use the {@code payment_method} field instead, which
-     * also supports Cards and <a
-     * href="https://stripe.com/docs/payments/payment-methods#compatibility">compatible Source</a>
-     * objects.If neither the {@code payment_method} parameter nor the {@code source} parameter are
-     * provided with {@code confirm=true}, this field will be automatically populated with {@code
-     * customer.default_source} to improve the migration experience for users of the Charges API. We
-     * recommend that you explicitly provide the {@code source} or {@code payment_method} parameter
-     * going forward.
-     */
-    public Builder setSource(String source) {
-      this.source = source;
       return this;
     }
 
@@ -2764,9 +2686,6 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
 
       @SerializedName("bancontact")
       BANCONTACT("bancontact"),
-
-      @SerializedName("card_present")
-      CARD_PRESENT("card_present"),
 
       @SerializedName("eps")
       EPS("eps"),

--- a/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
@@ -1897,7 +1897,7 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     public static class BillingDetails {
       /** Billing address. */
       @SerializedName("address")
-      Address address;
+      Object address;
 
       /** Email address. */
       @SerializedName("email")
@@ -1921,7 +1921,7 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       String phone;
 
       private BillingDetails(
-          Address address,
+          Object address,
           String email,
           Map<String, Object> extraParams,
           String name,
@@ -1938,7 +1938,7 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       }
 
       public static class Builder {
-        private Address address;
+        private Object address;
 
         private String email;
 
@@ -1956,6 +1956,12 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
 
         /** Billing address. */
         public Builder setAddress(Address address) {
+          this.address = address;
+          return this;
+        }
+
+        /** Billing address. */
+        public Builder setAddress(EmptyParam address) {
           this.address = address;
           return this;
         }

--- a/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
@@ -113,24 +113,6 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
   Object receiptEmail;
 
   /**
-   * If the PaymentIntent has a {@code payment_method} and a {@code customer} or if you're attaching
-   * a payment method to the PaymentIntent in this request, you can pass {@code
-   * save_payment_method=true} to save the payment method to the customer immediately.
-   *
-   * <p>If the payment method is already saved to a customer, this parameter does nothing. If this
-   * type of payment method cannot be saved to a customer, the request will error.
-   *
-   * <p>Saving a payment method using this parameter is <em>not recommended</em> because it will
-   * save the payment method even if it cannot be charged (e.g. the user made a typo). To ensure
-   * that only payment methods which are likely to be chargeable are saved to a customer, use the
-   * (setup_future_usage)[#payment_intents/object#payment_intent_object-setup_future_usage]
-   * property, which saves the payment method after the PaymentIntent has been confirmed and all
-   * required actions by the customer are complete.
-   */
-  @SerializedName("save_payment_method")
-  Boolean savePaymentMethod;
-
-  /**
    * Indicates that you intend to make future payments with this PaymentIntent's payment method.
    *
    * <p>Providing this parameter will <a
@@ -153,16 +135,6 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
   /** Shipping information for this PaymentIntent. */
   @SerializedName("shipping")
   Object shipping;
-
-  /**
-   * This is a legacy field that will be removed in the future. It is the ID of the Source object to
-   * attach to this PaymentIntent. Please use the {@code payment_method} field instead, which also
-   * supports Cards and <a
-   * href="https://stripe.com/docs/payments/payment-methods#compatibility">compatible Source</a>
-   * objects.
-   */
-  @SerializedName("source")
-  Object source;
 
   /**
    * For non-card charges, you can use this value as the complete description that appears on your
@@ -210,10 +182,8 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       PaymentMethodOptions paymentMethodOptions,
       List<String> paymentMethodTypes,
       Object receiptEmail,
-      Boolean savePaymentMethod,
       EnumParam setupFutureUsage,
       Object shipping,
-      Object source,
       Object statementDescriptor,
       Object statementDescriptorSuffix,
       TransferData transferData,
@@ -231,10 +201,8 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     this.paymentMethodOptions = paymentMethodOptions;
     this.paymentMethodTypes = paymentMethodTypes;
     this.receiptEmail = receiptEmail;
-    this.savePaymentMethod = savePaymentMethod;
     this.setupFutureUsage = setupFutureUsage;
     this.shipping = shipping;
-    this.source = source;
     this.statementDescriptor = statementDescriptor;
     this.statementDescriptorSuffix = statementDescriptorSuffix;
     this.transferData = transferData;
@@ -272,13 +240,9 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
 
     private Object receiptEmail;
 
-    private Boolean savePaymentMethod;
-
     private EnumParam setupFutureUsage;
 
     private Object shipping;
-
-    private Object source;
 
     private Object statementDescriptor;
 
@@ -304,10 +268,8 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
           this.paymentMethodOptions,
           this.paymentMethodTypes,
           this.receiptEmail,
-          this.savePaymentMethod,
           this.setupFutureUsage,
           this.shipping,
-          this.source,
           this.statementDescriptor,
           this.statementDescriptorSuffix,
           this.transferData,
@@ -600,26 +562,6 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     }
 
     /**
-     * If the PaymentIntent has a {@code payment_method} and a {@code customer} or if you're
-     * attaching a payment method to the PaymentIntent in this request, you can pass {@code
-     * save_payment_method=true} to save the payment method to the customer immediately.
-     *
-     * <p>If the payment method is already saved to a customer, this parameter does nothing. If this
-     * type of payment method cannot be saved to a customer, the request will error.
-     *
-     * <p>Saving a payment method using this parameter is <em>not recommended</em> because it will
-     * save the payment method even if it cannot be charged (e.g. the user made a typo). To ensure
-     * that only payment methods which are likely to be chargeable are saved to a customer, use the
-     * (setup_future_usage)[#payment_intents/object#payment_intent_object-setup_future_usage]
-     * property, which saves the payment method after the PaymentIntent has been confirmed and all
-     * required actions by the customer are complete.
-     */
-    public Builder setSavePaymentMethod(Boolean savePaymentMethod) {
-      this.savePaymentMethod = savePaymentMethod;
-      return this;
-    }
-
-    /**
      * Indicates that you intend to make future payments with this PaymentIntent's payment method.
      *
      * <p>Providing this parameter will <a
@@ -674,30 +616,6 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     /** Shipping information for this PaymentIntent. */
     public Builder setShipping(EmptyParam shipping) {
       this.shipping = shipping;
-      return this;
-    }
-
-    /**
-     * This is a legacy field that will be removed in the future. It is the ID of the Source object
-     * to attach to this PaymentIntent. Please use the {@code payment_method} field instead, which
-     * also supports Cards and <a
-     * href="https://stripe.com/docs/payments/payment-methods#compatibility">compatible Source</a>
-     * objects.
-     */
-    public Builder setSource(String source) {
-      this.source = source;
-      return this;
-    }
-
-    /**
-     * This is a legacy field that will be removed in the future. It is the ID of the Source object
-     * to attach to this PaymentIntent. Please use the {@code payment_method} field instead, which
-     * also supports Cards and <a
-     * href="https://stripe.com/docs/payments/payment-methods#compatibility">compatible Source</a>
-     * objects.
-     */
-    public Builder setSource(EmptyParam source) {
-      this.source = source;
       return this;
     }
 
@@ -2386,9 +2304,6 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
 
       @SerializedName("bancontact")
       BANCONTACT("bancontact"),
-
-      @SerializedName("card_present")
-      CARD_PRESENT("card_present"),
 
       @SerializedName("eps")
       EPS("eps"),

--- a/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
@@ -1456,7 +1456,7 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     public static class BillingDetails {
       /** Billing address. */
       @SerializedName("address")
-      Address address;
+      Object address;
 
       /** Email address. */
       @SerializedName("email")
@@ -1480,7 +1480,7 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       Object phone;
 
       private BillingDetails(
-          Address address,
+          Object address,
           Object email,
           Map<String, Object> extraParams,
           Object name,
@@ -1497,7 +1497,7 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       }
 
       public static class Builder {
-        private Address address;
+        private Object address;
 
         private Object email;
 
@@ -1515,6 +1515,12 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
 
         /** Billing address. */
         public Builder setAddress(Address address) {
+          this.address = address;
+          return this;
+        }
+
+        /** Billing address. */
+        public Builder setAddress(EmptyParam address) {
           this.address = address;
           return this;
         }

--- a/src/main/java/com/stripe/param/PaymentMethodCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentMethodCreateParams.java
@@ -1787,9 +1787,6 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
     @SerializedName("card")
     CARD("card"),
 
-    @SerializedName("card_present")
-    CARD_PRESENT("card_present"),
-
     @SerializedName("eps")
     EPS("eps"),
 

--- a/src/main/java/com/stripe/param/PaymentMethodCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentMethodCreateParams.java
@@ -2,6 +2,7 @@ package com.stripe.param;
 
 import com.google.gson.annotations.SerializedName;
 import com.stripe.net.ApiRequestParams;
+import com.stripe.param.common.EmptyParam;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -761,7 +762,7 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
   public static class BillingDetails {
     /** Billing address. */
     @SerializedName("address")
-    Address address;
+    Object address;
 
     /** Email address. */
     @SerializedName("email")
@@ -785,7 +786,7 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
     String phone;
 
     private BillingDetails(
-        Address address, String email, Map<String, Object> extraParams, String name, String phone) {
+        Object address, String email, Map<String, Object> extraParams, String name, String phone) {
       this.address = address;
       this.email = email;
       this.extraParams = extraParams;
@@ -798,7 +799,7 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
     }
 
     public static class Builder {
-      private Address address;
+      private Object address;
 
       private String email;
 
@@ -816,6 +817,12 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
 
       /** Billing address. */
       public Builder setAddress(Address address) {
+        this.address = address;
+        return this;
+      }
+
+      /** Billing address. */
+      public Builder setAddress(EmptyParam address) {
         this.address = address;
         return this;
       }

--- a/src/main/java/com/stripe/param/PaymentMethodUpdateParams.java
+++ b/src/main/java/com/stripe/param/PaymentMethodUpdateParams.java
@@ -301,7 +301,7 @@ public class PaymentMethodUpdateParams extends ApiRequestParams {
   public static class BillingDetails {
     /** Billing address. */
     @SerializedName("address")
-    Address address;
+    Object address;
 
     /** Email address. */
     @SerializedName("email")
@@ -325,7 +325,7 @@ public class PaymentMethodUpdateParams extends ApiRequestParams {
     Object phone;
 
     private BillingDetails(
-        Address address, Object email, Map<String, Object> extraParams, Object name, Object phone) {
+        Object address, Object email, Map<String, Object> extraParams, Object name, Object phone) {
       this.address = address;
       this.email = email;
       this.extraParams = extraParams;
@@ -338,7 +338,7 @@ public class PaymentMethodUpdateParams extends ApiRequestParams {
     }
 
     public static class Builder {
-      private Address address;
+      private Object address;
 
       private Object email;
 
@@ -356,6 +356,12 @@ public class PaymentMethodUpdateParams extends ApiRequestParams {
 
       /** Billing address. */
       public Builder setAddress(Address address) {
+        this.address = address;
+        return this;
+      }
+
+      /** Billing address. */
+      public Builder setAddress(EmptyParam address) {
         this.address = address;
         return this;
       }

--- a/src/main/java/com/stripe/param/SubscriptionCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionCreateParams.java
@@ -187,14 +187,6 @@ public class SubscriptionCreateParams extends ApiRequestParams {
   String promotionCode;
 
   /**
-   * This field has been renamed to {@code proration_behavior}. {@code prorate=true} can be replaced
-   * with {@code proration_behavior=create_prorations} and {@code prorate=false} can be replaced
-   * with {@code proration_behavior=none}.
-   */
-  @SerializedName("prorate")
-  Boolean prorate;
-
-  /**
    * Determines how to handle <a
    * href="https://stripe.com/docs/subscriptions/billing-cycle#prorations">prorations</a> resulting
    * from the {@code billing_cycle_anchor}. Valid values are {@code create_prorations} or {@code
@@ -206,19 +198,6 @@ public class SubscriptionCreateParams extends ApiRequestParams {
    */
   @SerializedName("proration_behavior")
   ProrationBehavior prorationBehavior;
-
-  /**
-   * A non-negative decimal (with at most four decimal places) between 0 and 100. This represents
-   * the percentage of the subscription invoice subtotal that will be calculated and added as tax to
-   * the final amount in each billing period. For example, a plan which charges $10/month with a
-   * {@code tax_percent} of {@code 20.0} will charge $12 per invoice. To unset a previously-set
-   * value, pass an empty string. This field has been deprecated and will be removed in a future API
-   * version, for further information view the <a
-   * href="https://stripe.com/docs/billing/migration/taxes">migration docs</a> for {@code
-   * tax_rates}.
-   */
-  @SerializedName("tax_percent")
-  Object taxPercent;
 
   /**
    * If specified, the funds from the subscription's invoices will be transferred to the destination
@@ -275,9 +254,7 @@ public class SubscriptionCreateParams extends ApiRequestParams {
       PaymentBehavior paymentBehavior,
       Object pendingInvoiceItemInterval,
       String promotionCode,
-      Boolean prorate,
       ProrationBehavior prorationBehavior,
-      Object taxPercent,
       TransferData transferData,
       Object trialEnd,
       Boolean trialFromPlan,
@@ -304,9 +281,7 @@ public class SubscriptionCreateParams extends ApiRequestParams {
     this.paymentBehavior = paymentBehavior;
     this.pendingInvoiceItemInterval = pendingInvoiceItemInterval;
     this.promotionCode = promotionCode;
-    this.prorate = prorate;
     this.prorationBehavior = prorationBehavior;
-    this.taxPercent = taxPercent;
     this.transferData = transferData;
     this.trialEnd = trialEnd;
     this.trialFromPlan = trialFromPlan;
@@ -362,11 +337,7 @@ public class SubscriptionCreateParams extends ApiRequestParams {
 
     private String promotionCode;
 
-    private Boolean prorate;
-
     private ProrationBehavior prorationBehavior;
-
-    private Object taxPercent;
 
     private TransferData transferData;
 
@@ -401,9 +372,7 @@ public class SubscriptionCreateParams extends ApiRequestParams {
           this.paymentBehavior,
           this.pendingInvoiceItemInterval,
           this.promotionCode,
-          this.prorate,
           this.prorationBehavior,
-          this.taxPercent,
           this.transferData,
           this.trialEnd,
           this.trialFromPlan,
@@ -798,16 +767,6 @@ public class SubscriptionCreateParams extends ApiRequestParams {
     }
 
     /**
-     * This field has been renamed to {@code proration_behavior}. {@code prorate=true} can be
-     * replaced with {@code proration_behavior=create_prorations} and {@code prorate=false} can be
-     * replaced with {@code proration_behavior=none}.
-     */
-    public Builder setProrate(Boolean prorate) {
-      this.prorate = prorate;
-      return this;
-    }
-
-    /**
      * Determines how to handle <a
      * href="https://stripe.com/docs/subscriptions/billing-cycle#prorations">prorations</a>
      * resulting from the {@code billing_cycle_anchor}. Valid values are {@code create_prorations}
@@ -819,36 +778,6 @@ public class SubscriptionCreateParams extends ApiRequestParams {
      */
     public Builder setProrationBehavior(ProrationBehavior prorationBehavior) {
       this.prorationBehavior = prorationBehavior;
-      return this;
-    }
-
-    /**
-     * A non-negative decimal (with at most four decimal places) between 0 and 100. This represents
-     * the percentage of the subscription invoice subtotal that will be calculated and added as tax
-     * to the final amount in each billing period. For example, a plan which charges $10/month with
-     * a {@code tax_percent} of {@code 20.0} will charge $12 per invoice. To unset a previously-set
-     * value, pass an empty string. This field has been deprecated and will be removed in a future
-     * API version, for further information view the <a
-     * href="https://stripe.com/docs/billing/migration/taxes">migration docs</a> for {@code
-     * tax_rates}.
-     */
-    public Builder setTaxPercent(BigDecimal taxPercent) {
-      this.taxPercent = taxPercent;
-      return this;
-    }
-
-    /**
-     * A non-negative decimal (with at most four decimal places) between 0 and 100. This represents
-     * the percentage of the subscription invoice subtotal that will be calculated and added as tax
-     * to the final amount in each billing period. For example, a plan which charges $10/month with
-     * a {@code tax_percent} of {@code 20.0} will charge $12 per invoice. To unset a previously-set
-     * value, pass an empty string. This field has been deprecated and will be removed in a future
-     * API version, for further information view the <a
-     * href="https://stripe.com/docs/billing/migration/taxes">migration docs</a> for {@code
-     * tax_rates}.
-     */
-    public Builder setTaxPercent(EmptyParam taxPercent) {
-      this.taxPercent = taxPercent;
       return this;
     }
 

--- a/src/main/java/com/stripe/param/SubscriptionItemCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionItemCreateParams.java
@@ -81,14 +81,6 @@ public class SubscriptionItemCreateParams extends ApiRequestParams {
   PriceData priceData;
 
   /**
-   * This field has been renamed to {@code proration_behavior}. {@code prorate=true} can be replaced
-   * with {@code proration_behavior=create_prorations} and {@code prorate=false} can be replaced
-   * with {@code proration_behavior=none}.
-   */
-  @SerializedName("prorate")
-  Boolean prorate;
-
-  /**
    * Determines how to handle <a
    * href="https://stripe.com/docs/subscriptions/billing-cycle#prorations">prorations</a> when the
    * billing cycle changes (e.g., when switching plans, resetting {@code billing_cycle_anchor=now},
@@ -141,7 +133,6 @@ public class SubscriptionItemCreateParams extends ApiRequestParams {
       String plan,
       String price,
       PriceData priceData,
-      Boolean prorate,
       ProrationBehavior prorationBehavior,
       Long prorationDate,
       Long quantity,
@@ -155,7 +146,6 @@ public class SubscriptionItemCreateParams extends ApiRequestParams {
     this.plan = plan;
     this.price = price;
     this.priceData = priceData;
-    this.prorate = prorate;
     this.prorationBehavior = prorationBehavior;
     this.prorationDate = prorationDate;
     this.quantity = quantity;
@@ -184,8 +174,6 @@ public class SubscriptionItemCreateParams extends ApiRequestParams {
 
     private PriceData priceData;
 
-    private Boolean prorate;
-
     private ProrationBehavior prorationBehavior;
 
     private Long prorationDate;
@@ -207,7 +195,6 @@ public class SubscriptionItemCreateParams extends ApiRequestParams {
           this.plan,
           this.price,
           this.priceData,
-          this.prorate,
           this.prorationBehavior,
           this.prorationDate,
           this.quantity,
@@ -355,16 +342,6 @@ public class SubscriptionItemCreateParams extends ApiRequestParams {
      */
     public Builder setPriceData(PriceData priceData) {
       this.priceData = priceData;
-      return this;
-    }
-
-    /**
-     * This field has been renamed to {@code proration_behavior}. {@code prorate=true} can be
-     * replaced with {@code proration_behavior=create_prorations} and {@code prorate=false} can be
-     * replaced with {@code proration_behavior=none}.
-     */
-    public Builder setProrate(Boolean prorate) {
-      this.prorate = prorate;
       return this;
     }
 

--- a/src/main/java/com/stripe/param/SubscriptionItemDeleteParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionItemDeleteParams.java
@@ -25,9 +25,11 @@ public class SubscriptionItemDeleteParams extends ApiRequestParams {
   Map<String, Object> extraParams;
 
   /**
-   * This field has been renamed to {@code proration_behavior}. {@code prorate=true} can be replaced
-   * with {@code proration_behavior=create_prorations} and {@code prorate=false} can be replaced
-   * with {@code proration_behavior=none}.
+   * Flag indicating whether to <a
+   * href="https://stripe.com/docs/billing/subscriptions/prorations">prorate</a> switching plans
+   * during a billing cycle. This field has been deprecated and will be removed in a future API
+   * version. Use {@code proration_behavior=create_prorations} as a replacement for {@code
+   * prorate=true} and {@code proration_behavior=none} for {@code prorate=false}.
    */
   @SerializedName("prorate")
   Boolean prorate;
@@ -132,9 +134,11 @@ public class SubscriptionItemDeleteParams extends ApiRequestParams {
     }
 
     /**
-     * This field has been renamed to {@code proration_behavior}. {@code prorate=true} can be
-     * replaced with {@code proration_behavior=create_prorations} and {@code prorate=false} can be
-     * replaced with {@code proration_behavior=none}.
+     * Flag indicating whether to <a
+     * href="https://stripe.com/docs/billing/subscriptions/prorations">prorate</a> switching plans
+     * during a billing cycle. This field has been deprecated and will be removed in a future API
+     * version. Use {@code proration_behavior=create_prorations} as a replacement for {@code
+     * prorate=true} and {@code proration_behavior=none} for {@code prorate=false}.
      */
     public Builder setProrate(Boolean prorate) {
       this.prorate = prorate;

--- a/src/main/java/com/stripe/param/SubscriptionItemDeleteParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionItemDeleteParams.java
@@ -25,16 +25,6 @@ public class SubscriptionItemDeleteParams extends ApiRequestParams {
   Map<String, Object> extraParams;
 
   /**
-   * Flag indicating whether to <a
-   * href="https://stripe.com/docs/billing/subscriptions/prorations">prorate</a> switching plans
-   * during a billing cycle. This field has been deprecated and will be removed in a future API
-   * version. Use {@code proration_behavior=create_prorations} as a replacement for {@code
-   * prorate=true} and {@code proration_behavior=none} for {@code prorate=false}.
-   */
-  @SerializedName("prorate")
-  Boolean prorate;
-
-  /**
    * Determines how to handle <a
    * href="https://stripe.com/docs/subscriptions/billing-cycle#prorations">prorations</a> when the
    * billing cycle changes (e.g., when switching plans, resetting {@code billing_cycle_anchor=now},
@@ -63,12 +53,10 @@ public class SubscriptionItemDeleteParams extends ApiRequestParams {
   private SubscriptionItemDeleteParams(
       Boolean clearUsage,
       Map<String, Object> extraParams,
-      Boolean prorate,
       ProrationBehavior prorationBehavior,
       Long prorationDate) {
     this.clearUsage = clearUsage;
     this.extraParams = extraParams;
-    this.prorate = prorate;
     this.prorationBehavior = prorationBehavior;
     this.prorationDate = prorationDate;
   }
@@ -82,8 +70,6 @@ public class SubscriptionItemDeleteParams extends ApiRequestParams {
 
     private Map<String, Object> extraParams;
 
-    private Boolean prorate;
-
     private ProrationBehavior prorationBehavior;
 
     private Long prorationDate;
@@ -91,11 +77,7 @@ public class SubscriptionItemDeleteParams extends ApiRequestParams {
     /** Finalize and obtain parameter instance from this builder. */
     public SubscriptionItemDeleteParams build() {
       return new SubscriptionItemDeleteParams(
-          this.clearUsage,
-          this.extraParams,
-          this.prorate,
-          this.prorationBehavior,
-          this.prorationDate);
+          this.clearUsage, this.extraParams, this.prorationBehavior, this.prorationDate);
     }
 
     /**
@@ -130,18 +112,6 @@ public class SubscriptionItemDeleteParams extends ApiRequestParams {
         this.extraParams = new HashMap<>();
       }
       this.extraParams.putAll(map);
-      return this;
-    }
-
-    /**
-     * Flag indicating whether to <a
-     * href="https://stripe.com/docs/billing/subscriptions/prorations">prorate</a> switching plans
-     * during a billing cycle. This field has been deprecated and will be removed in a future API
-     * version. Use {@code proration_behavior=create_prorations} as a replacement for {@code
-     * prorate=true} and {@code proration_behavior=none} for {@code prorate=false}.
-     */
-    public Builder setProrate(Boolean prorate) {
-      this.prorate = prorate;
       return this;
     }
 

--- a/src/main/java/com/stripe/param/SubscriptionItemUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionItemUpdateParams.java
@@ -85,14 +85,6 @@ public class SubscriptionItemUpdateParams extends ApiRequestParams {
   PriceData priceData;
 
   /**
-   * This field has been renamed to {@code proration_behavior}. {@code prorate=true} can be replaced
-   * with {@code proration_behavior=create_prorations} and {@code prorate=false} can be replaced
-   * with {@code proration_behavior=none}.
-   */
-  @SerializedName("prorate")
-  Boolean prorate;
-
-  /**
    * Determines how to handle <a
    * href="https://stripe.com/docs/subscriptions/billing-cycle#prorations">prorations</a> when the
    * billing cycle changes (e.g., when switching plans, resetting {@code billing_cycle_anchor=now},
@@ -142,7 +134,6 @@ public class SubscriptionItemUpdateParams extends ApiRequestParams {
       Object plan,
       Object price,
       PriceData priceData,
-      Boolean prorate,
       ProrationBehavior prorationBehavior,
       Long prorationDate,
       Long quantity,
@@ -156,7 +147,6 @@ public class SubscriptionItemUpdateParams extends ApiRequestParams {
     this.plan = plan;
     this.price = price;
     this.priceData = priceData;
-    this.prorate = prorate;
     this.prorationBehavior = prorationBehavior;
     this.prorationDate = prorationDate;
     this.quantity = quantity;
@@ -186,8 +176,6 @@ public class SubscriptionItemUpdateParams extends ApiRequestParams {
 
     private PriceData priceData;
 
-    private Boolean prorate;
-
     private ProrationBehavior prorationBehavior;
 
     private Long prorationDate;
@@ -208,7 +196,6 @@ public class SubscriptionItemUpdateParams extends ApiRequestParams {
           this.plan,
           this.price,
           this.priceData,
-          this.prorate,
           this.prorationBehavior,
           this.prorationDate,
           this.quantity,
@@ -397,16 +384,6 @@ public class SubscriptionItemUpdateParams extends ApiRequestParams {
      */
     public Builder setPriceData(PriceData priceData) {
       this.priceData = priceData;
-      return this;
-    }
-
-    /**
-     * This field has been renamed to {@code proration_behavior}. {@code prorate=true} can be
-     * replaced with {@code proration_behavior=create_prorations} and {@code prorate=false} can be
-     * replaced with {@code proration_behavior=none}.
-     */
-    public Builder setProrate(Boolean prorate) {
-      this.prorate = prorate;
       return this;
     }
 

--- a/src/main/java/com/stripe/param/SubscriptionScheduleCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionScheduleCreateParams.java
@@ -369,8 +369,8 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
     InvoiceSettings invoiceSettings;
 
     /**
-     * The data with which to automatically create a Transfer for each of the subscription's
-     * invoices.
+     * The data with which to automatically create a Transfer for each of the associated
+     * subscription's invoices.
      */
     @SerializedName("transfer_data")
     Object transferData;
@@ -508,8 +508,8 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
       }
 
       /**
-       * The data with which to automatically create a Transfer for each of the subscription's
-       * invoices.
+       * The data with which to automatically create a Transfer for each of the associated
+       * subscription's invoices.
        */
       public Builder setTransferData(TransferData transferData) {
         this.transferData = transferData;
@@ -517,8 +517,8 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
       }
 
       /**
-       * The data with which to automatically create a Transfer for each of the subscription's
-       * invoices.
+       * The data with which to automatically create a Transfer for each of the associated
+       * subscription's invoices.
        */
       public Builder setTransferData(EmptyParam transferData) {
         this.transferData = transferData;
@@ -917,6 +917,13 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
     InvoiceSettings invoiceSettings;
 
     /**
+     * List of configuration items, each with an attached price, to apply during this phase of the
+     * subscription schedule.
+     */
+    @SerializedName("items")
+    List<Item> items;
+
+    /**
      * Integer representing the multiplier applied to the price interval. For example, {@code
      * iterations=2} applied to a price with {@code interval=month} and {@code interval_count=3}
      * results in a phase of duration {@code 2 * 3 months = 6 months}. If set, {@code end_date} must
@@ -924,13 +931,6 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
      */
     @SerializedName("iterations")
     Long iterations;
-
-    /**
-     * List of configuration items, each with an attached price, to apply during this phase of the
-     * subscription schedule.
-     */
-    @SerializedName("plans")
-    List<Plan> plans;
 
     /**
      * If a subscription schedule will create prorations when transitioning to this phase. Possible
@@ -942,21 +942,8 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
     ProrationBehavior prorationBehavior;
 
     /**
-     * A non-negative decimal (with at most four decimal places) between 0 and 100. This represents
-     * the percentage of the subscription invoice subtotal that will be calculated and added as tax
-     * to the final amount in each billing period during thise phase of the schedule. For example, a
-     * price which charges $10/month with a {@code tax_percent} of {@code 20.0} will charge $12 per
-     * invoice. To unset a previously-set value, pass an empty string. This field has been
-     * deprecated and will be removed in a future API version, for further information view the <a
-     * href="https://stripe.com/docs/billing/migration/taxes">migration docs</a> for {@code
-     * tax_rates}.
-     */
-    @SerializedName("tax_percent")
-    BigDecimal taxPercent;
-
-    /**
-     * The data with which to automatically create a Transfer for each of the subscription's
-     * invoices.
+     * The data with which to automatically create a Transfer for each of the associated
+     * subscription's invoices.
      */
     @SerializedName("transfer_data")
     TransferData transferData;
@@ -987,10 +974,9 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
         Long endDate,
         Map<String, Object> extraParams,
         InvoiceSettings invoiceSettings,
+        List<Item> items,
         Long iterations,
-        List<Plan> plans,
         ProrationBehavior prorationBehavior,
-        BigDecimal taxPercent,
         TransferData transferData,
         Boolean trial,
         Long trialEnd) {
@@ -1005,10 +991,9 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
       this.endDate = endDate;
       this.extraParams = extraParams;
       this.invoiceSettings = invoiceSettings;
+      this.items = items;
       this.iterations = iterations;
-      this.plans = plans;
       this.prorationBehavior = prorationBehavior;
-      this.taxPercent = taxPercent;
       this.transferData = transferData;
       this.trial = trial;
       this.trialEnd = trialEnd;
@@ -1041,13 +1026,11 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
 
       private InvoiceSettings invoiceSettings;
 
+      private List<Item> items;
+
       private Long iterations;
 
-      private List<Plan> plans;
-
       private ProrationBehavior prorationBehavior;
-
-      private BigDecimal taxPercent;
 
       private TransferData transferData;
 
@@ -1069,10 +1052,9 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
             this.endDate,
             this.extraParams,
             this.invoiceSettings,
+            this.items,
             this.iterations,
-            this.plans,
             this.prorationBehavior,
-            this.taxPercent,
             this.transferData,
             this.trial,
             this.trialEnd);
@@ -1270,6 +1252,32 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
       }
 
       /**
+       * Add an element to `items` list. A list is initialized for the first `add/addAll` call, and
+       * subsequent calls adds additional elements to the original list. See {@link
+       * SubscriptionScheduleCreateParams.Phase#items} for the field documentation.
+       */
+      public Builder addItem(Item element) {
+        if (this.items == null) {
+          this.items = new ArrayList<>();
+        }
+        this.items.add(element);
+        return this;
+      }
+
+      /**
+       * Add all elements to `items` list. A list is initialized for the first `add/addAll` call,
+       * and subsequent calls adds additional elements to the original list. See {@link
+       * SubscriptionScheduleCreateParams.Phase#items} for the field documentation.
+       */
+      public Builder addAllItem(List<Item> elements) {
+        if (this.items == null) {
+          this.items = new ArrayList<>();
+        }
+        this.items.addAll(elements);
+        return this;
+      }
+
+      /**
        * Integer representing the multiplier applied to the price interval. For example, {@code
        * iterations=2} applied to a price with {@code interval=month} and {@code interval_count=3}
        * results in a phase of duration {@code 2 * 3 months = 6 months}. If set, {@code end_date}
@@ -1277,32 +1285,6 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
        */
       public Builder setIterations(Long iterations) {
         this.iterations = iterations;
-        return this;
-      }
-
-      /**
-       * Add an element to `plans` list. A list is initialized for the first `add/addAll` call, and
-       * subsequent calls adds additional elements to the original list. See {@link
-       * SubscriptionScheduleCreateParams.Phase#plans} for the field documentation.
-       */
-      public Builder addPlan(Plan element) {
-        if (this.plans == null) {
-          this.plans = new ArrayList<>();
-        }
-        this.plans.add(element);
-        return this;
-      }
-
-      /**
-       * Add all elements to `plans` list. A list is initialized for the first `add/addAll` call,
-       * and subsequent calls adds additional elements to the original list. See {@link
-       * SubscriptionScheduleCreateParams.Phase#plans} for the field documentation.
-       */
-      public Builder addAllPlan(List<Plan> elements) {
-        if (this.plans == null) {
-          this.plans = new ArrayList<>();
-        }
-        this.plans.addAll(elements);
         return this;
       }
 
@@ -1318,23 +1300,8 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
       }
 
       /**
-       * A non-negative decimal (with at most four decimal places) between 0 and 100. This
-       * represents the percentage of the subscription invoice subtotal that will be calculated and
-       * added as tax to the final amount in each billing period during thise phase of the schedule.
-       * For example, a price which charges $10/month with a {@code tax_percent} of {@code 20.0}
-       * will charge $12 per invoice. To unset a previously-set value, pass an empty string. This
-       * field has been deprecated and will be removed in a future API version, for further
-       * information view the <a href="https://stripe.com/docs/billing/migration/taxes">migration
-       * docs</a> for {@code tax_rates}.
-       */
-      public Builder setTaxPercent(BigDecimal taxPercent) {
-        this.taxPercent = taxPercent;
-        return this;
-      }
-
-      /**
-       * The data with which to automatically create a Transfer for each of the subscription's
-       * invoices.
+       * The data with which to automatically create a Transfer for each of the associated
+       * subscription's invoices.
        */
       public Builder setTransferData(TransferData transferData) {
         this.transferData = transferData;
@@ -1773,7 +1740,7 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
     }
 
     @Getter
-    public static class Plan {
+    public static class Item {
       /**
        * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
        * billing period. When updating, pass an empty string to remove previously-defined
@@ -1825,7 +1792,7 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
       @SerializedName("tax_rates")
       Object taxRates;
 
-      private Plan(
+      private Item(
           Object billingThresholds,
           Map<String, Object> extraParams,
           String plan,
@@ -1862,8 +1829,8 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
         private Object taxRates;
 
         /** Finalize and obtain parameter instance from this builder. */
-        public Plan build() {
-          return new Plan(
+        public Item build() {
+          return new Item(
               this.billingThresholds,
               this.extraParams,
               this.plan,
@@ -1896,7 +1863,7 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
         /**
          * Add a key/value pair to `extraParams` map. A map is initialized for the first
          * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
-         * map. See {@link SubscriptionScheduleCreateParams.Phase.Plan#extraParams} for the field
+         * map. See {@link SubscriptionScheduleCreateParams.Phase.Item#extraParams} for the field
          * documentation.
          */
         public Builder putExtraParam(String key, Object value) {
@@ -1910,7 +1877,7 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
         /**
          * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
          * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
-         * map. See {@link SubscriptionScheduleCreateParams.Phase.Plan#extraParams} for the field
+         * map. See {@link SubscriptionScheduleCreateParams.Phase.Item#extraParams} for the field
          * documentation.
          */
         public Builder putAllExtraParam(Map<String, Object> map) {
@@ -1957,7 +1924,7 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
         /**
          * Add an element to `taxRates` list. A list is initialized for the first `add/addAll` call,
          * and subsequent calls adds additional elements to the original list. See {@link
-         * SubscriptionScheduleCreateParams.Phase.Plan#taxRates} for the field documentation.
+         * SubscriptionScheduleCreateParams.Phase.Item#taxRates} for the field documentation.
          */
         @SuppressWarnings("unchecked")
         public Builder addTaxRate(String element) {
@@ -1971,7 +1938,7 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
         /**
          * Add all elements to `taxRates` list. A list is initialized for the first `add/addAll`
          * call, and subsequent calls adds additional elements to the original list. See {@link
-         * SubscriptionScheduleCreateParams.Phase.Plan#taxRates} for the field documentation.
+         * SubscriptionScheduleCreateParams.Phase.Item#taxRates} for the field documentation.
          */
         @SuppressWarnings("unchecked")
         public Builder addAllTaxRate(List<String> elements) {
@@ -2046,7 +2013,7 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
            * Add a key/value pair to `extraParams` map. A map is initialized for the first
            * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
            * map. See {@link
-           * SubscriptionScheduleCreateParams.Phase.Plan.BillingThresholds#extraParams} for the
+           * SubscriptionScheduleCreateParams.Phase.Item.BillingThresholds#extraParams} for the
            * field documentation.
            */
           public Builder putExtraParam(String key, Object value) {
@@ -2061,7 +2028,7 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
            * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
            * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
            * map. See {@link
-           * SubscriptionScheduleCreateParams.Phase.Plan.BillingThresholds#extraParams} for the
+           * SubscriptionScheduleCreateParams.Phase.Item.BillingThresholds#extraParams} for the
            * field documentation.
            */
           public Builder putAllExtraParam(Map<String, Object> map) {
@@ -2176,7 +2143,7 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
           /**
            * Add a key/value pair to `extraParams` map. A map is initialized for the first
            * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
-           * map. See {@link SubscriptionScheduleCreateParams.Phase.Plan.PriceData#extraParams} for
+           * map. See {@link SubscriptionScheduleCreateParams.Phase.Item.PriceData#extraParams} for
            * the field documentation.
            */
           public Builder putExtraParam(String key, Object value) {
@@ -2190,7 +2157,7 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
           /**
            * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
            * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
-           * map. See {@link SubscriptionScheduleCreateParams.Phase.Plan.PriceData#extraParams} for
+           * map. See {@link SubscriptionScheduleCreateParams.Phase.Item.PriceData#extraParams} for
            * the field documentation.
            */
           public Builder putAllExtraParam(Map<String, Object> map) {
@@ -2286,7 +2253,7 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
              * Add a key/value pair to `extraParams` map. A map is initialized for the first
              * `put/putAll` call, and subsequent calls add additional key/value pairs to the
              * original map. See {@link
-             * SubscriptionScheduleCreateParams.Phase.Plan.PriceData.Recurring#extraParams} for the
+             * SubscriptionScheduleCreateParams.Phase.Item.PriceData.Recurring#extraParams} for the
              * field documentation.
              */
             public Builder putExtraParam(String key, Object value) {
@@ -2301,7 +2268,7 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
              * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
              * `put/putAll` call, and subsequent calls add additional key/value pairs to the
              * original map. See {@link
-             * SubscriptionScheduleCreateParams.Phase.Plan.PriceData.Recurring#extraParams} for the
+             * SubscriptionScheduleCreateParams.Phase.Item.PriceData.Recurring#extraParams} for the
              * field documentation.
              */
             public Builder putAllExtraParam(Map<String, Object> map) {

--- a/src/main/java/com/stripe/param/SubscriptionScheduleUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionScheduleUpdateParams.java
@@ -57,14 +57,6 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
   List<Phase> phases;
 
   /**
-   * This field has been renamed to {@code proration_behavior}. {@code prorate=true} can be replaced
-   * with {@code proration_behavior=create_prorations} and {@code prorate=false} can be replaced
-   * with {@code proration_behavior=none}.
-   */
-  @SerializedName("prorate")
-  Boolean prorate;
-
-  /**
    * If the update changes the current phase, indicates if the changes should be prorated. Possible
    * values are {@code create_prorations} or {@code none}, and the default value is {@code
    * create_prorations}.
@@ -79,7 +71,6 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
       Map<String, Object> extraParams,
       Object metadata,
       List<Phase> phases,
-      Boolean prorate,
       ProrationBehavior prorationBehavior) {
     this.defaultSettings = defaultSettings;
     this.endBehavior = endBehavior;
@@ -87,7 +78,6 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
     this.extraParams = extraParams;
     this.metadata = metadata;
     this.phases = phases;
-    this.prorate = prorate;
     this.prorationBehavior = prorationBehavior;
   }
 
@@ -108,8 +98,6 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
 
     private List<Phase> phases;
 
-    private Boolean prorate;
-
     private ProrationBehavior prorationBehavior;
 
     /** Finalize and obtain parameter instance from this builder. */
@@ -121,7 +109,6 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
           this.extraParams,
           this.metadata,
           this.phases,
-          this.prorate,
           this.prorationBehavior);
     }
 
@@ -271,16 +258,6 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
     }
 
     /**
-     * This field has been renamed to {@code proration_behavior}. {@code prorate=true} can be
-     * replaced with {@code proration_behavior=create_prorations} and {@code prorate=false} can be
-     * replaced with {@code proration_behavior=none}.
-     */
-    public Builder setProrate(Boolean prorate) {
-      this.prorate = prorate;
-      return this;
-    }
-
-    /**
      * If the update changes the current phase, indicates if the changes should be prorated.
      * Possible values are {@code create_prorations} or {@code none}, and the default value is
      * {@code create_prorations}.
@@ -341,8 +318,8 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
     InvoiceSettings invoiceSettings;
 
     /**
-     * The data with which to automatically create a Transfer for each of the subscription's
-     * invoices.
+     * The data with which to automatically create a Transfer for each of the associated
+     * subscription's invoices.
      */
     @SerializedName("transfer_data")
     Object transferData;
@@ -490,8 +467,8 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
       }
 
       /**
-       * The data with which to automatically create a Transfer for each of the subscription's
-       * invoices.
+       * The data with which to automatically create a Transfer for each of the associated
+       * subscription's invoices.
        */
       public Builder setTransferData(TransferData transferData) {
         this.transferData = transferData;
@@ -499,8 +476,8 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
       }
 
       /**
-       * The data with which to automatically create a Transfer for each of the subscription's
-       * invoices.
+       * The data with which to automatically create a Transfer for each of the associated
+       * subscription's invoices.
        */
       public Builder setTransferData(EmptyParam transferData) {
         this.transferData = transferData;
@@ -905,6 +882,13 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
     InvoiceSettings invoiceSettings;
 
     /**
+     * List of configuration items, each with an attached price, to apply during this phase of the
+     * subscription schedule.
+     */
+    @SerializedName("items")
+    List<Item> items;
+
+    /**
      * Integer representing the multiplier applied to the price interval. For example, {@code
      * iterations=2} applied to a price with {@code interval=month} and {@code interval_count=3}
      * results in a phase of duration {@code 2 * 3 months = 6 months}. If set, {@code end_date} must
@@ -912,13 +896,6 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
      */
     @SerializedName("iterations")
     Long iterations;
-
-    /**
-     * List of configuration items, each with an attached price, to apply during this phase of the
-     * subscription schedule.
-     */
-    @SerializedName("plans")
-    List<Plan> plans;
 
     /**
      * If a subscription schedule will create prorations when transitioning to this phase. Possible
@@ -937,21 +914,8 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
     Object startDate;
 
     /**
-     * A non-negative decimal (with at most four decimal places) between 0 and 100. This represents
-     * the percentage of the subscription invoice subtotal that will be calculated and added as tax
-     * to the final amount in each billing period during thise phase of the schedule. For example, a
-     * price which charges $10/month with a {@code tax_percent} of {@code 20.0} will charge $12 per
-     * invoice. To unset a previously-set value, pass an empty string. This field has been
-     * deprecated and will be removed in a future API version, for further information view the <a
-     * href="https://stripe.com/docs/billing/migration/taxes">migration docs</a> for {@code
-     * tax_rates}.
-     */
-    @SerializedName("tax_percent")
-    BigDecimal taxPercent;
-
-    /**
-     * The data with which to automatically create a Transfer for each of the subscription's
-     * invoices.
+     * The data with which to automatically create a Transfer for each of the associated
+     * subscription's invoices.
      */
     @SerializedName("transfer_data")
     TransferData transferData;
@@ -982,11 +946,10 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
         Object endDate,
         Map<String, Object> extraParams,
         InvoiceSettings invoiceSettings,
+        List<Item> items,
         Long iterations,
-        List<Plan> plans,
         ProrationBehavior prorationBehavior,
         Object startDate,
-        BigDecimal taxPercent,
         TransferData transferData,
         Boolean trial,
         Object trialEnd) {
@@ -1001,11 +964,10 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
       this.endDate = endDate;
       this.extraParams = extraParams;
       this.invoiceSettings = invoiceSettings;
+      this.items = items;
       this.iterations = iterations;
-      this.plans = plans;
       this.prorationBehavior = prorationBehavior;
       this.startDate = startDate;
-      this.taxPercent = taxPercent;
       this.transferData = transferData;
       this.trial = trial;
       this.trialEnd = trialEnd;
@@ -1038,15 +1000,13 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
 
       private InvoiceSettings invoiceSettings;
 
-      private Long iterations;
+      private List<Item> items;
 
-      private List<Plan> plans;
+      private Long iterations;
 
       private ProrationBehavior prorationBehavior;
 
       private Object startDate;
-
-      private BigDecimal taxPercent;
 
       private TransferData transferData;
 
@@ -1068,11 +1028,10 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
             this.endDate,
             this.extraParams,
             this.invoiceSettings,
+            this.items,
             this.iterations,
-            this.plans,
             this.prorationBehavior,
             this.startDate,
-            this.taxPercent,
             this.transferData,
             this.trial,
             this.trialEnd);
@@ -1295,6 +1254,32 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
       }
 
       /**
+       * Add an element to `items` list. A list is initialized for the first `add/addAll` call, and
+       * subsequent calls adds additional elements to the original list. See {@link
+       * SubscriptionScheduleUpdateParams.Phase#items} for the field documentation.
+       */
+      public Builder addItem(Item element) {
+        if (this.items == null) {
+          this.items = new ArrayList<>();
+        }
+        this.items.add(element);
+        return this;
+      }
+
+      /**
+       * Add all elements to `items` list. A list is initialized for the first `add/addAll` call,
+       * and subsequent calls adds additional elements to the original list. See {@link
+       * SubscriptionScheduleUpdateParams.Phase#items} for the field documentation.
+       */
+      public Builder addAllItem(List<Item> elements) {
+        if (this.items == null) {
+          this.items = new ArrayList<>();
+        }
+        this.items.addAll(elements);
+        return this;
+      }
+
+      /**
        * Integer representing the multiplier applied to the price interval. For example, {@code
        * iterations=2} applied to a price with {@code interval=month} and {@code interval_count=3}
        * results in a phase of duration {@code 2 * 3 months = 6 months}. If set, {@code end_date}
@@ -1302,32 +1287,6 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
        */
       public Builder setIterations(Long iterations) {
         this.iterations = iterations;
-        return this;
-      }
-
-      /**
-       * Add an element to `plans` list. A list is initialized for the first `add/addAll` call, and
-       * subsequent calls adds additional elements to the original list. See {@link
-       * SubscriptionScheduleUpdateParams.Phase#plans} for the field documentation.
-       */
-      public Builder addPlan(Plan element) {
-        if (this.plans == null) {
-          this.plans = new ArrayList<>();
-        }
-        this.plans.add(element);
-        return this;
-      }
-
-      /**
-       * Add all elements to `plans` list. A list is initialized for the first `add/addAll` call,
-       * and subsequent calls adds additional elements to the original list. See {@link
-       * SubscriptionScheduleUpdateParams.Phase#plans} for the field documentation.
-       */
-      public Builder addAllPlan(List<Plan> elements) {
-        if (this.plans == null) {
-          this.plans = new ArrayList<>();
-        }
-        this.plans.addAll(elements);
         return this;
       }
 
@@ -1361,23 +1320,8 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
       }
 
       /**
-       * A non-negative decimal (with at most four decimal places) between 0 and 100. This
-       * represents the percentage of the subscription invoice subtotal that will be calculated and
-       * added as tax to the final amount in each billing period during thise phase of the schedule.
-       * For example, a price which charges $10/month with a {@code tax_percent} of {@code 20.0}
-       * will charge $12 per invoice. To unset a previously-set value, pass an empty string. This
-       * field has been deprecated and will be removed in a future API version, for further
-       * information view the <a href="https://stripe.com/docs/billing/migration/taxes">migration
-       * docs</a> for {@code tax_rates}.
-       */
-      public Builder setTaxPercent(BigDecimal taxPercent) {
-        this.taxPercent = taxPercent;
-        return this;
-      }
-
-      /**
-       * The data with which to automatically create a Transfer for each of the subscription's
-       * invoices.
+       * The data with which to automatically create a Transfer for each of the associated
+       * subscription's invoices.
        */
       public Builder setTransferData(TransferData transferData) {
         this.transferData = transferData;
@@ -1857,7 +1801,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
     }
 
     @Getter
-    public static class Plan {
+    public static class Item {
       /**
        * Define thresholds at which an invoice will be sent, and the subscription advanced to a new
        * billing period. When updating, pass an empty string to remove previously-defined
@@ -1909,7 +1853,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
       @SerializedName("tax_rates")
       Object taxRates;
 
-      private Plan(
+      private Item(
           Object billingThresholds,
           Map<String, Object> extraParams,
           Object plan,
@@ -1946,8 +1890,8 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
         private Object taxRates;
 
         /** Finalize and obtain parameter instance from this builder. */
-        public Plan build() {
-          return new Plan(
+        public Item build() {
+          return new Item(
               this.billingThresholds,
               this.extraParams,
               this.plan,
@@ -1980,7 +1924,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
         /**
          * Add a key/value pair to `extraParams` map. A map is initialized for the first
          * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
-         * map. See {@link SubscriptionScheduleUpdateParams.Phase.Plan#extraParams} for the field
+         * map. See {@link SubscriptionScheduleUpdateParams.Phase.Item#extraParams} for the field
          * documentation.
          */
         public Builder putExtraParam(String key, Object value) {
@@ -1994,7 +1938,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
         /**
          * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
          * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
-         * map. See {@link SubscriptionScheduleUpdateParams.Phase.Plan#extraParams} for the field
+         * map. See {@link SubscriptionScheduleUpdateParams.Phase.Item#extraParams} for the field
          * documentation.
          */
         public Builder putAllExtraParam(Map<String, Object> map) {
@@ -2056,7 +2000,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
         /**
          * Add an element to `taxRates` list. A list is initialized for the first `add/addAll` call,
          * and subsequent calls adds additional elements to the original list. See {@link
-         * SubscriptionScheduleUpdateParams.Phase.Plan#taxRates} for the field documentation.
+         * SubscriptionScheduleUpdateParams.Phase.Item#taxRates} for the field documentation.
          */
         @SuppressWarnings("unchecked")
         public Builder addTaxRate(String element) {
@@ -2070,7 +2014,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
         /**
          * Add all elements to `taxRates` list. A list is initialized for the first `add/addAll`
          * call, and subsequent calls adds additional elements to the original list. See {@link
-         * SubscriptionScheduleUpdateParams.Phase.Plan#taxRates} for the field documentation.
+         * SubscriptionScheduleUpdateParams.Phase.Item#taxRates} for the field documentation.
          */
         @SuppressWarnings("unchecked")
         public Builder addAllTaxRate(List<String> elements) {
@@ -2145,7 +2089,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
            * Add a key/value pair to `extraParams` map. A map is initialized for the first
            * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
            * map. See {@link
-           * SubscriptionScheduleUpdateParams.Phase.Plan.BillingThresholds#extraParams} for the
+           * SubscriptionScheduleUpdateParams.Phase.Item.BillingThresholds#extraParams} for the
            * field documentation.
            */
           public Builder putExtraParam(String key, Object value) {
@@ -2160,7 +2104,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
            * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
            * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
            * map. See {@link
-           * SubscriptionScheduleUpdateParams.Phase.Plan.BillingThresholds#extraParams} for the
+           * SubscriptionScheduleUpdateParams.Phase.Item.BillingThresholds#extraParams} for the
            * field documentation.
            */
           public Builder putAllExtraParam(Map<String, Object> map) {
@@ -2285,7 +2229,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
           /**
            * Add a key/value pair to `extraParams` map. A map is initialized for the first
            * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
-           * map. See {@link SubscriptionScheduleUpdateParams.Phase.Plan.PriceData#extraParams} for
+           * map. See {@link SubscriptionScheduleUpdateParams.Phase.Item.PriceData#extraParams} for
            * the field documentation.
            */
           public Builder putExtraParam(String key, Object value) {
@@ -2299,7 +2243,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
           /**
            * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
            * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
-           * map. See {@link SubscriptionScheduleUpdateParams.Phase.Plan.PriceData#extraParams} for
+           * map. See {@link SubscriptionScheduleUpdateParams.Phase.Item.PriceData#extraParams} for
            * the field documentation.
            */
           public Builder putAllExtraParam(Map<String, Object> map) {
@@ -2411,7 +2355,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
              * Add a key/value pair to `extraParams` map. A map is initialized for the first
              * `put/putAll` call, and subsequent calls add additional key/value pairs to the
              * original map. See {@link
-             * SubscriptionScheduleUpdateParams.Phase.Plan.PriceData.Recurring#extraParams} for the
+             * SubscriptionScheduleUpdateParams.Phase.Item.PriceData.Recurring#extraParams} for the
              * field documentation.
              */
             public Builder putExtraParam(String key, Object value) {
@@ -2426,7 +2370,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
              * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
              * `put/putAll` call, and subsequent calls add additional key/value pairs to the
              * original map. See {@link
-             * SubscriptionScheduleUpdateParams.Phase.Plan.PriceData.Recurring#extraParams} for the
+             * SubscriptionScheduleUpdateParams.Phase.Item.PriceData.Recurring#extraParams} for the
              * field documentation.
              */
             public Builder putAllExtraParam(Map<String, Object> map) {

--- a/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
@@ -181,14 +181,6 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
   Object promotionCode;
 
   /**
-   * This field has been renamed to {@code proration_behavior}. {@code prorate=true} can be replaced
-   * with {@code proration_behavior=create_prorations} and {@code prorate=false} can be replaced
-   * with {@code proration_behavior=none}.
-   */
-  @SerializedName("prorate")
-  Boolean prorate;
-
-  /**
    * Determines how to handle <a
    * href="https://stripe.com/docs/subscriptions/billing-cycle#prorations">prorations</a> when the
    * billing cycle changes (e.g., when switching plans, resetting {@code billing_cycle_anchor=now},
@@ -215,19 +207,6 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
    */
   @SerializedName("proration_date")
   Long prorationDate;
-
-  /**
-   * A non-negative decimal (with at most four decimal places) between 0 and 100. This represents
-   * the percentage of the subscription invoice subtotal that will be calculated and added as tax to
-   * the final amount in each billing period. For example, a plan which charges $10/month with a
-   * {@code tax_percent} of {@code 20.0} will charge $12 per invoice. To unset a previously-set
-   * value, pass an empty string. This field has been deprecated and will be removed in a future API
-   * version, for further information view the <a
-   * href="https://stripe.com/docs/billing/migration/taxes">migration docs</a> for {@code
-   * tax_rates}.
-   */
-  @SerializedName("tax_percent")
-  Object taxPercent;
 
   /**
    * If specified, the funds from the subscription's invoices will be transferred to the destination
@@ -277,10 +256,8 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
       PaymentBehavior paymentBehavior,
       Object pendingInvoiceItemInterval,
       Object promotionCode,
-      Boolean prorate,
       ProrationBehavior prorationBehavior,
       Long prorationDate,
-      Object taxPercent,
       Object transferData,
       Object trialEnd,
       Boolean trialFromPlan) {
@@ -305,10 +282,8 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
     this.paymentBehavior = paymentBehavior;
     this.pendingInvoiceItemInterval = pendingInvoiceItemInterval;
     this.promotionCode = promotionCode;
-    this.prorate = prorate;
     this.prorationBehavior = prorationBehavior;
     this.prorationDate = prorationDate;
-    this.taxPercent = taxPercent;
     this.transferData = transferData;
     this.trialEnd = trialEnd;
     this.trialFromPlan = trialFromPlan;
@@ -361,13 +336,9 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
 
     private Object promotionCode;
 
-    private Boolean prorate;
-
     private ProrationBehavior prorationBehavior;
 
     private Long prorationDate;
-
-    private Object taxPercent;
 
     private Object transferData;
 
@@ -399,10 +370,8 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
           this.paymentBehavior,
           this.pendingInvoiceItemInterval,
           this.promotionCode,
-          this.prorate,
           this.prorationBehavior,
           this.prorationDate,
-          this.taxPercent,
           this.transferData,
           this.trialEnd,
           this.trialFromPlan);
@@ -844,16 +813,6 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
     }
 
     /**
-     * This field has been renamed to {@code proration_behavior}. {@code prorate=true} can be
-     * replaced with {@code proration_behavior=create_prorations} and {@code prorate=false} can be
-     * replaced with {@code proration_behavior=none}.
-     */
-    public Builder setProrate(Boolean prorate) {
-      this.prorate = prorate;
-      return this;
-    }
-
-    /**
      * Determines how to handle <a
      * href="https://stripe.com/docs/subscriptions/billing-cycle#prorations">prorations</a> when the
      * billing cycle changes (e.g., when switching plans, resetting {@code
@@ -882,36 +841,6 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
      */
     public Builder setProrationDate(Long prorationDate) {
       this.prorationDate = prorationDate;
-      return this;
-    }
-
-    /**
-     * A non-negative decimal (with at most four decimal places) between 0 and 100. This represents
-     * the percentage of the subscription invoice subtotal that will be calculated and added as tax
-     * to the final amount in each billing period. For example, a plan which charges $10/month with
-     * a {@code tax_percent} of {@code 20.0} will charge $12 per invoice. To unset a previously-set
-     * value, pass an empty string. This field has been deprecated and will be removed in a future
-     * API version, for further information view the <a
-     * href="https://stripe.com/docs/billing/migration/taxes">migration docs</a> for {@code
-     * tax_rates}.
-     */
-    public Builder setTaxPercent(BigDecimal taxPercent) {
-      this.taxPercent = taxPercent;
-      return this;
-    }
-
-    /**
-     * A non-negative decimal (with at most four decimal places) between 0 and 100. This represents
-     * the percentage of the subscription invoice subtotal that will be calculated and added as tax
-     * to the final amount in each billing period. For example, a plan which charges $10/month with
-     * a {@code tax_percent} of {@code 20.0} will charge $12 per invoice. To unset a previously-set
-     * value, pass an empty string. This field has been deprecated and will be removed in a future
-     * API version, for further information view the <a
-     * href="https://stripe.com/docs/billing/migration/taxes">migration docs</a> for {@code
-     * tax_rates}.
-     */
-    public Builder setTaxPercent(EmptyParam taxPercent) {
-      this.taxPercent = taxPercent;
       return this;
     }
 

--- a/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
+++ b/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
@@ -755,9 +755,6 @@ public class WebhookEndpointCreateParams extends ApiRequestParams {
     @SerializedName("invoice.payment_failed")
     INVOICE__PAYMENT_FAILED("invoice.payment_failed"),
 
-    @SerializedName("invoice.payment_succeeded")
-    INVOICE__PAYMENT_SUCCEEDED("invoice.payment_succeeded"),
-
     @SerializedName("invoice.sent")
     INVOICE__SENT("invoice.sent"),
 
@@ -856,9 +853,6 @@ public class WebhookEndpointCreateParams extends ApiRequestParams {
 
     @SerializedName("payment_method.attached")
     PAYMENT_METHOD__ATTACHED("payment_method.attached"),
-
-    @SerializedName("payment_method.card_automatically_updated")
-    PAYMENT_METHOD__CARD_AUTOMATICALLY_UPDATED("payment_method.card_automatically_updated"),
 
     @SerializedName("payment_method.detached")
     PAYMENT_METHOD__DETACHED("payment_method.detached"),

--- a/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
+++ b/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
@@ -558,7 +558,10 @@ public class WebhookEndpointCreateParams extends ApiRequestParams {
     VERSION_2019_12_03("2019-12-03"),
 
     @SerializedName("2020-03-02")
-    VERSION_2020_03_02("2020-03-02");
+    VERSION_2020_03_02("2020-03-02"),
+
+    @SerializedName("2020-08-27")
+    VERSION_2020_08_27("2020-08-27");
 
     @Getter(onMethod_ = {@Override})
     private final String value;

--- a/src/main/java/com/stripe/param/WebhookEndpointUpdateParams.java
+++ b/src/main/java/com/stripe/param/WebhookEndpointUpdateParams.java
@@ -443,9 +443,6 @@ public class WebhookEndpointUpdateParams extends ApiRequestParams {
     @SerializedName("invoice.payment_failed")
     INVOICE__PAYMENT_FAILED("invoice.payment_failed"),
 
-    @SerializedName("invoice.payment_succeeded")
-    INVOICE__PAYMENT_SUCCEEDED("invoice.payment_succeeded"),
-
     @SerializedName("invoice.sent")
     INVOICE__SENT("invoice.sent"),
 
@@ -544,9 +541,6 @@ public class WebhookEndpointUpdateParams extends ApiRequestParams {
 
     @SerializedName("payment_method.attached")
     PAYMENT_METHOD__ATTACHED("payment_method.attached"),
-
-    @SerializedName("payment_method.card_automatically_updated")
-    PAYMENT_METHOD__CARD_AUTOMATICALLY_UPDATED("payment_method.card_automatically_updated"),
 
     @SerializedName("payment_method.detached")
     PAYMENT_METHOD__DETACHED("payment_method.detached"),

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -33,7 +33,7 @@ import org.mockito.Mockito;
 
 public class BaseStripeTest {
   // If changing this number, please also change it in `.travis.yml`.
-  private static final String MOCK_MINIMUM_VERSION = "0.95.0";
+  private static final String MOCK_MINIMUM_VERSION = "0.96.0";
 
   private static String port;
 

--- a/src/test/java/com/stripe/functional/BankAccountTest.java
+++ b/src/test/java/com/stripe/functional/BankAccountTest.java
@@ -19,8 +19,17 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 public class BankAccountTest extends BaseStripeTest {
-  public static final String CUSTOMER_ID = "cus_123";
   public static final String BANK_ACCOUNT_ID = "ba_123";
+
+  private Customer getCustomerFixture() throws IOException {
+    // We want a mocked version of the customer that has the `sources` sub-list present
+    final Customer customer =
+        ApiResource.GSON.fromJson(
+            getResourceAsString("/api_fixtures/customer_with_sources_and_tax_ids.json"),
+            Customer.class);
+
+    return customer;
+  }
 
   private BankAccount getBankAccountFixture(Customer customer) throws IOException, StripeException {
     // stripe-mock doesn't handle bank accounts very well just yet, so use a local fixture
@@ -34,7 +43,7 @@ public class BankAccountTest extends BaseStripeTest {
 
   @Test
   public void testCreate() throws IOException, StripeException {
-    final Customer customer = Customer.retrieve(CUSTOMER_ID);
+    final Customer customer = getCustomerFixture();
 
     final Map<String, Object> params = new HashMap<>();
     params.put("source", "btok_123");
@@ -58,7 +67,7 @@ public class BankAccountTest extends BaseStripeTest {
 
   @Test
   public void testRetrieve() throws IOException, StripeException {
-    final Customer customer = Customer.retrieve(CUSTOMER_ID);
+    final Customer customer = getCustomerFixture();
 
     // stripe-mock does not always return a Bank Account so we have to mock
     stubRequest(
@@ -78,7 +87,7 @@ public class BankAccountTest extends BaseStripeTest {
 
   @Test
   public void testUpdate() throws IOException, StripeException {
-    final Customer customer = Customer.retrieve(CUSTOMER_ID);
+    final Customer customer = getCustomerFixture();
     final BankAccount bankAccount = getBankAccountFixture(customer);
 
     final Map<String, Object> metadata = new HashMap<>();
@@ -105,7 +114,7 @@ public class BankAccountTest extends BaseStripeTest {
 
   @Test
   public void testList() throws IOException, StripeException {
-    final Customer customer = Customer.retrieve(CUSTOMER_ID);
+    final Customer customer = getCustomerFixture();
 
     Map<String, Object> params = new HashMap<>();
     params.put("object", "bank_account");
@@ -139,7 +148,7 @@ public class BankAccountTest extends BaseStripeTest {
 
   @Test
   public void testDelete() throws IOException, StripeException {
-    final Customer customer = Customer.retrieve(CUSTOMER_ID);
+    final Customer customer = getCustomerFixture();
     final BankAccount bankAccount = getBankAccountFixture(customer);
     final String deleteBankAccountData =
         String.format(
@@ -163,7 +172,7 @@ public class BankAccountTest extends BaseStripeTest {
 
   @Test
   public void testVerify() throws IOException, StripeException {
-    final Customer customer = Customer.retrieve(CUSTOMER_ID);
+    final Customer customer = getCustomerFixture();
     final BankAccount bankAccount = getBankAccountFixture(customer);
 
     final List<Integer> values = new ArrayList<>();

--- a/src/test/java/com/stripe/functional/CardTest.java
+++ b/src/test/java/com/stripe/functional/CardTest.java
@@ -19,8 +19,17 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 public class CardTest extends BaseStripeTest {
-  public static final String CUSTOMER_ID = "cus_123";
   public static final String CARD_ID = "card_123";
+
+  private Customer getCustomerFixture() throws IOException {
+    // We want a mocked version of the customer that has the `sources` sub-list present
+    final Customer customer =
+        ApiResource.GSON.fromJson(
+            getResourceAsString("/api_fixtures/customer_with_sources_and_tax_ids.json"),
+            Customer.class);
+
+    return customer;
+  }
 
   private Card getCardFixture(Customer customer) throws IOException {
     // stripe-mock doesn't handle cards very well just yet, so use a local fixture
@@ -33,7 +42,7 @@ public class CardTest extends BaseStripeTest {
 
   @Test
   public void testCreate() throws IOException, StripeException {
-    final Customer customer = Customer.retrieve(CUSTOMER_ID);
+    final Customer customer = getCustomerFixture();
 
     final Map<String, Object> params = new HashMap<>();
     params.put("source", "btok_123");
@@ -57,7 +66,7 @@ public class CardTest extends BaseStripeTest {
 
   @Test
   public void testRetrieve() throws IOException, StripeException {
-    final Customer customer = Customer.retrieve(CUSTOMER_ID);
+    final Customer customer = getCustomerFixture();
 
     // stripe-mock returns a BankAccount instance instead of a Card
     stubRequest(
@@ -77,7 +86,7 @@ public class CardTest extends BaseStripeTest {
 
   @Test
   public void testUpdate() throws IOException, StripeException {
-    final Customer customer = Customer.retrieve(CUSTOMER_ID);
+    final Customer customer = getCustomerFixture();
     final Card card = getCardFixture(customer);
 
     final Map<String, Object> metadata = new HashMap<>();
@@ -96,8 +105,10 @@ public class CardTest extends BaseStripeTest {
 
   @Test
   public void testList() throws IOException, StripeException {
-    final Customer customer = Customer.retrieve(CUSTOMER_ID);
+    final Customer customer = getCustomerFixture();
 
+    System.out.println("remiremi");
+    System.out.println(customer.getSources());
     final Map<String, Object> params = new HashMap<>();
     params.put("object", "card");
     params.put("limit", 1);
@@ -128,7 +139,7 @@ public class CardTest extends BaseStripeTest {
 
   @Test
   public void testDelete() throws IOException, StripeException {
-    final Customer customer = Customer.retrieve(CUSTOMER_ID);
+    final Customer customer = getCustomerFixture();
     final Card card = getCardFixture(customer);
     final String deleteCardData =
         String.format("{\"id\": \"%s\", \"object\": \"card\", \"deleted\": true}", card.getId());

--- a/src/test/java/com/stripe/functional/InvoiceTest.java
+++ b/src/test/java/com/stripe/functional/InvoiceTest.java
@@ -14,7 +14,6 @@ import com.stripe.param.InvoiceCreateParams;
 import com.stripe.param.InvoiceUpcomingParams;
 import com.stripe.param.InvoiceUpdateParams;
 import com.stripe.param.common.EmptyParam;
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -81,7 +80,6 @@ public class InvoiceTest extends BaseStripeTest {
 
     final Map<String, Object> params = new HashMap<>();
     params.put("custom_fields", Arrays.asList(customField1, customField2));
-    params.put("tax_percent", new BigDecimal("12.45333"));
     params.put("metadata", metadata);
 
     InvoiceUpdateParams.CustomField typedCustomField1 =
@@ -93,7 +91,6 @@ public class InvoiceTest extends BaseStripeTest {
     InvoiceUpdateParams typedParams =
         InvoiceUpdateParams.builder()
             .setCustomFields(Arrays.asList(typedCustomField1, typedCustomField2))
-            .setTaxPercent(new BigDecimal("12.45333"))
             .putMetadata("key", "value")
             .build();
 
@@ -110,14 +107,14 @@ public class InvoiceTest extends BaseStripeTest {
     InvoiceUpdateParams typedParamsWithEmpty =
         InvoiceUpdateParams.builder()
             .setCustomFields(EmptyParam.EMPTY)
-            .setTaxPercent(EmptyParam.EMPTY)
+            .setDefaultPaymentMethod(EmptyParam.EMPTY)
             .build();
 
     Invoice updatedInvoice = invoice.update(typedParamsWithEmpty, RequestOptions.getDefault());
 
     Map<String, Object> paramsWithEmpty = new HashMap<>();
     paramsWithEmpty.put("custom_fields", null);
-    paramsWithEmpty.put("tax_percent", null);
+    paramsWithEmpty.put("default_payment_method", null);
 
     assertNotNull(updatedInvoice);
     verifyRequest(

--- a/src/test/java/com/stripe/model/SubscriptionTest.java
+++ b/src/test/java/com/stripe/model/SubscriptionTest.java
@@ -2,11 +2,9 @@ package com.stripe.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
-import java.math.BigDecimal;
 import org.junit.jupiter.api.Test;
 
 public class SubscriptionTest extends BaseStripeTest {
@@ -43,15 +41,5 @@ public class SubscriptionTest extends BaseStripeTest {
     assertNotNull(invoice);
     assertNotNull(invoice.getId());
     assertEquals(subscription.getLatestInvoice(), invoice.getId());
-  }
-
-  @Test
-  @SuppressWarnings("BigDecimalEquals")
-  public void testDeserializeBigDecimal() {
-    final String data = "{\"object\": \"subscription\", \"tax_percent\": 0.3}";
-    final Subscription subscription = ApiResource.GSON.fromJson(data, Subscription.class);
-    assertNotNull(subscription);
-    assertNotNull(subscription.getTaxPercent());
-    assertTrue(subscription.getTaxPercent().equals(new BigDecimal("0.3")));
   }
 }

--- a/src/test/java/com/stripe/model/TaxRateTest.java
+++ b/src/test/java/com/stripe/model/TaxRateTest.java
@@ -1,0 +1,31 @@
+package com.stripe.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.stripe.BaseStripeTest;
+import com.stripe.net.ApiResource;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Test;
+
+public class TaxRateTest extends BaseStripeTest {
+  @Test
+  public void testDeserialize() throws Exception {
+    final String data = getFixture("/v1/tax_rates/txr_123");
+    final TaxRate taxRate = ApiResource.GSON.fromJson(data, TaxRate.class);
+    assertNotNull(taxRate);
+    assertNotNull(taxRate.getId());
+    assertEquals("tax_rate", taxRate.getObject());
+  }
+
+  @Test
+  @SuppressWarnings("BigDecimalEquals")
+  public void testDeserializeBigDecimal() {
+    final String data = "{\"object\": \"tax_rate\", \"percentage\": 0.3}";
+    final TaxRate taxRate = ApiResource.GSON.fromJson(data, TaxRate.class);
+    assertNotNull(taxRate);
+    assertNotNull(taxRate.getPercentage());
+    assertTrue(taxRate.getPercentage().equals(new BigDecimal("0.3")));
+  }
+}

--- a/src/test/resources/api_fixtures/customer_with_sources_and_tax_ids.json
+++ b/src/test/resources/api_fixtures/customer_with_sources_and_tax_ids.json
@@ -1,0 +1,39 @@
+{
+  "id": "cus_123",
+  "object": "customer",
+  "address": null,
+  "balance": 0,
+  "created": 1598574431,
+  "currency": "usd",
+  "default_source": null,
+  "delinquent": false,
+  "description": null,
+  "discount": null,
+  "email": null,
+  "invoice_prefix": "657F4A3",
+  "invoice_settings": {
+    "custom_fields": null,
+    "default_payment_method": null,
+    "footer": null
+  },
+  "livemode": false,
+  "metadata": {},
+  "name": null,
+  "next_invoice_sequence": 1,
+  "phone": null,
+  "preferred_locales": [],
+  "shipping": null,
+  "sources": {
+    "object": "list",
+    "data": [],
+    "has_more": false,
+    "url": "/v1/customers/cus_123/sources"
+  },
+  "tax_exempt": "none",
+  "tax_ids": {
+    "object": "list",
+    "data": [],
+    "has_more": false,
+    "url": "/v1/customers/cus_123/tax_ids"
+  }
+}


### PR DESCRIPTION
Multiple API changes
  * Pin to API version `2020-08-27`
  * Removed `authenticated` and `succeeded` on `payment_method_details[card][three_d_secure]` on `Charge`
  * Removed `tax_percent` and `prorate` across all Billing APIs
  * Renamed `plans` to `items` on `SubscriptionSchedule`
  * Removed `display_items` on Checkout `Session`
  * Removed `save_payment_method` and `source` on `PaymentIntent` confirm, create and update. Those parameters still work in the API but are removed from the library
  * Removed `payment_method_details[bitcoin]` on `Charge`
  * Removed `unified_proration` on Billing API as this is a deprecated feature that never shipped publicly
  * Removed `plan` and `quantity` from `Subscription`, use `items` instead
  * Removed `requested_capabilities` on `Account` creation, use `capabilities` instead
  * Removed `failure_url` and `success_url` from `AccountLink`, use `refresh_url` and `return_url` instead
  * Removed `invoice.payment_succeeded` and `payment_method.card_automatically_updated` events.

Codegen for openapi 6c45bc9

cc @stripe/api-libraries 