### PR TITLE
Multiple API changes

### DIFF
--- a/src/main/java/com/stripe/model/BalanceTransactionSourceTypeAdapterFactory.java
+++ b/src/main/java/com/stripe/model/BalanceTransactionSourceTypeAdapterFactory.java
@@ -9,9 +9,6 @@ import com.google.gson.TypeAdapterFactory;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
-import com.stripe.model.issuing.Authorization;
-import com.stripe.model.issuing.Dispute;
-import com.stripe.model.issuing.Transaction;
 import java.io.IOException;
 import lombok.Getter;
 
@@ -28,40 +25,42 @@ public class BalanceTransactionSourceTypeAdapterFactory implements TypeAdapterFa
     }
     final String discriminator = "object";
     final TypeAdapter<JsonElement> jsonElementAdapter = gson.getAdapter(JsonElement.class);
-    final TypeAdapter<BalanceTransactionSource> balanceTransactionSourceAdapter =
-        gson.getDelegateAdapter(this, TypeToken.get(BalanceTransactionSource.class));
-    final TypeAdapter<ApplicationFee> applicationFeeAdapter =
-        gson.getDelegateAdapter(this, TypeToken.get(ApplicationFee.class));
-    final TypeAdapter<Charge> chargeAdapter =
-        gson.getDelegateAdapter(this, TypeToken.get(Charge.class));
-    final TypeAdapter<ConnectCollectionTransfer> connectCollectionTransferAdapter =
-        gson.getDelegateAdapter(this, TypeToken.get(ConnectCollectionTransfer.class));
-    final TypeAdapter<Dispute> disputeAdapter =
-        gson.getDelegateAdapter(this, TypeToken.get(Dispute.class));
-    final TypeAdapter<FeeRefund> feeRefundAdapter =
-        gson.getDelegateAdapter(this, TypeToken.get(FeeRefund.class));
-    final TypeAdapter<Authorization> authorizationAdapter =
-        gson.getDelegateAdapter(this, TypeToken.get(Authorization.class));
-    final TypeAdapter<Dispute> disputeAdapter =
-        gson.getDelegateAdapter(this, TypeToken.get(Dispute.class));
-    final TypeAdapter<Transaction> transactionAdapter =
-        gson.getDelegateAdapter(this, TypeToken.get(Transaction.class));
-    final TypeAdapter<Payout> payoutAdapter =
-        gson.getDelegateAdapter(this, TypeToken.get(Payout.class));
-    final TypeAdapter<PlatformTaxFee> platformTaxFeeAdapter =
-        gson.getDelegateAdapter(this, TypeToken.get(PlatformTaxFee.class));
-    final TypeAdapter<Refund> refundAdapter =
-        gson.getDelegateAdapter(this, TypeToken.get(Refund.class));
-    final TypeAdapter<ReserveTransaction> reserveTransactionAdapter =
-        gson.getDelegateAdapter(this, TypeToken.get(ReserveTransaction.class));
-    final TypeAdapter<TaxDeductedAtSource> taxDeductedAtSourceAdapter =
-        gson.getDelegateAdapter(this, TypeToken.get(TaxDeductedAtSource.class));
-    final TypeAdapter<Topup> topupAdapter =
-        gson.getDelegateAdapter(this, TypeToken.get(Topup.class));
-    final TypeAdapter<Transfer> transferAdapter =
-        gson.getDelegateAdapter(this, TypeToken.get(Transfer.class));
-    final TypeAdapter<TransferReversal> transferReversalAdapter =
-        gson.getDelegateAdapter(this, TypeToken.get(TransferReversal.class));
+    final TypeAdapter<com.stripe.model.BalanceTransactionSource> balanceTransactionSourceAdapter =
+        gson.getDelegateAdapter(
+            this, TypeToken.get(com.stripe.model.BalanceTransactionSource.class));
+    final TypeAdapter<com.stripe.model.ApplicationFee> applicationFeeAdapter =
+        gson.getDelegateAdapter(this, TypeToken.get(com.stripe.model.ApplicationFee.class));
+    final TypeAdapter<com.stripe.model.Charge> chargeAdapter =
+        gson.getDelegateAdapter(this, TypeToken.get(com.stripe.model.Charge.class));
+    final TypeAdapter<com.stripe.model.ConnectCollectionTransfer> connectCollectionTransferAdapter =
+        gson.getDelegateAdapter(
+            this, TypeToken.get(com.stripe.model.ConnectCollectionTransfer.class));
+    final TypeAdapter<com.stripe.model.Dispute> disputeAdapter =
+        gson.getDelegateAdapter(this, TypeToken.get(com.stripe.model.Dispute.class));
+    final TypeAdapter<com.stripe.model.FeeRefund> feeRefundAdapter =
+        gson.getDelegateAdapter(this, TypeToken.get(com.stripe.model.FeeRefund.class));
+    final TypeAdapter<com.stripe.model.issuing.Authorization> issuingAuthorizationAdapter =
+        gson.getDelegateAdapter(this, TypeToken.get(com.stripe.model.issuing.Authorization.class));
+    final TypeAdapter<com.stripe.model.issuing.Dispute> issuingDisputeAdapter =
+        gson.getDelegateAdapter(this, TypeToken.get(com.stripe.model.issuing.Dispute.class));
+    final TypeAdapter<com.stripe.model.issuing.Transaction> issuingTransactionAdapter =
+        gson.getDelegateAdapter(this, TypeToken.get(com.stripe.model.issuing.Transaction.class));
+    final TypeAdapter<com.stripe.model.Payout> payoutAdapter =
+        gson.getDelegateAdapter(this, TypeToken.get(com.stripe.model.Payout.class));
+    final TypeAdapter<com.stripe.model.PlatformTaxFee> platformTaxFeeAdapter =
+        gson.getDelegateAdapter(this, TypeToken.get(com.stripe.model.PlatformTaxFee.class));
+    final TypeAdapter<com.stripe.model.Refund> refundAdapter =
+        gson.getDelegateAdapter(this, TypeToken.get(com.stripe.model.Refund.class));
+    final TypeAdapter<com.stripe.model.ReserveTransaction> reserveTransactionAdapter =
+        gson.getDelegateAdapter(this, TypeToken.get(com.stripe.model.ReserveTransaction.class));
+    final TypeAdapter<com.stripe.model.TaxDeductedAtSource> taxDeductedAtSourceAdapter =
+        gson.getDelegateAdapter(this, TypeToken.get(com.stripe.model.TaxDeductedAtSource.class));
+    final TypeAdapter<com.stripe.model.Topup> topupAdapter =
+        gson.getDelegateAdapter(this, TypeToken.get(com.stripe.model.Topup.class));
+    final TypeAdapter<com.stripe.model.Transfer> transferAdapter =
+        gson.getDelegateAdapter(this, TypeToken.get(com.stripe.model.Transfer.class));
+    final TypeAdapter<com.stripe.model.TransferReversal> transferReversalAdapter =
+        gson.getDelegateAdapter(this, TypeToken.get(com.stripe.model.TransferReversal.class));
 
     TypeAdapter<BalanceTransactionSource> resultCustomTypeAdapter =
         new TypeAdapter<BalanceTransactionSource>() {
@@ -86,11 +85,11 @@ public class BalanceTransactionSourceTypeAdapterFactory implements TypeAdapterFa
             } else if ("fee_refund".equals(objectType)) {
               objectResult = feeRefundAdapter.fromJsonTree(object);
             } else if ("issuing.authorization".equals(objectType)) {
-              objectResult = authorizationAdapter.fromJsonTree(object);
+              objectResult = issuingAuthorizationAdapter.fromJsonTree(object);
             } else if ("issuing.dispute".equals(objectType)) {
-              objectResult = disputeAdapter.fromJsonTree(object);
+              objectResult = issuingDisputeAdapter.fromJsonTree(object);
             } else if ("issuing.transaction".equals(objectType)) {
-              objectResult = transactionAdapter.fromJsonTree(object);
+              objectResult = issuingTransactionAdapter.fromJsonTree(object);
             } else if ("payout".equals(objectType)) {
               objectResult = payoutAdapter.fromJsonTree(object);
             } else if ("platform_tax_fee".equals(objectType)) {

--- a/src/main/java/com/stripe/model/BalanceTransactionSourceTypeAdapterFactory.java
+++ b/src/main/java/com/stripe/model/BalanceTransactionSourceTypeAdapterFactory.java
@@ -10,6 +10,7 @@ import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import com.stripe.model.issuing.Authorization;
+import com.stripe.model.issuing.Dispute;
 import com.stripe.model.issuing.Transaction;
 import java.io.IOException;
 import lombok.Getter;
@@ -41,6 +42,8 @@ public class BalanceTransactionSourceTypeAdapterFactory implements TypeAdapterFa
         gson.getDelegateAdapter(this, TypeToken.get(FeeRefund.class));
     final TypeAdapter<Authorization> authorizationAdapter =
         gson.getDelegateAdapter(this, TypeToken.get(Authorization.class));
+    final TypeAdapter<Dispute> disputeAdapter =
+        gson.getDelegateAdapter(this, TypeToken.get(Dispute.class));
     final TypeAdapter<Transaction> transactionAdapter =
         gson.getDelegateAdapter(this, TypeToken.get(Transaction.class));
     final TypeAdapter<Payout> payoutAdapter =
@@ -84,6 +87,8 @@ public class BalanceTransactionSourceTypeAdapterFactory implements TypeAdapterFa
               objectResult = feeRefundAdapter.fromJsonTree(object);
             } else if ("issuing.authorization".equals(objectType)) {
               objectResult = authorizationAdapter.fromJsonTree(object);
+            } else if ("issuing.dispute".equals(objectType)) {
+              objectResult = disputeAdapter.fromJsonTree(object);
             } else if ("issuing.transaction".equals(objectType)) {
               objectResult = transactionAdapter.fromJsonTree(object);
             } else if ("payout".equals(objectType)) {

--- a/src/main/java/com/stripe/model/ExternalAccountTypeAdapterFactory.java
+++ b/src/main/java/com/stripe/model/ExternalAccountTypeAdapterFactory.java
@@ -28,11 +28,12 @@ public class ExternalAccountTypeAdapterFactory implements TypeAdapterFactory {
     }
     final String discriminator = "object";
     final TypeAdapter<JsonElement> jsonElementAdapter = gson.getAdapter(JsonElement.class);
-    final TypeAdapter<ExternalAccount> externalAccountAdapter =
-        gson.getDelegateAdapter(this, TypeToken.get(ExternalAccount.class));
-    final TypeAdapter<BankAccount> bankAccountAdapter =
-        gson.getDelegateAdapter(this, TypeToken.get(BankAccount.class));
-    final TypeAdapter<Card> cardAdapter = gson.getDelegateAdapter(this, TypeToken.get(Card.class));
+    final TypeAdapter<com.stripe.model.ExternalAccount> externalAccountAdapter =
+        gson.getDelegateAdapter(this, TypeToken.get(com.stripe.model.ExternalAccount.class));
+    final TypeAdapter<com.stripe.model.BankAccount> bankAccountAdapter =
+        gson.getDelegateAdapter(this, TypeToken.get(com.stripe.model.BankAccount.class));
+    final TypeAdapter<com.stripe.model.Card> cardAdapter =
+        gson.getDelegateAdapter(this, TypeToken.get(com.stripe.model.Card.class));
 
     TypeAdapter<ExternalAccount> resultCustomTypeAdapter =
         new TypeAdapter<ExternalAccount>() {

--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -288,6 +288,13 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
   String invoicePdf;
 
   /**
+   * The error encountered during the previous attempt to finalize the invoice. This field is
+   * cleared when the invoice is successfully finalized.
+   */
+  @SerializedName("last_finalization_error")
+  StripeError lastFinalizationError;
+
+  /**
    * The individual line items that make up the invoice. {@code lines} is sorted as follows: invoice
    * items in reverse chronological order, followed by the subscription, if any.
    */

--- a/src/main/java/com/stripe/model/PaymentSourceTypeAdapterFactory.java
+++ b/src/main/java/com/stripe/model/PaymentSourceTypeAdapterFactory.java
@@ -25,19 +25,20 @@ public class PaymentSourceTypeAdapterFactory implements TypeAdapterFactory {
     }
     final String discriminator = "object";
     final TypeAdapter<JsonElement> jsonElementAdapter = gson.getAdapter(JsonElement.class);
-    final TypeAdapter<PaymentSource> paymentSourceAdapter =
-        gson.getDelegateAdapter(this, TypeToken.get(PaymentSource.class));
-    final TypeAdapter<Account> accountAdapter =
-        gson.getDelegateAdapter(this, TypeToken.get(Account.class));
-    final TypeAdapter<AlipayAccount> alipayAccountAdapter =
-        gson.getDelegateAdapter(this, TypeToken.get(AlipayAccount.class));
-    final TypeAdapter<BankAccount> bankAccountAdapter =
-        gson.getDelegateAdapter(this, TypeToken.get(BankAccount.class));
-    final TypeAdapter<BitcoinReceiver> bitcoinReceiverAdapter =
-        gson.getDelegateAdapter(this, TypeToken.get(BitcoinReceiver.class));
-    final TypeAdapter<Card> cardAdapter = gson.getDelegateAdapter(this, TypeToken.get(Card.class));
-    final TypeAdapter<Source> sourceAdapter =
-        gson.getDelegateAdapter(this, TypeToken.get(Source.class));
+    final TypeAdapter<com.stripe.model.PaymentSource> paymentSourceAdapter =
+        gson.getDelegateAdapter(this, TypeToken.get(com.stripe.model.PaymentSource.class));
+    final TypeAdapter<com.stripe.model.Account> accountAdapter =
+        gson.getDelegateAdapter(this, TypeToken.get(com.stripe.model.Account.class));
+    final TypeAdapter<com.stripe.model.AlipayAccount> alipayAccountAdapter =
+        gson.getDelegateAdapter(this, TypeToken.get(com.stripe.model.AlipayAccount.class));
+    final TypeAdapter<com.stripe.model.BankAccount> bankAccountAdapter =
+        gson.getDelegateAdapter(this, TypeToken.get(com.stripe.model.BankAccount.class));
+    final TypeAdapter<com.stripe.model.BitcoinReceiver> bitcoinReceiverAdapter =
+        gson.getDelegateAdapter(this, TypeToken.get(com.stripe.model.BitcoinReceiver.class));
+    final TypeAdapter<com.stripe.model.Card> cardAdapter =
+        gson.getDelegateAdapter(this, TypeToken.get(com.stripe.model.Card.class));
+    final TypeAdapter<com.stripe.model.Source> sourceAdapter =
+        gson.getDelegateAdapter(this, TypeToken.get(com.stripe.model.Source.class));
 
     TypeAdapter<PaymentSource> resultCustomTypeAdapter =
         new TypeAdapter<PaymentSource>() {

--- a/src/main/java/com/stripe/model/StripeError.java
+++ b/src/main/java/com/stripe/model/StripeError.java
@@ -80,6 +80,13 @@ public class StripeError extends StripeObject {
   PaymentMethod paymentMethod;
 
   /**
+   * If the error is specific to the type of payment method, the payment method type that had a
+   * problem. This field is only populated for invoice-related errors.
+   */
+  @SerializedName("payment_method_type")
+  String paymentMethodType;
+
+  /**
    * A SetupIntent guides you through the process of setting up and saving a customer's payment
    * credentials for future payments. For example, you could use a SetupIntent to set up and save
    * your customer's card without immediately collecting a payment. Later, you can use <a

--- a/src/main/java/com/stripe/model/issuing/Dispute.java
+++ b/src/main/java/com/stripe/model/issuing/Dispute.java
@@ -5,9 +5,9 @@ import com.google.gson.annotations.SerializedName;
 import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
 import com.stripe.model.BalanceTransaction;
+import com.stripe.model.BalanceTransactionSource;
 import com.stripe.model.ExpandableField;
 import com.stripe.model.File;
-import com.stripe.model.HasId;
 import com.stripe.model.MetadataStore;
 import com.stripe.model.StripeObject;
 import com.stripe.net.ApiResource;
@@ -26,7 +26,8 @@ import lombok.Setter;
 @Getter
 @Setter
 @EqualsAndHashCode(callSuper = false)
-public class Dispute extends ApiResource implements HasId, MetadataStore<Dispute> {
+public class Dispute extends ApiResource
+    implements MetadataStore<Dispute>, BalanceTransactionSource {
   /**
    * Disputed amount. Usually the amount of the {@code disputed_transaction}, but can differ
    * (usually because of currency fluctuation).

--- a/src/test/java/com/stripe/model/BalanceTransactionTest.java
+++ b/src/test/java/com/stripe/model/BalanceTransactionTest.java
@@ -86,6 +86,11 @@ public class BalanceTransactionTest extends BaseStripeTest {
         assertNotNull(btSource);
         assertEquals("issuing.transaction", btSource.getObject());
       } else if ("txn_110".equals(btId)) {
+        com.stripe.model.issuing.Dispute btSource =
+            (com.stripe.model.issuing.Dispute) bt.getSourceObject();
+        assertNotNull(btSource);
+        assertEquals("issuing.dispute", btSource.getObject());
+      } else if ("txn_111".equals(btId)) {
         BalanceTransactionSourceTypeAdapterFactory.UnknownSubType btSource =
             (BalanceTransactionSourceTypeAdapterFactory.UnknownSubType) bt.getSourceObject();
         assertNotNull(btSource);

--- a/src/test/resources/api_fixtures/balance_transaction_collection_with_source_expansion.json
+++ b/src/test/resources/api_fixtures/balance_transaction_collection_with_source_expansion.json
@@ -88,6 +88,14 @@
       "object": "balance_transaction",
       "source": {
         "id": "foo_123",
+        "object": "issuing.dispute"
+      }
+    },
+    {
+      "id": "txn_111",
+      "object": "balance_transaction",
+      "source": {
+        "id": "foo_123",
         "object": "foo_unknown_type"
       }
     }


### PR DESCRIPTION
Multiple API changes:
  * Add support for `last_finalization_error` on `Invoice`
  * Add support for deserializing Issuing `Dispute` as a `source` on `BalanceTransaction`
  * Add support for `payment_method_type` on `StripeError` used by other API resources

Codegen for openapi 83680bb + manual additions for non codegen-edfiles

r? @richardm-stripe
cc @stripe/api-libraries