### PR TITLE
Multiple API changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 env:
   global:
     # If changing this number, please also change it in `BaseStripeTest.java`.
-  - STRIPE_MOCK_VERSION=0.96.0
+  - STRIPE_MOCK_VERSION=0.98.0
 
 matrix:
   include:

--- a/src/main/java/com/stripe/model/BankAccount.java
+++ b/src/main/java/com/stripe/model/BankAccount.java
@@ -9,6 +9,7 @@ import com.stripe.net.RequestOptions;
 import com.stripe.param.BankAccountUpdateOnAccountParams;
 import com.stripe.param.BankAccountUpdateOnCustomerParams;
 import com.stripe.param.BankAccountVerifyParams;
+import java.util.List;
 import java.util.Map;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -35,6 +36,13 @@ public class BankAccount extends ApiResource
    */
   @SerializedName("account_holder_type")
   String accountHolderType;
+
+  /**
+   * A set of available payout methods for this bank account. Only values from this set should be
+   * passed as the {@code method} when creating a payout.
+   */
+  @SerializedName("available_payout_methods")
+  List<String> availablePayoutMethods;
 
   /** Name of the bank associated with the routing number (e.g., {@code WELLS FARGO}). */
   @SerializedName("bank_name")

--- a/src/main/java/com/stripe/model/Card.java
+++ b/src/main/java/com/stripe/model/Card.java
@@ -67,9 +67,8 @@ public class Card extends ApiResource
   String addressZipCheck;
 
   /**
-   * A set of available payout methods for this card. Will be either {@code ["standard"]} or {@code
-   * ["standard", "instant"]}. Only values from this set should be passed as the {@code method} when
-   * creating a transfer.
+   * A set of available payout methods for this card. Only values from this set should be passed as
+   * the {@code method} when creating a payout.
    */
   @SerializedName("available_payout_methods")
   List<String> availablePayoutMethods;

--- a/src/main/java/com/stripe/model/checkout/Session.java
+++ b/src/main/java/com/stripe/model/checkout/Session.java
@@ -153,6 +153,13 @@ public class Session extends ApiResource implements HasId {
   @SerializedName("payment_method_types")
   List<String> paymentMethodTypes;
 
+  /**
+   * The payment status of the Checkout Session, one of {@code paid}, {@code unpaid}, or {@code
+   * no_payment_required}. You can use this value to decide when to fulfill your customer's order.
+   */
+  @SerializedName("payment_status")
+  String paymentStatus;
+
   /** The ID of the SetupIntent for Checkout Sessions in {@code setup} mode. */
   @SerializedName("setup_intent")
   @Getter(lombok.AccessLevel.NONE)

--- a/src/main/java/com/stripe/model/issuing/Dispute.java
+++ b/src/main/java/com/stripe/model/issuing/Dispute.java
@@ -5,12 +5,16 @@ import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
 import com.stripe.model.BalanceTransaction;
 import com.stripe.model.ExpandableField;
+import com.stripe.model.File;
 import com.stripe.model.HasId;
+import com.stripe.model.MetadataStore;
+import com.stripe.model.StripeObject;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 import com.stripe.param.issuing.DisputeCreateParams;
 import com.stripe.param.issuing.DisputeListParams;
 import com.stripe.param.issuing.DisputeRetrieveParams;
+import com.stripe.param.issuing.DisputeSubmitParams;
 import com.stripe.param.issuing.DisputeUpdateParams;
 import java.util.List;
 import java.util.Map;
@@ -21,10 +25,28 @@ import lombok.Setter;
 @Getter
 @Setter
 @EqualsAndHashCode(callSuper = false)
-public class Dispute extends ApiResource implements HasId {
+public class Dispute extends ApiResource implements HasId, MetadataStore<Dispute> {
+  /**
+   * Disputed amount. Usually the amount of the {@code disputed_transaction}, but can differ
+   * (usually because of currency fluctuation).
+   */
+  @SerializedName("amount")
+  Long amount;
+
   /** List of balance transactions associated with the dispute. */
   @SerializedName("balance_transactions")
   List<BalanceTransaction> balanceTransactions;
+
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  @SerializedName("created")
+  Long created;
+
+  /** The currency the {@code disputed_transaction} was made in. */
+  @SerializedName("currency")
+  String currency;
+
+  @SerializedName("evidence")
+  Evidence evidence;
 
   /** Unique identifier for the object. */
   @Getter(onMethod_ = {@Override})
@@ -39,12 +61,30 @@ public class Dispute extends ApiResource implements HasId {
   Boolean livemode;
 
   /**
+   * Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can attach
+   * to an object. This can be useful for storing additional information about the object in a
+   * structured format.
+   */
+  @Getter(onMethod_ = {@Override})
+  @SerializedName("metadata")
+  Map<String, String> metadata;
+
+  /**
    * String representing the object's type. Objects of the same type share the same value.
    *
    * <p>Equal to {@code issuing.dispute}.
    */
   @SerializedName("object")
   String object;
+
+  /**
+   * Current status of the dispute.
+   *
+   * <p>One of {@code expired}, {@code lost}, {@code submitted}, {@code unsubmitted}, or {@code
+   * won}.
+   */
+  @SerializedName("status")
+  String status;
 
   /** The transaction being disputed. */
   @SerializedName("transaction")
@@ -159,6 +199,7 @@ public class Dispute extends ApiResource implements HasId {
    * parameters passed. Any parameters not provided will be left unchanged. Properties on the <code>
    * evidence</code> object can be unset by passing in an empty string.
    */
+  @Override
   public Dispute update(Map<String, Object> params) throws StripeException {
     return update(params, (RequestOptions) null);
   }
@@ -168,6 +209,7 @@ public class Dispute extends ApiResource implements HasId {
    * parameters passed. Any parameters not provided will be left unchanged. Properties on the <code>
    * evidence</code> object can be unset by passing in an empty string.
    */
+  @Override
   public Dispute update(Map<String, Object> params, RequestOptions options) throws StripeException {
     String url =
         String.format(
@@ -230,5 +272,579 @@ public class Dispute extends ApiResource implements HasId {
             Stripe.getApiBase(),
             String.format("/v1/issuing/disputes/%s", ApiResource.urlEncodeId(dispute)));
     return ApiResource.request(ApiResource.RequestMethod.GET, url, params, Dispute.class, options);
+  }
+
+  /**
+   * Submits an Issuing <code>Dispute</code> to the card network. Stripe validates that all evidence
+   * fields required for the dispute’s reason are present. For more details, see <a
+   * href="https://stripe.com/docs/issuing/purchases/disputes#dispute-reasons-and-evidence">Dispute
+   * reasons and evidence</a>.
+   */
+  public Dispute submit() throws StripeException {
+    return submit((Map<String, Object>) null, (RequestOptions) null);
+  }
+
+  /**
+   * Submits an Issuing <code>Dispute</code> to the card network. Stripe validates that all evidence
+   * fields required for the dispute’s reason are present. For more details, see <a
+   * href="https://stripe.com/docs/issuing/purchases/disputes#dispute-reasons-and-evidence">Dispute
+   * reasons and evidence</a>.
+   */
+  public Dispute submit(RequestOptions options) throws StripeException {
+    return submit((Map<String, Object>) null, options);
+  }
+
+  /**
+   * Submits an Issuing <code>Dispute</code> to the card network. Stripe validates that all evidence
+   * fields required for the dispute’s reason are present. For more details, see <a
+   * href="https://stripe.com/docs/issuing/purchases/disputes#dispute-reasons-and-evidence">Dispute
+   * reasons and evidence</a>.
+   */
+  public Dispute submit(Map<String, Object> params) throws StripeException {
+    return submit(params, (RequestOptions) null);
+  }
+
+  /**
+   * Submits an Issuing <code>Dispute</code> to the card network. Stripe validates that all evidence
+   * fields required for the dispute’s reason are present. For more details, see <a
+   * href="https://stripe.com/docs/issuing/purchases/disputes#dispute-reasons-and-evidence">Dispute
+   * reasons and evidence</a>.
+   */
+  public Dispute submit(Map<String, Object> params, RequestOptions options) throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/issuing/disputes/%s/submit", ApiResource.urlEncodeId(this.getId())));
+    return ApiResource.request(ApiResource.RequestMethod.POST, url, params, Dispute.class, options);
+  }
+
+  /**
+   * Submits an Issuing <code>Dispute</code> to the card network. Stripe validates that all evidence
+   * fields required for the dispute’s reason are present. For more details, see <a
+   * href="https://stripe.com/docs/issuing/purchases/disputes#dispute-reasons-and-evidence">Dispute
+   * reasons and evidence</a>.
+   */
+  public Dispute submit(DisputeSubmitParams params) throws StripeException {
+    return submit(params, (RequestOptions) null);
+  }
+
+  /**
+   * Submits an Issuing <code>Dispute</code> to the card network. Stripe validates that all evidence
+   * fields required for the dispute’s reason are present. For more details, see <a
+   * href="https://stripe.com/docs/issuing/purchases/disputes#dispute-reasons-and-evidence">Dispute
+   * reasons and evidence</a>.
+   */
+  public Dispute submit(DisputeSubmitParams params, RequestOptions options) throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/issuing/disputes/%s/submit", ApiResource.urlEncodeId(this.getId())));
+    return ApiResource.request(ApiResource.RequestMethod.POST, url, params, Dispute.class, options);
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class Evidence extends StripeObject {
+    @SerializedName("canceled")
+    Canceled canceled;
+
+    @SerializedName("duplicate")
+    Duplicate duplicate;
+
+    @SerializedName("fraudulent")
+    Fraudulent fraudulent;
+
+    @SerializedName("merchandise_not_as_described")
+    MerchandiseNotAsDescribed merchandiseNotAsDescribed;
+
+    @SerializedName("not_received")
+    NotReceived notReceived;
+
+    @SerializedName("other")
+    Other other;
+
+    /**
+     * The reason for filing the dispute. Its value will match the field containing the evidence.
+     *
+     * <p>One of {@code canceled}, {@code duplicate}, {@code fraudulent}, {@code
+     * merchandise_not_as_described}, {@code not_received}, {@code other}, or {@code
+     * service_not_as_described}.
+     */
+    @SerializedName("reason")
+    String reason;
+
+    @SerializedName("service_not_as_described")
+    ServiceNotAsDescribed serviceNotAsDescribed;
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class Canceled extends StripeObject {
+      /**
+       * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+       * documentation supporting the dispute.
+       */
+      @SerializedName("additional_documentation")
+      @Getter(lombok.AccessLevel.NONE)
+      @Setter(lombok.AccessLevel.NONE)
+      ExpandableField<File> additionalDocumentation;
+
+      /** Date when order was canceled. */
+      @SerializedName("canceled_at")
+      Long canceledAt;
+
+      /** Whether the cardholder was provided with a cancellation policy. */
+      @SerializedName("cancellation_policy_provided")
+      Boolean cancellationPolicyProvided;
+
+      /** Reason for canceling the order. */
+      @SerializedName("cancellation_reason")
+      String cancellationReason;
+
+      /** Date when the cardholder expected to receive the product. */
+      @SerializedName("expected_at")
+      Long expectedAt;
+
+      /** Explanation of why the cardholder is disputing this transaction. */
+      @SerializedName("explanation")
+      String explanation;
+
+      /** Description of the merchandise or service that was purchased. */
+      @SerializedName("product_description")
+      String productDescription;
+
+      /**
+       * Whether the product was a merchandise or service.
+       *
+       * <p>One of {@code merchandise}, or {@code service}.
+       */
+      @SerializedName("product_type")
+      String productType;
+
+      /**
+       * Result of cardholder's attempt to return the product.
+       *
+       * <p>One of {@code merchant_rejected}, or {@code successful}.
+       */
+      @SerializedName("return_status")
+      String returnStatus;
+
+      /** Date when the product was returned or attempted to be returned. */
+      @SerializedName("returned_at")
+      Long returnedAt;
+
+      /** Get ID of expandable {@code additionalDocumentation} object. */
+      public String getAdditionalDocumentation() {
+        return (this.additionalDocumentation != null) ? this.additionalDocumentation.getId() : null;
+      }
+
+      public void setAdditionalDocumentation(String id) {
+        this.additionalDocumentation =
+            ApiResource.setExpandableFieldId(id, this.additionalDocumentation);
+      }
+
+      /** Get expanded {@code additionalDocumentation}. */
+      public File getAdditionalDocumentationObject() {
+        return (this.additionalDocumentation != null)
+            ? this.additionalDocumentation.getExpanded()
+            : null;
+      }
+
+      public void setAdditionalDocumentationObject(File expandableObject) {
+        this.additionalDocumentation =
+            new ExpandableField<File>(expandableObject.getId(), expandableObject);
+      }
+    }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class Duplicate extends StripeObject {
+      /**
+       * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+       * documentation supporting the dispute.
+       */
+      @SerializedName("additional_documentation")
+      @Getter(lombok.AccessLevel.NONE)
+      @Setter(lombok.AccessLevel.NONE)
+      ExpandableField<File> additionalDocumentation;
+
+      /**
+       * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Copy of the
+       * card statement showing that the product had already been paid for.
+       */
+      @SerializedName("card_statement")
+      @Getter(lombok.AccessLevel.NONE)
+      @Setter(lombok.AccessLevel.NONE)
+      ExpandableField<File> cardStatement;
+
+      /**
+       * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Copy of the
+       * receipt showing that the product had been paid for in cash.
+       */
+      @SerializedName("cash_receipt")
+      @Getter(lombok.AccessLevel.NONE)
+      @Setter(lombok.AccessLevel.NONE)
+      ExpandableField<File> cashReceipt;
+
+      /**
+       * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Image of the
+       * front and back of the check that was used to pay for the product.
+       */
+      @SerializedName("check_image")
+      @Getter(lombok.AccessLevel.NONE)
+      @Setter(lombok.AccessLevel.NONE)
+      ExpandableField<File> checkImage;
+
+      /** Explanation of why the cardholder is disputing this transaction. */
+      @SerializedName("explanation")
+      String explanation;
+
+      /**
+       * Transaction (e.g., ipi_...) that the disputed transaction is a duplicate of. Of the two or
+       * more transactions that are copies of each other, this is original undisputed one.
+       */
+      @SerializedName("original_transaction")
+      String originalTransaction;
+
+      /** Get ID of expandable {@code additionalDocumentation} object. */
+      public String getAdditionalDocumentation() {
+        return (this.additionalDocumentation != null) ? this.additionalDocumentation.getId() : null;
+      }
+
+      public void setAdditionalDocumentation(String id) {
+        this.additionalDocumentation =
+            ApiResource.setExpandableFieldId(id, this.additionalDocumentation);
+      }
+
+      /** Get expanded {@code additionalDocumentation}. */
+      public File getAdditionalDocumentationObject() {
+        return (this.additionalDocumentation != null)
+            ? this.additionalDocumentation.getExpanded()
+            : null;
+      }
+
+      public void setAdditionalDocumentationObject(File expandableObject) {
+        this.additionalDocumentation =
+            new ExpandableField<File>(expandableObject.getId(), expandableObject);
+      }
+
+      /** Get ID of expandable {@code cardStatement} object. */
+      public String getCardStatement() {
+        return (this.cardStatement != null) ? this.cardStatement.getId() : null;
+      }
+
+      public void setCardStatement(String id) {
+        this.cardStatement = ApiResource.setExpandableFieldId(id, this.cardStatement);
+      }
+
+      /** Get expanded {@code cardStatement}. */
+      public File getCardStatementObject() {
+        return (this.cardStatement != null) ? this.cardStatement.getExpanded() : null;
+      }
+
+      public void setCardStatementObject(File expandableObject) {
+        this.cardStatement = new ExpandableField<File>(expandableObject.getId(), expandableObject);
+      }
+
+      /** Get ID of expandable {@code cashReceipt} object. */
+      public String getCashReceipt() {
+        return (this.cashReceipt != null) ? this.cashReceipt.getId() : null;
+      }
+
+      public void setCashReceipt(String id) {
+        this.cashReceipt = ApiResource.setExpandableFieldId(id, this.cashReceipt);
+      }
+
+      /** Get expanded {@code cashReceipt}. */
+      public File getCashReceiptObject() {
+        return (this.cashReceipt != null) ? this.cashReceipt.getExpanded() : null;
+      }
+
+      public void setCashReceiptObject(File expandableObject) {
+        this.cashReceipt = new ExpandableField<File>(expandableObject.getId(), expandableObject);
+      }
+
+      /** Get ID of expandable {@code checkImage} object. */
+      public String getCheckImage() {
+        return (this.checkImage != null) ? this.checkImage.getId() : null;
+      }
+
+      public void setCheckImage(String id) {
+        this.checkImage = ApiResource.setExpandableFieldId(id, this.checkImage);
+      }
+
+      /** Get expanded {@code checkImage}. */
+      public File getCheckImageObject() {
+        return (this.checkImage != null) ? this.checkImage.getExpanded() : null;
+      }
+
+      public void setCheckImageObject(File expandableObject) {
+        this.checkImage = new ExpandableField<File>(expandableObject.getId(), expandableObject);
+      }
+    }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class Fraudulent extends StripeObject {
+      /**
+       * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+       * documentation supporting the dispute.
+       */
+      @SerializedName("additional_documentation")
+      @Getter(lombok.AccessLevel.NONE)
+      @Setter(lombok.AccessLevel.NONE)
+      ExpandableField<File> additionalDocumentation;
+
+      /** Explanation of why the cardholder is disputing this transaction. */
+      @SerializedName("explanation")
+      String explanation;
+
+      /** Get ID of expandable {@code additionalDocumentation} object. */
+      public String getAdditionalDocumentation() {
+        return (this.additionalDocumentation != null) ? this.additionalDocumentation.getId() : null;
+      }
+
+      public void setAdditionalDocumentation(String id) {
+        this.additionalDocumentation =
+            ApiResource.setExpandableFieldId(id, this.additionalDocumentation);
+      }
+
+      /** Get expanded {@code additionalDocumentation}. */
+      public File getAdditionalDocumentationObject() {
+        return (this.additionalDocumentation != null)
+            ? this.additionalDocumentation.getExpanded()
+            : null;
+      }
+
+      public void setAdditionalDocumentationObject(File expandableObject) {
+        this.additionalDocumentation =
+            new ExpandableField<File>(expandableObject.getId(), expandableObject);
+      }
+    }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class MerchandiseNotAsDescribed extends StripeObject {
+      /**
+       * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+       * documentation supporting the dispute.
+       */
+      @SerializedName("additional_documentation")
+      @Getter(lombok.AccessLevel.NONE)
+      @Setter(lombok.AccessLevel.NONE)
+      ExpandableField<File> additionalDocumentation;
+
+      /** Explanation of why the cardholder is disputing this transaction. */
+      @SerializedName("explanation")
+      String explanation;
+
+      /** Date when the product was received. */
+      @SerializedName("received_at")
+      Long receivedAt;
+
+      /** Description of the cardholder's attempt to return the product. */
+      @SerializedName("return_description")
+      String returnDescription;
+
+      /**
+       * Result of cardholder's attempt to return the product.
+       *
+       * <p>One of {@code merchant_rejected}, or {@code successful}.
+       */
+      @SerializedName("return_status")
+      String returnStatus;
+
+      /** Date when the product was returned or attempted to be returned. */
+      @SerializedName("returned_at")
+      Long returnedAt;
+
+      /** Get ID of expandable {@code additionalDocumentation} object. */
+      public String getAdditionalDocumentation() {
+        return (this.additionalDocumentation != null) ? this.additionalDocumentation.getId() : null;
+      }
+
+      public void setAdditionalDocumentation(String id) {
+        this.additionalDocumentation =
+            ApiResource.setExpandableFieldId(id, this.additionalDocumentation);
+      }
+
+      /** Get expanded {@code additionalDocumentation}. */
+      public File getAdditionalDocumentationObject() {
+        return (this.additionalDocumentation != null)
+            ? this.additionalDocumentation.getExpanded()
+            : null;
+      }
+
+      public void setAdditionalDocumentationObject(File expandableObject) {
+        this.additionalDocumentation =
+            new ExpandableField<File>(expandableObject.getId(), expandableObject);
+      }
+    }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class NotReceived extends StripeObject {
+      /**
+       * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+       * documentation supporting the dispute.
+       */
+      @SerializedName("additional_documentation")
+      @Getter(lombok.AccessLevel.NONE)
+      @Setter(lombok.AccessLevel.NONE)
+      ExpandableField<File> additionalDocumentation;
+
+      /** Date when the cardholder expected to receive the product. */
+      @SerializedName("expected_at")
+      Long expectedAt;
+
+      /** Explanation of why the cardholder is disputing this transaction. */
+      @SerializedName("explanation")
+      String explanation;
+
+      /** Description of the merchandise or service that was purchased. */
+      @SerializedName("product_description")
+      String productDescription;
+
+      /**
+       * Whether the product was a merchandise or service.
+       *
+       * <p>One of {@code merchandise}, or {@code service}.
+       */
+      @SerializedName("product_type")
+      String productType;
+
+      /** Get ID of expandable {@code additionalDocumentation} object. */
+      public String getAdditionalDocumentation() {
+        return (this.additionalDocumentation != null) ? this.additionalDocumentation.getId() : null;
+      }
+
+      public void setAdditionalDocumentation(String id) {
+        this.additionalDocumentation =
+            ApiResource.setExpandableFieldId(id, this.additionalDocumentation);
+      }
+
+      /** Get expanded {@code additionalDocumentation}. */
+      public File getAdditionalDocumentationObject() {
+        return (this.additionalDocumentation != null)
+            ? this.additionalDocumentation.getExpanded()
+            : null;
+      }
+
+      public void setAdditionalDocumentationObject(File expandableObject) {
+        this.additionalDocumentation =
+            new ExpandableField<File>(expandableObject.getId(), expandableObject);
+      }
+    }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class Other extends StripeObject {
+      /**
+       * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+       * documentation supporting the dispute.
+       */
+      @SerializedName("additional_documentation")
+      @Getter(lombok.AccessLevel.NONE)
+      @Setter(lombok.AccessLevel.NONE)
+      ExpandableField<File> additionalDocumentation;
+
+      /** Explanation of why the cardholder is disputing this transaction. */
+      @SerializedName("explanation")
+      String explanation;
+
+      /** Description of the merchandise or service that was purchased. */
+      @SerializedName("product_description")
+      String productDescription;
+
+      /**
+       * Whether the product was a merchandise or service.
+       *
+       * <p>One of {@code merchandise}, or {@code service}.
+       */
+      @SerializedName("product_type")
+      String productType;
+
+      /** Get ID of expandable {@code additionalDocumentation} object. */
+      public String getAdditionalDocumentation() {
+        return (this.additionalDocumentation != null) ? this.additionalDocumentation.getId() : null;
+      }
+
+      public void setAdditionalDocumentation(String id) {
+        this.additionalDocumentation =
+            ApiResource.setExpandableFieldId(id, this.additionalDocumentation);
+      }
+
+      /** Get expanded {@code additionalDocumentation}. */
+      public File getAdditionalDocumentationObject() {
+        return (this.additionalDocumentation != null)
+            ? this.additionalDocumentation.getExpanded()
+            : null;
+      }
+
+      public void setAdditionalDocumentationObject(File expandableObject) {
+        this.additionalDocumentation =
+            new ExpandableField<File>(expandableObject.getId(), expandableObject);
+      }
+    }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class ServiceNotAsDescribed extends StripeObject {
+      /**
+       * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+       * documentation supporting the dispute.
+       */
+      @SerializedName("additional_documentation")
+      @Getter(lombok.AccessLevel.NONE)
+      @Setter(lombok.AccessLevel.NONE)
+      ExpandableField<File> additionalDocumentation;
+
+      /** Date when order was canceled. */
+      @SerializedName("canceled_at")
+      Long canceledAt;
+
+      /** Reason for canceling the order. */
+      @SerializedName("cancellation_reason")
+      String cancellationReason;
+
+      /** Explanation of why the cardholder is disputing this transaction. */
+      @SerializedName("explanation")
+      String explanation;
+
+      /** Date when the product was received. */
+      @SerializedName("received_at")
+      Long receivedAt;
+
+      /** Get ID of expandable {@code additionalDocumentation} object. */
+      public String getAdditionalDocumentation() {
+        return (this.additionalDocumentation != null) ? this.additionalDocumentation.getId() : null;
+      }
+
+      public void setAdditionalDocumentation(String id) {
+        this.additionalDocumentation =
+            ApiResource.setExpandableFieldId(id, this.additionalDocumentation);
+      }
+
+      /** Get expanded {@code additionalDocumentation}. */
+      public File getAdditionalDocumentationObject() {
+        return (this.additionalDocumentation != null)
+            ? this.additionalDocumentation.getExpanded()
+            : null;
+      }
+
+      public void setAdditionalDocumentationObject(File expandableObject) {
+        this.additionalDocumentation =
+            new ExpandableField<File>(expandableObject.getId(), expandableObject);
+      }
+    }
   }
 }

--- a/src/main/java/com/stripe/model/issuing/Transaction.java
+++ b/src/main/java/com/stripe/model/issuing/Transaction.java
@@ -78,6 +78,12 @@ public class Transaction extends ApiResource
   @SerializedName("currency")
   String currency;
 
+  /** If you've disputed the transaction, the ID of the dispute. */
+  @SerializedName("dispute")
+  @Getter(lombok.AccessLevel.NONE)
+  @Setter(lombok.AccessLevel.NONE)
+  ExpandableField<Dispute> dispute;
+
   /** Unique identifier for the object. */
   @Getter(onMethod_ = {@Override})
   @SerializedName("id")
@@ -129,7 +135,7 @@ public class Transaction extends ApiResource
   /**
    * The nature of the transaction.
    *
-   * <p>One of {@code capture}, or {@code refund}.
+   * <p>One of {@code capture}, {@code dispute}, or {@code refund}.
    */
   @SerializedName("type")
   String type;
@@ -206,6 +212,24 @@ public class Transaction extends ApiResource
 
   public void setCardholderObject(Cardholder expandableObject) {
     this.cardholder = new ExpandableField<Cardholder>(expandableObject.getId(), expandableObject);
+  }
+
+  /** Get ID of expandable {@code dispute} object. */
+  public String getDispute() {
+    return (this.dispute != null) ? this.dispute.getId() : null;
+  }
+
+  public void setDispute(String id) {
+    this.dispute = ApiResource.setExpandableFieldId(id, this.dispute);
+  }
+
+  /** Get expanded {@code dispute}. */
+  public Dispute getDisputeObject() {
+    return (this.dispute != null) ? this.dispute.getExpanded() : null;
+  }
+
+  public void setDisputeObject(Dispute expandableObject) {
+    this.dispute = new ExpandableField<Dispute>(expandableObject.getId(), expandableObject);
   }
 
   /**

--- a/src/main/java/com/stripe/model/reporting/ReportRun.java
+++ b/src/main/java/com/stripe/model/reporting/ReportRun.java
@@ -53,8 +53,8 @@ public class ReportRun extends ApiResource implements HasId {
   Parameters parameters;
 
   /**
-   * The ID of the <a href="https://stripe.com/docs/reporting/statements/api#report-types">report
-   * type</a> to run, such as {@code "balance.summary.1"}.
+   * The ID of the <a href="https://stripe.com/docs/reports/report-types">report type</a> to run,
+   * such as {@code "balance.summary.1"}.
    */
   @SerializedName("report_type")
   String reportType;

--- a/src/main/java/com/stripe/param/issuing/DisputeCreateParams.java
+++ b/src/main/java/com/stripe/param/issuing/DisputeCreateParams.java
@@ -2,6 +2,8 @@ package com.stripe.param.issuing;
 
 import com.google.gson.annotations.SerializedName;
 import com.stripe.net.ApiRequestParams;
+import com.stripe.net.ApiRequestParams.EnumParam;
+import com.stripe.param.common.EmptyParam;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -10,6 +12,10 @@ import lombok.Getter;
 
 @Getter
 public class DisputeCreateParams extends ApiRequestParams {
+  /** A hash containing all the evidence related to the dispute. */
+  @SerializedName("evidence")
+  Evidence evidence;
+
   /** Specifies which fields in the response should be expanded. */
   @SerializedName("expand")
   List<String> expand;
@@ -32,11 +38,21 @@ public class DisputeCreateParams extends ApiRequestParams {
   @SerializedName("metadata")
   Map<String, String> metadata;
 
+  /** The ID of the issuing transaction to create a dispute for. */
+  @SerializedName("transaction")
+  String transaction;
+
   private DisputeCreateParams(
-      List<String> expand, Map<String, Object> extraParams, Map<String, String> metadata) {
+      Evidence evidence,
+      List<String> expand,
+      Map<String, Object> extraParams,
+      Map<String, String> metadata,
+      String transaction) {
+    this.evidence = evidence;
     this.expand = expand;
     this.extraParams = extraParams;
     this.metadata = metadata;
+    this.transaction = transaction;
   }
 
   public static Builder builder() {
@@ -44,15 +60,26 @@ public class DisputeCreateParams extends ApiRequestParams {
   }
 
   public static class Builder {
+    private Evidence evidence;
+
     private List<String> expand;
 
     private Map<String, Object> extraParams;
 
     private Map<String, String> metadata;
 
+    private String transaction;
+
     /** Finalize and obtain parameter instance from this builder. */
     public DisputeCreateParams build() {
-      return new DisputeCreateParams(this.expand, this.extraParams, this.metadata);
+      return new DisputeCreateParams(
+          this.evidence, this.expand, this.extraParams, this.metadata, this.transaction);
+    }
+
+    /** A hash containing all the evidence related to the dispute. */
+    public Builder setEvidence(Evidence evidence) {
+      this.evidence = evidence;
+      return this;
     }
 
     /**
@@ -131,6 +158,1561 @@ public class DisputeCreateParams extends ApiRequestParams {
       }
       this.metadata.putAll(map);
       return this;
+    }
+
+    /** The ID of the issuing transaction to create a dispute for. */
+    public Builder setTransaction(String transaction) {
+      this.transaction = transaction;
+      return this;
+    }
+  }
+
+  @Getter
+  public static class Evidence {
+    /** Evidence provided when {@code reason} is 'canceled'. */
+    @SerializedName("canceled")
+    Object canceled;
+
+    /** Evidence provided when {@code reason} is 'duplicate'. */
+    @SerializedName("duplicate")
+    Object duplicate;
+
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /** Evidence provided when {@code reason} is 'fraudulent'. */
+    @SerializedName("fraudulent")
+    Object fraudulent;
+
+    /** Evidence provided when {@code reason} is 'merchandise_not_as_described'. */
+    @SerializedName("merchandise_not_as_described")
+    Object merchandiseNotAsDescribed;
+
+    /** Evidence provided when {@code reason} is 'not_received'. */
+    @SerializedName("not_received")
+    Object notReceived;
+
+    /** Evidence provided when {@code reason} is 'other'. */
+    @SerializedName("other")
+    Object other;
+
+    /**
+     * The reason for filing the dispute. The evidence should be submitted in the field of the same
+     * name.
+     */
+    @SerializedName("reason")
+    Reason reason;
+
+    /** Evidence provided when {@code reason} is 'service_not_as_described'. */
+    @SerializedName("service_not_as_described")
+    Object serviceNotAsDescribed;
+
+    private Evidence(
+        Object canceled,
+        Object duplicate,
+        Map<String, Object> extraParams,
+        Object fraudulent,
+        Object merchandiseNotAsDescribed,
+        Object notReceived,
+        Object other,
+        Reason reason,
+        Object serviceNotAsDescribed) {
+      this.canceled = canceled;
+      this.duplicate = duplicate;
+      this.extraParams = extraParams;
+      this.fraudulent = fraudulent;
+      this.merchandiseNotAsDescribed = merchandiseNotAsDescribed;
+      this.notReceived = notReceived;
+      this.other = other;
+      this.reason = reason;
+      this.serviceNotAsDescribed = serviceNotAsDescribed;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Object canceled;
+
+      private Object duplicate;
+
+      private Map<String, Object> extraParams;
+
+      private Object fraudulent;
+
+      private Object merchandiseNotAsDescribed;
+
+      private Object notReceived;
+
+      private Object other;
+
+      private Reason reason;
+
+      private Object serviceNotAsDescribed;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public Evidence build() {
+        return new Evidence(
+            this.canceled,
+            this.duplicate,
+            this.extraParams,
+            this.fraudulent,
+            this.merchandiseNotAsDescribed,
+            this.notReceived,
+            this.other,
+            this.reason,
+            this.serviceNotAsDescribed);
+      }
+
+      /** Evidence provided when {@code reason} is 'canceled'. */
+      public Builder setCanceled(Canceled canceled) {
+        this.canceled = canceled;
+        return this;
+      }
+
+      /** Evidence provided when {@code reason} is 'canceled'. */
+      public Builder setCanceled(EmptyParam canceled) {
+        this.canceled = canceled;
+        return this;
+      }
+
+      /** Evidence provided when {@code reason} is 'duplicate'. */
+      public Builder setDuplicate(Duplicate duplicate) {
+        this.duplicate = duplicate;
+        return this;
+      }
+
+      /** Evidence provided when {@code reason} is 'duplicate'. */
+      public Builder setDuplicate(EmptyParam duplicate) {
+        this.duplicate = duplicate;
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * DisputeCreateParams.Evidence#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link DisputeCreateParams.Evidence#extraParams} for the field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** Evidence provided when {@code reason} is 'fraudulent'. */
+      public Builder setFraudulent(Fraudulent fraudulent) {
+        this.fraudulent = fraudulent;
+        return this;
+      }
+
+      /** Evidence provided when {@code reason} is 'fraudulent'. */
+      public Builder setFraudulent(EmptyParam fraudulent) {
+        this.fraudulent = fraudulent;
+        return this;
+      }
+
+      /** Evidence provided when {@code reason} is 'merchandise_not_as_described'. */
+      public Builder setMerchandiseNotAsDescribed(
+          MerchandiseNotAsDescribed merchandiseNotAsDescribed) {
+        this.merchandiseNotAsDescribed = merchandiseNotAsDescribed;
+        return this;
+      }
+
+      /** Evidence provided when {@code reason} is 'merchandise_not_as_described'. */
+      public Builder setMerchandiseNotAsDescribed(EmptyParam merchandiseNotAsDescribed) {
+        this.merchandiseNotAsDescribed = merchandiseNotAsDescribed;
+        return this;
+      }
+
+      /** Evidence provided when {@code reason} is 'not_received'. */
+      public Builder setNotReceived(NotReceived notReceived) {
+        this.notReceived = notReceived;
+        return this;
+      }
+
+      /** Evidence provided when {@code reason} is 'not_received'. */
+      public Builder setNotReceived(EmptyParam notReceived) {
+        this.notReceived = notReceived;
+        return this;
+      }
+
+      /** Evidence provided when {@code reason} is 'other'. */
+      public Builder setOther(Other other) {
+        this.other = other;
+        return this;
+      }
+
+      /** Evidence provided when {@code reason} is 'other'. */
+      public Builder setOther(EmptyParam other) {
+        this.other = other;
+        return this;
+      }
+
+      /**
+       * The reason for filing the dispute. The evidence should be submitted in the field of the
+       * same name.
+       */
+      public Builder setReason(Reason reason) {
+        this.reason = reason;
+        return this;
+      }
+
+      /** Evidence provided when {@code reason} is 'service_not_as_described'. */
+      public Builder setServiceNotAsDescribed(ServiceNotAsDescribed serviceNotAsDescribed) {
+        this.serviceNotAsDescribed = serviceNotAsDescribed;
+        return this;
+      }
+
+      /** Evidence provided when {@code reason} is 'service_not_as_described'. */
+      public Builder setServiceNotAsDescribed(EmptyParam serviceNotAsDescribed) {
+        this.serviceNotAsDescribed = serviceNotAsDescribed;
+        return this;
+      }
+    }
+
+    @Getter
+    public static class Canceled {
+      /**
+       * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+       * documentation supporting the dispute.
+       */
+      @SerializedName("additional_documentation")
+      Object additionalDocumentation;
+
+      /** Date when order was canceled. */
+      @SerializedName("canceled_at")
+      Object canceledAt;
+
+      /** Whether the cardholder was provided with a cancellation policy. */
+      @SerializedName("cancellation_policy_provided")
+      Object cancellationPolicyProvided;
+
+      /** Reason for canceling the order. */
+      @SerializedName("cancellation_reason")
+      String cancellationReason;
+
+      /** Date when the cardholder expected to receive the product. */
+      @SerializedName("expected_at")
+      Object expectedAt;
+
+      /** Explanation of why the cardholder is disputing this transaction. */
+      @SerializedName("explanation")
+      String explanation;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Description of the merchandise or service that was purchased. */
+      @SerializedName("product_description")
+      String productDescription;
+
+      /** Whether the product was a merchandise or service. */
+      @SerializedName("product_type")
+      EnumParam productType;
+
+      /** Result of cardholder's attempt to return the product. */
+      @SerializedName("return_status")
+      EnumParam returnStatus;
+
+      /** Date when the product was returned or attempted to be returned. */
+      @SerializedName("returned_at")
+      Object returnedAt;
+
+      private Canceled(
+          Object additionalDocumentation,
+          Object canceledAt,
+          Object cancellationPolicyProvided,
+          String cancellationReason,
+          Object expectedAt,
+          String explanation,
+          Map<String, Object> extraParams,
+          String productDescription,
+          EnumParam productType,
+          EnumParam returnStatus,
+          Object returnedAt) {
+        this.additionalDocumentation = additionalDocumentation;
+        this.canceledAt = canceledAt;
+        this.cancellationPolicyProvided = cancellationPolicyProvided;
+        this.cancellationReason = cancellationReason;
+        this.expectedAt = expectedAt;
+        this.explanation = explanation;
+        this.extraParams = extraParams;
+        this.productDescription = productDescription;
+        this.productType = productType;
+        this.returnStatus = returnStatus;
+        this.returnedAt = returnedAt;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Object additionalDocumentation;
+
+        private Object canceledAt;
+
+        private Object cancellationPolicyProvided;
+
+        private String cancellationReason;
+
+        private Object expectedAt;
+
+        private String explanation;
+
+        private Map<String, Object> extraParams;
+
+        private String productDescription;
+
+        private EnumParam productType;
+
+        private EnumParam returnStatus;
+
+        private Object returnedAt;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Canceled build() {
+          return new Canceled(
+              this.additionalDocumentation,
+              this.canceledAt,
+              this.cancellationPolicyProvided,
+              this.cancellationReason,
+              this.expectedAt,
+              this.explanation,
+              this.extraParams,
+              this.productDescription,
+              this.productType,
+              this.returnStatus,
+              this.returnedAt);
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+         * documentation supporting the dispute.
+         */
+        public Builder setAdditionalDocumentation(String additionalDocumentation) {
+          this.additionalDocumentation = additionalDocumentation;
+          return this;
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+         * documentation supporting the dispute.
+         */
+        public Builder setAdditionalDocumentation(EmptyParam additionalDocumentation) {
+          this.additionalDocumentation = additionalDocumentation;
+          return this;
+        }
+
+        /** Date when order was canceled. */
+        public Builder setCanceledAt(Long canceledAt) {
+          this.canceledAt = canceledAt;
+          return this;
+        }
+
+        /** Date when order was canceled. */
+        public Builder setCanceledAt(EmptyParam canceledAt) {
+          this.canceledAt = canceledAt;
+          return this;
+        }
+
+        /** Whether the cardholder was provided with a cancellation policy. */
+        public Builder setCancellationPolicyProvided(Boolean cancellationPolicyProvided) {
+          this.cancellationPolicyProvided = cancellationPolicyProvided;
+          return this;
+        }
+
+        /** Whether the cardholder was provided with a cancellation policy. */
+        public Builder setCancellationPolicyProvided(EmptyParam cancellationPolicyProvided) {
+          this.cancellationPolicyProvided = cancellationPolicyProvided;
+          return this;
+        }
+
+        /** Reason for canceling the order. */
+        public Builder setCancellationReason(String cancellationReason) {
+          this.cancellationReason = cancellationReason;
+          return this;
+        }
+
+        /** Date when the cardholder expected to receive the product. */
+        public Builder setExpectedAt(Long expectedAt) {
+          this.expectedAt = expectedAt;
+          return this;
+        }
+
+        /** Date when the cardholder expected to receive the product. */
+        public Builder setExpectedAt(EmptyParam expectedAt) {
+          this.expectedAt = expectedAt;
+          return this;
+        }
+
+        /** Explanation of why the cardholder is disputing this transaction. */
+        public Builder setExplanation(String explanation) {
+          this.explanation = explanation;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link DisputeCreateParams.Evidence.Canceled#extraParams} for the field
+         * documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link DisputeCreateParams.Evidence.Canceled#extraParams} for the field
+         * documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Description of the merchandise or service that was purchased. */
+        public Builder setProductDescription(String productDescription) {
+          this.productDescription = productDescription;
+          return this;
+        }
+
+        /** Whether the product was a merchandise or service. */
+        public Builder setProductType(ProductType productType) {
+          this.productType = productType;
+          return this;
+        }
+
+        /** Whether the product was a merchandise or service. */
+        public Builder setProductType(EmptyParam productType) {
+          this.productType = productType;
+          return this;
+        }
+
+        /** Result of cardholder's attempt to return the product. */
+        public Builder setReturnStatus(ReturnStatus returnStatus) {
+          this.returnStatus = returnStatus;
+          return this;
+        }
+
+        /** Result of cardholder's attempt to return the product. */
+        public Builder setReturnStatus(EmptyParam returnStatus) {
+          this.returnStatus = returnStatus;
+          return this;
+        }
+
+        /** Date when the product was returned or attempted to be returned. */
+        public Builder setReturnedAt(Long returnedAt) {
+          this.returnedAt = returnedAt;
+          return this;
+        }
+
+        /** Date when the product was returned or attempted to be returned. */
+        public Builder setReturnedAt(EmptyParam returnedAt) {
+          this.returnedAt = returnedAt;
+          return this;
+        }
+      }
+
+      public enum ProductType implements ApiRequestParams.EnumParam {
+        @SerializedName("merchandise")
+        MERCHANDISE("merchandise"),
+
+        @SerializedName("service")
+        SERVICE("service");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        ProductType(String value) {
+          this.value = value;
+        }
+      }
+
+      public enum ReturnStatus implements ApiRequestParams.EnumParam {
+        @SerializedName("merchant_rejected")
+        MERCHANT_REJECTED("merchant_rejected"),
+
+        @SerializedName("successful")
+        SUCCESSFUL("successful");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        ReturnStatus(String value) {
+          this.value = value;
+        }
+      }
+    }
+
+    @Getter
+    public static class Duplicate {
+      /**
+       * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+       * documentation supporting the dispute.
+       */
+      @SerializedName("additional_documentation")
+      Object additionalDocumentation;
+
+      /**
+       * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Copy of the
+       * card statement showing that the product had already been paid for.
+       */
+      @SerializedName("card_statement")
+      Object cardStatement;
+
+      /**
+       * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Copy of the
+       * receipt showing that the product had been paid for in cash.
+       */
+      @SerializedName("cash_receipt")
+      Object cashReceipt;
+
+      /**
+       * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Image of the
+       * front and back of the check that was used to pay for the product.
+       */
+      @SerializedName("check_image")
+      Object checkImage;
+
+      /** Explanation of why the cardholder is disputing this transaction. */
+      @SerializedName("explanation")
+      String explanation;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /**
+       * Transaction (e.g., ipi_...) that the disputed transaction is a duplicate of. Of the two or
+       * more transactions that are copies of each other, this is original undisputed one.
+       */
+      @SerializedName("original_transaction")
+      String originalTransaction;
+
+      private Duplicate(
+          Object additionalDocumentation,
+          Object cardStatement,
+          Object cashReceipt,
+          Object checkImage,
+          String explanation,
+          Map<String, Object> extraParams,
+          String originalTransaction) {
+        this.additionalDocumentation = additionalDocumentation;
+        this.cardStatement = cardStatement;
+        this.cashReceipt = cashReceipt;
+        this.checkImage = checkImage;
+        this.explanation = explanation;
+        this.extraParams = extraParams;
+        this.originalTransaction = originalTransaction;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Object additionalDocumentation;
+
+        private Object cardStatement;
+
+        private Object cashReceipt;
+
+        private Object checkImage;
+
+        private String explanation;
+
+        private Map<String, Object> extraParams;
+
+        private String originalTransaction;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Duplicate build() {
+          return new Duplicate(
+              this.additionalDocumentation,
+              this.cardStatement,
+              this.cashReceipt,
+              this.checkImage,
+              this.explanation,
+              this.extraParams,
+              this.originalTransaction);
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+         * documentation supporting the dispute.
+         */
+        public Builder setAdditionalDocumentation(String additionalDocumentation) {
+          this.additionalDocumentation = additionalDocumentation;
+          return this;
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+         * documentation supporting the dispute.
+         */
+        public Builder setAdditionalDocumentation(EmptyParam additionalDocumentation) {
+          this.additionalDocumentation = additionalDocumentation;
+          return this;
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Copy of
+         * the card statement showing that the product had already been paid for.
+         */
+        public Builder setCardStatement(String cardStatement) {
+          this.cardStatement = cardStatement;
+          return this;
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Copy of
+         * the card statement showing that the product had already been paid for.
+         */
+        public Builder setCardStatement(EmptyParam cardStatement) {
+          this.cardStatement = cardStatement;
+          return this;
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Copy of
+         * the receipt showing that the product had been paid for in cash.
+         */
+        public Builder setCashReceipt(String cashReceipt) {
+          this.cashReceipt = cashReceipt;
+          return this;
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Copy of
+         * the receipt showing that the product had been paid for in cash.
+         */
+        public Builder setCashReceipt(EmptyParam cashReceipt) {
+          this.cashReceipt = cashReceipt;
+          return this;
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Image of
+         * the front and back of the check that was used to pay for the product.
+         */
+        public Builder setCheckImage(String checkImage) {
+          this.checkImage = checkImage;
+          return this;
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Image of
+         * the front and back of the check that was used to pay for the product.
+         */
+        public Builder setCheckImage(EmptyParam checkImage) {
+          this.checkImage = checkImage;
+          return this;
+        }
+
+        /** Explanation of why the cardholder is disputing this transaction. */
+        public Builder setExplanation(String explanation) {
+          this.explanation = explanation;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link DisputeCreateParams.Evidence.Duplicate#extraParams} for the field
+         * documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link DisputeCreateParams.Evidence.Duplicate#extraParams} for the field
+         * documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /**
+         * Transaction (e.g., ipi_...) that the disputed transaction is a duplicate of. Of the two
+         * or more transactions that are copies of each other, this is original undisputed one.
+         */
+        public Builder setOriginalTransaction(String originalTransaction) {
+          this.originalTransaction = originalTransaction;
+          return this;
+        }
+      }
+    }
+
+    @Getter
+    public static class Fraudulent {
+      /**
+       * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+       * documentation supporting the dispute.
+       */
+      @SerializedName("additional_documentation")
+      Object additionalDocumentation;
+
+      /** Explanation of why the cardholder is disputing this transaction. */
+      @SerializedName("explanation")
+      String explanation;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private Fraudulent(
+          Object additionalDocumentation, String explanation, Map<String, Object> extraParams) {
+        this.additionalDocumentation = additionalDocumentation;
+        this.explanation = explanation;
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Object additionalDocumentation;
+
+        private String explanation;
+
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Fraudulent build() {
+          return new Fraudulent(this.additionalDocumentation, this.explanation, this.extraParams);
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+         * documentation supporting the dispute.
+         */
+        public Builder setAdditionalDocumentation(String additionalDocumentation) {
+          this.additionalDocumentation = additionalDocumentation;
+          return this;
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+         * documentation supporting the dispute.
+         */
+        public Builder setAdditionalDocumentation(EmptyParam additionalDocumentation) {
+          this.additionalDocumentation = additionalDocumentation;
+          return this;
+        }
+
+        /** Explanation of why the cardholder is disputing this transaction. */
+        public Builder setExplanation(String explanation) {
+          this.explanation = explanation;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link DisputeCreateParams.Evidence.Fraudulent#extraParams} for the field
+         * documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link DisputeCreateParams.Evidence.Fraudulent#extraParams} for the field
+         * documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+      }
+    }
+
+    @Getter
+    public static class MerchandiseNotAsDescribed {
+      /**
+       * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+       * documentation supporting the dispute.
+       */
+      @SerializedName("additional_documentation")
+      Object additionalDocumentation;
+
+      /** Explanation of why the cardholder is disputing this transaction. */
+      @SerializedName("explanation")
+      String explanation;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Date when the product was received. */
+      @SerializedName("received_at")
+      Object receivedAt;
+
+      /** Description of the cardholder's attempt to return the product. */
+      @SerializedName("return_description")
+      String returnDescription;
+
+      /** Result of cardholder's attempt to return the product. */
+      @SerializedName("return_status")
+      EnumParam returnStatus;
+
+      /** Date when the product was returned or attempted to be returned. */
+      @SerializedName("returned_at")
+      Object returnedAt;
+
+      private MerchandiseNotAsDescribed(
+          Object additionalDocumentation,
+          String explanation,
+          Map<String, Object> extraParams,
+          Object receivedAt,
+          String returnDescription,
+          EnumParam returnStatus,
+          Object returnedAt) {
+        this.additionalDocumentation = additionalDocumentation;
+        this.explanation = explanation;
+        this.extraParams = extraParams;
+        this.receivedAt = receivedAt;
+        this.returnDescription = returnDescription;
+        this.returnStatus = returnStatus;
+        this.returnedAt = returnedAt;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Object additionalDocumentation;
+
+        private String explanation;
+
+        private Map<String, Object> extraParams;
+
+        private Object receivedAt;
+
+        private String returnDescription;
+
+        private EnumParam returnStatus;
+
+        private Object returnedAt;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public MerchandiseNotAsDescribed build() {
+          return new MerchandiseNotAsDescribed(
+              this.additionalDocumentation,
+              this.explanation,
+              this.extraParams,
+              this.receivedAt,
+              this.returnDescription,
+              this.returnStatus,
+              this.returnedAt);
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+         * documentation supporting the dispute.
+         */
+        public Builder setAdditionalDocumentation(String additionalDocumentation) {
+          this.additionalDocumentation = additionalDocumentation;
+          return this;
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+         * documentation supporting the dispute.
+         */
+        public Builder setAdditionalDocumentation(EmptyParam additionalDocumentation) {
+          this.additionalDocumentation = additionalDocumentation;
+          return this;
+        }
+
+        /** Explanation of why the cardholder is disputing this transaction. */
+        public Builder setExplanation(String explanation) {
+          this.explanation = explanation;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link DisputeCreateParams.Evidence.MerchandiseNotAsDescribed#extraParams} for
+         * the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link DisputeCreateParams.Evidence.MerchandiseNotAsDescribed#extraParams} for
+         * the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Date when the product was received. */
+        public Builder setReceivedAt(Long receivedAt) {
+          this.receivedAt = receivedAt;
+          return this;
+        }
+
+        /** Date when the product was received. */
+        public Builder setReceivedAt(EmptyParam receivedAt) {
+          this.receivedAt = receivedAt;
+          return this;
+        }
+
+        /** Description of the cardholder's attempt to return the product. */
+        public Builder setReturnDescription(String returnDescription) {
+          this.returnDescription = returnDescription;
+          return this;
+        }
+
+        /** Result of cardholder's attempt to return the product. */
+        public Builder setReturnStatus(ReturnStatus returnStatus) {
+          this.returnStatus = returnStatus;
+          return this;
+        }
+
+        /** Result of cardholder's attempt to return the product. */
+        public Builder setReturnStatus(EmptyParam returnStatus) {
+          this.returnStatus = returnStatus;
+          return this;
+        }
+
+        /** Date when the product was returned or attempted to be returned. */
+        public Builder setReturnedAt(Long returnedAt) {
+          this.returnedAt = returnedAt;
+          return this;
+        }
+
+        /** Date when the product was returned or attempted to be returned. */
+        public Builder setReturnedAt(EmptyParam returnedAt) {
+          this.returnedAt = returnedAt;
+          return this;
+        }
+      }
+
+      public enum ReturnStatus implements ApiRequestParams.EnumParam {
+        @SerializedName("merchant_rejected")
+        MERCHANT_REJECTED("merchant_rejected"),
+
+        @SerializedName("successful")
+        SUCCESSFUL("successful");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        ReturnStatus(String value) {
+          this.value = value;
+        }
+      }
+    }
+
+    @Getter
+    public static class NotReceived {
+      /**
+       * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+       * documentation supporting the dispute.
+       */
+      @SerializedName("additional_documentation")
+      Object additionalDocumentation;
+
+      /** Date when the cardholder expected to receive the product. */
+      @SerializedName("expected_at")
+      Object expectedAt;
+
+      /** Explanation of why the cardholder is disputing this transaction. */
+      @SerializedName("explanation")
+      String explanation;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Description of the merchandise or service that was purchased. */
+      @SerializedName("product_description")
+      String productDescription;
+
+      /** Whether the product was a merchandise or service. */
+      @SerializedName("product_type")
+      EnumParam productType;
+
+      private NotReceived(
+          Object additionalDocumentation,
+          Object expectedAt,
+          String explanation,
+          Map<String, Object> extraParams,
+          String productDescription,
+          EnumParam productType) {
+        this.additionalDocumentation = additionalDocumentation;
+        this.expectedAt = expectedAt;
+        this.explanation = explanation;
+        this.extraParams = extraParams;
+        this.productDescription = productDescription;
+        this.productType = productType;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Object additionalDocumentation;
+
+        private Object expectedAt;
+
+        private String explanation;
+
+        private Map<String, Object> extraParams;
+
+        private String productDescription;
+
+        private EnumParam productType;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public NotReceived build() {
+          return new NotReceived(
+              this.additionalDocumentation,
+              this.expectedAt,
+              this.explanation,
+              this.extraParams,
+              this.productDescription,
+              this.productType);
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+         * documentation supporting the dispute.
+         */
+        public Builder setAdditionalDocumentation(String additionalDocumentation) {
+          this.additionalDocumentation = additionalDocumentation;
+          return this;
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+         * documentation supporting the dispute.
+         */
+        public Builder setAdditionalDocumentation(EmptyParam additionalDocumentation) {
+          this.additionalDocumentation = additionalDocumentation;
+          return this;
+        }
+
+        /** Date when the cardholder expected to receive the product. */
+        public Builder setExpectedAt(Long expectedAt) {
+          this.expectedAt = expectedAt;
+          return this;
+        }
+
+        /** Date when the cardholder expected to receive the product. */
+        public Builder setExpectedAt(EmptyParam expectedAt) {
+          this.expectedAt = expectedAt;
+          return this;
+        }
+
+        /** Explanation of why the cardholder is disputing this transaction. */
+        public Builder setExplanation(String explanation) {
+          this.explanation = explanation;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link DisputeCreateParams.Evidence.NotReceived#extraParams} for the field
+         * documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link DisputeCreateParams.Evidence.NotReceived#extraParams} for the field
+         * documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Description of the merchandise or service that was purchased. */
+        public Builder setProductDescription(String productDescription) {
+          this.productDescription = productDescription;
+          return this;
+        }
+
+        /** Whether the product was a merchandise or service. */
+        public Builder setProductType(ProductType productType) {
+          this.productType = productType;
+          return this;
+        }
+
+        /** Whether the product was a merchandise or service. */
+        public Builder setProductType(EmptyParam productType) {
+          this.productType = productType;
+          return this;
+        }
+      }
+
+      public enum ProductType implements ApiRequestParams.EnumParam {
+        @SerializedName("merchandise")
+        MERCHANDISE("merchandise"),
+
+        @SerializedName("service")
+        SERVICE("service");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        ProductType(String value) {
+          this.value = value;
+        }
+      }
+    }
+
+    @Getter
+    public static class Other {
+      /**
+       * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+       * documentation supporting the dispute.
+       */
+      @SerializedName("additional_documentation")
+      Object additionalDocumentation;
+
+      /** Explanation of why the cardholder is disputing this transaction. */
+      @SerializedName("explanation")
+      String explanation;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Description of the merchandise or service that was purchased. */
+      @SerializedName("product_description")
+      String productDescription;
+
+      /** Whether the product was a merchandise or service. */
+      @SerializedName("product_type")
+      EnumParam productType;
+
+      private Other(
+          Object additionalDocumentation,
+          String explanation,
+          Map<String, Object> extraParams,
+          String productDescription,
+          EnumParam productType) {
+        this.additionalDocumentation = additionalDocumentation;
+        this.explanation = explanation;
+        this.extraParams = extraParams;
+        this.productDescription = productDescription;
+        this.productType = productType;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Object additionalDocumentation;
+
+        private String explanation;
+
+        private Map<String, Object> extraParams;
+
+        private String productDescription;
+
+        private EnumParam productType;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Other build() {
+          return new Other(
+              this.additionalDocumentation,
+              this.explanation,
+              this.extraParams,
+              this.productDescription,
+              this.productType);
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+         * documentation supporting the dispute.
+         */
+        public Builder setAdditionalDocumentation(String additionalDocumentation) {
+          this.additionalDocumentation = additionalDocumentation;
+          return this;
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+         * documentation supporting the dispute.
+         */
+        public Builder setAdditionalDocumentation(EmptyParam additionalDocumentation) {
+          this.additionalDocumentation = additionalDocumentation;
+          return this;
+        }
+
+        /** Explanation of why the cardholder is disputing this transaction. */
+        public Builder setExplanation(String explanation) {
+          this.explanation = explanation;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link DisputeCreateParams.Evidence.Other#extraParams} for the field
+         * documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link DisputeCreateParams.Evidence.Other#extraParams} for the field
+         * documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Description of the merchandise or service that was purchased. */
+        public Builder setProductDescription(String productDescription) {
+          this.productDescription = productDescription;
+          return this;
+        }
+
+        /** Whether the product was a merchandise or service. */
+        public Builder setProductType(ProductType productType) {
+          this.productType = productType;
+          return this;
+        }
+
+        /** Whether the product was a merchandise or service. */
+        public Builder setProductType(EmptyParam productType) {
+          this.productType = productType;
+          return this;
+        }
+      }
+
+      public enum ProductType implements ApiRequestParams.EnumParam {
+        @SerializedName("merchandise")
+        MERCHANDISE("merchandise"),
+
+        @SerializedName("service")
+        SERVICE("service");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        ProductType(String value) {
+          this.value = value;
+        }
+      }
+    }
+
+    @Getter
+    public static class ServiceNotAsDescribed {
+      /**
+       * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+       * documentation supporting the dispute.
+       */
+      @SerializedName("additional_documentation")
+      Object additionalDocumentation;
+
+      /** Date when order was canceled. */
+      @SerializedName("canceled_at")
+      Object canceledAt;
+
+      /** Reason for canceling the order. */
+      @SerializedName("cancellation_reason")
+      String cancellationReason;
+
+      /** Explanation of why the cardholder is disputing this transaction. */
+      @SerializedName("explanation")
+      String explanation;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Date when the product was received. */
+      @SerializedName("received_at")
+      Object receivedAt;
+
+      private ServiceNotAsDescribed(
+          Object additionalDocumentation,
+          Object canceledAt,
+          String cancellationReason,
+          String explanation,
+          Map<String, Object> extraParams,
+          Object receivedAt) {
+        this.additionalDocumentation = additionalDocumentation;
+        this.canceledAt = canceledAt;
+        this.cancellationReason = cancellationReason;
+        this.explanation = explanation;
+        this.extraParams = extraParams;
+        this.receivedAt = receivedAt;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Object additionalDocumentation;
+
+        private Object canceledAt;
+
+        private String cancellationReason;
+
+        private String explanation;
+
+        private Map<String, Object> extraParams;
+
+        private Object receivedAt;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public ServiceNotAsDescribed build() {
+          return new ServiceNotAsDescribed(
+              this.additionalDocumentation,
+              this.canceledAt,
+              this.cancellationReason,
+              this.explanation,
+              this.extraParams,
+              this.receivedAt);
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+         * documentation supporting the dispute.
+         */
+        public Builder setAdditionalDocumentation(String additionalDocumentation) {
+          this.additionalDocumentation = additionalDocumentation;
+          return this;
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+         * documentation supporting the dispute.
+         */
+        public Builder setAdditionalDocumentation(EmptyParam additionalDocumentation) {
+          this.additionalDocumentation = additionalDocumentation;
+          return this;
+        }
+
+        /** Date when order was canceled. */
+        public Builder setCanceledAt(Long canceledAt) {
+          this.canceledAt = canceledAt;
+          return this;
+        }
+
+        /** Date when order was canceled. */
+        public Builder setCanceledAt(EmptyParam canceledAt) {
+          this.canceledAt = canceledAt;
+          return this;
+        }
+
+        /** Reason for canceling the order. */
+        public Builder setCancellationReason(String cancellationReason) {
+          this.cancellationReason = cancellationReason;
+          return this;
+        }
+
+        /** Explanation of why the cardholder is disputing this transaction. */
+        public Builder setExplanation(String explanation) {
+          this.explanation = explanation;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link DisputeCreateParams.Evidence.ServiceNotAsDescribed#extraParams} for the
+         * field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link DisputeCreateParams.Evidence.ServiceNotAsDescribed#extraParams} for the
+         * field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Date when the product was received. */
+        public Builder setReceivedAt(Long receivedAt) {
+          this.receivedAt = receivedAt;
+          return this;
+        }
+
+        /** Date when the product was received. */
+        public Builder setReceivedAt(EmptyParam receivedAt) {
+          this.receivedAt = receivedAt;
+          return this;
+        }
+      }
+    }
+
+    public enum Reason implements ApiRequestParams.EnumParam {
+      @SerializedName("canceled")
+      CANCELED("canceled"),
+
+      @SerializedName("duplicate")
+      DUPLICATE("duplicate"),
+
+      @SerializedName("fraudulent")
+      FRAUDULENT("fraudulent"),
+
+      @SerializedName("merchandise_not_as_described")
+      MERCHANDISE_NOT_AS_DESCRIBED("merchandise_not_as_described"),
+
+      @SerializedName("not_received")
+      NOT_RECEIVED("not_received"),
+
+      @SerializedName("other")
+      OTHER("other"),
+
+      @SerializedName("service_not_as_described")
+      SERVICE_NOT_AS_DESCRIBED("service_not_as_described");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      Reason(String value) {
+        this.value = value;
+      }
     }
   }
 }

--- a/src/main/java/com/stripe/param/issuing/DisputeListParams.java
+++ b/src/main/java/com/stripe/param/issuing/DisputeListParams.java
@@ -10,6 +10,10 @@ import lombok.Getter;
 
 @Getter
 public class DisputeListParams extends ApiRequestParams {
+  /** Select Issuing disputes that were created during the given date interval. */
+  @SerializedName("created")
+  Object created;
+
   /**
    * A cursor for use in pagination. {@code ending_before} is an object ID that defines your place
    * in the list. For instance, if you make a list request and receive 100 objects, starting with
@@ -48,17 +52,31 @@ public class DisputeListParams extends ApiRequestParams {
   @SerializedName("starting_after")
   String startingAfter;
 
+  /** Select Issuing disputes with the given status. */
+  @SerializedName("status")
+  Status status;
+
+  /** Select the Issuing dispute for the given transaction. */
+  @SerializedName("transaction")
+  String transaction;
+
   private DisputeListParams(
+      Object created,
       String endingBefore,
       List<String> expand,
       Map<String, Object> extraParams,
       Long limit,
-      String startingAfter) {
+      String startingAfter,
+      Status status,
+      String transaction) {
+    this.created = created;
     this.endingBefore = endingBefore;
     this.expand = expand;
     this.extraParams = extraParams;
     this.limit = limit;
     this.startingAfter = startingAfter;
+    this.status = status;
+    this.transaction = transaction;
   }
 
   public static Builder builder() {
@@ -66,6 +84,8 @@ public class DisputeListParams extends ApiRequestParams {
   }
 
   public static class Builder {
+    private Object created;
+
     private String endingBefore;
 
     private List<String> expand;
@@ -76,10 +96,33 @@ public class DisputeListParams extends ApiRequestParams {
 
     private String startingAfter;
 
+    private Status status;
+
+    private String transaction;
+
     /** Finalize and obtain parameter instance from this builder. */
     public DisputeListParams build() {
       return new DisputeListParams(
-          this.endingBefore, this.expand, this.extraParams, this.limit, this.startingAfter);
+          this.created,
+          this.endingBefore,
+          this.expand,
+          this.extraParams,
+          this.limit,
+          this.startingAfter,
+          this.status,
+          this.transaction);
+    }
+
+    /** Select Issuing disputes that were created during the given date interval. */
+    public Builder setCreated(Created created) {
+      this.created = created;
+      return this;
+    }
+
+    /** Select Issuing disputes that were created during the given date interval. */
+    public Builder setCreated(Long created) {
+      this.created = created;
+      return this;
     }
 
     /**
@@ -163,6 +206,149 @@ public class DisputeListParams extends ApiRequestParams {
     public Builder setStartingAfter(String startingAfter) {
       this.startingAfter = startingAfter;
       return this;
+    }
+
+    /** Select Issuing disputes with the given status. */
+    public Builder setStatus(Status status) {
+      this.status = status;
+      return this;
+    }
+
+    /** Select the Issuing dispute for the given transaction. */
+    public Builder setTransaction(String transaction) {
+      this.transaction = transaction;
+      return this;
+    }
+  }
+
+  @Getter
+  public static class Created {
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /** Minimum value to filter by (exclusive). */
+    @SerializedName("gt")
+    Long gt;
+
+    /** Minimum value to filter by (inclusive). */
+    @SerializedName("gte")
+    Long gte;
+
+    /** Maximum value to filter by (exclusive). */
+    @SerializedName("lt")
+    Long lt;
+
+    /** Maximum value to filter by (inclusive). */
+    @SerializedName("lte")
+    Long lte;
+
+    private Created(Map<String, Object> extraParams, Long gt, Long gte, Long lt, Long lte) {
+      this.extraParams = extraParams;
+      this.gt = gt;
+      this.gte = gte;
+      this.lt = lt;
+      this.lte = lte;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Map<String, Object> extraParams;
+
+      private Long gt;
+
+      private Long gte;
+
+      private Long lt;
+
+      private Long lte;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public Created build() {
+        return new Created(this.extraParams, this.gt, this.gte, this.lt, this.lte);
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * DisputeListParams.Created#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link DisputeListParams.Created#extraParams} for the field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** Minimum value to filter by (exclusive). */
+      public Builder setGt(Long gt) {
+        this.gt = gt;
+        return this;
+      }
+
+      /** Minimum value to filter by (inclusive). */
+      public Builder setGte(Long gte) {
+        this.gte = gte;
+        return this;
+      }
+
+      /** Maximum value to filter by (exclusive). */
+      public Builder setLt(Long lt) {
+        this.lt = lt;
+        return this;
+      }
+
+      /** Maximum value to filter by (inclusive). */
+      public Builder setLte(Long lte) {
+        this.lte = lte;
+        return this;
+      }
+    }
+  }
+
+  public enum Status implements ApiRequestParams.EnumParam {
+    @SerializedName("expired")
+    EXPIRED("expired"),
+
+    @SerializedName("lost")
+    LOST("lost"),
+
+    @SerializedName("submitted")
+    SUBMITTED("submitted"),
+
+    @SerializedName("unsubmitted")
+    UNSUBMITTED("unsubmitted"),
+
+    @SerializedName("won")
+    WON("won");
+
+    @Getter(onMethod_ = {@Override})
+    private final String value;
+
+    Status(String value) {
+      this.value = value;
     }
   }
 }

--- a/src/main/java/com/stripe/param/issuing/DisputeSubmitParams.java
+++ b/src/main/java/com/stripe/param/issuing/DisputeSubmitParams.java
@@ -1,0 +1,161 @@
+package com.stripe.param.issuing;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import com.stripe.param.common.EmptyParam;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class DisputeSubmitParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  /**
+   * Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can attach
+   * to an object. This can be useful for storing additional information about the object in a
+   * structured format. Individual keys can be unset by posting an empty value to them. All keys can
+   * be unset by posting an empty value to {@code metadata}.
+   */
+  @SerializedName("metadata")
+  Object metadata;
+
+  private DisputeSubmitParams(
+      List<String> expand, Map<String, Object> extraParams, Object metadata) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+    this.metadata = metadata;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    private Object metadata;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public DisputeSubmitParams build() {
+      return new DisputeSubmitParams(this.expand, this.extraParams, this.metadata);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * DisputeSubmitParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * DisputeSubmitParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * DisputeSubmitParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link DisputeSubmitParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `metadata` map. A map is initialized for the first `put/putAll` call,
+     * and subsequent calls add additional key/value pairs to the original map. See {@link
+     * DisputeSubmitParams#metadata} for the field documentation.
+     */
+    @SuppressWarnings("unchecked")
+    public Builder putMetadata(String key, String value) {
+      if (this.metadata == null || this.metadata instanceof EmptyParam) {
+        this.metadata = new HashMap<String, String>();
+      }
+      ((Map<String, String>) this.metadata).put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `metadata` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link DisputeSubmitParams#metadata} for the field documentation.
+     */
+    @SuppressWarnings("unchecked")
+    public Builder putAllMetadata(Map<String, String> map) {
+      if (this.metadata == null || this.metadata instanceof EmptyParam) {
+        this.metadata = new HashMap<String, String>();
+      }
+      ((Map<String, String>) this.metadata).putAll(map);
+      return this;
+    }
+
+    /**
+     * Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can attach
+     * to an object. This can be useful for storing additional information about the object in a
+     * structured format. Individual keys can be unset by posting an empty value to them. All keys
+     * can be unset by posting an empty value to {@code metadata}.
+     */
+    public Builder setMetadata(EmptyParam metadata) {
+      this.metadata = metadata;
+      return this;
+    }
+
+    /**
+     * Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can attach
+     * to an object. This can be useful for storing additional information about the object in a
+     * structured format. Individual keys can be unset by posting an empty value to them. All keys
+     * can be unset by posting an empty value to {@code metadata}.
+     */
+    public Builder setMetadata(Map<String, String> metadata) {
+      this.metadata = metadata;
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/issuing/DisputeUpdateParams.java
+++ b/src/main/java/com/stripe/param/issuing/DisputeUpdateParams.java
@@ -2,6 +2,7 @@ package com.stripe.param.issuing;
 
 import com.google.gson.annotations.SerializedName;
 import com.stripe.net.ApiRequestParams;
+import com.stripe.net.ApiRequestParams.EnumParam;
 import com.stripe.param.common.EmptyParam;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -11,6 +12,10 @@ import lombok.Getter;
 
 @Getter
 public class DisputeUpdateParams extends ApiRequestParams {
+  /** A hash containing all the evidence related to the dispute. */
+  @SerializedName("evidence")
+  Evidence evidence;
+
   /** Specifies which fields in the response should be expanded. */
   @SerializedName("expand")
   List<String> expand;
@@ -34,7 +39,8 @@ public class DisputeUpdateParams extends ApiRequestParams {
   Object metadata;
 
   private DisputeUpdateParams(
-      List<String> expand, Map<String, Object> extraParams, Object metadata) {
+      Evidence evidence, List<String> expand, Map<String, Object> extraParams, Object metadata) {
+    this.evidence = evidence;
     this.expand = expand;
     this.extraParams = extraParams;
     this.metadata = metadata;
@@ -45,6 +51,8 @@ public class DisputeUpdateParams extends ApiRequestParams {
   }
 
   public static class Builder {
+    private Evidence evidence;
+
     private List<String> expand;
 
     private Map<String, Object> extraParams;
@@ -53,7 +61,13 @@ public class DisputeUpdateParams extends ApiRequestParams {
 
     /** Finalize and obtain parameter instance from this builder. */
     public DisputeUpdateParams build() {
-      return new DisputeUpdateParams(this.expand, this.extraParams, this.metadata);
+      return new DisputeUpdateParams(this.evidence, this.expand, this.extraParams, this.metadata);
+    }
+
+    /** A hash containing all the evidence related to the dispute. */
+    public Builder setEvidence(Evidence evidence) {
+      this.evidence = evidence;
+      return this;
     }
 
     /**
@@ -156,6 +170,1642 @@ public class DisputeUpdateParams extends ApiRequestParams {
     public Builder setMetadata(Map<String, String> metadata) {
       this.metadata = metadata;
       return this;
+    }
+  }
+
+  @Getter
+  public static class Evidence {
+    /** Evidence provided when {@code reason} is 'canceled'. */
+    @SerializedName("canceled")
+    Object canceled;
+
+    /** Evidence provided when {@code reason} is 'duplicate'. */
+    @SerializedName("duplicate")
+    Object duplicate;
+
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /** Evidence provided when {@code reason} is 'fraudulent'. */
+    @SerializedName("fraudulent")
+    Object fraudulent;
+
+    /** Evidence provided when {@code reason} is 'merchandise_not_as_described'. */
+    @SerializedName("merchandise_not_as_described")
+    Object merchandiseNotAsDescribed;
+
+    /** Evidence provided when {@code reason} is 'not_received'. */
+    @SerializedName("not_received")
+    Object notReceived;
+
+    /** Evidence provided when {@code reason} is 'other'. */
+    @SerializedName("other")
+    Object other;
+
+    /**
+     * The reason for filing the dispute. The evidence should be submitted in the field of the same
+     * name.
+     */
+    @SerializedName("reason")
+    Reason reason;
+
+    /** Evidence provided when {@code reason} is 'service_not_as_described'. */
+    @SerializedName("service_not_as_described")
+    Object serviceNotAsDescribed;
+
+    private Evidence(
+        Object canceled,
+        Object duplicate,
+        Map<String, Object> extraParams,
+        Object fraudulent,
+        Object merchandiseNotAsDescribed,
+        Object notReceived,
+        Object other,
+        Reason reason,
+        Object serviceNotAsDescribed) {
+      this.canceled = canceled;
+      this.duplicate = duplicate;
+      this.extraParams = extraParams;
+      this.fraudulent = fraudulent;
+      this.merchandiseNotAsDescribed = merchandiseNotAsDescribed;
+      this.notReceived = notReceived;
+      this.other = other;
+      this.reason = reason;
+      this.serviceNotAsDescribed = serviceNotAsDescribed;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Object canceled;
+
+      private Object duplicate;
+
+      private Map<String, Object> extraParams;
+
+      private Object fraudulent;
+
+      private Object merchandiseNotAsDescribed;
+
+      private Object notReceived;
+
+      private Object other;
+
+      private Reason reason;
+
+      private Object serviceNotAsDescribed;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public Evidence build() {
+        return new Evidence(
+            this.canceled,
+            this.duplicate,
+            this.extraParams,
+            this.fraudulent,
+            this.merchandiseNotAsDescribed,
+            this.notReceived,
+            this.other,
+            this.reason,
+            this.serviceNotAsDescribed);
+      }
+
+      /** Evidence provided when {@code reason} is 'canceled'. */
+      public Builder setCanceled(Canceled canceled) {
+        this.canceled = canceled;
+        return this;
+      }
+
+      /** Evidence provided when {@code reason} is 'canceled'. */
+      public Builder setCanceled(EmptyParam canceled) {
+        this.canceled = canceled;
+        return this;
+      }
+
+      /** Evidence provided when {@code reason} is 'duplicate'. */
+      public Builder setDuplicate(Duplicate duplicate) {
+        this.duplicate = duplicate;
+        return this;
+      }
+
+      /** Evidence provided when {@code reason} is 'duplicate'. */
+      public Builder setDuplicate(EmptyParam duplicate) {
+        this.duplicate = duplicate;
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * DisputeUpdateParams.Evidence#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link DisputeUpdateParams.Evidence#extraParams} for the field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** Evidence provided when {@code reason} is 'fraudulent'. */
+      public Builder setFraudulent(Fraudulent fraudulent) {
+        this.fraudulent = fraudulent;
+        return this;
+      }
+
+      /** Evidence provided when {@code reason} is 'fraudulent'. */
+      public Builder setFraudulent(EmptyParam fraudulent) {
+        this.fraudulent = fraudulent;
+        return this;
+      }
+
+      /** Evidence provided when {@code reason} is 'merchandise_not_as_described'. */
+      public Builder setMerchandiseNotAsDescribed(
+          MerchandiseNotAsDescribed merchandiseNotAsDescribed) {
+        this.merchandiseNotAsDescribed = merchandiseNotAsDescribed;
+        return this;
+      }
+
+      /** Evidence provided when {@code reason} is 'merchandise_not_as_described'. */
+      public Builder setMerchandiseNotAsDescribed(EmptyParam merchandiseNotAsDescribed) {
+        this.merchandiseNotAsDescribed = merchandiseNotAsDescribed;
+        return this;
+      }
+
+      /** Evidence provided when {@code reason} is 'not_received'. */
+      public Builder setNotReceived(NotReceived notReceived) {
+        this.notReceived = notReceived;
+        return this;
+      }
+
+      /** Evidence provided when {@code reason} is 'not_received'. */
+      public Builder setNotReceived(EmptyParam notReceived) {
+        this.notReceived = notReceived;
+        return this;
+      }
+
+      /** Evidence provided when {@code reason} is 'other'. */
+      public Builder setOther(Other other) {
+        this.other = other;
+        return this;
+      }
+
+      /** Evidence provided when {@code reason} is 'other'. */
+      public Builder setOther(EmptyParam other) {
+        this.other = other;
+        return this;
+      }
+
+      /**
+       * The reason for filing the dispute. The evidence should be submitted in the field of the
+       * same name.
+       */
+      public Builder setReason(Reason reason) {
+        this.reason = reason;
+        return this;
+      }
+
+      /** Evidence provided when {@code reason} is 'service_not_as_described'. */
+      public Builder setServiceNotAsDescribed(ServiceNotAsDescribed serviceNotAsDescribed) {
+        this.serviceNotAsDescribed = serviceNotAsDescribed;
+        return this;
+      }
+
+      /** Evidence provided when {@code reason} is 'service_not_as_described'. */
+      public Builder setServiceNotAsDescribed(EmptyParam serviceNotAsDescribed) {
+        this.serviceNotAsDescribed = serviceNotAsDescribed;
+        return this;
+      }
+    }
+
+    @Getter
+    public static class Canceled {
+      /**
+       * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+       * documentation supporting the dispute.
+       */
+      @SerializedName("additional_documentation")
+      Object additionalDocumentation;
+
+      /** Date when order was canceled. */
+      @SerializedName("canceled_at")
+      Object canceledAt;
+
+      /** Whether the cardholder was provided with a cancellation policy. */
+      @SerializedName("cancellation_policy_provided")
+      Object cancellationPolicyProvided;
+
+      /** Reason for canceling the order. */
+      @SerializedName("cancellation_reason")
+      Object cancellationReason;
+
+      /** Date when the cardholder expected to receive the product. */
+      @SerializedName("expected_at")
+      Object expectedAt;
+
+      /** Explanation of why the cardholder is disputing this transaction. */
+      @SerializedName("explanation")
+      Object explanation;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Description of the merchandise or service that was purchased. */
+      @SerializedName("product_description")
+      Object productDescription;
+
+      /** Whether the product was a merchandise or service. */
+      @SerializedName("product_type")
+      EnumParam productType;
+
+      /** Result of cardholder's attempt to return the product. */
+      @SerializedName("return_status")
+      EnumParam returnStatus;
+
+      /** Date when the product was returned or attempted to be returned. */
+      @SerializedName("returned_at")
+      Object returnedAt;
+
+      private Canceled(
+          Object additionalDocumentation,
+          Object canceledAt,
+          Object cancellationPolicyProvided,
+          Object cancellationReason,
+          Object expectedAt,
+          Object explanation,
+          Map<String, Object> extraParams,
+          Object productDescription,
+          EnumParam productType,
+          EnumParam returnStatus,
+          Object returnedAt) {
+        this.additionalDocumentation = additionalDocumentation;
+        this.canceledAt = canceledAt;
+        this.cancellationPolicyProvided = cancellationPolicyProvided;
+        this.cancellationReason = cancellationReason;
+        this.expectedAt = expectedAt;
+        this.explanation = explanation;
+        this.extraParams = extraParams;
+        this.productDescription = productDescription;
+        this.productType = productType;
+        this.returnStatus = returnStatus;
+        this.returnedAt = returnedAt;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Object additionalDocumentation;
+
+        private Object canceledAt;
+
+        private Object cancellationPolicyProvided;
+
+        private Object cancellationReason;
+
+        private Object expectedAt;
+
+        private Object explanation;
+
+        private Map<String, Object> extraParams;
+
+        private Object productDescription;
+
+        private EnumParam productType;
+
+        private EnumParam returnStatus;
+
+        private Object returnedAt;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Canceled build() {
+          return new Canceled(
+              this.additionalDocumentation,
+              this.canceledAt,
+              this.cancellationPolicyProvided,
+              this.cancellationReason,
+              this.expectedAt,
+              this.explanation,
+              this.extraParams,
+              this.productDescription,
+              this.productType,
+              this.returnStatus,
+              this.returnedAt);
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+         * documentation supporting the dispute.
+         */
+        public Builder setAdditionalDocumentation(String additionalDocumentation) {
+          this.additionalDocumentation = additionalDocumentation;
+          return this;
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+         * documentation supporting the dispute.
+         */
+        public Builder setAdditionalDocumentation(EmptyParam additionalDocumentation) {
+          this.additionalDocumentation = additionalDocumentation;
+          return this;
+        }
+
+        /** Date when order was canceled. */
+        public Builder setCanceledAt(Long canceledAt) {
+          this.canceledAt = canceledAt;
+          return this;
+        }
+
+        /** Date when order was canceled. */
+        public Builder setCanceledAt(EmptyParam canceledAt) {
+          this.canceledAt = canceledAt;
+          return this;
+        }
+
+        /** Whether the cardholder was provided with a cancellation policy. */
+        public Builder setCancellationPolicyProvided(Boolean cancellationPolicyProvided) {
+          this.cancellationPolicyProvided = cancellationPolicyProvided;
+          return this;
+        }
+
+        /** Whether the cardholder was provided with a cancellation policy. */
+        public Builder setCancellationPolicyProvided(EmptyParam cancellationPolicyProvided) {
+          this.cancellationPolicyProvided = cancellationPolicyProvided;
+          return this;
+        }
+
+        /** Reason for canceling the order. */
+        public Builder setCancellationReason(String cancellationReason) {
+          this.cancellationReason = cancellationReason;
+          return this;
+        }
+
+        /** Reason for canceling the order. */
+        public Builder setCancellationReason(EmptyParam cancellationReason) {
+          this.cancellationReason = cancellationReason;
+          return this;
+        }
+
+        /** Date when the cardholder expected to receive the product. */
+        public Builder setExpectedAt(Long expectedAt) {
+          this.expectedAt = expectedAt;
+          return this;
+        }
+
+        /** Date when the cardholder expected to receive the product. */
+        public Builder setExpectedAt(EmptyParam expectedAt) {
+          this.expectedAt = expectedAt;
+          return this;
+        }
+
+        /** Explanation of why the cardholder is disputing this transaction. */
+        public Builder setExplanation(String explanation) {
+          this.explanation = explanation;
+          return this;
+        }
+
+        /** Explanation of why the cardholder is disputing this transaction. */
+        public Builder setExplanation(EmptyParam explanation) {
+          this.explanation = explanation;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link DisputeUpdateParams.Evidence.Canceled#extraParams} for the field
+         * documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link DisputeUpdateParams.Evidence.Canceled#extraParams} for the field
+         * documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Description of the merchandise or service that was purchased. */
+        public Builder setProductDescription(String productDescription) {
+          this.productDescription = productDescription;
+          return this;
+        }
+
+        /** Description of the merchandise or service that was purchased. */
+        public Builder setProductDescription(EmptyParam productDescription) {
+          this.productDescription = productDescription;
+          return this;
+        }
+
+        /** Whether the product was a merchandise or service. */
+        public Builder setProductType(ProductType productType) {
+          this.productType = productType;
+          return this;
+        }
+
+        /** Whether the product was a merchandise or service. */
+        public Builder setProductType(EmptyParam productType) {
+          this.productType = productType;
+          return this;
+        }
+
+        /** Result of cardholder's attempt to return the product. */
+        public Builder setReturnStatus(ReturnStatus returnStatus) {
+          this.returnStatus = returnStatus;
+          return this;
+        }
+
+        /** Result of cardholder's attempt to return the product. */
+        public Builder setReturnStatus(EmptyParam returnStatus) {
+          this.returnStatus = returnStatus;
+          return this;
+        }
+
+        /** Date when the product was returned or attempted to be returned. */
+        public Builder setReturnedAt(Long returnedAt) {
+          this.returnedAt = returnedAt;
+          return this;
+        }
+
+        /** Date when the product was returned or attempted to be returned. */
+        public Builder setReturnedAt(EmptyParam returnedAt) {
+          this.returnedAt = returnedAt;
+          return this;
+        }
+      }
+
+      public enum ProductType implements ApiRequestParams.EnumParam {
+        @SerializedName("merchandise")
+        MERCHANDISE("merchandise"),
+
+        @SerializedName("service")
+        SERVICE("service");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        ProductType(String value) {
+          this.value = value;
+        }
+      }
+
+      public enum ReturnStatus implements ApiRequestParams.EnumParam {
+        @SerializedName("merchant_rejected")
+        MERCHANT_REJECTED("merchant_rejected"),
+
+        @SerializedName("successful")
+        SUCCESSFUL("successful");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        ReturnStatus(String value) {
+          this.value = value;
+        }
+      }
+    }
+
+    @Getter
+    public static class Duplicate {
+      /**
+       * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+       * documentation supporting the dispute.
+       */
+      @SerializedName("additional_documentation")
+      Object additionalDocumentation;
+
+      /**
+       * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Copy of the
+       * card statement showing that the product had already been paid for.
+       */
+      @SerializedName("card_statement")
+      Object cardStatement;
+
+      /**
+       * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Copy of the
+       * receipt showing that the product had been paid for in cash.
+       */
+      @SerializedName("cash_receipt")
+      Object cashReceipt;
+
+      /**
+       * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Image of the
+       * front and back of the check that was used to pay for the product.
+       */
+      @SerializedName("check_image")
+      Object checkImage;
+
+      /** Explanation of why the cardholder is disputing this transaction. */
+      @SerializedName("explanation")
+      Object explanation;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /**
+       * Transaction (e.g., ipi_...) that the disputed transaction is a duplicate of. Of the two or
+       * more transactions that are copies of each other, this is original undisputed one.
+       */
+      @SerializedName("original_transaction")
+      Object originalTransaction;
+
+      private Duplicate(
+          Object additionalDocumentation,
+          Object cardStatement,
+          Object cashReceipt,
+          Object checkImage,
+          Object explanation,
+          Map<String, Object> extraParams,
+          Object originalTransaction) {
+        this.additionalDocumentation = additionalDocumentation;
+        this.cardStatement = cardStatement;
+        this.cashReceipt = cashReceipt;
+        this.checkImage = checkImage;
+        this.explanation = explanation;
+        this.extraParams = extraParams;
+        this.originalTransaction = originalTransaction;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Object additionalDocumentation;
+
+        private Object cardStatement;
+
+        private Object cashReceipt;
+
+        private Object checkImage;
+
+        private Object explanation;
+
+        private Map<String, Object> extraParams;
+
+        private Object originalTransaction;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Duplicate build() {
+          return new Duplicate(
+              this.additionalDocumentation,
+              this.cardStatement,
+              this.cashReceipt,
+              this.checkImage,
+              this.explanation,
+              this.extraParams,
+              this.originalTransaction);
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+         * documentation supporting the dispute.
+         */
+        public Builder setAdditionalDocumentation(String additionalDocumentation) {
+          this.additionalDocumentation = additionalDocumentation;
+          return this;
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+         * documentation supporting the dispute.
+         */
+        public Builder setAdditionalDocumentation(EmptyParam additionalDocumentation) {
+          this.additionalDocumentation = additionalDocumentation;
+          return this;
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Copy of
+         * the card statement showing that the product had already been paid for.
+         */
+        public Builder setCardStatement(String cardStatement) {
+          this.cardStatement = cardStatement;
+          return this;
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Copy of
+         * the card statement showing that the product had already been paid for.
+         */
+        public Builder setCardStatement(EmptyParam cardStatement) {
+          this.cardStatement = cardStatement;
+          return this;
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Copy of
+         * the receipt showing that the product had been paid for in cash.
+         */
+        public Builder setCashReceipt(String cashReceipt) {
+          this.cashReceipt = cashReceipt;
+          return this;
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Copy of
+         * the receipt showing that the product had been paid for in cash.
+         */
+        public Builder setCashReceipt(EmptyParam cashReceipt) {
+          this.cashReceipt = cashReceipt;
+          return this;
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Image of
+         * the front and back of the check that was used to pay for the product.
+         */
+        public Builder setCheckImage(String checkImage) {
+          this.checkImage = checkImage;
+          return this;
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Image of
+         * the front and back of the check that was used to pay for the product.
+         */
+        public Builder setCheckImage(EmptyParam checkImage) {
+          this.checkImage = checkImage;
+          return this;
+        }
+
+        /** Explanation of why the cardholder is disputing this transaction. */
+        public Builder setExplanation(String explanation) {
+          this.explanation = explanation;
+          return this;
+        }
+
+        /** Explanation of why the cardholder is disputing this transaction. */
+        public Builder setExplanation(EmptyParam explanation) {
+          this.explanation = explanation;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link DisputeUpdateParams.Evidence.Duplicate#extraParams} for the field
+         * documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link DisputeUpdateParams.Evidence.Duplicate#extraParams} for the field
+         * documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /**
+         * Transaction (e.g., ipi_...) that the disputed transaction is a duplicate of. Of the two
+         * or more transactions that are copies of each other, this is original undisputed one.
+         */
+        public Builder setOriginalTransaction(String originalTransaction) {
+          this.originalTransaction = originalTransaction;
+          return this;
+        }
+
+        /**
+         * Transaction (e.g., ipi_...) that the disputed transaction is a duplicate of. Of the two
+         * or more transactions that are copies of each other, this is original undisputed one.
+         */
+        public Builder setOriginalTransaction(EmptyParam originalTransaction) {
+          this.originalTransaction = originalTransaction;
+          return this;
+        }
+      }
+    }
+
+    @Getter
+    public static class Fraudulent {
+      /**
+       * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+       * documentation supporting the dispute.
+       */
+      @SerializedName("additional_documentation")
+      Object additionalDocumentation;
+
+      /** Explanation of why the cardholder is disputing this transaction. */
+      @SerializedName("explanation")
+      Object explanation;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private Fraudulent(
+          Object additionalDocumentation, Object explanation, Map<String, Object> extraParams) {
+        this.additionalDocumentation = additionalDocumentation;
+        this.explanation = explanation;
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Object additionalDocumentation;
+
+        private Object explanation;
+
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Fraudulent build() {
+          return new Fraudulent(this.additionalDocumentation, this.explanation, this.extraParams);
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+         * documentation supporting the dispute.
+         */
+        public Builder setAdditionalDocumentation(String additionalDocumentation) {
+          this.additionalDocumentation = additionalDocumentation;
+          return this;
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+         * documentation supporting the dispute.
+         */
+        public Builder setAdditionalDocumentation(EmptyParam additionalDocumentation) {
+          this.additionalDocumentation = additionalDocumentation;
+          return this;
+        }
+
+        /** Explanation of why the cardholder is disputing this transaction. */
+        public Builder setExplanation(String explanation) {
+          this.explanation = explanation;
+          return this;
+        }
+
+        /** Explanation of why the cardholder is disputing this transaction. */
+        public Builder setExplanation(EmptyParam explanation) {
+          this.explanation = explanation;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link DisputeUpdateParams.Evidence.Fraudulent#extraParams} for the field
+         * documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link DisputeUpdateParams.Evidence.Fraudulent#extraParams} for the field
+         * documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+      }
+    }
+
+    @Getter
+    public static class MerchandiseNotAsDescribed {
+      /**
+       * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+       * documentation supporting the dispute.
+       */
+      @SerializedName("additional_documentation")
+      Object additionalDocumentation;
+
+      /** Explanation of why the cardholder is disputing this transaction. */
+      @SerializedName("explanation")
+      Object explanation;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Date when the product was received. */
+      @SerializedName("received_at")
+      Object receivedAt;
+
+      /** Description of the cardholder's attempt to return the product. */
+      @SerializedName("return_description")
+      Object returnDescription;
+
+      /** Result of cardholder's attempt to return the product. */
+      @SerializedName("return_status")
+      EnumParam returnStatus;
+
+      /** Date when the product was returned or attempted to be returned. */
+      @SerializedName("returned_at")
+      Object returnedAt;
+
+      private MerchandiseNotAsDescribed(
+          Object additionalDocumentation,
+          Object explanation,
+          Map<String, Object> extraParams,
+          Object receivedAt,
+          Object returnDescription,
+          EnumParam returnStatus,
+          Object returnedAt) {
+        this.additionalDocumentation = additionalDocumentation;
+        this.explanation = explanation;
+        this.extraParams = extraParams;
+        this.receivedAt = receivedAt;
+        this.returnDescription = returnDescription;
+        this.returnStatus = returnStatus;
+        this.returnedAt = returnedAt;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Object additionalDocumentation;
+
+        private Object explanation;
+
+        private Map<String, Object> extraParams;
+
+        private Object receivedAt;
+
+        private Object returnDescription;
+
+        private EnumParam returnStatus;
+
+        private Object returnedAt;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public MerchandiseNotAsDescribed build() {
+          return new MerchandiseNotAsDescribed(
+              this.additionalDocumentation,
+              this.explanation,
+              this.extraParams,
+              this.receivedAt,
+              this.returnDescription,
+              this.returnStatus,
+              this.returnedAt);
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+         * documentation supporting the dispute.
+         */
+        public Builder setAdditionalDocumentation(String additionalDocumentation) {
+          this.additionalDocumentation = additionalDocumentation;
+          return this;
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+         * documentation supporting the dispute.
+         */
+        public Builder setAdditionalDocumentation(EmptyParam additionalDocumentation) {
+          this.additionalDocumentation = additionalDocumentation;
+          return this;
+        }
+
+        /** Explanation of why the cardholder is disputing this transaction. */
+        public Builder setExplanation(String explanation) {
+          this.explanation = explanation;
+          return this;
+        }
+
+        /** Explanation of why the cardholder is disputing this transaction. */
+        public Builder setExplanation(EmptyParam explanation) {
+          this.explanation = explanation;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link DisputeUpdateParams.Evidence.MerchandiseNotAsDescribed#extraParams} for
+         * the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link DisputeUpdateParams.Evidence.MerchandiseNotAsDescribed#extraParams} for
+         * the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Date when the product was received. */
+        public Builder setReceivedAt(Long receivedAt) {
+          this.receivedAt = receivedAt;
+          return this;
+        }
+
+        /** Date when the product was received. */
+        public Builder setReceivedAt(EmptyParam receivedAt) {
+          this.receivedAt = receivedAt;
+          return this;
+        }
+
+        /** Description of the cardholder's attempt to return the product. */
+        public Builder setReturnDescription(String returnDescription) {
+          this.returnDescription = returnDescription;
+          return this;
+        }
+
+        /** Description of the cardholder's attempt to return the product. */
+        public Builder setReturnDescription(EmptyParam returnDescription) {
+          this.returnDescription = returnDescription;
+          return this;
+        }
+
+        /** Result of cardholder's attempt to return the product. */
+        public Builder setReturnStatus(ReturnStatus returnStatus) {
+          this.returnStatus = returnStatus;
+          return this;
+        }
+
+        /** Result of cardholder's attempt to return the product. */
+        public Builder setReturnStatus(EmptyParam returnStatus) {
+          this.returnStatus = returnStatus;
+          return this;
+        }
+
+        /** Date when the product was returned or attempted to be returned. */
+        public Builder setReturnedAt(Long returnedAt) {
+          this.returnedAt = returnedAt;
+          return this;
+        }
+
+        /** Date when the product was returned or attempted to be returned. */
+        public Builder setReturnedAt(EmptyParam returnedAt) {
+          this.returnedAt = returnedAt;
+          return this;
+        }
+      }
+
+      public enum ReturnStatus implements ApiRequestParams.EnumParam {
+        @SerializedName("merchant_rejected")
+        MERCHANT_REJECTED("merchant_rejected"),
+
+        @SerializedName("successful")
+        SUCCESSFUL("successful");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        ReturnStatus(String value) {
+          this.value = value;
+        }
+      }
+    }
+
+    @Getter
+    public static class NotReceived {
+      /**
+       * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+       * documentation supporting the dispute.
+       */
+      @SerializedName("additional_documentation")
+      Object additionalDocumentation;
+
+      /** Date when the cardholder expected to receive the product. */
+      @SerializedName("expected_at")
+      Object expectedAt;
+
+      /** Explanation of why the cardholder is disputing this transaction. */
+      @SerializedName("explanation")
+      Object explanation;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Description of the merchandise or service that was purchased. */
+      @SerializedName("product_description")
+      Object productDescription;
+
+      /** Whether the product was a merchandise or service. */
+      @SerializedName("product_type")
+      EnumParam productType;
+
+      private NotReceived(
+          Object additionalDocumentation,
+          Object expectedAt,
+          Object explanation,
+          Map<String, Object> extraParams,
+          Object productDescription,
+          EnumParam productType) {
+        this.additionalDocumentation = additionalDocumentation;
+        this.expectedAt = expectedAt;
+        this.explanation = explanation;
+        this.extraParams = extraParams;
+        this.productDescription = productDescription;
+        this.productType = productType;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Object additionalDocumentation;
+
+        private Object expectedAt;
+
+        private Object explanation;
+
+        private Map<String, Object> extraParams;
+
+        private Object productDescription;
+
+        private EnumParam productType;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public NotReceived build() {
+          return new NotReceived(
+              this.additionalDocumentation,
+              this.expectedAt,
+              this.explanation,
+              this.extraParams,
+              this.productDescription,
+              this.productType);
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+         * documentation supporting the dispute.
+         */
+        public Builder setAdditionalDocumentation(String additionalDocumentation) {
+          this.additionalDocumentation = additionalDocumentation;
+          return this;
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+         * documentation supporting the dispute.
+         */
+        public Builder setAdditionalDocumentation(EmptyParam additionalDocumentation) {
+          this.additionalDocumentation = additionalDocumentation;
+          return this;
+        }
+
+        /** Date when the cardholder expected to receive the product. */
+        public Builder setExpectedAt(Long expectedAt) {
+          this.expectedAt = expectedAt;
+          return this;
+        }
+
+        /** Date when the cardholder expected to receive the product. */
+        public Builder setExpectedAt(EmptyParam expectedAt) {
+          this.expectedAt = expectedAt;
+          return this;
+        }
+
+        /** Explanation of why the cardholder is disputing this transaction. */
+        public Builder setExplanation(String explanation) {
+          this.explanation = explanation;
+          return this;
+        }
+
+        /** Explanation of why the cardholder is disputing this transaction. */
+        public Builder setExplanation(EmptyParam explanation) {
+          this.explanation = explanation;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link DisputeUpdateParams.Evidence.NotReceived#extraParams} for the field
+         * documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link DisputeUpdateParams.Evidence.NotReceived#extraParams} for the field
+         * documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Description of the merchandise or service that was purchased. */
+        public Builder setProductDescription(String productDescription) {
+          this.productDescription = productDescription;
+          return this;
+        }
+
+        /** Description of the merchandise or service that was purchased. */
+        public Builder setProductDescription(EmptyParam productDescription) {
+          this.productDescription = productDescription;
+          return this;
+        }
+
+        /** Whether the product was a merchandise or service. */
+        public Builder setProductType(ProductType productType) {
+          this.productType = productType;
+          return this;
+        }
+
+        /** Whether the product was a merchandise or service. */
+        public Builder setProductType(EmptyParam productType) {
+          this.productType = productType;
+          return this;
+        }
+      }
+
+      public enum ProductType implements ApiRequestParams.EnumParam {
+        @SerializedName("merchandise")
+        MERCHANDISE("merchandise"),
+
+        @SerializedName("service")
+        SERVICE("service");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        ProductType(String value) {
+          this.value = value;
+        }
+      }
+    }
+
+    @Getter
+    public static class Other {
+      /**
+       * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+       * documentation supporting the dispute.
+       */
+      @SerializedName("additional_documentation")
+      Object additionalDocumentation;
+
+      /** Explanation of why the cardholder is disputing this transaction. */
+      @SerializedName("explanation")
+      Object explanation;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Description of the merchandise or service that was purchased. */
+      @SerializedName("product_description")
+      Object productDescription;
+
+      /** Whether the product was a merchandise or service. */
+      @SerializedName("product_type")
+      EnumParam productType;
+
+      private Other(
+          Object additionalDocumentation,
+          Object explanation,
+          Map<String, Object> extraParams,
+          Object productDescription,
+          EnumParam productType) {
+        this.additionalDocumentation = additionalDocumentation;
+        this.explanation = explanation;
+        this.extraParams = extraParams;
+        this.productDescription = productDescription;
+        this.productType = productType;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Object additionalDocumentation;
+
+        private Object explanation;
+
+        private Map<String, Object> extraParams;
+
+        private Object productDescription;
+
+        private EnumParam productType;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Other build() {
+          return new Other(
+              this.additionalDocumentation,
+              this.explanation,
+              this.extraParams,
+              this.productDescription,
+              this.productType);
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+         * documentation supporting the dispute.
+         */
+        public Builder setAdditionalDocumentation(String additionalDocumentation) {
+          this.additionalDocumentation = additionalDocumentation;
+          return this;
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+         * documentation supporting the dispute.
+         */
+        public Builder setAdditionalDocumentation(EmptyParam additionalDocumentation) {
+          this.additionalDocumentation = additionalDocumentation;
+          return this;
+        }
+
+        /** Explanation of why the cardholder is disputing this transaction. */
+        public Builder setExplanation(String explanation) {
+          this.explanation = explanation;
+          return this;
+        }
+
+        /** Explanation of why the cardholder is disputing this transaction. */
+        public Builder setExplanation(EmptyParam explanation) {
+          this.explanation = explanation;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link DisputeUpdateParams.Evidence.Other#extraParams} for the field
+         * documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link DisputeUpdateParams.Evidence.Other#extraParams} for the field
+         * documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Description of the merchandise or service that was purchased. */
+        public Builder setProductDescription(String productDescription) {
+          this.productDescription = productDescription;
+          return this;
+        }
+
+        /** Description of the merchandise or service that was purchased. */
+        public Builder setProductDescription(EmptyParam productDescription) {
+          this.productDescription = productDescription;
+          return this;
+        }
+
+        /** Whether the product was a merchandise or service. */
+        public Builder setProductType(ProductType productType) {
+          this.productType = productType;
+          return this;
+        }
+
+        /** Whether the product was a merchandise or service. */
+        public Builder setProductType(EmptyParam productType) {
+          this.productType = productType;
+          return this;
+        }
+      }
+
+      public enum ProductType implements ApiRequestParams.EnumParam {
+        @SerializedName("merchandise")
+        MERCHANDISE("merchandise"),
+
+        @SerializedName("service")
+        SERVICE("service");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        ProductType(String value) {
+          this.value = value;
+        }
+      }
+    }
+
+    @Getter
+    public static class ServiceNotAsDescribed {
+      /**
+       * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+       * documentation supporting the dispute.
+       */
+      @SerializedName("additional_documentation")
+      Object additionalDocumentation;
+
+      /** Date when order was canceled. */
+      @SerializedName("canceled_at")
+      Object canceledAt;
+
+      /** Reason for canceling the order. */
+      @SerializedName("cancellation_reason")
+      Object cancellationReason;
+
+      /** Explanation of why the cardholder is disputing this transaction. */
+      @SerializedName("explanation")
+      Object explanation;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Date when the product was received. */
+      @SerializedName("received_at")
+      Object receivedAt;
+
+      private ServiceNotAsDescribed(
+          Object additionalDocumentation,
+          Object canceledAt,
+          Object cancellationReason,
+          Object explanation,
+          Map<String, Object> extraParams,
+          Object receivedAt) {
+        this.additionalDocumentation = additionalDocumentation;
+        this.canceledAt = canceledAt;
+        this.cancellationReason = cancellationReason;
+        this.explanation = explanation;
+        this.extraParams = extraParams;
+        this.receivedAt = receivedAt;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Object additionalDocumentation;
+
+        private Object canceledAt;
+
+        private Object cancellationReason;
+
+        private Object explanation;
+
+        private Map<String, Object> extraParams;
+
+        private Object receivedAt;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public ServiceNotAsDescribed build() {
+          return new ServiceNotAsDescribed(
+              this.additionalDocumentation,
+              this.canceledAt,
+              this.cancellationReason,
+              this.explanation,
+              this.extraParams,
+              this.receivedAt);
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+         * documentation supporting the dispute.
+         */
+        public Builder setAdditionalDocumentation(String additionalDocumentation) {
+          this.additionalDocumentation = additionalDocumentation;
+          return this;
+        }
+
+        /**
+         * (ID of a <a href="https://stripe.com/docs/guides/file-upload">file upload</a>) Additional
+         * documentation supporting the dispute.
+         */
+        public Builder setAdditionalDocumentation(EmptyParam additionalDocumentation) {
+          this.additionalDocumentation = additionalDocumentation;
+          return this;
+        }
+
+        /** Date when order was canceled. */
+        public Builder setCanceledAt(Long canceledAt) {
+          this.canceledAt = canceledAt;
+          return this;
+        }
+
+        /** Date when order was canceled. */
+        public Builder setCanceledAt(EmptyParam canceledAt) {
+          this.canceledAt = canceledAt;
+          return this;
+        }
+
+        /** Reason for canceling the order. */
+        public Builder setCancellationReason(String cancellationReason) {
+          this.cancellationReason = cancellationReason;
+          return this;
+        }
+
+        /** Reason for canceling the order. */
+        public Builder setCancellationReason(EmptyParam cancellationReason) {
+          this.cancellationReason = cancellationReason;
+          return this;
+        }
+
+        /** Explanation of why the cardholder is disputing this transaction. */
+        public Builder setExplanation(String explanation) {
+          this.explanation = explanation;
+          return this;
+        }
+
+        /** Explanation of why the cardholder is disputing this transaction. */
+        public Builder setExplanation(EmptyParam explanation) {
+          this.explanation = explanation;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link DisputeUpdateParams.Evidence.ServiceNotAsDescribed#extraParams} for the
+         * field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link DisputeUpdateParams.Evidence.ServiceNotAsDescribed#extraParams} for the
+         * field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Date when the product was received. */
+        public Builder setReceivedAt(Long receivedAt) {
+          this.receivedAt = receivedAt;
+          return this;
+        }
+
+        /** Date when the product was received. */
+        public Builder setReceivedAt(EmptyParam receivedAt) {
+          this.receivedAt = receivedAt;
+          return this;
+        }
+      }
+    }
+
+    public enum Reason implements ApiRequestParams.EnumParam {
+      @SerializedName("canceled")
+      CANCELED("canceled"),
+
+      @SerializedName("duplicate")
+      DUPLICATE("duplicate"),
+
+      @SerializedName("fraudulent")
+      FRAUDULENT("fraudulent"),
+
+      @SerializedName("merchandise_not_as_described")
+      MERCHANDISE_NOT_AS_DESCRIBED("merchandise_not_as_described"),
+
+      @SerializedName("not_received")
+      NOT_RECEIVED("not_received"),
+
+      @SerializedName("other")
+      OTHER("other"),
+
+      @SerializedName("service_not_as_described")
+      SERVICE_NOT_AS_DESCRIBED("service_not_as_described");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      Reason(String value) {
+        this.value = value;
+      }
     }
   }
 }

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -33,7 +33,7 @@ import org.mockito.Mockito;
 
 public class BaseStripeTest {
   // If changing this number, please also change it in `.travis.yml`.
-  private static final String MOCK_MINIMUM_VERSION = "0.96.0";
+  private static final String MOCK_MINIMUM_VERSION = "0.98.0";
 
   private static String port;
 

--- a/src/test/java/com/stripe/functional/issuing/DisputeTest.java
+++ b/src/test/java/com/stripe/functional/issuing/DisputeTest.java
@@ -16,10 +16,8 @@ public class DisputeTest extends BaseStripeTest {
 
   @Test
   public void testCreate() throws StripeException {
-    final Map<String, String> metadata = new HashMap<>();
-    metadata.put("key", "value");
     final Map<String, Object> params = new HashMap<>();
-    params.put("metadata", metadata);
+    params.put("transaction", "ipi_123");
 
     final Dispute dispute = Dispute.create(params);
 
@@ -34,6 +32,24 @@ public class DisputeTest extends BaseStripeTest {
     assertNotNull(dispute);
     verifyRequest(
         ApiResource.RequestMethod.GET, String.format("/v1/issuing/disputes/%s", DISPUTE_ID));
+  }
+
+  @Test
+  public void testsubmit() throws StripeException {
+    final Dispute dispute = Dispute.retrieve(DISPUTE_ID);
+
+    final Map<String, String> metadata = new HashMap<>();
+    metadata.put("key", "value");
+    final Map<String, Object> params = new HashMap<>();
+    params.put("metadata", metadata);
+
+    final Dispute submitdDispute = dispute.submit(params);
+
+    assertNotNull(submitdDispute);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        String.format("/v1/issuing/disputes/%s/submit", dispute.getId()),
+        params);
   }
 
   @Test

--- a/src/test/java/com/stripe/model/issuing/DisputeTest.java
+++ b/src/test/java/com/stripe/model/issuing/DisputeTest.java
@@ -17,4 +17,20 @@ public class DisputeTest extends BaseStripeTest {
     assertNotNull(dispute.getId());
     assertEquals("issuing.dispute", dispute.getObject());
   }
+
+  @Test
+  public void testDeserializeWithExpansions() throws Exception {
+    // TODO: handle support for balance_transactions expansion as stripe-mock doesn't support this
+    // well
+    final String[] expansions = {
+      "transaction",
+    };
+    final String data = getFixture("/v1/issuing/disputes/idp_123", expansions);
+    final Dispute dispute = ApiResource.GSON.fromJson(data, Dispute.class);
+    assertNotNull(dispute);
+    final Transaction transaction = dispute.getTransactionObject();
+    assertNotNull(transaction);
+    assertNotNull(transaction.getId());
+    assertEquals(dispute.getTransaction(), transaction.getId());
+  }
 }


### PR DESCRIPTION
Multiple API changes
  * Improve support for the Issuing `Dispute` APIs. Added the Submit API, missing parameters on creation, update and list and returned evidence details
  * Add support for `dispute` on Issuing `Transaction`
  * Add `available_payout_methods` on `BankAccount`
  * Add `payment_status` on Checkout `Session`

Codegen for openapi 4c67ab9 and dd28064

r? @cjavilla-stripe 
cc @stripe/api-libraries 