### PR TITLE
MetadataStore extends HasId

### DIFF
--- a/src/main/java/com/stripe/model/MetadataStore.java
+++ b/src/main/java/com/stripe/model/MetadataStore.java
@@ -5,11 +5,10 @@ import com.stripe.net.RequestOptions;
 import java.util.Map;
 
 /** Common interface for Stripe objects that can store metadata. */
-public interface MetadataStore<T> {
+public interface MetadataStore<T extends MetadataStore<T>> extends HasId {
   Map<String, String> getMetadata();
 
-  MetadataStore<T> update(Map<String, Object> params) throws StripeException;
+  T update(Map<String, Object> params) throws StripeException;
 
-  MetadataStore<T> update(Map<String, Object> params, RequestOptions options)
-      throws StripeException;
+  T update(Map<String, Object> params, RequestOptions options) throws StripeException;
 }


### PR DESCRIPTION
We're getting a bit of a "generics headache" re. `MetadataStore` vs `HasId`, mainly due to the fact that `MetadataStore` does not extend `HasId` (even though all impls that I found do). This makes it hard to write generic code that expects an object that has both interfaces.

Would this change to the `MetadataStore` make sense?

Before change we have to write:
```java
private <T extends MetadataStore<T>> T updateMetadata(T t, Map<String, String> metadata) throws StripeException {
	log.info("Adding metadata to {} in account {}: {}.", ((HasId) t).getId(), metadata);
	Map<String, Object> params = new HashMap<>();
	params.put("metadata", metadata);
	@SuppressWarnings("unchecked")
	T updated = (T) t.update(params);
	t = updated;
	return t;
}
```

After we can do:
```java
private <T extends MetadataStore<T>> T updateMetadata(T t, Map<String, String> metadata) throws StripeException {
	log.info("Adding metadata to {} in account {}: {}.", t.getId(), metadata);
	Map<String, Object> params = new HashMap<>();
	params.put("metadata", metadata);
	return t.update(params);
}
```
