### PR TITLE
Better log the error causing the JSON parsing to fail on deserialization

### DIFF
--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -65,7 +65,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
     try {
       resource = ApiResource.GSON.fromJson(responseBody, clazz);
     } catch (JsonSyntaxException e) {
-      raiseMalformedJsonError(responseBody, responseCode, requestId);
+      raiseMalformedJsonError(responseBody, responseCode, requestId, e);
     }
 
     resource.setLastResponse(response);
@@ -96,7 +96,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
     try {
       resource = ApiResource.GSON.fromJson(responseBody, clazz);
     } catch (JsonSyntaxException e) {
-      raiseMalformedJsonError(responseBody, responseCode, requestId);
+      raiseMalformedJsonError(responseBody, responseCode, requestId, e);
     }
 
     if (resource instanceof StripeObject) {
@@ -112,15 +112,16 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
   }
 
   private static void raiseMalformedJsonError(
-      String responseBody, int responseCode, String requestId) throws ApiException {
+      String responseBody, int responseCode, String requestId, Throwable e) throws ApiException {
+    String details = e == null ? "none" : e.getMessage();
     throw new ApiException(
         String.format(
-            "Invalid response object from API: %s. (HTTP response code was %d)",
-            responseBody, responseCode),
+            "Invalid response object from API: %s. (HTTP response code was %d). Additional details: %s.",
+            responseBody, responseCode, details),
         requestId,
         null,
         responseCode,
-        null);
+        e);
   }
 
   private static void handleApiError(StripeResponse response) throws StripeException {
@@ -132,10 +133,10 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
           ApiResource.GSON.fromJson(response.body(), JsonObject.class).getAsJsonObject("error");
       error = ApiResource.GSON.fromJson(jsonObject, StripeError.class);
     } catch (JsonSyntaxException e) {
-      raiseMalformedJsonError(response.body(), response.code(), response.requestId());
+      raiseMalformedJsonError(response.body(), response.code(), response.requestId(), e);
     }
     if (error == null) {
-      raiseMalformedJsonError(response.body(), response.code(), response.requestId());
+      raiseMalformedJsonError(response.body(), response.code(), response.requestId(), null);
     }
 
     error.setLastResponse(response);
@@ -209,10 +210,10 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
     try {
       error = ApiResource.GSON.fromJson(response.body(), OAuthError.class);
     } catch (JsonSyntaxException e) {
-      raiseMalformedJsonError(response.body(), response.code(), response.requestId());
+      raiseMalformedJsonError(response.body(), response.code(), response.requestId(), e);
     }
     if (error == null) {
-      raiseMalformedJsonError(response.body(), response.code(), response.requestId());
+      raiseMalformedJsonError(response.body(), response.code(), response.requestId(), null);
     }
 
     error.setLastResponse(response);

--- a/src/test/java/com/stripe/functional/LiveStripeResponseGetterTest.java
+++ b/src/test/java/com/stripe/functional/LiveStripeResponseGetterTest.java
@@ -1,0 +1,44 @@
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.google.gson.JsonSyntaxException;
+import com.stripe.BaseStripeTest;
+import com.stripe.exception.ApiException;
+import com.stripe.exception.StripeException;
+import com.stripe.model.Subscription;
+import com.stripe.net.ApiResource;
+import com.stripe.net.HttpClient;
+import com.stripe.net.HttpHeaders;
+import com.stripe.net.HttpURLConnectionClient;
+import com.stripe.net.LiveStripeResponseGetter;
+import com.stripe.net.StripeRequest;
+import com.stripe.net.StripeResponse;
+import com.stripe.net.StripeResponseGetter;
+import java.util.Collections;
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class LiveStripeResponseGetterTest extends BaseStripeTest {
+
+  @Test
+  public void testInvalidJson() throws StripeException {
+    HttpClient spy = Mockito.spy(new HttpURLConnectionClient());
+    StripeResponseGetter srg = new LiveStripeResponseGetter(spy);
+    ApiResource.setStripeResponseGetter(srg);
+    StripeResponse response =
+        new StripeResponse(200, HttpHeaders.of(Collections.emptyMap()), "invalid JSON");
+    Mockito.doReturn(response).when(spy).requestWithRetries(Mockito.<StripeRequest>any());
+    Exception exception =
+        assertThrows(
+            ApiException.class,
+            () -> {
+              Subscription.retrieve("sub_123");
+            });
+    assertThat(
+        exception.getMessage(), CoreMatchers.containsString("Invalid response object from API"));
+    assertNotNull(exception.getCause());
+    assertThat(exception.getCause(), CoreMatchers.instanceOf(JsonSyntaxException.class));
+  }
+}

--- a/src/test/java/com/stripe/functional/StripeObjectTest.java
+++ b/src/test/java/com/stripe/functional/StripeObjectTest.java
@@ -1,25 +1,11 @@
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+package com.stripe.functional;
 
-import com.google.gson.JsonSyntaxException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import com.stripe.BaseStripeTest;
-import com.stripe.exception.ApiException;
 import com.stripe.exception.StripeException;
 import com.stripe.model.Subscription;
-import com.stripe.net.ApiResource;
-import com.stripe.net.HttpClient;
-import com.stripe.net.HttpHeaders;
-import com.stripe.net.HttpURLConnectionClient;
-import com.stripe.net.LiveStripeResponseGetter;
-import com.stripe.net.StripeRequest;
-import com.stripe.net.StripeResponse;
-import com.stripe.net.StripeResponseGetter;
-import java.util.Collections;
-import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 public class StripeObjectTest extends BaseStripeTest {
   @Test
@@ -47,25 +33,5 @@ public class StripeObjectTest extends BaseStripeTest {
             .getAsJsonObject()
             .getAsJsonPrimitive("id")
             .getAsString());
-  }
-
-  @Test
-  public void testInvalidJson() throws StripeException {
-    HttpClient spy = Mockito.spy(new HttpURLConnectionClient());
-    StripeResponseGetter srg = new LiveStripeResponseGetter(spy);
-    ApiResource.setStripeResponseGetter(srg);
-    StripeResponse response =
-        new StripeResponse(200, HttpHeaders.of(Collections.emptyMap()), "invalid JSON");
-    Mockito.doReturn(response).when(spy).requestWithRetries(Mockito.<StripeRequest>any());
-    Exception exception =
-        assertThrows(
-            ApiException.class,
-            () -> {
-              Subscription.retrieve("sub_123");
-            });
-    assertThat(
-        exception.getMessage(), CoreMatchers.containsString("Invalid response object from API"));
-    assertNotNull(exception.getCause());
-    assertThat(exception.getCause(), CoreMatchers.instanceOf(JsonSyntaxException.class));
   }
 }

--- a/src/test/java/com/stripe/functional/StripeObjectTest.java
+++ b/src/test/java/com/stripe/functional/StripeObjectTest.java
@@ -1,11 +1,25 @@
-package com.stripe.functional;
-
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.google.gson.JsonSyntaxException;
 import com.stripe.BaseStripeTest;
+import com.stripe.exception.ApiException;
 import com.stripe.exception.StripeException;
 import com.stripe.model.Subscription;
+import com.stripe.net.ApiResource;
+import com.stripe.net.HttpClient;
+import com.stripe.net.HttpHeaders;
+import com.stripe.net.HttpURLConnectionClient;
+import com.stripe.net.LiveStripeResponseGetter;
+import com.stripe.net.StripeRequest;
+import com.stripe.net.StripeResponse;
+import com.stripe.net.StripeResponseGetter;
+import java.util.Collections;
+import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 public class StripeObjectTest extends BaseStripeTest {
   @Test
@@ -33,5 +47,25 @@ public class StripeObjectTest extends BaseStripeTest {
             .getAsJsonObject()
             .getAsJsonPrimitive("id")
             .getAsString());
+  }
+
+  @Test
+  public void testInvalidJson() throws StripeException {
+    HttpClient spy = Mockito.spy(new HttpURLConnectionClient());
+    StripeResponseGetter srg = new LiveStripeResponseGetter(spy);
+    ApiResource.setStripeResponseGetter(srg);
+    StripeResponse response =
+        new StripeResponse(200, HttpHeaders.of(Collections.emptyMap()), "invalid JSON");
+    Mockito.doReturn(response).when(spy).requestWithRetries(Mockito.<StripeRequest>any());
+    Exception exception =
+        assertThrows(
+            ApiException.class,
+            () -> {
+              Subscription.retrieve("sub_123");
+            });
+    assertThat(
+        exception.getMessage(), CoreMatchers.containsString("Invalid response object from API"));
+    assertNotNull(exception.getCause());
+    assertThat(exception.getCause(), CoreMatchers.instanceOf(JsonSyntaxException.class));
   }
 }


### PR DESCRIPTION
We're now logging the error message associated with the `JsonSyntaxException` exception raised on parsing, if any. We also record that exception as the cause of the `ApiException` we throw.

r? @richardm-stripe 
cc @stripe/api-libraries 