### PR TITLE
Accept all InputStreams for FileCreateParams.setFile

### DIFF
--- a/src/main/java/com/stripe/param/FileCreateParams.java
+++ b/src/main/java/com/stripe/param/FileCreateParams.java
@@ -103,7 +103,7 @@ public class FileCreateParams extends ApiRequestParams {
      * A file to upload. The file should follow the specifications of RFC 2388 (which defines file
      * transfers for the `multipart/form-data` protocol).
      */
-    public Builder setFile(java.io.FileInputStream file) {
+    public Builder setFile(java.io.InputStream file) {
       this.file = file;
       return this;
     }
@@ -241,9 +241,8 @@ public class FileCreateParams extends ApiRequestParams {
 
   /**
    * Returns untyped parameters for file creation. Map value for {@code "file"} is the same instance
-   * of value set in {@link Builder#setFile(File)} or {@link
-   * Builder#setFile(java.io.FileInputStream)}; the file is not transformed or serialized at this
-   * level.
+   * of value set in {@link Builder#setFile(File)} or {@link Builder#setFile(java.io.InputStream)};
+   * the file is not transformed or serialized at this level.
    *
    * @return Untyped parameters containing file object set in the builder.
    */

--- a/src/test/java/com/stripe/functional/FileTest.java
+++ b/src/test/java/com/stripe/functional/FileTest.java
@@ -12,9 +12,11 @@ import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 import com.stripe.param.FileCreateParams;
 import com.stripe.param.FileListParams;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -73,10 +75,24 @@ public class FileTest extends BaseStripeTest {
   }
 
   @Test
-  public void testCreateWithStream() throws IOException, StripeException {
+  public void testCreateWithFileInputStream() throws IOException, StripeException {
     final Map<String, Object> params = new HashMap<>();
     params.put("purpose", "dispute_evidence");
     FileInputStream value = new FileInputStream(getClass().getResource("/test.png").getFile());
+    params.put("file", value);
+
+    final com.stripe.model.File file = com.stripe.model.File.create(params);
+
+    assertNotNull(file);
+    verifyRequest(ApiResource.RequestMethod.POST, "/v1/files", params, null);
+  }
+
+  @Test
+  public void testCreateWithByteArrayInputStream() throws IOException, StripeException {
+    final Map<String, Object> params = new HashMap<>();
+    params.put("purpose", "dispute_evidence");
+    ByteArrayInputStream value =
+        new ByteArrayInputStream("file contents".getBytes(StandardCharsets.UTF_8));
     params.put("file", value);
 
     final com.stripe.model.File file = com.stripe.model.File.create(params);

--- a/src/test/java/com/stripe/param/FileCreateParamsTest.java
+++ b/src/test/java/com/stripe/param/FileCreateParamsTest.java
@@ -3,9 +3,11 @@ package com.stripe.param;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -41,6 +43,23 @@ class FileCreateParamsTest {
     // file object is not deserialized/transformed into something other than
     // the value set in builder
     assertSame(fileInputStream, untypedParams.get("file"));
+    assertEquals(FileCreateParams.Purpose.BUSINESS_ICON.getValue(), untypedParams.get("purpose"));
+  }
+
+  @Test
+  public void testToMapWithByteArrayInputStream() throws FileNotFoundException {
+    java.io.ByteArrayInputStream byteArrayInputStream =
+        new ByteArrayInputStream("file contents".getBytes(StandardCharsets.UTF_8));
+    FileCreateParams fileCreateParams =
+        FileCreateParams.builder()
+            .setFile(byteArrayInputStream)
+            .setPurpose(FileCreateParams.Purpose.BUSINESS_ICON)
+            .build();
+
+    Map<String, Object> untypedParams = fileCreateParams.toMap();
+    // file object is not deserialized/transformed into something other than
+    // the value set in builder
+    assertSame(byteArrayInputStream, untypedParams.get("file"));
     assertEquals(FileCreateParams.Purpose.BUSINESS_ICON.getValue(), untypedParams.get("purpose"));
   }
 }


### PR DESCRIPTION
r? @richardm-stripe 
cc @stripe/api-libraries 

Change `FileCreateParams.setFile` to accept any `InputStream`. Since `InputStream` is a supertype of `FileInputStream`, this is not a breaking change.

Fixes #1170.
