### PR TITLE
Support passing `tax_rates` when creating invoice items through `Subscription` or `SubscriptionSchedule`

### DIFF
--- a/src/main/java/com/stripe/model/Card.java
+++ b/src/main/java/com/stripe/model/Card.java
@@ -144,9 +144,9 @@ public class Card extends ApiResource
 
   /**
    * Uniquely identifies this particular card number. You can use this attribute to check whether
-   * two customers who’ve signed up with you are using the same card number,for example. For payment
-   * methods that tokenize card information (Apple Pay, Google Pay), the tokenized number might be
-   * provided instead of the underlying card number.
+   * two customers who’ve signed up with you are using the same card number, for example. For
+   * payment methods that tokenize card information (Apple Pay, Google Pay), the tokenized number
+   * might be provided instead of the underlying card number.
    */
   @SerializedName("fingerprint")
   String fingerprint;

--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -1366,9 +1366,9 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
 
       /**
        * Uniquely identifies this particular card number. You can use this attribute to check
-       * whether two customers who’ve signed up with you are using the same card number,for example.
-       * For payment methods that tokenize card information (Apple Pay, Google Pay), the tokenized
-       * number might be provided instead of the underlying card number.
+       * whether two customers who’ve signed up with you are using the same card number, for
+       * example. For payment methods that tokenize card information (Apple Pay, Google Pay), the
+       * tokenized number might be provided instead of the underlying card number.
        */
       @SerializedName("fingerprint")
       String fingerprint;
@@ -1677,9 +1677,9 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
 
       /**
        * Uniquely identifies this particular card number. You can use this attribute to check
-       * whether two customers who’ve signed up with you are using the same card number,for example.
-       * For payment methods that tokenize card information (Apple Pay, Google Pay), the tokenized
-       * number might be provided instead of the underlying card number.
+       * whether two customers who’ve signed up with you are using the same card number, for
+       * example. For payment methods that tokenize card information (Apple Pay, Google Pay), the
+       * tokenized number might be provided instead of the underlying card number.
        */
       @SerializedName("fingerprint")
       String fingerprint;
@@ -1983,9 +1983,9 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
 
       /**
        * Uniquely identifies this particular card number. You can use this attribute to check
-       * whether two customers who’ve signed up with you are using the same card number,for example.
-       * For payment methods that tokenize card information (Apple Pay, Google Pay), the tokenized
-       * number might be provided instead of the underlying card number.
+       * whether two customers who’ve signed up with you are using the same card number, for
+       * example. For payment methods that tokenize card information (Apple Pay, Google Pay), the
+       * tokenized number might be provided instead of the underlying card number.
        */
       @SerializedName("fingerprint")
       String fingerprint;

--- a/src/main/java/com/stripe/model/PaymentMethod.java
+++ b/src/main/java/com/stripe/model/PaymentMethod.java
@@ -533,7 +533,7 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
 
     /**
      * Uniquely identifies this particular card number. You can use this attribute to check whether
-     * two customers who’ve signed up with you are using the same card number,for example. For
+     * two customers who’ve signed up with you are using the same card number, for example. For
      * payment methods that tokenize card information (Apple Pay, Google Pay), the tokenized number
      * might be provided instead of the underlying card number.
      */

--- a/src/main/java/com/stripe/model/SubscriptionSchedule.java
+++ b/src/main/java/com/stripe/model/SubscriptionSchedule.java
@@ -484,6 +484,13 @@ public class SubscriptionSchedule extends ApiResource
     @SerializedName("quantity")
     Long quantity;
 
+    /**
+     * The tax rates which apply to the item. When set, the {@code default_tax_rates} do not apply
+     * to this item.
+     */
+    @SerializedName("tax_rates")
+    List<TaxRate> taxRates;
+
     /** Get ID of expandable {@code price} object. */
     public String getPrice() {
       return (this.price != null) ? this.price.getId() : null;

--- a/src/main/java/com/stripe/param/SubscriptionCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionCreateParams.java
@@ -875,12 +875,24 @@ public class SubscriptionCreateParams extends ApiRequestParams {
     @SerializedName("quantity")
     Long quantity;
 
+    /**
+     * The tax rates which apply to the item. When set, the {@code default_tax_rates} do not apply
+     * to this item.
+     */
+    @SerializedName("tax_rates")
+    Object taxRates;
+
     private AddInvoiceItem(
-        Map<String, Object> extraParams, String price, PriceData priceData, Long quantity) {
+        Map<String, Object> extraParams,
+        String price,
+        PriceData priceData,
+        Long quantity,
+        Object taxRates) {
       this.extraParams = extraParams;
       this.price = price;
       this.priceData = priceData;
       this.quantity = quantity;
+      this.taxRates = taxRates;
     }
 
     public static Builder builder() {
@@ -896,9 +908,12 @@ public class SubscriptionCreateParams extends ApiRequestParams {
 
       private Long quantity;
 
+      private Object taxRates;
+
       /** Finalize and obtain parameter instance from this builder. */
       public AddInvoiceItem build() {
-        return new AddInvoiceItem(this.extraParams, this.price, this.priceData, this.quantity);
+        return new AddInvoiceItem(
+            this.extraParams, this.price, this.priceData, this.quantity, this.taxRates);
       }
 
       /**
@@ -946,6 +961,52 @@ public class SubscriptionCreateParams extends ApiRequestParams {
       /** Quantity for this item. Defaults to 1. */
       public Builder setQuantity(Long quantity) {
         this.quantity = quantity;
+        return this;
+      }
+
+      /**
+       * Add an element to `taxRates` list. A list is initialized for the first `add/addAll` call,
+       * and subsequent calls adds additional elements to the original list. See {@link
+       * SubscriptionCreateParams.AddInvoiceItem#taxRates} for the field documentation.
+       */
+      @SuppressWarnings("unchecked")
+      public Builder addTaxRate(String element) {
+        if (this.taxRates == null || this.taxRates instanceof EmptyParam) {
+          this.taxRates = new ArrayList<String>();
+        }
+        ((List<String>) this.taxRates).add(element);
+        return this;
+      }
+
+      /**
+       * Add all elements to `taxRates` list. A list is initialized for the first `add/addAll` call,
+       * and subsequent calls adds additional elements to the original list. See {@link
+       * SubscriptionCreateParams.AddInvoiceItem#taxRates} for the field documentation.
+       */
+      @SuppressWarnings("unchecked")
+      public Builder addAllTaxRate(List<String> elements) {
+        if (this.taxRates == null || this.taxRates instanceof EmptyParam) {
+          this.taxRates = new ArrayList<String>();
+        }
+        ((List<String>) this.taxRates).addAll(elements);
+        return this;
+      }
+
+      /**
+       * The tax rates which apply to the item. When set, the {@code default_tax_rates} do not apply
+       * to this item.
+       */
+      public Builder setTaxRates(EmptyParam taxRates) {
+        this.taxRates = taxRates;
+        return this;
+      }
+
+      /**
+       * The tax rates which apply to the item. When set, the {@code default_tax_rates} do not apply
+       * to this item.
+       */
+      public Builder setTaxRates(List<String> taxRates) {
+        this.taxRates = taxRates;
         return this;
       }
     }

--- a/src/main/java/com/stripe/param/SubscriptionScheduleCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionScheduleCreateParams.java
@@ -1354,12 +1354,24 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
       @SerializedName("quantity")
       Long quantity;
 
+      /**
+       * The tax rates which apply to the item. When set, the {@code default_tax_rates} do not apply
+       * to this item.
+       */
+      @SerializedName("tax_rates")
+      Object taxRates;
+
       private AddInvoiceItem(
-          Map<String, Object> extraParams, String price, PriceData priceData, Long quantity) {
+          Map<String, Object> extraParams,
+          String price,
+          PriceData priceData,
+          Long quantity,
+          Object taxRates) {
         this.extraParams = extraParams;
         this.price = price;
         this.priceData = priceData;
         this.quantity = quantity;
+        this.taxRates = taxRates;
       }
 
       public static Builder builder() {
@@ -1375,9 +1387,12 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
 
         private Long quantity;
 
+        private Object taxRates;
+
         /** Finalize and obtain parameter instance from this builder. */
         public AddInvoiceItem build() {
-          return new AddInvoiceItem(this.extraParams, this.price, this.priceData, this.quantity);
+          return new AddInvoiceItem(
+              this.extraParams, this.price, this.priceData, this.quantity, this.taxRates);
         }
 
         /**
@@ -1426,6 +1441,54 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
         /** Quantity for this item. Defaults to 1. */
         public Builder setQuantity(Long quantity) {
           this.quantity = quantity;
+          return this;
+        }
+
+        /**
+         * Add an element to `taxRates` list. A list is initialized for the first `add/addAll` call,
+         * and subsequent calls adds additional elements to the original list. See {@link
+         * SubscriptionScheduleCreateParams.Phase.AddInvoiceItem#taxRates} for the field
+         * documentation.
+         */
+        @SuppressWarnings("unchecked")
+        public Builder addTaxRate(String element) {
+          if (this.taxRates == null || this.taxRates instanceof EmptyParam) {
+            this.taxRates = new ArrayList<String>();
+          }
+          ((List<String>) this.taxRates).add(element);
+          return this;
+        }
+
+        /**
+         * Add all elements to `taxRates` list. A list is initialized for the first `add/addAll`
+         * call, and subsequent calls adds additional elements to the original list. See {@link
+         * SubscriptionScheduleCreateParams.Phase.AddInvoiceItem#taxRates} for the field
+         * documentation.
+         */
+        @SuppressWarnings("unchecked")
+        public Builder addAllTaxRate(List<String> elements) {
+          if (this.taxRates == null || this.taxRates instanceof EmptyParam) {
+            this.taxRates = new ArrayList<String>();
+          }
+          ((List<String>) this.taxRates).addAll(elements);
+          return this;
+        }
+
+        /**
+         * The tax rates which apply to the item. When set, the {@code default_tax_rates} do not
+         * apply to this item.
+         */
+        public Builder setTaxRates(EmptyParam taxRates) {
+          this.taxRates = taxRates;
+          return this;
+        }
+
+        /**
+         * The tax rates which apply to the item. When set, the {@code default_tax_rates} do not
+         * apply to this item.
+         */
+        public Builder setTaxRates(List<String> taxRates) {
+          this.taxRates = taxRates;
           return this;
         }
       }

--- a/src/main/java/com/stripe/param/SubscriptionScheduleUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionScheduleUpdateParams.java
@@ -1383,12 +1383,24 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
       @SerializedName("quantity")
       Long quantity;
 
+      /**
+       * The tax rates which apply to the item. When set, the {@code default_tax_rates} do not apply
+       * to this item.
+       */
+      @SerializedName("tax_rates")
+      Object taxRates;
+
       private AddInvoiceItem(
-          Map<String, Object> extraParams, Object price, PriceData priceData, Long quantity) {
+          Map<String, Object> extraParams,
+          Object price,
+          PriceData priceData,
+          Long quantity,
+          Object taxRates) {
         this.extraParams = extraParams;
         this.price = price;
         this.priceData = priceData;
         this.quantity = quantity;
+        this.taxRates = taxRates;
       }
 
       public static Builder builder() {
@@ -1404,9 +1416,12 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
 
         private Long quantity;
 
+        private Object taxRates;
+
         /** Finalize and obtain parameter instance from this builder. */
         public AddInvoiceItem build() {
-          return new AddInvoiceItem(this.extraParams, this.price, this.priceData, this.quantity);
+          return new AddInvoiceItem(
+              this.extraParams, this.price, this.priceData, this.quantity, this.taxRates);
         }
 
         /**
@@ -1461,6 +1476,54 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
         /** Quantity for this item. Defaults to 1. */
         public Builder setQuantity(Long quantity) {
           this.quantity = quantity;
+          return this;
+        }
+
+        /**
+         * Add an element to `taxRates` list. A list is initialized for the first `add/addAll` call,
+         * and subsequent calls adds additional elements to the original list. See {@link
+         * SubscriptionScheduleUpdateParams.Phase.AddInvoiceItem#taxRates} for the field
+         * documentation.
+         */
+        @SuppressWarnings("unchecked")
+        public Builder addTaxRate(String element) {
+          if (this.taxRates == null || this.taxRates instanceof EmptyParam) {
+            this.taxRates = new ArrayList<String>();
+          }
+          ((List<String>) this.taxRates).add(element);
+          return this;
+        }
+
+        /**
+         * Add all elements to `taxRates` list. A list is initialized for the first `add/addAll`
+         * call, and subsequent calls adds additional elements to the original list. See {@link
+         * SubscriptionScheduleUpdateParams.Phase.AddInvoiceItem#taxRates} for the field
+         * documentation.
+         */
+        @SuppressWarnings("unchecked")
+        public Builder addAllTaxRate(List<String> elements) {
+          if (this.taxRates == null || this.taxRates instanceof EmptyParam) {
+            this.taxRates = new ArrayList<String>();
+          }
+          ((List<String>) this.taxRates).addAll(elements);
+          return this;
+        }
+
+        /**
+         * The tax rates which apply to the item. When set, the {@code default_tax_rates} do not
+         * apply to this item.
+         */
+        public Builder setTaxRates(EmptyParam taxRates) {
+          this.taxRates = taxRates;
+          return this;
+        }
+
+        /**
+         * The tax rates which apply to the item. When set, the {@code default_tax_rates} do not
+         * apply to this item.
+         */
+        public Builder setTaxRates(List<String> taxRates) {
+          this.taxRates = taxRates;
           return this;
         }
       }

--- a/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
@@ -947,12 +947,24 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
     @SerializedName("quantity")
     Long quantity;
 
+    /**
+     * The tax rates which apply to the item. When set, the {@code default_tax_rates} do not apply
+     * to this item.
+     */
+    @SerializedName("tax_rates")
+    Object taxRates;
+
     private AddInvoiceItem(
-        Map<String, Object> extraParams, Object price, PriceData priceData, Long quantity) {
+        Map<String, Object> extraParams,
+        Object price,
+        PriceData priceData,
+        Long quantity,
+        Object taxRates) {
       this.extraParams = extraParams;
       this.price = price;
       this.priceData = priceData;
       this.quantity = quantity;
+      this.taxRates = taxRates;
     }
 
     public static Builder builder() {
@@ -968,9 +980,12 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
 
       private Long quantity;
 
+      private Object taxRates;
+
       /** Finalize and obtain parameter instance from this builder. */
       public AddInvoiceItem build() {
-        return new AddInvoiceItem(this.extraParams, this.price, this.priceData, this.quantity);
+        return new AddInvoiceItem(
+            this.extraParams, this.price, this.priceData, this.quantity, this.taxRates);
       }
 
       /**
@@ -1024,6 +1039,52 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
       /** Quantity for this item. Defaults to 1. */
       public Builder setQuantity(Long quantity) {
         this.quantity = quantity;
+        return this;
+      }
+
+      /**
+       * Add an element to `taxRates` list. A list is initialized for the first `add/addAll` call,
+       * and subsequent calls adds additional elements to the original list. See {@link
+       * SubscriptionUpdateParams.AddInvoiceItem#taxRates} for the field documentation.
+       */
+      @SuppressWarnings("unchecked")
+      public Builder addTaxRate(String element) {
+        if (this.taxRates == null || this.taxRates instanceof EmptyParam) {
+          this.taxRates = new ArrayList<String>();
+        }
+        ((List<String>) this.taxRates).add(element);
+        return this;
+      }
+
+      /**
+       * Add all elements to `taxRates` list. A list is initialized for the first `add/addAll` call,
+       * and subsequent calls adds additional elements to the original list. See {@link
+       * SubscriptionUpdateParams.AddInvoiceItem#taxRates} for the field documentation.
+       */
+      @SuppressWarnings("unchecked")
+      public Builder addAllTaxRate(List<String> elements) {
+        if (this.taxRates == null || this.taxRates instanceof EmptyParam) {
+          this.taxRates = new ArrayList<String>();
+        }
+        ((List<String>) this.taxRates).addAll(elements);
+        return this;
+      }
+
+      /**
+       * The tax rates which apply to the item. When set, the {@code default_tax_rates} do not apply
+       * to this item.
+       */
+      public Builder setTaxRates(EmptyParam taxRates) {
+        this.taxRates = taxRates;
+        return this;
+      }
+
+      /**
+       * The tax rates which apply to the item. When set, the {@code default_tax_rates} do not apply
+       * to this item.
+       */
+      public Builder setTaxRates(List<String> taxRates) {
+        this.taxRates = taxRates;
         return this;
       }
     }


### PR DESCRIPTION
Codegen for openapi ea5fa98

r? @ctrudeau-stripe 
cc @stripe/api-libraries 