### PR TITLE
API Updates

### DIFF
--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -1893,7 +1893,8 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
       /**
        * The customer's bank. Can be one of {@code abn_amro}, {@code asn_bank}, {@code bunq}, {@code
        * handelsbanken}, {@code ing}, {@code knab}, {@code moneyou}, {@code rabobank}, {@code
-       * regiobank}, {@code sns_bank}, {@code triodos_bank}, or {@code van_lanschot}.
+       * regiobank}, {@code revolut}, {@code sns_bank}, {@code triodos_bank}, or {@code
+       * van_lanschot}.
        */
       @SerializedName("bank")
       String bank;
@@ -1903,7 +1904,7 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
        *
        * <p>One of {@code ABNANL2A}, {@code ASNBNL21}, {@code BUNQNL2A}, {@code FVLBNL22}, {@code
        * HANDNL2A}, {@code INGBNL2A}, {@code KNABNL2H}, {@code MOYONL21}, {@code RABONL2U}, {@code
-       * RBRBNL21}, {@code SNSBNL2A}, or {@code TRIONL2U}.
+       * RBRBNL21}, {@code REVOLT21}, {@code SNSBNL2A}, or {@code TRIONL2U}.
        */
       @SerializedName("bic")
       String bic;

--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -344,6 +344,17 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
   String object;
 
   /**
+   * The account (if any) for which the funds of the invoice payment are intended. If set, the
+   * invoice will be presented with the branding and support information of the specified account.
+   * See the <a href="https://stripe.com/docs/billing/invoices/connect">Invoices with Connect</a>
+   * documentation for details.
+   */
+  @SerializedName("on_behalf_of")
+  @Getter(lombok.AccessLevel.NONE)
+  @Setter(lombok.AccessLevel.NONE)
+  ExpandableField<Account> onBehalfOf;
+
+  /**
    * Whether payment was successfully collected for this invoice. An invoice can be paid (most
    * commonly) with a charge or with credit from the customer's account balance.
    */
@@ -532,6 +543,24 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
   public void setDefaultSourceObject(PaymentSource expandableObject) {
     this.defaultSource =
         new ExpandableField<PaymentSource>(expandableObject.getId(), expandableObject);
+  }
+
+  /** Get ID of expandable {@code onBehalfOf} object. */
+  public String getOnBehalfOf() {
+    return (this.onBehalfOf != null) ? this.onBehalfOf.getId() : null;
+  }
+
+  public void setOnBehalfOf(String id) {
+    this.onBehalfOf = ApiResource.setExpandableFieldId(id, this.onBehalfOf);
+  }
+
+  /** Get expanded {@code onBehalfOf}. */
+  public Account getOnBehalfOfObject() {
+    return (this.onBehalfOf != null) ? this.onBehalfOf.getExpanded() : null;
+  }
+
+  public void setOnBehalfOfObject(Account expandableObject) {
+    this.onBehalfOf = new ExpandableField<Account>(expandableObject.getId(), expandableObject);
   }
 
   /** Get ID of expandable {@code paymentIntent} object. */

--- a/src/main/java/com/stripe/model/PaymentMethod.java
+++ b/src/main/java/com/stripe/model/PaymentMethod.java
@@ -821,7 +821,8 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
     /**
      * The customer's bank, if provided. Can be one of {@code abn_amro}, {@code asn_bank}, {@code
      * bunq}, {@code handelsbanken}, {@code ing}, {@code knab}, {@code moneyou}, {@code rabobank},
-     * {@code regiobank}, {@code sns_bank}, {@code triodos_bank}, or {@code van_lanschot}.
+     * {@code regiobank}, {@code revolut}, {@code sns_bank}, {@code triodos_bank}, or {@code
+     * van_lanschot}.
      */
     @SerializedName("bank")
     String bank;
@@ -831,7 +832,7 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
      *
      * <p>One of {@code ABNANL2A}, {@code ASNBNL21}, {@code BUNQNL2A}, {@code FVLBNL22}, {@code
      * HANDNL2A}, {@code INGBNL2A}, {@code KNABNL2H}, {@code MOYONL21}, {@code RABONL2U}, {@code
-     * RBRBNL21}, {@code SNSBNL2A}, or {@code TRIONL2U}.
+     * RBRBNL21}, {@code REVOLT21}, {@code SNSBNL2A}, or {@code TRIONL2U}.
      */
     @SerializedName("bic")
     String bic;

--- a/src/main/java/com/stripe/model/SetupAttempt.java
+++ b/src/main/java/com/stripe/model/SetupAttempt.java
@@ -405,7 +405,8 @@ public class SetupAttempt extends ApiResource implements HasId {
       /**
        * The customer's bank. Can be one of {@code abn_amro}, {@code asn_bank}, {@code bunq}, {@code
        * handelsbanken}, {@code ing}, {@code knab}, {@code moneyou}, {@code rabobank}, {@code
-       * regiobank}, {@code sns_bank}, {@code triodos_bank}, or {@code van_lanschot}.
+       * regiobank}, {@code revolut}, {@code sns_bank}, {@code triodos_bank}, or {@code
+       * van_lanschot}.
        */
       @SerializedName("bank")
       String bank;
@@ -415,7 +416,7 @@ public class SetupAttempt extends ApiResource implements HasId {
        *
        * <p>One of {@code ABNANL2A}, {@code ASNBNL21}, {@code BUNQNL2A}, {@code FVLBNL22}, {@code
        * HANDNL2A}, {@code INGBNL2A}, {@code KNABNL2H}, {@code MOYONL21}, {@code RABONL2U}, {@code
-       * RBRBNL21}, {@code SNSBNL2A}, or {@code TRIONL2U}.
+       * RBRBNL21}, {@code REVOLT21}, {@code SNSBNL2A}, or {@code TRIONL2U}.
        */
       @SerializedName("bic")
       String bic;

--- a/src/main/java/com/stripe/param/InvoiceCreateParams.java
+++ b/src/main/java/com/stripe/param/InvoiceCreateParams.java
@@ -126,6 +126,15 @@ public class InvoiceCreateParams extends ApiRequestParams {
   Object metadata;
 
   /**
+   * The account (if any) for which the funds of the invoice payment are intended. If set, the
+   * invoice will be presented with the branding and support information of the specified account.
+   * See the <a href="https://stripe.com/docs/billing/invoices/connect">Invoices with Connect</a>
+   * documentation for details.
+   */
+  @SerializedName("on_behalf_of")
+  String onBehalfOf;
+
+  /**
    * Configuration settings for the PaymentIntent that is generated when the invoice is finalized.
    */
   @SerializedName("payment_settings")
@@ -175,6 +184,7 @@ public class InvoiceCreateParams extends ApiRequestParams {
       Map<String, Object> extraParams,
       String footer,
       Object metadata,
+      String onBehalfOf,
       PaymentSettings paymentSettings,
       String statementDescriptor,
       String subscription,
@@ -196,6 +206,7 @@ public class InvoiceCreateParams extends ApiRequestParams {
     this.extraParams = extraParams;
     this.footer = footer;
     this.metadata = metadata;
+    this.onBehalfOf = onBehalfOf;
     this.paymentSettings = paymentSettings;
     this.statementDescriptor = statementDescriptor;
     this.subscription = subscription;
@@ -241,6 +252,8 @@ public class InvoiceCreateParams extends ApiRequestParams {
 
     private Object metadata;
 
+    private String onBehalfOf;
+
     private PaymentSettings paymentSettings;
 
     private String statementDescriptor;
@@ -269,6 +282,7 @@ public class InvoiceCreateParams extends ApiRequestParams {
           this.extraParams,
           this.footer,
           this.metadata,
+          this.onBehalfOf,
           this.paymentSettings,
           this.statementDescriptor,
           this.subscription,
@@ -622,6 +636,17 @@ public class InvoiceCreateParams extends ApiRequestParams {
      */
     public Builder setMetadata(Map<String, String> metadata) {
       this.metadata = metadata;
+      return this;
+    }
+
+    /**
+     * The account (if any) for which the funds of the invoice payment are intended. If set, the
+     * invoice will be presented with the branding and support information of the specified account.
+     * See the <a href="https://stripe.com/docs/billing/invoices/connect">Invoices with Connect</a>
+     * documentation for details.
+     */
+    public Builder setOnBehalfOf(String onBehalfOf) {
+      this.onBehalfOf = onBehalfOf;
       return this;
     }
 

--- a/src/main/java/com/stripe/param/InvoiceFinalizeInvoiceParams.java
+++ b/src/main/java/com/stripe/param/InvoiceFinalizeInvoiceParams.java
@@ -13,7 +13,7 @@ import lombok.Getter;
 public class InvoiceFinalizeInvoiceParams extends ApiRequestParams {
   /**
    * Controls whether Stripe will perform <a
-   * href="https://stripe.com/docs/billing/invoices/workflow/#auto_advance">automatic collection</a>
+   * href="https://stripe.com/docs/billing/invoices/overview#auto-advance">automatic collection</a>
    * of the invoice. When {@code false}, the invoice's state will not automatically advance without
    * an explicit action.
    */
@@ -58,7 +58,7 @@ public class InvoiceFinalizeInvoiceParams extends ApiRequestParams {
 
     /**
      * Controls whether Stripe will perform <a
-     * href="https://stripe.com/docs/billing/invoices/workflow/#auto_advance">automatic
+     * href="https://stripe.com/docs/billing/invoices/overview#auto-advance">automatic
      * collection</a> of the invoice. When {@code false}, the invoice's state will not automatically
      * advance without an explicit action.
      */

--- a/src/main/java/com/stripe/param/InvoiceUpdateParams.java
+++ b/src/main/java/com/stripe/param/InvoiceUpdateParams.java
@@ -127,6 +127,15 @@ public class InvoiceUpdateParams extends ApiRequestParams {
   Object metadata;
 
   /**
+   * The account (if any) for which the funds of the invoice payment are intended. If set, the
+   * invoice will be presented with the branding and support information of the specified account.
+   * See the <a href="https://stripe.com/docs/billing/invoices/connect">Invoices with Connect</a>
+   * documentation for details.
+   */
+  @SerializedName("on_behalf_of")
+  Object onBehalfOf;
+
+  /**
    * Configuration settings for the PaymentIntent that is generated when the invoice is finalized.
    */
   @SerializedName("payment_settings")
@@ -166,6 +175,7 @@ public class InvoiceUpdateParams extends ApiRequestParams {
       Map<String, Object> extraParams,
       Object footer,
       Object metadata,
+      Object onBehalfOf,
       PaymentSettings paymentSettings,
       Object statementDescriptor,
       Object transferData) {
@@ -185,6 +195,7 @@ public class InvoiceUpdateParams extends ApiRequestParams {
     this.extraParams = extraParams;
     this.footer = footer;
     this.metadata = metadata;
+    this.onBehalfOf = onBehalfOf;
     this.paymentSettings = paymentSettings;
     this.statementDescriptor = statementDescriptor;
     this.transferData = transferData;
@@ -227,6 +238,8 @@ public class InvoiceUpdateParams extends ApiRequestParams {
 
     private Object metadata;
 
+    private Object onBehalfOf;
+
     private PaymentSettings paymentSettings;
 
     private Object statementDescriptor;
@@ -252,6 +265,7 @@ public class InvoiceUpdateParams extends ApiRequestParams {
           this.extraParams,
           this.footer,
           this.metadata,
+          this.onBehalfOf,
           this.paymentSettings,
           this.statementDescriptor,
           this.transferData);
@@ -659,6 +673,28 @@ public class InvoiceUpdateParams extends ApiRequestParams {
      */
     public Builder setMetadata(Map<String, String> metadata) {
       this.metadata = metadata;
+      return this;
+    }
+
+    /**
+     * The account (if any) for which the funds of the invoice payment are intended. If set, the
+     * invoice will be presented with the branding and support information of the specified account.
+     * See the <a href="https://stripe.com/docs/billing/invoices/connect">Invoices with Connect</a>
+     * documentation for details.
+     */
+    public Builder setOnBehalfOf(String onBehalfOf) {
+      this.onBehalfOf = onBehalfOf;
+      return this;
+    }
+
+    /**
+     * The account (if any) for which the funds of the invoice payment are intended. If set, the
+     * invoice will be presented with the branding and support information of the specified account.
+     * See the <a href="https://stripe.com/docs/billing/invoices/connect">Invoices with Connect</a>
+     * documentation for details.
+     */
+    public Builder setOnBehalfOf(EmptyParam onBehalfOf) {
+      this.onBehalfOf = onBehalfOf;
       return this;
     }
 

--- a/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
@@ -2404,6 +2404,9 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
         @SerializedName("regiobank")
         REGIOBANK("regiobank"),
 
+        @SerializedName("revolut")
+        REVOLUT("revolut"),
+
         @SerializedName("sns_bank")
         SNS_BANK("sns_bank"),
 

--- a/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
@@ -2775,6 +2775,9 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
         @SerializedName("regiobank")
         REGIOBANK("regiobank"),
 
+        @SerializedName("revolut")
+        REVOLUT("revolut"),
+
         @SerializedName("sns_bank")
         SNS_BANK("sns_bank"),
 

--- a/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
@@ -2387,6 +2387,9 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
         @SerializedName("regiobank")
         REGIOBANK("regiobank"),
 
+        @SerializedName("revolut")
+        REVOLUT("revolut"),
+
         @SerializedName("sns_bank")
         SNS_BANK("sns_bank"),
 

--- a/src/main/java/com/stripe/param/PaymentMethodCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentMethodCreateParams.java
@@ -1873,6 +1873,9 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
       @SerializedName("regiobank")
       REGIOBANK("regiobank"),
 
+      @SerializedName("revolut")
+      REVOLUT("revolut"),
+
       @SerializedName("sns_bank")
       SNS_BANK("sns_bank"),
 


### PR DESCRIPTION
Codegen for openapi 9918f6f.
r? @ctrudeau-stripe 
cc @stripe/api-libraries

## Changelog
* Added support for `on_behalf_of` to `Invoice`
* Added support `revolut` as an enum member on `PaymentMethodCreateParams.Ideal.Bank`, `PaymentIntentConfirmParams.Ideal.Bank`, `PaymentIntentUpdateParams.Ideal.Bank`, and `PaymentIntentCreateParams.Ideal.Bank`

