### PR TITLE
add docs to readme about JVM caching risk

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,9 @@ servers.
 
 We cannot guarantee that the IP address of the Stripe API will be static.
 Commonly, default JVM configurations can have their DNS cache TTL set to
-forever. If Stripe's IP address changes, your application's requests to Stripe will all fail until the JVM restarts. Therefore we recommend that you modify the JVM's [networkaddress.cache.ttl
+forever. If Stripe's IP address changes, your application's requests to
+Stripe will all fail until the JVM restarts. Therefore we recommend that
+you modify the JVM's [networkaddress.cache.ttl
 property](https://docs.oracle.com/javase/7/docs/technotes/guides/net/properties.html)
 to `60` seconds.
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,14 @@ Please take care to set conservative read timeouts. Some API requests can take
 some time, and a short timeout increases the likelihood of a problem within our
 servers.
 
+### Configuring DNS Cache TTL
+
+We cannot guarantee that the IP address of the Stripe API will be static.
+Commonly, default JVM configurations can have their DNS cache TTL set to
+forever. Therefore we recommend that you modify the JVM's [networkaddress.cache.ttl
+property](https://docs.oracle.com/javase/7/docs/technotes/guides/net/properties.html)
+to `60` seconds to prevent availability interruptions.
+
 ### Writing a plugin
 
 If you're writing a plugin that uses the library, we'd appreciate it if you

--- a/README.md
+++ b/README.md
@@ -161,9 +161,9 @@ servers.
 
 We cannot guarantee that the IP address of the Stripe API will be static.
 Commonly, default JVM configurations can have their DNS cache TTL set to
-forever. Therefore we recommend that you modify the JVM's [networkaddress.cache.ttl
+forever. If Stripe's IP address changes, your application's requests to Stripe will all fail until the JVM restarts. Therefore we recommend that you modify the JVM's [networkaddress.cache.ttl
 property](https://docs.oracle.com/javase/7/docs/technotes/guides/net/properties.html)
-to `60` seconds to prevent availability interruptions.
+to `60` seconds.
 
 ### Writing a plugin
 


### PR DESCRIPTION
r? @richardm-stripe 

Some of our users have reported intermittent timeouts / issues and we were able to identify them as DNS related when the Stripe API's IP address can be subject to change.

Updating the docs to make a recommendation around this since we already advise best practice for other network related mitigations.