### PR TITLE
Add support for `oxxo` as a valid `type` on the List PaymentMethod API

### DIFF
--- a/src/main/java/com/stripe/param/PaymentMethodListParams.java
+++ b/src/main/java/com/stripe/param/PaymentMethodListParams.java
@@ -232,6 +232,9 @@ public class PaymentMethodListParams extends ApiRequestParams {
     @SerializedName("ideal")
     IDEAL("ideal"),
 
+    @SerializedName("oxxo")
+    OXXO("oxxo"),
+
     @SerializedName("p24")
     P24("p24"),
 


### PR DESCRIPTION
Codegen for openapi 0cb9b14

r? @ctrudeau-stripe 
cc @stripe/api-libraries 