### PR TITLE
Add support for `jp_rn` and `ru_kpp` as a `type` on `TaxId`

### DIFF
--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -1320,10 +1320,11 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
     /**
      * The type of the tax ID, one of {@code eu_vat}, {@code br_cnpj}, {@code br_cpf}, {@code
      * nz_gst}, {@code au_abn}, {@code in_gst}, {@code no_vat}, {@code za_vat}, {@code ch_vat},
-     * {@code mx_rfc}, {@code sg_uen}, {@code ru_inn}, {@code ca_bn}, {@code hk_br}, {@code es_cif},
-     * {@code tw_vat}, {@code th_vat}, {@code jp_cn}, {@code li_uid}, {@code my_itn}, {@code
-     * us_ein}, {@code kr_brn}, {@code ca_qst}, {@code my_sst}, {@code sg_gst}, {@code ae_trn},
-     * {@code cl_tin}, {@code sa_vat}, {@code id_npwp}, {@code my_frp}, or {@code unknown}.
+     * {@code mx_rfc}, {@code sg_uen}, {@code ru_inn}, {@code ru_kpp}, {@code ca_bn}, {@code hk_br},
+     * {@code es_cif}, {@code tw_vat}, {@code th_vat}, {@code jp_cn}, {@code jp_rn}, {@code li_uid},
+     * {@code my_itn}, {@code us_ein}, {@code kr_brn}, {@code ca_qst}, {@code my_sst}, {@code
+     * sg_gst}, {@code ae_trn}, {@code cl_tin}, {@code sa_vat}, {@code id_npwp}, {@code my_frp}, or
+     * {@code unknown}.
      */
     @SerializedName("type")
     String type;

--- a/src/main/java/com/stripe/model/TaxId.java
+++ b/src/main/java/com/stripe/model/TaxId.java
@@ -56,10 +56,11 @@ public class TaxId extends ApiResource implements HasId {
   /**
    * Type of the tax ID, one of {@code ae_trn}, {@code au_abn}, {@code br_cnpj}, {@code br_cpf},
    * {@code ca_bn}, {@code ca_qst}, {@code ch_vat}, {@code cl_tin}, {@code es_cif}, {@code eu_vat},
-   * {@code hk_br}, {@code id_npwp}, {@code in_gst}, {@code jp_cn}, {@code kr_brn}, {@code li_uid},
-   * {@code mx_rfc}, {@code my_frp}, {@code my_itn}, {@code my_sst}, {@code no_vat}, {@code nz_gst},
-   * {@code ru_inn}, {@code sa_vat}, {@code sg_gst}, {@code sg_uen}, {@code th_vat}, {@code tw_vat},
-   * {@code us_ein}, or {@code za_vat}. Note that some legacy tax IDs have type {@code unknown}
+   * {@code hk_br}, {@code id_npwp}, {@code in_gst}, {@code jp_cn}, {@code jp_rn}, {@code kr_brn},
+   * {@code li_uid}, {@code mx_rfc}, {@code my_frp}, {@code my_itn}, {@code my_sst}, {@code no_vat},
+   * {@code nz_gst}, {@code ru_inn}, {@code ru_kpp}, {@code sa_vat}, {@code sg_gst}, {@code sg_uen},
+   * {@code th_vat}, {@code tw_vat}, {@code us_ein}, or {@code za_vat}. Note that some legacy tax
+   * IDs have type {@code unknown}
    */
   @SerializedName("type")
   String type;

--- a/src/main/java/com/stripe/model/checkout/Session.java
+++ b/src/main/java/com/stripe/model/checkout/Session.java
@@ -128,8 +128,9 @@ public class Session extends ApiResource implements HasId {
   Map<String, String> metadata;
 
   /**
-   * The mode of the Checkout Session, one of {@code payment}, {@code setup}, or {@code
-   * subscription}.
+   * The mode of the Checkout Session.
+   *
+   * <p>One of {@code payment}, {@code setup}, or {@code subscription}.
    */
   @SerializedName("mode")
   String mode;

--- a/src/main/java/com/stripe/param/CustomerCreateParams.java
+++ b/src/main/java/com/stripe/param/CustomerCreateParams.java
@@ -1155,10 +1155,10 @@ public class CustomerCreateParams extends ApiRequestParams {
     /**
      * Type of the tax ID, one of {@code ae_trn}, {@code au_abn}, {@code br_cnpj}, {@code br_cpf},
      * {@code ca_bn}, {@code ca_qst}, {@code ch_vat}, {@code cl_tin}, {@code es_cif}, {@code
-     * eu_vat}, {@code hk_br}, {@code id_npwp}, {@code in_gst}, {@code jp_cn}, {@code kr_brn},
-     * {@code li_uid}, {@code mx_rfc}, {@code my_frp}, {@code my_itn}, {@code my_sst}, {@code
-     * no_vat}, {@code nz_gst}, {@code ru_inn}, {@code sa_vat}, {@code sg_gst}, {@code sg_uen},
-     * {@code th_vat}, {@code tw_vat}, {@code us_ein}, or {@code za_vat}.
+     * eu_vat}, {@code hk_br}, {@code id_npwp}, {@code in_gst}, {@code jp_cn}, {@code jp_rn}, {@code
+     * kr_brn}, {@code li_uid}, {@code mx_rfc}, {@code my_frp}, {@code my_itn}, {@code my_sst},
+     * {@code no_vat}, {@code nz_gst}, {@code ru_inn}, {@code ru_kpp}, {@code sa_vat}, {@code
+     * sg_gst}, {@code sg_uen}, {@code th_vat}, {@code tw_vat}, {@code us_ein}, or {@code za_vat}.
      */
     @SerializedName("type")
     Type type;
@@ -1218,10 +1218,11 @@ public class CustomerCreateParams extends ApiRequestParams {
       /**
        * Type of the tax ID, one of {@code ae_trn}, {@code au_abn}, {@code br_cnpj}, {@code br_cpf},
        * {@code ca_bn}, {@code ca_qst}, {@code ch_vat}, {@code cl_tin}, {@code es_cif}, {@code
-       * eu_vat}, {@code hk_br}, {@code id_npwp}, {@code in_gst}, {@code jp_cn}, {@code kr_brn},
-       * {@code li_uid}, {@code mx_rfc}, {@code my_frp}, {@code my_itn}, {@code my_sst}, {@code
-       * no_vat}, {@code nz_gst}, {@code ru_inn}, {@code sa_vat}, {@code sg_gst}, {@code sg_uen},
-       * {@code th_vat}, {@code tw_vat}, {@code us_ein}, or {@code za_vat}.
+       * eu_vat}, {@code hk_br}, {@code id_npwp}, {@code in_gst}, {@code jp_cn}, {@code jp_rn},
+       * {@code kr_brn}, {@code li_uid}, {@code mx_rfc}, {@code my_frp}, {@code my_itn}, {@code
+       * my_sst}, {@code no_vat}, {@code nz_gst}, {@code ru_inn}, {@code ru_kpp}, {@code sa_vat},
+       * {@code sg_gst}, {@code sg_uen}, {@code th_vat}, {@code tw_vat}, {@code us_ein}, or {@code
+       * za_vat}.
        */
       public Builder setType(Type type) {
         this.type = type;
@@ -1278,6 +1279,9 @@ public class CustomerCreateParams extends ApiRequestParams {
       @SerializedName("jp_cn")
       JP_CN("jp_cn"),
 
+      @SerializedName("jp_rn")
+      JP_RN("jp_rn"),
+
       @SerializedName("kr_brn")
       KR_BRN("kr_brn"),
 
@@ -1304,6 +1308,9 @@ public class CustomerCreateParams extends ApiRequestParams {
 
       @SerializedName("ru_inn")
       RU_INN("ru_inn"),
+
+      @SerializedName("ru_kpp")
+      RU_KPP("ru_kpp"),
 
       @SerializedName("sa_vat")
       SA_VAT("sa_vat"),

--- a/src/main/java/com/stripe/param/TaxIdCollectionCreateParams.java
+++ b/src/main/java/com/stripe/param/TaxIdCollectionCreateParams.java
@@ -27,10 +27,10 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
   /**
    * Type of the tax ID, one of {@code ae_trn}, {@code au_abn}, {@code br_cnpj}, {@code br_cpf},
    * {@code ca_bn}, {@code ca_qst}, {@code ch_vat}, {@code cl_tin}, {@code es_cif}, {@code eu_vat},
-   * {@code hk_br}, {@code id_npwp}, {@code in_gst}, {@code jp_cn}, {@code kr_brn}, {@code li_uid},
-   * {@code mx_rfc}, {@code my_frp}, {@code my_itn}, {@code my_sst}, {@code no_vat}, {@code nz_gst},
-   * {@code ru_inn}, {@code sa_vat}, {@code sg_gst}, {@code sg_uen}, {@code th_vat}, {@code tw_vat},
-   * {@code us_ein}, or {@code za_vat}.
+   * {@code hk_br}, {@code id_npwp}, {@code in_gst}, {@code jp_cn}, {@code jp_rn}, {@code kr_brn},
+   * {@code li_uid}, {@code mx_rfc}, {@code my_frp}, {@code my_itn}, {@code my_sst}, {@code no_vat},
+   * {@code nz_gst}, {@code ru_inn}, {@code ru_kpp}, {@code sa_vat}, {@code sg_gst}, {@code sg_uen},
+   * {@code th_vat}, {@code tw_vat}, {@code us_ein}, or {@code za_vat}.
    */
   @SerializedName("type")
   Type type;
@@ -120,10 +120,10 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
     /**
      * Type of the tax ID, one of {@code ae_trn}, {@code au_abn}, {@code br_cnpj}, {@code br_cpf},
      * {@code ca_bn}, {@code ca_qst}, {@code ch_vat}, {@code cl_tin}, {@code es_cif}, {@code
-     * eu_vat}, {@code hk_br}, {@code id_npwp}, {@code in_gst}, {@code jp_cn}, {@code kr_brn},
-     * {@code li_uid}, {@code mx_rfc}, {@code my_frp}, {@code my_itn}, {@code my_sst}, {@code
-     * no_vat}, {@code nz_gst}, {@code ru_inn}, {@code sa_vat}, {@code sg_gst}, {@code sg_uen},
-     * {@code th_vat}, {@code tw_vat}, {@code us_ein}, or {@code za_vat}.
+     * eu_vat}, {@code hk_br}, {@code id_npwp}, {@code in_gst}, {@code jp_cn}, {@code jp_rn}, {@code
+     * kr_brn}, {@code li_uid}, {@code mx_rfc}, {@code my_frp}, {@code my_itn}, {@code my_sst},
+     * {@code no_vat}, {@code nz_gst}, {@code ru_inn}, {@code ru_kpp}, {@code sa_vat}, {@code
+     * sg_gst}, {@code sg_uen}, {@code th_vat}, {@code tw_vat}, {@code us_ein}, or {@code za_vat}.
      */
     public Builder setType(Type type) {
       this.type = type;
@@ -180,6 +180,9 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
     @SerializedName("jp_cn")
     JP_CN("jp_cn"),
 
+    @SerializedName("jp_rn")
+    JP_RN("jp_rn"),
+
     @SerializedName("kr_brn")
     KR_BRN("kr_brn"),
 
@@ -206,6 +209,9 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
 
     @SerializedName("ru_inn")
     RU_INN("ru_inn"),
+
+    @SerializedName("ru_kpp")
+    RU_KPP("ru_kpp"),
 
     @SerializedName("sa_vat")
     SA_VAT("sa_vat"),

--- a/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
+++ b/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
@@ -101,9 +101,8 @@ public class SessionCreateParams extends ApiRequestParams {
   Map<String, String> metadata;
 
   /**
-   * The mode of the Checkout Session, one of {@code payment}, {@code setup}, or {@code
-   * subscription}. Required when using prices or {@code setup} mode. Pass {@code subscription} if
-   * Checkout session includes at least one recurring item.
+   * The mode of the Checkout Session. Required when using prices or {@code setup} mode. Pass {@code
+   * subscription} if Checkout session includes at least one recurring item.
    */
   @SerializedName("mode")
   Mode mode;
@@ -471,9 +470,8 @@ public class SessionCreateParams extends ApiRequestParams {
     }
 
     /**
-     * The mode of the Checkout Session, one of {@code payment}, {@code setup}, or {@code
-     * subscription}. Required when using prices or {@code setup} mode. Pass {@code subscription} if
-     * Checkout session includes at least one recurring item.
+     * The mode of the Checkout Session. Required when using prices or {@code setup} mode. Pass
+     * {@code subscription} if Checkout session includes at least one recurring item.
      */
     public Builder setMode(Mode mode) {
       this.mode = mode;


### PR DESCRIPTION
Codegen for openapi 555ca3b

r? @ctrudeau-stripe 
cc @stripe/api-libraries 