### PR TITLE
Fix deprecation warning in test file

### DIFF
--- a/src/test/java/com/stripe/net/FormEncoderTest.java
+++ b/src/test/java/com/stripe/net/FormEncoderTest.java
@@ -1,6 +1,6 @@
 package com.stripe.net;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 


### PR DESCRIPTION
r? @remi-stripe 

`org.junit.Assert.assertThat` is deprecated in favor of `org.hamcrest.MatcherAssert.assertThat`.
