### PR TITLE
API Updates

### DIFF
--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -1011,6 +1011,9 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
     @SerializedName("acss_debit")
     AcssDebit acssDebit;
 
+    @SerializedName("afterpay_clearpay")
+    AfterpayClearpay afterpayClearpay;
+
     @SerializedName("alipay")
     Alipay alipay;
 
@@ -1175,6 +1178,11 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
       @SerializedName("transit_number")
       String transitNumber;
     }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class AfterpayClearpay extends StripeObject {}
 
     @Getter
     @Setter

--- a/src/main/java/com/stripe/model/PaymentMethod.java
+++ b/src/main/java/com/stripe/model/PaymentMethod.java
@@ -22,6 +22,9 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class PaymentMethod extends ApiResource implements HasId, MetadataStore<PaymentMethod> {
+  @SerializedName("afterpay_clearpay")
+  AfterpayClearpay afterpayClearpay;
+
   @SerializedName("alipay")
   Alipay alipay;
 
@@ -119,10 +122,10 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
    * The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a name
    * matching this value. It contains additional information specific to the PaymentMethod type.
    *
-   * <p>One of {@code alipay}, {@code au_becs_debit}, {@code bacs_debit}, {@code bancontact}, {@code
-   * card}, {@code card_present}, {@code eps}, {@code fpx}, {@code giropay}, {@code grabpay}, {@code
-   * ideal}, {@code interac_present}, {@code oxxo}, {@code p24}, {@code sepa_debit}, or {@code
-   * sofort}.
+   * <p>One of {@code afterpay_clearpay}, {@code alipay}, {@code au_becs_debit}, {@code bacs_debit},
+   * {@code bancontact}, {@code card}, {@code card_present}, {@code eps}, {@code fpx}, {@code
+   * giropay}, {@code grabpay}, {@code ideal}, {@code interac_present}, {@code oxxo}, {@code p24},
+   * {@code sepa_debit}, or {@code sofort}.
    */
   @SerializedName("type")
   String type;
@@ -426,6 +429,11 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
     return ApiResource.request(
         ApiResource.RequestMethod.POST, url, params, PaymentMethod.class, options);
   }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class AfterpayClearpay extends StripeObject {}
 
   @Getter
   @Setter

--- a/src/main/java/com/stripe/model/SetupAttempt.java
+++ b/src/main/java/com/stripe/model/SetupAttempt.java
@@ -224,6 +224,12 @@ public class SetupAttempt extends ApiResource implements HasId {
   @Setter
   @EqualsAndHashCode(callSuper = false)
   public static class PaymentMethodDetails extends StripeObject {
+    @SerializedName("au_becs_debit")
+    AuBecsDebit auBecsDebit;
+
+    @SerializedName("bacs_debit")
+    BacsDebit bacsDebit;
+
     @SerializedName("bancontact")
     Bancontact bancontact;
 
@@ -236,6 +242,9 @@ public class SetupAttempt extends ApiResource implements HasId {
     @SerializedName("ideal")
     Ideal ideal;
 
+    @SerializedName("sepa_debit")
+    SepaDebit sepaDebit;
+
     @SerializedName("sofort")
     Sofort sofort;
 
@@ -246,6 +255,16 @@ public class SetupAttempt extends ApiResource implements HasId {
      */
     @SerializedName("type")
     String type;
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class AuBecsDebit extends StripeObject {}
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class BacsDebit extends StripeObject {}
 
     @Getter
     @Setter
@@ -470,6 +489,11 @@ public class SetupAttempt extends ApiResource implements HasId {
             new ExpandableField<Mandate>(expandableObject.getId(), expandableObject);
       }
     }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class SepaDebit extends StripeObject {}
 
     @Getter
     @Setter

--- a/src/main/java/com/stripe/model/issuing/Authorization.java
+++ b/src/main/java/com/stripe/model/issuing/Authorization.java
@@ -138,12 +138,11 @@ public class Authorization extends ApiResource
   PendingRequest pendingRequest;
 
   /**
-   * History of every time the authorization was approved/denied (whether approved/denied by you
-   * directly or by Stripe based on your {@code spending_controls}). If the merchant changes the
+   * History of every time {@code pending_request} was approved/denied, either by you directly or by
+   * Stripe (e.g. based on your {@code spending_controls}). If the merchant changes the
    * authorization by performing an <a
-   * href="https://stripe.com/docs/issuing/purchases/authorizations">incremental authorization or
-   * partial capture</a>, you can look at this field to see the previous states of the
-   * authorization.
+   * href="https://stripe.com/docs/issuing/purchases/authorizations">incremental authorization</a>,
+   * you can look at this field to see the previous requests for the authorization.
    */
   @SerializedName("request_history")
   List<Authorization.RequestHistory> requestHistory;
@@ -566,9 +565,10 @@ public class Authorization extends ApiResource
   @EqualsAndHashCode(callSuper = false)
   public static class RequestHistory extends StripeObject {
     /**
-     * The authorization amount in your card's currency and in the <a
-     * href="https://stripe.com/docs/currencies#zero-decimal">smallest currency unit</a>. Stripe
-     * held this amount from your account to fund the authorization if the request was approved.
+     * The {@code pending_request.amount} at the time of the request, presented in your card's
+     * currency and in the <a href="https://stripe.com/docs/currencies#zero-decimal">smallest
+     * currency unit</a>. Stripe held this amount from your account to fund the authorization if the
+     * request was approved.
      */
     @SerializedName("amount")
     Long amount;
@@ -598,8 +598,8 @@ public class Authorization extends ApiResource
     String currency;
 
     /**
-     * The amount that was authorized at the time of this request. This amount is in the {@code
-     * merchant_currency} and in the <a
+     * The {@code pending_request.merchant_amount} at the time of the request, presented in the
+     * {@code merchant_currency} and in the <a
      * href="https://stripe.com/docs/currencies#zero-decimal">smallest currency unit</a>.
      */
     @SerializedName("merchant_amount")

--- a/src/main/java/com/stripe/param/AccountLinkCreateParams.java
+++ b/src/main/java/com/stripe/param/AccountLinkCreateParams.java
@@ -36,9 +36,12 @@ public class AccountLinkCreateParams extends ApiRequestParams {
   Map<String, Object> extraParams;
 
   /**
-   * The URL that the user will be redirected to if the account link is no longer valid. Your {@code
-   * refresh_url} should trigger a method on your server to create a new account link using this
-   * API, with the same parameters, and redirect the user to the new account link.
+   * The URL the user will be redirected to if the account link is expired, has been
+   * previously-visited, or is otherwise invalid. The URL you specify should attempt to generate a
+   * new account link with the same parameters used to create the original account link, then
+   * redirect the user to the new account link's URL so they can continue with Connect Onboarding.
+   * If a new account link cannot be generated or the redirect fails you should display a useful
+   * error to the user.
    */
   @SerializedName("refresh_url")
   String refreshUrl;
@@ -170,9 +173,12 @@ public class AccountLinkCreateParams extends ApiRequestParams {
     }
 
     /**
-     * The URL that the user will be redirected to if the account link is no longer valid. Your
-     * {@code refresh_url} should trigger a method on your server to create a new account link using
-     * this API, with the same parameters, and redirect the user to the new account link.
+     * The URL the user will be redirected to if the account link is expired, has been
+     * previously-visited, or is otherwise invalid. The URL you specify should attempt to generate a
+     * new account link with the same parameters used to create the original account link, then
+     * redirect the user to the new account link's URL so they can continue with Connect Onboarding.
+     * If a new account link cannot be generated or the redirect fails you should display a useful
+     * error to the user.
      */
     public Builder setRefreshUrl(String refreshUrl) {
       this.refreshUrl = refreshUrl;

--- a/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
@@ -794,6 +794,13 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
   @Getter
   public static class PaymentMethodData {
     /**
+     * If this is an {@code AfterpayClearpay} PaymentMethod, this hash contains details about the
+     * AfterpayClearpay payment method.
+     */
+    @SerializedName("afterpay_clearpay")
+    AfterpayClearpay afterpayClearpay;
+
+    /**
      * If this is an {@code Alipay} PaymentMethod, this hash contains details about the Alipay
      * payment method.
      */
@@ -925,6 +932,7 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
     Type type;
 
     private PaymentMethodData(
+        AfterpayClearpay afterpayClearpay,
         Alipay alipay,
         AuBecsDebit auBecsDebit,
         BacsDebit bacsDebit,
@@ -943,6 +951,7 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
         SepaDebit sepaDebit,
         Sofort sofort,
         Type type) {
+      this.afterpayClearpay = afterpayClearpay;
       this.alipay = alipay;
       this.auBecsDebit = auBecsDebit;
       this.bacsDebit = bacsDebit;
@@ -968,6 +977,8 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
     }
 
     public static class Builder {
+      private AfterpayClearpay afterpayClearpay;
+
       private Alipay alipay;
 
       private AuBecsDebit auBecsDebit;
@@ -1007,6 +1018,7 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       /** Finalize and obtain parameter instance from this builder. */
       public PaymentMethodData build() {
         return new PaymentMethodData(
+            this.afterpayClearpay,
             this.alipay,
             this.auBecsDebit,
             this.bacsDebit,
@@ -1025,6 +1037,15 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
             this.sepaDebit,
             this.sofort,
             this.type);
+      }
+
+      /**
+       * If this is an {@code AfterpayClearpay} PaymentMethod, this hash contains details about the
+       * AfterpayClearpay payment method.
+       */
+      public Builder setAfterpayClearpay(AfterpayClearpay afterpayClearpay) {
+        this.afterpayClearpay = afterpayClearpay;
+        return this;
       }
 
       /**
@@ -1224,6 +1245,65 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       public Builder setType(Type type) {
         this.type = type;
         return this;
+      }
+    }
+
+    @Getter
+    public static class AfterpayClearpay {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private AfterpayClearpay(Map<String, Object> extraParams) {
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public AfterpayClearpay build() {
+          return new AfterpayClearpay(this.extraParams);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * PaymentIntentConfirmParams.PaymentMethodData.AfterpayClearpay#extraParams} for the field
+         * documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * PaymentIntentConfirmParams.PaymentMethodData.AfterpayClearpay#extraParams} for the field
+         * documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
       }
     }
 
@@ -2778,6 +2858,9 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
     }
 
     public enum Type implements ApiRequestParams.EnumParam {
+      @SerializedName("afterpay_clearpay")
+      AFTERPAY_CLEARPAY("afterpay_clearpay"),
+
       @SerializedName("alipay")
       ALIPAY("alipay"),
 

--- a/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
@@ -1167,6 +1167,13 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
   @Getter
   public static class PaymentMethodData {
     /**
+     * If this is an {@code AfterpayClearpay} PaymentMethod, this hash contains details about the
+     * AfterpayClearpay payment method.
+     */
+    @SerializedName("afterpay_clearpay")
+    AfterpayClearpay afterpayClearpay;
+
+    /**
      * If this is an {@code Alipay} PaymentMethod, this hash contains details about the Alipay
      * payment method.
      */
@@ -1298,6 +1305,7 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     Type type;
 
     private PaymentMethodData(
+        AfterpayClearpay afterpayClearpay,
         Alipay alipay,
         AuBecsDebit auBecsDebit,
         BacsDebit bacsDebit,
@@ -1316,6 +1324,7 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
         SepaDebit sepaDebit,
         Sofort sofort,
         Type type) {
+      this.afterpayClearpay = afterpayClearpay;
       this.alipay = alipay;
       this.auBecsDebit = auBecsDebit;
       this.bacsDebit = bacsDebit;
@@ -1341,6 +1350,8 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     }
 
     public static class Builder {
+      private AfterpayClearpay afterpayClearpay;
+
       private Alipay alipay;
 
       private AuBecsDebit auBecsDebit;
@@ -1380,6 +1391,7 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       /** Finalize and obtain parameter instance from this builder. */
       public PaymentMethodData build() {
         return new PaymentMethodData(
+            this.afterpayClearpay,
             this.alipay,
             this.auBecsDebit,
             this.bacsDebit,
@@ -1398,6 +1410,15 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
             this.sepaDebit,
             this.sofort,
             this.type);
+      }
+
+      /**
+       * If this is an {@code AfterpayClearpay} PaymentMethod, this hash contains details about the
+       * AfterpayClearpay payment method.
+       */
+      public Builder setAfterpayClearpay(AfterpayClearpay afterpayClearpay) {
+        this.afterpayClearpay = afterpayClearpay;
+        return this;
       }
 
       /**
@@ -1597,6 +1618,63 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       public Builder setType(Type type) {
         this.type = type;
         return this;
+      }
+    }
+
+    @Getter
+    public static class AfterpayClearpay {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private AfterpayClearpay(Map<String, Object> extraParams) {
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public AfterpayClearpay build() {
+          return new AfterpayClearpay(this.extraParams);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentCreateParams.PaymentMethodData.AfterpayClearpay#extraParams}
+         * for the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentCreateParams.PaymentMethodData.AfterpayClearpay#extraParams}
+         * for the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
       }
     }
 
@@ -3151,6 +3229,9 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     }
 
     public enum Type implements ApiRequestParams.EnumParam {
+      @SerializedName("afterpay_clearpay")
+      AFTERPAY_CLEARPAY("afterpay_clearpay"),
+
       @SerializedName("alipay")
       ALIPAY("alipay"),
 

--- a/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
@@ -698,6 +698,13 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
   @Getter
   public static class PaymentMethodData {
     /**
+     * If this is an {@code AfterpayClearpay} PaymentMethod, this hash contains details about the
+     * AfterpayClearpay payment method.
+     */
+    @SerializedName("afterpay_clearpay")
+    AfterpayClearpay afterpayClearpay;
+
+    /**
      * If this is an {@code Alipay} PaymentMethod, this hash contains details about the Alipay
      * payment method.
      */
@@ -829,6 +836,7 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     Type type;
 
     private PaymentMethodData(
+        AfterpayClearpay afterpayClearpay,
         Alipay alipay,
         AuBecsDebit auBecsDebit,
         BacsDebit bacsDebit,
@@ -847,6 +855,7 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
         SepaDebit sepaDebit,
         Sofort sofort,
         Type type) {
+      this.afterpayClearpay = afterpayClearpay;
       this.alipay = alipay;
       this.auBecsDebit = auBecsDebit;
       this.bacsDebit = bacsDebit;
@@ -872,6 +881,8 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     }
 
     public static class Builder {
+      private AfterpayClearpay afterpayClearpay;
+
       private Alipay alipay;
 
       private AuBecsDebit auBecsDebit;
@@ -911,6 +922,7 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       /** Finalize and obtain parameter instance from this builder. */
       public PaymentMethodData build() {
         return new PaymentMethodData(
+            this.afterpayClearpay,
             this.alipay,
             this.auBecsDebit,
             this.bacsDebit,
@@ -929,6 +941,15 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
             this.sepaDebit,
             this.sofort,
             this.type);
+      }
+
+      /**
+       * If this is an {@code AfterpayClearpay} PaymentMethod, this hash contains details about the
+       * AfterpayClearpay payment method.
+       */
+      public Builder setAfterpayClearpay(AfterpayClearpay afterpayClearpay) {
+        this.afterpayClearpay = afterpayClearpay;
+        return this;
       }
 
       /**
@@ -1128,6 +1149,63 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       public Builder setType(Type type) {
         this.type = type;
         return this;
+      }
+    }
+
+    @Getter
+    public static class AfterpayClearpay {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private AfterpayClearpay(Map<String, Object> extraParams) {
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public AfterpayClearpay build() {
+          return new AfterpayClearpay(this.extraParams);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentUpdateParams.PaymentMethodData.AfterpayClearpay#extraParams}
+         * for the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentUpdateParams.PaymentMethodData.AfterpayClearpay#extraParams}
+         * for the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
       }
     }
 
@@ -2769,6 +2847,9 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     }
 
     public enum Type implements ApiRequestParams.EnumParam {
+      @SerializedName("afterpay_clearpay")
+      AFTERPAY_CLEARPAY("afterpay_clearpay"),
+
       @SerializedName("alipay")
       ALIPAY("alipay"),
 

--- a/src/main/java/com/stripe/param/PaymentMethodCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentMethodCreateParams.java
@@ -13,6 +13,13 @@ import lombok.Getter;
 @Getter
 public class PaymentMethodCreateParams extends ApiRequestParams {
   /**
+   * If this is an {@code AfterpayClearpay} PaymentMethod, this hash contains details about the
+   * AfterpayClearpay payment method.
+   */
+  @SerializedName("afterpay_clearpay")
+  AfterpayClearpay afterpayClearpay;
+
+  /**
    * If this is an {@code Alipay} PaymentMethod, this hash contains details about the Alipay payment
    * method.
    */
@@ -166,6 +173,7 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
   Type type;
 
   private PaymentMethodCreateParams(
+      AfterpayClearpay afterpayClearpay,
       Alipay alipay,
       AuBecsDebit auBecsDebit,
       BacsDebit bacsDebit,
@@ -188,6 +196,7 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
       SepaDebit sepaDebit,
       Sofort sofort,
       Type type) {
+    this.afterpayClearpay = afterpayClearpay;
     this.alipay = alipay;
     this.auBecsDebit = auBecsDebit;
     this.bacsDebit = bacsDebit;
@@ -217,6 +226,8 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
   }
 
   public static class Builder {
+    private AfterpayClearpay afterpayClearpay;
+
     private Alipay alipay;
 
     private AuBecsDebit auBecsDebit;
@@ -264,6 +275,7 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
     /** Finalize and obtain parameter instance from this builder. */
     public PaymentMethodCreateParams build() {
       return new PaymentMethodCreateParams(
+          this.afterpayClearpay,
           this.alipay,
           this.auBecsDebit,
           this.bacsDebit,
@@ -286,6 +298,15 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
           this.sepaDebit,
           this.sofort,
           this.type);
+    }
+
+    /**
+     * If this is an {@code AfterpayClearpay} PaymentMethod, this hash contains details about the
+     * AfterpayClearpay payment method.
+     */
+    public Builder setAfterpayClearpay(AfterpayClearpay afterpayClearpay) {
+      this.afterpayClearpay = afterpayClearpay;
+      return this;
     }
 
     /**
@@ -547,6 +568,62 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
     public Builder setType(Type type) {
       this.type = type;
       return this;
+    }
+  }
+
+  @Getter
+  public static class AfterpayClearpay {
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    private AfterpayClearpay(Map<String, Object> extraParams) {
+      this.extraParams = extraParams;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Map<String, Object> extraParams;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public AfterpayClearpay build() {
+        return new AfterpayClearpay(this.extraParams);
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * PaymentMethodCreateParams.AfterpayClearpay#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link PaymentMethodCreateParams.AfterpayClearpay#extraParams} for the field
+       * documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
     }
   }
 
@@ -2241,6 +2318,9 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
   }
 
   public enum Type implements ApiRequestParams.EnumParam {
+    @SerializedName("afterpay_clearpay")
+    AFTERPAY_CLEARPAY("afterpay_clearpay"),
+
     @SerializedName("alipay")
     ALIPAY("alipay"),
 

--- a/src/main/java/com/stripe/param/PaymentMethodListParams.java
+++ b/src/main/java/com/stripe/param/PaymentMethodListParams.java
@@ -202,6 +202,9 @@ public class PaymentMethodListParams extends ApiRequestParams {
   }
 
   public enum Type implements ApiRequestParams.EnumParam {
+    @SerializedName("afterpay_clearpay")
+    AFTERPAY_CLEARPAY("afterpay_clearpay"),
+
     @SerializedName("alipay")
     ALIPAY("alipay"),
 

--- a/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
+++ b/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
@@ -647,6 +647,13 @@ public class SessionCreateParams extends ApiRequestParams {
   @Getter
   public static class LineItem {
     /**
+     * When set, provides configuration for this item’s quantity to be adjusted by the customer
+     * during Checkout.
+     */
+    @SerializedName("adjustable_quantity")
+    AdjustableQuantity adjustableQuantity;
+
+    /**
      * The amount to be collected per unit of the line item. If specified, must also pass {@code
      * currency} and {@code name}.
      */
@@ -732,6 +739,7 @@ public class SessionCreateParams extends ApiRequestParams {
     List<String> taxRates;
 
     private LineItem(
+        AdjustableQuantity adjustableQuantity,
         Long amount,
         String currency,
         String description,
@@ -743,6 +751,7 @@ public class SessionCreateParams extends ApiRequestParams {
         PriceData priceData,
         Long quantity,
         List<String> taxRates) {
+      this.adjustableQuantity = adjustableQuantity;
       this.amount = amount;
       this.currency = currency;
       this.description = description;
@@ -761,6 +770,8 @@ public class SessionCreateParams extends ApiRequestParams {
     }
 
     public static class Builder {
+      private AdjustableQuantity adjustableQuantity;
+
       private Long amount;
 
       private String currency;
@@ -786,6 +797,7 @@ public class SessionCreateParams extends ApiRequestParams {
       /** Finalize and obtain parameter instance from this builder. */
       public LineItem build() {
         return new LineItem(
+            this.adjustableQuantity,
             this.amount,
             this.currency,
             this.description,
@@ -797,6 +809,15 @@ public class SessionCreateParams extends ApiRequestParams {
             this.priceData,
             this.quantity,
             this.taxRates);
+      }
+
+      /**
+       * When set, provides configuration for this item’s quantity to be adjusted by the customer
+       * during Checkout.
+       */
+      public Builder setAdjustableQuantity(AdjustableQuantity adjustableQuantity) {
+        this.adjustableQuantity = adjustableQuantity;
+        return this;
       }
 
       /**
@@ -968,6 +989,121 @@ public class SessionCreateParams extends ApiRequestParams {
         }
         this.taxRates.addAll(elements);
         return this;
+      }
+    }
+
+    @Getter
+    public static class AdjustableQuantity {
+      /**
+       * Set to true if the quantity can be adjusted to any non-negative integer. By default
+       * customers will be able to remove the line item by setting the quantity to 0.
+       */
+      @SerializedName("enabled")
+      Boolean enabled;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /**
+       * The maximum quantity the customer can purchase for the Checkout Session. By default this
+       * value is 99.
+       */
+      @SerializedName("maximum")
+      Long maximum;
+
+      /**
+       * The minimum quantity the customer must purchase for the Checkout Session. By default this
+       * value is 0.
+       */
+      @SerializedName("minimum")
+      Long minimum;
+
+      private AdjustableQuantity(
+          Boolean enabled, Map<String, Object> extraParams, Long maximum, Long minimum) {
+        this.enabled = enabled;
+        this.extraParams = extraParams;
+        this.maximum = maximum;
+        this.minimum = minimum;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Boolean enabled;
+
+        private Map<String, Object> extraParams;
+
+        private Long maximum;
+
+        private Long minimum;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public AdjustableQuantity build() {
+          return new AdjustableQuantity(this.enabled, this.extraParams, this.maximum, this.minimum);
+        }
+
+        /**
+         * Set to true if the quantity can be adjusted to any non-negative integer. By default
+         * customers will be able to remove the line item by setting the quantity to 0.
+         */
+        public Builder setEnabled(Boolean enabled) {
+          this.enabled = enabled;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link SessionCreateParams.LineItem.AdjustableQuantity#extraParams} for the
+         * field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link SessionCreateParams.LineItem.AdjustableQuantity#extraParams} for the
+         * field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /**
+         * The maximum quantity the customer can purchase for the Checkout Session. By default this
+         * value is 99.
+         */
+        public Builder setMaximum(Long maximum) {
+          this.maximum = maximum;
+          return this;
+        }
+
+        /**
+         * The minimum quantity the customer must purchase for the Checkout Session. By default this
+         * value is 0.
+         */
+        public Builder setMinimum(Long minimum) {
+          this.minimum = minimum;
+          return this;
+        }
       }
     }
 
@@ -3739,6 +3875,9 @@ public class SessionCreateParams extends ApiRequestParams {
   }
 
   public enum PaymentMethodType implements ApiRequestParams.EnumParam {
+    @SerializedName("afterpay_clearpay")
+    AFTERPAY_CLEARPAY("afterpay_clearpay"),
+
     @SerializedName("alipay")
     ALIPAY("alipay"),
 


### PR DESCRIPTION
Codegen for openapi 546b28b.
r? @remi-stripe 
cc @stripe/api-libraries

## Changelog
* Add support for `afterpay_clearpay` on `PaymentMethod`, `PaymentIntent.payment_method_data`, and `Charge.payment_method_details`.
* Add support for `afterpay_clearpay` as a payment method type on `PaymentMethod.type`, `PaymentIntent.PaymentMethodData.type`, and `Checkout.SessionCreateParams.payment_method_types`.
* Add support for `adjustable_quantity` on `SessionCreateParams.LineItem`
* Add support for `bacs_debit`, `au_becs_debit` and `sepa_debit` on `SetupAttempt.payment_method_details`


