### PR TITLE
Add `nationality` to Person

### DIFF
--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -1382,12 +1382,12 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
   public static class CustomerTaxId extends StripeObject {
     /**
      * The type of the tax ID, one of {@code eu_vat}, {@code br_cnpj}, {@code br_cpf}, {@code
-     * nz_gst}, {@code au_abn}, {@code in_gst}, {@code no_vat}, {@code za_vat}, {@code ch_vat},
-     * {@code mx_rfc}, {@code sg_uen}, {@code ru_inn}, {@code ru_kpp}, {@code ca_bn}, {@code hk_br},
-     * {@code es_cif}, {@code tw_vat}, {@code th_vat}, {@code jp_cn}, {@code jp_rn}, {@code li_uid},
-     * {@code my_itn}, {@code us_ein}, {@code kr_brn}, {@code ca_qst}, {@code my_sst}, {@code
-     * sg_gst}, {@code ae_trn}, {@code cl_tin}, {@code sa_vat}, {@code id_npwp}, {@code my_frp}, or
-     * {@code unknown}.
+     * gb_vat}, {@code nz_gst}, {@code au_abn}, {@code in_gst}, {@code no_vat}, {@code za_vat},
+     * {@code ch_vat}, {@code mx_rfc}, {@code sg_uen}, {@code ru_inn}, {@code ru_kpp}, {@code
+     * ca_bn}, {@code hk_br}, {@code es_cif}, {@code tw_vat}, {@code th_vat}, {@code jp_cn}, {@code
+     * jp_rn}, {@code li_uid}, {@code my_itn}, {@code us_ein}, {@code kr_brn}, {@code ca_qst},
+     * {@code my_sst}, {@code sg_gst}, {@code ae_trn}, {@code cl_tin}, {@code sa_vat}, {@code
+     * id_npwp}, {@code my_frp}, or {@code unknown}.
      */
     @SerializedName("type")
     String type;

--- a/src/main/java/com/stripe/model/PaymentIntent.java
+++ b/src/main/java/com/stripe/model/PaymentIntent.java
@@ -1067,7 +1067,8 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
     NextActionRedirectToUrl redirectToUrl;
 
     /**
-     * Type of the next action to perform, one of {@code redirect_to_url} or {@code use_stripe_sdk}.
+     * Type of the next action to perform, one of {@code redirect_to_url}, {@code use_stripe_sdk},
+     * {@code alipay_handle_redirect}, or {@code oxxo_display_details}.
      */
     @SerializedName("type")
     String type;

--- a/src/main/java/com/stripe/model/Person.java
+++ b/src/main/java/com/stripe/model/Person.java
@@ -101,6 +101,10 @@ public class Person extends ApiResource implements HasId, MetadataStore<Person> 
   @SerializedName("metadata")
   Map<String, String> metadata;
 
+  /** The country where the person is a national. */
+  @SerializedName("nationality")
+  String nationality;
+
   /**
    * String representing the object's type. Objects of the same type share the same value.
    *

--- a/src/main/java/com/stripe/model/SetupIntent.java
+++ b/src/main/java/com/stripe/model/SetupIntent.java
@@ -674,7 +674,8 @@ public class SetupIntent extends ApiResource implements HasId, MetadataStore<Set
     NextActionRedirectToUrl redirectToUrl;
 
     /**
-     * Type of the next action to perform, one of {@code redirect_to_url} or {@code use_stripe_sdk}.
+     * Type of the next action to perform, one of {@code redirect_to_url}, {@code use_stripe_sdk},
+     * {@code alipay_handle_redirect}, or {@code oxxo_display_details}.
      */
     @SerializedName("type")
     String type;

--- a/src/main/java/com/stripe/model/TaxId.java
+++ b/src/main/java/com/stripe/model/TaxId.java
@@ -56,11 +56,11 @@ public class TaxId extends ApiResource implements HasId {
   /**
    * Type of the tax ID, one of {@code ae_trn}, {@code au_abn}, {@code br_cnpj}, {@code br_cpf},
    * {@code ca_bn}, {@code ca_qst}, {@code ch_vat}, {@code cl_tin}, {@code es_cif}, {@code eu_vat},
-   * {@code hk_br}, {@code id_npwp}, {@code in_gst}, {@code jp_cn}, {@code jp_rn}, {@code kr_brn},
-   * {@code li_uid}, {@code mx_rfc}, {@code my_frp}, {@code my_itn}, {@code my_sst}, {@code no_vat},
-   * {@code nz_gst}, {@code ru_inn}, {@code ru_kpp}, {@code sa_vat}, {@code sg_gst}, {@code sg_uen},
-   * {@code th_vat}, {@code tw_vat}, {@code us_ein}, or {@code za_vat}. Note that some legacy tax
-   * IDs have type {@code unknown}
+   * {@code gb_vat}, {@code hk_br}, {@code id_npwp}, {@code in_gst}, {@code jp_cn}, {@code jp_rn},
+   * {@code kr_brn}, {@code li_uid}, {@code mx_rfc}, {@code my_frp}, {@code my_itn}, {@code my_sst},
+   * {@code no_vat}, {@code nz_gst}, {@code ru_inn}, {@code ru_kpp}, {@code sa_vat}, {@code sg_gst},
+   * {@code sg_uen}, {@code th_vat}, {@code tw_vat}, {@code us_ein}, or {@code za_vat}. Note that
+   * some legacy tax IDs have type {@code unknown}
    */
   @SerializedName("type")
   String type;

--- a/src/main/java/com/stripe/model/checkout/Session.java
+++ b/src/main/java/com/stripe/model/checkout/Session.java
@@ -427,12 +427,12 @@ public class Session extends ApiResource implements HasId {
     public static class TaxID extends StripeObject {
       /**
        * The type of the tax ID, one of {@code eu_vat}, {@code br_cnpj}, {@code br_cpf}, {@code
-       * nz_gst}, {@code au_abn}, {@code in_gst}, {@code no_vat}, {@code za_vat}, {@code ch_vat},
-       * {@code mx_rfc}, {@code sg_uen}, {@code ru_inn}, {@code ru_kpp}, {@code ca_bn}, {@code
-       * hk_br}, {@code es_cif}, {@code tw_vat}, {@code th_vat}, {@code jp_cn}, {@code jp_rn},
-       * {@code li_uid}, {@code my_itn}, {@code us_ein}, {@code kr_brn}, {@code ca_qst}, {@code
-       * my_sst}, {@code sg_gst}, {@code ae_trn}, {@code cl_tin}, {@code sa_vat}, {@code id_npwp},
-       * {@code my_frp}, or {@code unknown}.
+       * gb_vat}, {@code nz_gst}, {@code au_abn}, {@code in_gst}, {@code no_vat}, {@code za_vat},
+       * {@code ch_vat}, {@code mx_rfc}, {@code sg_uen}, {@code ru_inn}, {@code ru_kpp}, {@code
+       * ca_bn}, {@code hk_br}, {@code es_cif}, {@code tw_vat}, {@code th_vat}, {@code jp_cn},
+       * {@code jp_rn}, {@code li_uid}, {@code my_itn}, {@code us_ein}, {@code kr_brn}, {@code
+       * ca_qst}, {@code my_sst}, {@code sg_gst}, {@code ae_trn}, {@code cl_tin}, {@code sa_vat},
+       * {@code id_npwp}, {@code my_frp}, or {@code unknown}.
        */
       @SerializedName("type")
       String type;

--- a/src/main/java/com/stripe/model/issuing/Dispute.java
+++ b/src/main/java/com/stripe/model/issuing/Dispute.java
@@ -29,8 +29,8 @@ import lombok.Setter;
 public class Dispute extends ApiResource
     implements MetadataStore<Dispute>, BalanceTransactionSource {
   /**
-   * Disputed amount. Usually the amount of the {@code disputed_transaction}, but can differ
-   * (usually because of currency fluctuation).
+   * Disputed amount. Usually the amount of the {@code transaction}, but can differ (usually because
+   * of currency fluctuation).
    */
   @SerializedName("amount")
   Long amount;
@@ -43,7 +43,7 @@ public class Dispute extends ApiResource
   @SerializedName("created")
   Long created;
 
-  /** The currency the {@code disputed_transaction} was made in. */
+  /** The currency the {@code transaction} was made in. */
   @SerializedName("currency")
   String currency;
 

--- a/src/main/java/com/stripe/param/CustomerCreateParams.java
+++ b/src/main/java/com/stripe/param/CustomerCreateParams.java
@@ -1155,10 +1155,11 @@ public class CustomerCreateParams extends ApiRequestParams {
     /**
      * Type of the tax ID, one of {@code ae_trn}, {@code au_abn}, {@code br_cnpj}, {@code br_cpf},
      * {@code ca_bn}, {@code ca_qst}, {@code ch_vat}, {@code cl_tin}, {@code es_cif}, {@code
-     * eu_vat}, {@code hk_br}, {@code id_npwp}, {@code in_gst}, {@code jp_cn}, {@code jp_rn}, {@code
-     * kr_brn}, {@code li_uid}, {@code mx_rfc}, {@code my_frp}, {@code my_itn}, {@code my_sst},
-     * {@code no_vat}, {@code nz_gst}, {@code ru_inn}, {@code ru_kpp}, {@code sa_vat}, {@code
-     * sg_gst}, {@code sg_uen}, {@code th_vat}, {@code tw_vat}, {@code us_ein}, or {@code za_vat}.
+     * eu_vat}, {@code gb_vat}, {@code hk_br}, {@code id_npwp}, {@code in_gst}, {@code jp_cn},
+     * {@code jp_rn}, {@code kr_brn}, {@code li_uid}, {@code mx_rfc}, {@code my_frp}, {@code
+     * my_itn}, {@code my_sst}, {@code no_vat}, {@code nz_gst}, {@code ru_inn}, {@code ru_kpp},
+     * {@code sa_vat}, {@code sg_gst}, {@code sg_uen}, {@code th_vat}, {@code tw_vat}, {@code
+     * us_ein}, or {@code za_vat}.
      */
     @SerializedName("type")
     Type type;
@@ -1218,11 +1219,11 @@ public class CustomerCreateParams extends ApiRequestParams {
       /**
        * Type of the tax ID, one of {@code ae_trn}, {@code au_abn}, {@code br_cnpj}, {@code br_cpf},
        * {@code ca_bn}, {@code ca_qst}, {@code ch_vat}, {@code cl_tin}, {@code es_cif}, {@code
-       * eu_vat}, {@code hk_br}, {@code id_npwp}, {@code in_gst}, {@code jp_cn}, {@code jp_rn},
-       * {@code kr_brn}, {@code li_uid}, {@code mx_rfc}, {@code my_frp}, {@code my_itn}, {@code
-       * my_sst}, {@code no_vat}, {@code nz_gst}, {@code ru_inn}, {@code ru_kpp}, {@code sa_vat},
-       * {@code sg_gst}, {@code sg_uen}, {@code th_vat}, {@code tw_vat}, {@code us_ein}, or {@code
-       * za_vat}.
+       * eu_vat}, {@code gb_vat}, {@code hk_br}, {@code id_npwp}, {@code in_gst}, {@code jp_cn},
+       * {@code jp_rn}, {@code kr_brn}, {@code li_uid}, {@code mx_rfc}, {@code my_frp}, {@code
+       * my_itn}, {@code my_sst}, {@code no_vat}, {@code nz_gst}, {@code ru_inn}, {@code ru_kpp},
+       * {@code sa_vat}, {@code sg_gst}, {@code sg_uen}, {@code th_vat}, {@code tw_vat}, {@code
+       * us_ein}, or {@code za_vat}.
        */
       public Builder setType(Type type) {
         this.type = type;
@@ -1266,6 +1267,9 @@ public class CustomerCreateParams extends ApiRequestParams {
 
       @SerializedName("eu_vat")
       EU_VAT("eu_vat"),
+
+      @SerializedName("gb_vat")
+      GB_VAT("gb_vat"),
 
       @SerializedName("hk_br")
       HK_BR("hk_br"),

--- a/src/main/java/com/stripe/param/PersonCollectionCreateParams.java
+++ b/src/main/java/com/stripe/param/PersonCollectionCreateParams.java
@@ -100,6 +100,14 @@ public class PersonCollectionCreateParams extends ApiRequestParams {
   Object metadata;
 
   /**
+   * The country where the person is a national. Two-letter country code (<a
+   * href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO 3166-1 alpha-2</a>), or
+   * &quot;XX&quot; if unavailable.
+   */
+  @SerializedName("nationality")
+  String nationality;
+
+  /**
    * A <a href="https://stripe.com/docs/connect/account-tokens">person token</a>, used to securely
    * provide details to the person.
    */
@@ -148,6 +156,7 @@ public class PersonCollectionCreateParams extends ApiRequestParams {
       String lastNameKanji,
       String maidenName,
       Object metadata,
+      String nationality,
       String personToken,
       String phone,
       String politicalExposure,
@@ -171,6 +180,7 @@ public class PersonCollectionCreateParams extends ApiRequestParams {
     this.lastNameKanji = lastNameKanji;
     this.maidenName = maidenName;
     this.metadata = metadata;
+    this.nationality = nationality;
     this.personToken = personToken;
     this.phone = phone;
     this.politicalExposure = politicalExposure;
@@ -218,6 +228,8 @@ public class PersonCollectionCreateParams extends ApiRequestParams {
 
     private Object metadata;
 
+    private String nationality;
+
     private String personToken;
 
     private String phone;
@@ -250,6 +262,7 @@ public class PersonCollectionCreateParams extends ApiRequestParams {
           this.lastNameKanji,
           this.maidenName,
           this.metadata,
+          this.nationality,
           this.personToken,
           this.phone,
           this.politicalExposure,
@@ -455,6 +468,16 @@ public class PersonCollectionCreateParams extends ApiRequestParams {
      */
     public Builder setMetadata(Map<String, String> metadata) {
       this.metadata = metadata;
+      return this;
+    }
+
+    /**
+     * The country where the person is a national. Two-letter country code (<a
+     * href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO 3166-1 alpha-2</a>), or
+     * &quot;XX&quot; if unavailable.
+     */
+    public Builder setNationality(String nationality) {
+      this.nationality = nationality;
       return this;
     }
 

--- a/src/main/java/com/stripe/param/PersonUpdateParams.java
+++ b/src/main/java/com/stripe/param/PersonUpdateParams.java
@@ -100,6 +100,14 @@ public class PersonUpdateParams extends ApiRequestParams {
   Object metadata;
 
   /**
+   * The country where the person is a national. Two-letter country code (<a
+   * href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO 3166-1 alpha-2</a>), or
+   * &quot;XX&quot; if unavailable.
+   */
+  @SerializedName("nationality")
+  Object nationality;
+
+  /**
    * A <a href="https://stripe.com/docs/connect/account-tokens">person token</a>, used to securely
    * provide details to the person.
    */
@@ -148,6 +156,7 @@ public class PersonUpdateParams extends ApiRequestParams {
       Object lastNameKanji,
       Object maidenName,
       Object metadata,
+      Object nationality,
       Object personToken,
       Object phone,
       Object politicalExposure,
@@ -171,6 +180,7 @@ public class PersonUpdateParams extends ApiRequestParams {
     this.lastNameKanji = lastNameKanji;
     this.maidenName = maidenName;
     this.metadata = metadata;
+    this.nationality = nationality;
     this.personToken = personToken;
     this.phone = phone;
     this.politicalExposure = politicalExposure;
@@ -218,6 +228,8 @@ public class PersonUpdateParams extends ApiRequestParams {
 
     private Object metadata;
 
+    private Object nationality;
+
     private Object personToken;
 
     private Object phone;
@@ -250,6 +262,7 @@ public class PersonUpdateParams extends ApiRequestParams {
           this.lastNameKanji,
           this.maidenName,
           this.metadata,
+          this.nationality,
           this.personToken,
           this.phone,
           this.politicalExposure,
@@ -523,6 +536,26 @@ public class PersonUpdateParams extends ApiRequestParams {
      */
     public Builder setMetadata(Map<String, String> metadata) {
       this.metadata = metadata;
+      return this;
+    }
+
+    /**
+     * The country where the person is a national. Two-letter country code (<a
+     * href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO 3166-1 alpha-2</a>), or
+     * &quot;XX&quot; if unavailable.
+     */
+    public Builder setNationality(String nationality) {
+      this.nationality = nationality;
+      return this;
+    }
+
+    /**
+     * The country where the person is a national. Two-letter country code (<a
+     * href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO 3166-1 alpha-2</a>), or
+     * &quot;XX&quot; if unavailable.
+     */
+    public Builder setNationality(EmptyParam nationality) {
+      this.nationality = nationality;
       return this;
     }
 

--- a/src/main/java/com/stripe/param/TaxIdCollectionCreateParams.java
+++ b/src/main/java/com/stripe/param/TaxIdCollectionCreateParams.java
@@ -27,10 +27,10 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
   /**
    * Type of the tax ID, one of {@code ae_trn}, {@code au_abn}, {@code br_cnpj}, {@code br_cpf},
    * {@code ca_bn}, {@code ca_qst}, {@code ch_vat}, {@code cl_tin}, {@code es_cif}, {@code eu_vat},
-   * {@code hk_br}, {@code id_npwp}, {@code in_gst}, {@code jp_cn}, {@code jp_rn}, {@code kr_brn},
-   * {@code li_uid}, {@code mx_rfc}, {@code my_frp}, {@code my_itn}, {@code my_sst}, {@code no_vat},
-   * {@code nz_gst}, {@code ru_inn}, {@code ru_kpp}, {@code sa_vat}, {@code sg_gst}, {@code sg_uen},
-   * {@code th_vat}, {@code tw_vat}, {@code us_ein}, or {@code za_vat}.
+   * {@code gb_vat}, {@code hk_br}, {@code id_npwp}, {@code in_gst}, {@code jp_cn}, {@code jp_rn},
+   * {@code kr_brn}, {@code li_uid}, {@code mx_rfc}, {@code my_frp}, {@code my_itn}, {@code my_sst},
+   * {@code no_vat}, {@code nz_gst}, {@code ru_inn}, {@code ru_kpp}, {@code sa_vat}, {@code sg_gst},
+   * {@code sg_uen}, {@code th_vat}, {@code tw_vat}, {@code us_ein}, or {@code za_vat}.
    */
   @SerializedName("type")
   Type type;
@@ -120,10 +120,11 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
     /**
      * Type of the tax ID, one of {@code ae_trn}, {@code au_abn}, {@code br_cnpj}, {@code br_cpf},
      * {@code ca_bn}, {@code ca_qst}, {@code ch_vat}, {@code cl_tin}, {@code es_cif}, {@code
-     * eu_vat}, {@code hk_br}, {@code id_npwp}, {@code in_gst}, {@code jp_cn}, {@code jp_rn}, {@code
-     * kr_brn}, {@code li_uid}, {@code mx_rfc}, {@code my_frp}, {@code my_itn}, {@code my_sst},
-     * {@code no_vat}, {@code nz_gst}, {@code ru_inn}, {@code ru_kpp}, {@code sa_vat}, {@code
-     * sg_gst}, {@code sg_uen}, {@code th_vat}, {@code tw_vat}, {@code us_ein}, or {@code za_vat}.
+     * eu_vat}, {@code gb_vat}, {@code hk_br}, {@code id_npwp}, {@code in_gst}, {@code jp_cn},
+     * {@code jp_rn}, {@code kr_brn}, {@code li_uid}, {@code mx_rfc}, {@code my_frp}, {@code
+     * my_itn}, {@code my_sst}, {@code no_vat}, {@code nz_gst}, {@code ru_inn}, {@code ru_kpp},
+     * {@code sa_vat}, {@code sg_gst}, {@code sg_uen}, {@code th_vat}, {@code tw_vat}, {@code
+     * us_ein}, or {@code za_vat}.
      */
     public Builder setType(Type type) {
       this.type = type;
@@ -167,6 +168,9 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
 
     @SerializedName("eu_vat")
     EU_VAT("eu_vat"),
+
+    @SerializedName("gb_vat")
+    GB_VAT("gb_vat"),
 
     @SerializedName("hk_br")
     HK_BR("hk_br"),

--- a/src/main/java/com/stripe/param/TokenCreateParams.java
+++ b/src/main/java/com/stripe/param/TokenCreateParams.java
@@ -3376,6 +3376,14 @@ public class TokenCreateParams extends ApiRequestParams {
     @SerializedName("metadata")
     Object metadata;
 
+    /**
+     * The country where the person is a national. Two-letter country code (<a
+     * href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO 3166-1 alpha-2</a>), or
+     * &quot;XX&quot; if unavailable.
+     */
+    @SerializedName("nationality")
+    String nationality;
+
     /** The person's phone number. */
     @SerializedName("phone")
     String phone;
@@ -3417,6 +3425,7 @@ public class TokenCreateParams extends ApiRequestParams {
         String lastNameKanji,
         String maidenName,
         Object metadata,
+        String nationality,
         String phone,
         String politicalExposure,
         Relationship relationship,
@@ -3438,6 +3447,7 @@ public class TokenCreateParams extends ApiRequestParams {
       this.lastNameKanji = lastNameKanji;
       this.maidenName = maidenName;
       this.metadata = metadata;
+      this.nationality = nationality;
       this.phone = phone;
       this.politicalExposure = politicalExposure;
       this.relationship = relationship;
@@ -3482,6 +3492,8 @@ public class TokenCreateParams extends ApiRequestParams {
 
       private Object metadata;
 
+      private String nationality;
+
       private String phone;
 
       private String politicalExposure;
@@ -3511,6 +3523,7 @@ public class TokenCreateParams extends ApiRequestParams {
             this.lastNameKanji,
             this.maidenName,
             this.metadata,
+            this.nationality,
             this.phone,
             this.politicalExposure,
             this.relationship,
@@ -3689,6 +3702,16 @@ public class TokenCreateParams extends ApiRequestParams {
        */
       public Builder setMetadata(Map<String, String> metadata) {
         this.metadata = metadata;
+        return this;
+      }
+
+      /**
+       * The country where the person is a national. Two-letter country code (<a
+       * href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO 3166-1 alpha-2</a>), or
+       * &quot;XX&quot; if unavailable.
+       */
+      public Builder setNationality(String nationality) {
+        this.nationality = nationality;
         return this;
       }
 


### PR DESCRIPTION
Codegen for openapi 4d877a7.
r? @remi-stripe 
cc @stripe/api-libraries

## Changelog
* Add support for `nationality` on `Person`, `PersonUpdateParams`, `PersonCreateParams` and `TokenCreateParams.person`
* Add `gb_vat` to `TaxId.type` enum