### PR TITLE
Start testing Java 15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ matrix:
     - jdk: openjdk12
     - jdk: openjdk13
     - jdk: openjdk14
+    - jdk: openjdk15
     - jdk: openjdk-ea
   allow_failures:
     - jdk: openjdk-ea


### PR DESCRIPTION
r? @remi-stripe 

Java 15 was released last month, so start testing it.

As an aside, the list of tested versions is growing very large. We should strongly consider only testing currently supported versions, i.e. Java 8 and 11 (LTS versions) and 15 (latest version). These versions represent the vast majority of our traffic anyway. cc @richardm-stripe 
