### PR TITLE
Add support for `promotion_code.created` and `promotion_code.updated` on `Event`

### DIFF
--- a/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
+++ b/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
@@ -917,6 +917,12 @@ public class WebhookEndpointCreateParams extends ApiRequestParams {
     @SerializedName("product.updated")
     PRODUCT__UPDATED("product.updated"),
 
+    @SerializedName("promotion_code.created")
+    PROMOTION_CODE__CREATED("promotion_code.created"),
+
+    @SerializedName("promotion_code.updated")
+    PROMOTION_CODE__UPDATED("promotion_code.updated"),
+
     @SerializedName("radar.early_fraud_warning.created")
     RADAR__EARLY_FRAUD_WARNING__CREATED("radar.early_fraud_warning.created"),
 

--- a/src/main/java/com/stripe/param/WebhookEndpointUpdateParams.java
+++ b/src/main/java/com/stripe/param/WebhookEndpointUpdateParams.java
@@ -605,6 +605,12 @@ public class WebhookEndpointUpdateParams extends ApiRequestParams {
     @SerializedName("product.updated")
     PRODUCT__UPDATED("product.updated"),
 
+    @SerializedName("promotion_code.created")
+    PROMOTION_CODE__CREATED("promotion_code.created"),
+
+    @SerializedName("promotion_code.updated")
+    PROMOTION_CODE__UPDATED("promotion_code.updated"),
+
     @SerializedName("radar.early_fraud_warning.created")
     RADAR__EARLY_FRAUD_WARNING__CREATED("radar.early_fraud_warning.created"),
 


### PR DESCRIPTION
Codegen for openapi 92265b4

r? @cjavilla-stripe 
cc @stripe/api-libraries 