### PR TITLE
Adding getUserMessage() to exceptions

### DIFF
--- a/src/main/java/com/stripe/exception/StripeException.java
+++ b/src/main/java/com/stripe/exception/StripeException.java
@@ -11,8 +11,7 @@ public abstract class StripeException extends Exception {
   /** The error resource returned by Stripe's API that caused the exception. */
   // transient so the exception can be serialized, as StripeObject does not
   // implement Serializable
-  @Setter
-  transient StripeError stripeError;
+  @Setter transient StripeError stripeError;
 
   private String code;
   private String requestId;
@@ -23,7 +22,8 @@ public abstract class StripeException extends Exception {
   }
 
   /** Constructs a new Stripe exception with the specified details. */
-  protected StripeException(String message, String requestId, String code, Integer statusCode, Throwable e) {
+  protected StripeException(
+      String message, String requestId, String code, Integer statusCode, Throwable e) {
     super(message, e);
     this.code = code;
     this.requestId = requestId;
@@ -31,8 +31,8 @@ public abstract class StripeException extends Exception {
   }
 
   /**
-   * Returns a description of the exception, including the HTTP status code and
-   * request ID (if applicable).
+   * Returns a description of the exception, including the HTTP status code and request ID (if
+   * applicable).
    *
    * @return a string representation of the exception.
    */

--- a/src/main/java/com/stripe/exception/StripeException.java
+++ b/src/main/java/com/stripe/exception/StripeException.java
@@ -9,8 +9,10 @@ public abstract class StripeException extends Exception {
   private static final long serialVersionUID = 2L;
 
   /** The error resource returned by Stripe's API that caused the exception. */
-  // transient so the exception can be serialized, as StripeObject does not implement Serializable
-  @Setter transient StripeError stripeError;
+  // transient so the exception can be serialized, as StripeObject does not
+  // implement Serializable
+  @Setter
+  transient StripeError stripeError;
 
   private String code;
   private String requestId;
@@ -21,8 +23,7 @@ public abstract class StripeException extends Exception {
   }
 
   /** Constructs a new Stripe exception with the specified details. */
-  protected StripeException(
-      String message, String requestId, String code, Integer statusCode, Throwable e) {
+  protected StripeException(String message, String requestId, String code, Integer statusCode, Throwable e) {
     super(message, e);
     this.code = code;
     this.requestId = requestId;
@@ -30,8 +31,8 @@ public abstract class StripeException extends Exception {
   }
 
   /**
-   * Returns a description of the exception, including the HTTP status code and request ID (if
-   * applicable).
+   * Returns a description of the exception, including the HTTP status code and
+   * request ID (if applicable).
    *
    * @return a string representation of the exception.
    */
@@ -45,5 +46,14 @@ public abstract class StripeException extends Exception {
       additionalInfo += "; request-id: " + requestId;
     }
     return super.getMessage() + additionalInfo;
+  }
+
+  /**
+   * Returns a description of the user facing exception
+   *
+   * @return a string representation of the user facing exception.
+   */
+  public String getUserMessage() {
+    return super.getMessage();
   }
 }


### PR DESCRIPTION
r? @richardm-stripe 
cc @stripe/api-libraries

Currently calling `e.getMessage()` `returns <reason>.; code: <code>; request-id: <request-id>`. This adds a method to get only the reason. The reason is the error to display to users. 