### PR TITLE
Add `discounts` to SessionCreateParams

### DIFF
--- a/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
+++ b/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
@@ -53,6 +53,13 @@ public class SessionCreateParams extends ApiRequestParams {
   @SerializedName("customer_email")
   String customerEmail;
 
+  /**
+   * The coupon or promotion code to apply to this session. Currently, only up to one may be
+   * specified.
+   */
+  @SerializedName("discounts")
+  List<Discount> discounts;
+
   /** Specifies which fields in the response should be expanded. */
   @SerializedName("expand")
   List<String> expand;
@@ -165,6 +172,7 @@ public class SessionCreateParams extends ApiRequestParams {
       String clientReferenceId,
       String customer,
       String customerEmail,
+      List<Discount> discounts,
       List<String> expand,
       Map<String, Object> extraParams,
       List<LineItem> lineItems,
@@ -184,6 +192,7 @@ public class SessionCreateParams extends ApiRequestParams {
     this.clientReferenceId = clientReferenceId;
     this.customer = customer;
     this.customerEmail = customerEmail;
+    this.discounts = discounts;
     this.expand = expand;
     this.extraParams = extraParams;
     this.lineItems = lineItems;
@@ -215,6 +224,8 @@ public class SessionCreateParams extends ApiRequestParams {
     private String customer;
 
     private String customerEmail;
+
+    private List<Discount> discounts;
 
     private List<String> expand;
 
@@ -251,6 +262,7 @@ public class SessionCreateParams extends ApiRequestParams {
           this.clientReferenceId,
           this.customer,
           this.customerEmail,
+          this.discounts,
           this.expand,
           this.extraParams,
           this.lineItems,
@@ -316,6 +328,32 @@ public class SessionCreateParams extends ApiRequestParams {
      */
     public Builder setCustomerEmail(String customerEmail) {
       this.customerEmail = customerEmail;
+      return this;
+    }
+
+    /**
+     * Add an element to `discounts` list. A list is initialized for the first `add/addAll` call,
+     * and subsequent calls adds additional elements to the original list. See {@link
+     * SessionCreateParams#discounts} for the field documentation.
+     */
+    public Builder addDiscount(Discount element) {
+      if (this.discounts == null) {
+        this.discounts = new ArrayList<>();
+      }
+      this.discounts.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `discounts` list. A list is initialized for the first `add/addAll` call,
+     * and subsequent calls adds additional elements to the original list. See {@link
+     * SessionCreateParams#discounts} for the field documentation.
+     */
+    public Builder addAllDiscount(List<Discount> elements) {
+      if (this.discounts == null) {
+        this.discounts = new ArrayList<>();
+      }
+      this.discounts.addAll(elements);
       return this;
     }
 
@@ -524,6 +562,87 @@ public class SessionCreateParams extends ApiRequestParams {
     public Builder setSuccessUrl(String successUrl) {
       this.successUrl = successUrl;
       return this;
+    }
+  }
+
+  @Getter
+  public static class Discount {
+    /** The ID of the coupon to apply to this session. */
+    @SerializedName("coupon")
+    String coupon;
+
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /** The ID of a promotion code to apply to this session. */
+    @SerializedName("promotion_code")
+    String promotionCode;
+
+    private Discount(String coupon, Map<String, Object> extraParams, String promotionCode) {
+      this.coupon = coupon;
+      this.extraParams = extraParams;
+      this.promotionCode = promotionCode;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private String coupon;
+
+      private Map<String, Object> extraParams;
+
+      private String promotionCode;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public Discount build() {
+        return new Discount(this.coupon, this.extraParams, this.promotionCode);
+      }
+
+      /** The ID of the coupon to apply to this session. */
+      public Builder setCoupon(String coupon) {
+        this.coupon = coupon;
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * SessionCreateParams.Discount#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link SessionCreateParams.Discount#extraParams} for the field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** The ID of a promotion code to apply to this session. */
+      public Builder setPromotionCode(String promotionCode) {
+        this.promotionCode = promotionCode;
+        return this;
+      }
     }
   }
 


### PR DESCRIPTION
Codegen for openapi aacc1c6.
r? @remi-stripe
cc @stripe/api-libraries

## Changelog
* Added support for `discounts` on `SessionCreateParams`

