### PR TITLE
Fix #1190 by marking RequestOptions transient

### DIFF
--- a/src/main/java/com/stripe/model/StripeCollection.java
+++ b/src/main/java/com/stripe/model/StripeCollection.java
@@ -50,7 +50,7 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject
 
   @Getter(onMethod_ = {@Override})
   @Setter(onMethod = @__({@Override}))
-  private RequestOptions requestOptions;
+  private transient RequestOptions requestOptions;
 
   @Getter(onMethod_ = {@Override})
   @Setter(onMethod = @__({@Override}))

--- a/src/main/java/com/stripe/net/ApiResourceTypeAdapterFactoryProvider.java
+++ b/src/main/java/com/stripe/net/ApiResourceTypeAdapterFactoryProvider.java
@@ -18,6 +18,7 @@ final class ApiResourceTypeAdapterFactoryProvider {
     factories.add(new BalanceTransactionSourceTypeAdapterFactory());
     factories.add(new ExternalAccountTypeAdapterFactory());
     factories.add(new PaymentSourceTypeAdapterFactory());
+    factories.add(new ReflectionCheckingTypeAdapterFactory());
   }
 
   public static List<TypeAdapterFactory> getAll() {

--- a/src/main/java/com/stripe/net/ReflectionCheckingTypeAdapterFactory.java
+++ b/src/main/java/com/stripe/net/ReflectionCheckingTypeAdapterFactory.java
@@ -1,0 +1,26 @@
+package com.stripe.net;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.internal.bind.ReflectiveTypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+
+/**
+ * {@link TypeAdapterFactory} that checks that we don't use {@link ReflectiveTypeAdapterFactory}
+ * accidentally for classes outside {@code com.stripe} packages. This usually happens when we forget
+ * to mark a field {@code transient}.
+ */
+class ReflectionCheckingTypeAdapterFactory implements TypeAdapterFactory {
+  @Override
+  public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+    if (!type.getType().getTypeName().startsWith("com.stripe.")) {
+      TypeAdapter<T> adapter = gson.getDelegateAdapter(this, type);
+      if (adapter instanceof ReflectiveTypeAdapterFactory.Adapter) {
+        throw new IllegalArgumentException(
+            "Refusing to create type reflection-based type adapter for external class: " + type);
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
cc @stripe/api-libraries 
The problem was that Gson was attempting to make certain `java.net` classes constructors accessible through reflection but this is not longer allowed in JDK16 with the default module setup.

The reason that Gson was attempting to instantiate these classes was that we forgot to mark the field `StripeCollection.requestOptions` `transient` (it isn't part of the JSON response). The type `RequestOptions` in turn contains a `java.net.Proxy`-type field, which was the source of the problem.

I also added `ReflectionCheckingTypeAdapterFactory` which is a fake `TypeAdapterFactory` that just checks that we aren't using reflection to access anything outside of `com.stripe` packages.

In trying to replicate this problem I tried to get this project to build on JDK 16 but that required an upgrade to Gradle 7 which turned out to be too much to put into this PR. The WIP branch for that is [here](https://github.com/stripe/stripe-java/pull/1198).