### PR TITLE
Add  `payment_method_details[interac_present][preferred_locales]` on `Charge`

### DIFF
--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -2031,6 +2031,10 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
       @SerializedName("network")
       String network;
 
+      /** EMV tag 5F2D. Preferred languages specified by the integrated circuit chip. */
+      @SerializedName("preferred_locales")
+      List<String> preferredLocales;
+
       /**
        * How card details were read in this transaction.
        *

--- a/src/main/java/com/stripe/model/PaymentIntent.java
+++ b/src/main/java/com/stripe/model/PaymentIntent.java
@@ -1160,6 +1160,9 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
     @SerializedName("oxxo")
     Oxxo oxxo;
 
+    @SerializedName("p24")
+    P24 p24;
+
     @SerializedName("sofort")
     Sofort sofort;
 
@@ -1270,6 +1273,11 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
       @SerializedName("expires_after_days")
       Long expiresAfterDays;
     }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class P24 extends StripeObject {}
 
     @Getter
     @Setter

--- a/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
@@ -2679,6 +2679,13 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
     Object oxxo;
 
     /**
+     * If this is a {@code p24} PaymentMethod, this sub-hash contains details about the Przelewy24
+     * payment method options.
+     */
+    @SerializedName("p24")
+    Object p24;
+
+    /**
      * If this is a {@code sofort} PaymentMethod, this sub-hash contains details about the SOFORT
      * payment method options.
      */
@@ -2691,12 +2698,14 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
         Object card,
         Map<String, Object> extraParams,
         Object oxxo,
+        Object p24,
         Object sofort) {
       this.alipay = alipay;
       this.bancontact = bancontact;
       this.card = card;
       this.extraParams = extraParams;
       this.oxxo = oxxo;
+      this.p24 = p24;
       this.sofort = sofort;
     }
 
@@ -2715,12 +2724,20 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
 
       private Object oxxo;
 
+      private Object p24;
+
       private Object sofort;
 
       /** Finalize and obtain parameter instance from this builder. */
       public PaymentMethodOptions build() {
         return new PaymentMethodOptions(
-            this.alipay, this.bancontact, this.card, this.extraParams, this.oxxo, this.sofort);
+            this.alipay,
+            this.bancontact,
+            this.card,
+            this.extraParams,
+            this.oxxo,
+            this.p24,
+            this.sofort);
       }
 
       /**
@@ -2813,6 +2830,24 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
        */
       public Builder setOxxo(EmptyParam oxxo) {
         this.oxxo = oxxo;
+        return this;
+      }
+
+      /**
+       * If this is a {@code p24} PaymentMethod, this sub-hash contains details about the Przelewy24
+       * payment method options.
+       */
+      public Builder setP24(P24 p24) {
+        this.p24 = p24;
+        return this;
+      }
+
+      /**
+       * If this is a {@code p24} PaymentMethod, this sub-hash contains details about the Przelewy24
+       * payment method options.
+       */
+      public Builder setP24(EmptyParam p24) {
+        this.p24 = p24;
         return this;
       }
 
@@ -3538,6 +3573,63 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
          * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
          * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
          * map. See {@link PaymentIntentConfirmParams.PaymentMethodOptions.Oxxo#extraParams} for the
+         * field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+      }
+    }
+
+    @Getter
+    public static class P24 {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private P24(Map<String, Object> extraParams) {
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public P24 build() {
+          return new P24(this.extraParams);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentConfirmParams.PaymentMethodOptions.P24#extraParams} for the
+         * field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentConfirmParams.PaymentMethodOptions.P24#extraParams} for the
          * field documentation.
          */
         public Builder putAllExtraParam(Map<String, Object> map) {

--- a/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
@@ -3052,6 +3052,13 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     Object oxxo;
 
     /**
+     * If this is a {@code p24} PaymentMethod, this sub-hash contains details about the Przelewy24
+     * payment method options.
+     */
+    @SerializedName("p24")
+    Object p24;
+
+    /**
      * If this is a {@code sofort} PaymentMethod, this sub-hash contains details about the SOFORT
      * payment method options.
      */
@@ -3064,12 +3071,14 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
         Object card,
         Map<String, Object> extraParams,
         Object oxxo,
+        Object p24,
         Object sofort) {
       this.alipay = alipay;
       this.bancontact = bancontact;
       this.card = card;
       this.extraParams = extraParams;
       this.oxxo = oxxo;
+      this.p24 = p24;
       this.sofort = sofort;
     }
 
@@ -3088,12 +3097,20 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
 
       private Object oxxo;
 
+      private Object p24;
+
       private Object sofort;
 
       /** Finalize and obtain parameter instance from this builder. */
       public PaymentMethodOptions build() {
         return new PaymentMethodOptions(
-            this.alipay, this.bancontact, this.card, this.extraParams, this.oxxo, this.sofort);
+            this.alipay,
+            this.bancontact,
+            this.card,
+            this.extraParams,
+            this.oxxo,
+            this.p24,
+            this.sofort);
       }
 
       /**
@@ -3186,6 +3203,24 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
        */
       public Builder setOxxo(EmptyParam oxxo) {
         this.oxxo = oxxo;
+        return this;
+      }
+
+      /**
+       * If this is a {@code p24} PaymentMethod, this sub-hash contains details about the Przelewy24
+       * payment method options.
+       */
+      public Builder setP24(P24 p24) {
+        this.p24 = p24;
+        return this;
+      }
+
+      /**
+       * If this is a {@code p24} PaymentMethod, this sub-hash contains details about the Przelewy24
+       * payment method options.
+       */
+      public Builder setP24(EmptyParam p24) {
+        this.p24 = p24;
         return this;
       }
 
@@ -3911,6 +3946,63 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
          * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
          * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
          * map. See {@link PaymentIntentCreateParams.PaymentMethodOptions.Oxxo#extraParams} for the
+         * field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+      }
+    }
+
+    @Getter
+    public static class P24 {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private P24(Map<String, Object> extraParams) {
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public P24 build() {
+          return new P24(this.extraParams);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentCreateParams.PaymentMethodOptions.P24#extraParams} for the
+         * field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentCreateParams.PaymentMethodOptions.P24#extraParams} for the
          * field documentation.
          */
         public Builder putAllExtraParam(Map<String, Object> map) {

--- a/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
@@ -2670,6 +2670,13 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     Object oxxo;
 
     /**
+     * If this is a {@code p24} PaymentMethod, this sub-hash contains details about the Przelewy24
+     * payment method options.
+     */
+    @SerializedName("p24")
+    Object p24;
+
+    /**
      * If this is a {@code sofort} PaymentMethod, this sub-hash contains details about the SOFORT
      * payment method options.
      */
@@ -2682,12 +2689,14 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
         Object card,
         Map<String, Object> extraParams,
         Object oxxo,
+        Object p24,
         Object sofort) {
       this.alipay = alipay;
       this.bancontact = bancontact;
       this.card = card;
       this.extraParams = extraParams;
       this.oxxo = oxxo;
+      this.p24 = p24;
       this.sofort = sofort;
     }
 
@@ -2706,12 +2715,20 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
 
       private Object oxxo;
 
+      private Object p24;
+
       private Object sofort;
 
       /** Finalize and obtain parameter instance from this builder. */
       public PaymentMethodOptions build() {
         return new PaymentMethodOptions(
-            this.alipay, this.bancontact, this.card, this.extraParams, this.oxxo, this.sofort);
+            this.alipay,
+            this.bancontact,
+            this.card,
+            this.extraParams,
+            this.oxxo,
+            this.p24,
+            this.sofort);
       }
 
       /**
@@ -2804,6 +2821,24 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
        */
       public Builder setOxxo(EmptyParam oxxo) {
         this.oxxo = oxxo;
+        return this;
+      }
+
+      /**
+       * If this is a {@code p24} PaymentMethod, this sub-hash contains details about the Przelewy24
+       * payment method options.
+       */
+      public Builder setP24(P24 p24) {
+        this.p24 = p24;
+        return this;
+      }
+
+      /**
+       * If this is a {@code p24} PaymentMethod, this sub-hash contains details about the Przelewy24
+       * payment method options.
+       */
+      public Builder setP24(EmptyParam p24) {
+        this.p24 = p24;
         return this;
       }
 
@@ -3539,6 +3574,63 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
          * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
          * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
          * map. See {@link PaymentIntentUpdateParams.PaymentMethodOptions.Oxxo#extraParams} for the
+         * field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+      }
+    }
+
+    @Getter
+    public static class P24 {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private P24(Map<String, Object> extraParams) {
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public P24 build() {
+          return new P24(this.extraParams);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentUpdateParams.PaymentMethodOptions.P24#extraParams} for the
+         * field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentUpdateParams.PaymentMethodOptions.P24#extraParams} for the
          * field documentation.
          */
         public Builder putAllExtraParam(Map<String, Object> map) {


### PR DESCRIPTION
This PR adds support for `payment_method_details[interac_present][preferred_locales]` on `Charge`. It also adds an empty-able hash `payment_method_options[p24]` on `PaymentIntent` for an upcoming feature but this change is a no op

Codegen for openapi 9f2a7bc

r? @richardm-stripe 
cc @stripe/api-libraries 