### PR TITLE
API Updates

### DIFF
--- a/src/main/java/com/stripe/model/Account.java
+++ b/src/main/java/com/stripe/model/Account.java
@@ -892,8 +892,9 @@ public class Account extends ApiResource implements MetadataStore<Account>, Paym
      * incorporated_non_profit}, {@code limited_liability_partnership}, {@code multi_member_llc},
      * {@code private_company}, {@code private_corporation}, {@code private_partnership}, {@code
      * public_company}, {@code public_corporation}, {@code public_partnership}, {@code
-     * sole_proprietorship}, {@code tax_exempt_government_instrumentality}, {@code
-     * unincorporated_association}, or {@code unincorporated_non_profit}.
+     * single_member_llc}, {@code sole_proprietorship}, {@code
+     * tax_exempt_government_instrumentality}, {@code unincorporated_association}, or {@code
+     * unincorporated_non_profit}.
      */
     @SerializedName("structure")
     String structure;

--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -1076,12 +1076,12 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
 
     /**
      * The type of transaction-specific details of the payment method used in the payment, one of
-     * {@code ach_credit_transfer}, {@code ach_debit}, {@code alipay}, {@code au_becs_debit}, {@code
-     * bancontact}, {@code card}, {@code card_present}, {@code eps}, {@code giropay}, {@code ideal},
-     * {@code klarna}, {@code multibanco}, {@code p24}, {@code sepa_debit}, {@code sofort}, {@code
-     * stripe_account}, or {@code wechat}. An additional hash is included on {@code
-     * payment_method_details} with a name matching this value. It contains information specific to
-     * the payment method.
+     * {@code ach_credit_transfer}, {@code ach_debit}, {@code acss_debit}, {@code alipay}, {@code
+     * au_becs_debit}, {@code bancontact}, {@code card}, {@code card_present}, {@code eps}, {@code
+     * giropay}, {@code ideal}, {@code klarna}, {@code multibanco}, {@code p24}, {@code sepa_debit},
+     * {@code sofort}, {@code stripe_account}, or {@code wechat}. An additional hash is included on
+     * {@code payment_method_details} with a name matching this value. It contains information
+     * specific to the payment method.
      */
     @SerializedName("type")
     String type;

--- a/src/main/java/com/stripe/model/PaymentIntent.java
+++ b/src/main/java/com/stripe/model/PaymentIntent.java
@@ -1183,6 +1183,9 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
     @SerializedName("card")
     Card card;
 
+    @SerializedName("card_present")
+    CardPresent cardPresent;
+
     @SerializedName("oxxo")
     Oxxo oxxo;
 
@@ -1275,8 +1278,8 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
       Installments installments;
 
       /**
-       * Selected network to process this PaymentIntent on. Depends on the available networks of the
-       * card attached to the PaymentIntent. Can be only set confirm-time.
+       * Selected network to process this payment intent on. Depends on the available networks of
+       * the card attached to the payment intent. Can be only set confirm-time.
        */
       @SerializedName("network")
       String network;
@@ -1337,6 +1340,11 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
         }
       }
     }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class CardPresent extends StripeObject {}
 
     @Getter
     @Setter

--- a/src/main/java/com/stripe/model/checkout/Session.java
+++ b/src/main/java/com/stripe/model/checkout/Session.java
@@ -462,6 +462,14 @@ public class Session extends ApiResource implements HasId {
     @Setter
     @EqualsAndHashCode(callSuper = false)
     public static class AcssDebit extends StripeObject {
+      /**
+       * Currency supported by the bank account. Returned when the Session is in {@code setup} mode.
+       *
+       * <p>One of {@code cad}, or {@code usd}.
+       */
+      @SerializedName("currency")
+      String currency;
+
       @SerializedName("mandate_options")
       MandateOptions mandateOptions;
 
@@ -472,14 +480,6 @@ public class Session extends ApiResource implements HasId {
        */
       @SerializedName("verification_method")
       String verificationMethod;
-
-      /**
-       * Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency
-       * code</a>, in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported
-       * currency</a>.
-       */
-      @SerializedName("currency")
-      String currency;
 
       @Getter
       @Setter

--- a/src/main/java/com/stripe/model/issuing/Card.java
+++ b/src/main/java/com/stripe/model/issuing/Card.java
@@ -346,7 +346,7 @@ public class Card extends ApiResource implements HasId, MetadataStore<Card> {
     /**
      * The delivery company that shipped a card.
      *
-     * <p>One of {@code fedex}, or {@code usps}.
+     * <p>One of {@code dhl}, {@code fedex}, {@code royal_mail}, or {@code usps}.
      */
     @SerializedName("carrier")
     String carrier;

--- a/src/main/java/com/stripe/param/AccountCreateParams.java
+++ b/src/main/java/com/stripe/param/AccountCreateParams.java
@@ -3992,6 +3992,9 @@ public class AccountCreateParams extends ApiRequestParams {
       @SerializedName("public_partnership")
       PUBLIC_PARTNERSHIP("public_partnership"),
 
+      @SerializedName("single_member_llc")
+      SINGLE_MEMBER_LLC("single_member_llc"),
+
       @SerializedName("sole_proprietorship")
       SOLE_PROPRIETORSHIP("sole_proprietorship"),
 
@@ -6378,7 +6381,7 @@ public class AccountCreateParams extends ApiRequestParams {
 
       /**
        * Details on the account's acceptance of the <a
-       * href="stripe.com/docs/issuing/connect/tos_acceptance">Stripe Issuing Terms and
+       * href="https://stripe.com/docs/issuing/connect/tos_acceptance">Stripe Issuing Terms and
        * Disclosures</a>.
        */
       @SerializedName("tos_acceptance")
@@ -6433,7 +6436,7 @@ public class AccountCreateParams extends ApiRequestParams {
 
         /**
          * Details on the account's acceptance of the <a
-         * href="stripe.com/docs/issuing/connect/tos_acceptance">Stripe Issuing Terms and
+         * href="https://stripe.com/docs/issuing/connect/tos_acceptance">Stripe Issuing Terms and
          * Disclosures</a>.
          */
         public Builder setTosAcceptance(TosAcceptance tosAcceptance) {

--- a/src/main/java/com/stripe/param/AccountUpdateParams.java
+++ b/src/main/java/com/stripe/param/AccountUpdateParams.java
@@ -4297,6 +4297,9 @@ public class AccountUpdateParams extends ApiRequestParams {
       @SerializedName("public_partnership")
       PUBLIC_PARTNERSHIP("public_partnership"),
 
+      @SerializedName("single_member_llc")
+      SINGLE_MEMBER_LLC("single_member_llc"),
+
       @SerializedName("sole_proprietorship")
       SOLE_PROPRIETORSHIP("sole_proprietorship"),
 
@@ -6968,7 +6971,7 @@ public class AccountUpdateParams extends ApiRequestParams {
 
       /**
        * Details on the account's acceptance of the <a
-       * href="stripe.com/docs/issuing/connect/tos_acceptance">Stripe Issuing Terms and
+       * href="https://stripe.com/docs/issuing/connect/tos_acceptance">Stripe Issuing Terms and
        * Disclosures</a>.
        */
       @SerializedName("tos_acceptance")
@@ -7023,7 +7026,7 @@ public class AccountUpdateParams extends ApiRequestParams {
 
         /**
          * Details on the account's acceptance of the <a
-         * href="stripe.com/docs/issuing/connect/tos_acceptance">Stripe Issuing Terms and
+         * href="https://stripe.com/docs/issuing/connect/tos_acceptance">Stripe Issuing Terms and
          * Disclosures</a>.
          */
         public Builder setTosAcceptance(TosAcceptance tosAcceptance) {

--- a/src/main/java/com/stripe/param/InvoiceUpcomingParams.java
+++ b/src/main/java/com/stripe/param/InvoiceUpcomingParams.java
@@ -30,7 +30,8 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
   /**
    * The coupons to redeem into discounts for the invoice preview. If not specified, inherits the
    * discount from the customer or subscription. Pass an empty string to avoid inheriting any
-   * discounts.
+   * discounts. To preview the upcoming invoice for a subscription that hasn't been created, use
+   * {@code coupon} instead.
    */
   @SerializedName("discounts")
   Object discounts;
@@ -314,7 +315,8 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
     /**
      * The coupons to redeem into discounts for the invoice preview. If not specified, inherits the
      * discount from the customer or subscription. Pass an empty string to avoid inheriting any
-     * discounts.
+     * discounts. To preview the upcoming invoice for a subscription that hasn't been created, use
+     * {@code coupon} instead.
      */
     public Builder setDiscounts(EmptyParam discounts) {
       this.discounts = discounts;
@@ -324,7 +326,8 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
     /**
      * The coupons to redeem into discounts for the invoice preview. If not specified, inherits the
      * discount from the customer or subscription. Pass an empty string to avoid inheriting any
-     * discounts.
+     * discounts. To preview the upcoming invoice for a subscription that hasn't been created, use
+     * {@code coupon} instead.
      */
     public Builder setDiscounts(List<Discount> discounts) {
       this.discounts = discounts;

--- a/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
@@ -3065,6 +3065,13 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
     Object card;
 
     /**
+     * If this is a {@code card_present} PaymentMethod, this sub-hash contains details about the
+     * Card Present payment method options.
+     */
+    @SerializedName("card_present")
+    Object cardPresent;
+
+    /**
      * Map of extra parameters for custom features not available in this client library. The content
      * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
      * key/value pair is serialized as if the key is a root-level field (serialized) name in this
@@ -3106,6 +3113,7 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
         Object alipay,
         Object bancontact,
         Object card,
+        Object cardPresent,
         Map<String, Object> extraParams,
         Object oxxo,
         Object p24,
@@ -3115,6 +3123,7 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       this.alipay = alipay;
       this.bancontact = bancontact;
       this.card = card;
+      this.cardPresent = cardPresent;
       this.extraParams = extraParams;
       this.oxxo = oxxo;
       this.p24 = p24;
@@ -3135,6 +3144,8 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
 
       private Object card;
 
+      private Object cardPresent;
+
       private Map<String, Object> extraParams;
 
       private Object oxxo;
@@ -3152,6 +3163,7 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
             this.alipay,
             this.bancontact,
             this.card,
+            this.cardPresent,
             this.extraParams,
             this.oxxo,
             this.p24,
@@ -3222,6 +3234,24 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       /** Configuration for any card payments attempted on this PaymentIntent. */
       public Builder setCard(EmptyParam card) {
         this.card = card;
+        return this;
+      }
+
+      /**
+       * If this is a {@code card_present} PaymentMethod, this sub-hash contains details about the
+       * Card Present payment method options.
+       */
+      public Builder setCardPresent(CardPresent cardPresent) {
+        this.cardPresent = cardPresent;
+        return this;
+      }
+
+      /**
+       * If this is a {@code card_present} PaymentMethod, this sub-hash contains details about the
+       * Card Present payment method options.
+       */
+      public Builder setCardPresent(EmptyParam cardPresent) {
+        this.cardPresent = cardPresent;
         return this;
       }
 
@@ -4244,6 +4274,63 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
 
         RequestThreeDSecure(String value) {
           this.value = value;
+        }
+      }
+    }
+
+    @Getter
+    public static class CardPresent {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private CardPresent(Map<String, Object> extraParams) {
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public CardPresent build() {
+          return new CardPresent(this.extraParams);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentConfirmParams.PaymentMethodOptions.CardPresent#extraParams}
+         * for the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentConfirmParams.PaymentMethodOptions.CardPresent#extraParams}
+         * for the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
         }
       }
     }

--- a/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
@@ -3436,6 +3436,13 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     Object card;
 
     /**
+     * If this is a {@code card_present} PaymentMethod, this sub-hash contains details about the
+     * Card Present payment method options.
+     */
+    @SerializedName("card_present")
+    Object cardPresent;
+
+    /**
      * Map of extra parameters for custom features not available in this client library. The content
      * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
      * key/value pair is serialized as if the key is a root-level field (serialized) name in this
@@ -3477,6 +3484,7 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
         Object alipay,
         Object bancontact,
         Object card,
+        Object cardPresent,
         Map<String, Object> extraParams,
         Object oxxo,
         Object p24,
@@ -3486,6 +3494,7 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       this.alipay = alipay;
       this.bancontact = bancontact;
       this.card = card;
+      this.cardPresent = cardPresent;
       this.extraParams = extraParams;
       this.oxxo = oxxo;
       this.p24 = p24;
@@ -3506,6 +3515,8 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
 
       private Object card;
 
+      private Object cardPresent;
+
       private Map<String, Object> extraParams;
 
       private Object oxxo;
@@ -3523,6 +3534,7 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
             this.alipay,
             this.bancontact,
             this.card,
+            this.cardPresent,
             this.extraParams,
             this.oxxo,
             this.p24,
@@ -3593,6 +3605,24 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       /** Configuration for any card payments attempted on this PaymentIntent. */
       public Builder setCard(EmptyParam card) {
         this.card = card;
+        return this;
+      }
+
+      /**
+       * If this is a {@code card_present} PaymentMethod, this sub-hash contains details about the
+       * Card Present payment method options.
+       */
+      public Builder setCardPresent(CardPresent cardPresent) {
+        this.cardPresent = cardPresent;
+        return this;
+      }
+
+      /**
+       * If this is a {@code card_present} PaymentMethod, this sub-hash contains details about the
+       * Card Present payment method options.
+       */
+      public Builder setCardPresent(EmptyParam cardPresent) {
+        this.cardPresent = cardPresent;
         return this;
       }
 
@@ -4615,6 +4645,63 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
 
         RequestThreeDSecure(String value) {
           this.value = value;
+        }
+      }
+    }
+
+    @Getter
+    public static class CardPresent {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private CardPresent(Map<String, Object> extraParams) {
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public CardPresent build() {
+          return new CardPresent(this.extraParams);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentCreateParams.PaymentMethodOptions.CardPresent#extraParams}
+         * for the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentCreateParams.PaymentMethodOptions.CardPresent#extraParams}
+         * for the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
         }
       }
     }

--- a/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
@@ -3072,6 +3072,13 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     Object card;
 
     /**
+     * If this is a {@code card_present} PaymentMethod, this sub-hash contains details about the
+     * Card Present payment method options.
+     */
+    @SerializedName("card_present")
+    Object cardPresent;
+
+    /**
      * Map of extra parameters for custom features not available in this client library. The content
      * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
      * key/value pair is serialized as if the key is a root-level field (serialized) name in this
@@ -3113,6 +3120,7 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
         Object alipay,
         Object bancontact,
         Object card,
+        Object cardPresent,
         Map<String, Object> extraParams,
         Object oxxo,
         Object p24,
@@ -3122,6 +3130,7 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       this.alipay = alipay;
       this.bancontact = bancontact;
       this.card = card;
+      this.cardPresent = cardPresent;
       this.extraParams = extraParams;
       this.oxxo = oxxo;
       this.p24 = p24;
@@ -3142,6 +3151,8 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
 
       private Object card;
 
+      private Object cardPresent;
+
       private Map<String, Object> extraParams;
 
       private Object oxxo;
@@ -3159,6 +3170,7 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
             this.alipay,
             this.bancontact,
             this.card,
+            this.cardPresent,
             this.extraParams,
             this.oxxo,
             this.p24,
@@ -3229,6 +3241,24 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       /** Configuration for any card payments attempted on this PaymentIntent. */
       public Builder setCard(EmptyParam card) {
         this.card = card;
+        return this;
+      }
+
+      /**
+       * If this is a {@code card_present} PaymentMethod, this sub-hash contains details about the
+       * Card Present payment method options.
+       */
+      public Builder setCardPresent(CardPresent cardPresent) {
+        this.cardPresent = cardPresent;
+        return this;
+      }
+
+      /**
+       * If this is a {@code card_present} PaymentMethod, this sub-hash contains details about the
+       * Card Present payment method options.
+       */
+      public Builder setCardPresent(EmptyParam cardPresent) {
+        this.cardPresent = cardPresent;
         return this;
       }
 
@@ -4270,6 +4300,63 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
 
         RequestThreeDSecure(String value) {
           this.value = value;
+        }
+      }
+    }
+
+    @Getter
+    public static class CardPresent {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private CardPresent(Map<String, Object> extraParams) {
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public CardPresent build() {
+          return new CardPresent(this.extraParams);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentUpdateParams.PaymentMethodOptions.CardPresent#extraParams}
+         * for the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentUpdateParams.PaymentMethodOptions.CardPresent#extraParams}
+         * for the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
         }
       }
     }

--- a/src/main/java/com/stripe/param/SubscriptionCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionCreateParams.java
@@ -166,6 +166,16 @@ public class SubscriptionCreateParams extends ApiRequestParams {
    * href="https://stripe.com/docs/billing/migration/strong-customer-authentication">SCA Migration
    * Guide</a> for Billing to learn more. This is the default behavior.
    *
+   * <p>Use {@code default_incomplete} to create Subscriptions with {@code status=incomplete} when
+   * the first invoice requires payment, otherwise start as active. Subscriptions transition to
+   * {@code status=active} when successfully confirming the payment intent on the first invoice.
+   * This allows simpler management of scenarios where additional user actions are needed to pay a
+   * subscription’s invoice. Such as failed payments, <a
+   * href="https://stripe.com/docs/billing/migration/strong-customer-authentication">SCA
+   * regulation</a>, or collecting a mandate for a bank debit payment method. If the payment intent
+   * is not confirmed within 23 hours subscriptions transition to {@code status=expired_incomplete},
+   * which is a terminal state.
+   *
    * <p>Use {@code error_if_incomplete} if you want Stripe to return an HTTP 402 status code if a
    * subscription's first invoice cannot be paid. For example, if a payment method requires 3DS
    * authentication due to SCA regulation and further user action is needed, this parameter does not
@@ -735,6 +745,16 @@ public class SubscriptionCreateParams extends ApiRequestParams {
      * example, SCA regulation may require 3DS authentication to complete payment. See the <a
      * href="https://stripe.com/docs/billing/migration/strong-customer-authentication">SCA Migration
      * Guide</a> for Billing to learn more. This is the default behavior.
+     *
+     * <p>Use {@code default_incomplete} to create Subscriptions with {@code status=incomplete} when
+     * the first invoice requires payment, otherwise start as active. Subscriptions transition to
+     * {@code status=active} when successfully confirming the payment intent on the first invoice.
+     * This allows simpler management of scenarios where additional user actions are needed to pay a
+     * subscription’s invoice. Such as failed payments, <a
+     * href="https://stripe.com/docs/billing/migration/strong-customer-authentication">SCA
+     * regulation</a>, or collecting a mandate for a bank debit payment method. If the payment
+     * intent is not confirmed within 23 hours subscriptions transition to {@code
+     * status=expired_incomplete}, which is a terminal state.
      *
      * <p>Use {@code error_if_incomplete} if you want Stripe to return an HTTP 402 status code if a
      * subscription's first invoice cannot be paid. For example, if a payment method requires 3DS
@@ -2063,6 +2083,9 @@ public class SubscriptionCreateParams extends ApiRequestParams {
   public enum PaymentBehavior implements ApiRequestParams.EnumParam {
     @SerializedName("allow_incomplete")
     ALLOW_INCOMPLETE("allow_incomplete"),
+
+    @SerializedName("default_incomplete")
+    DEFAULT_INCOMPLETE("default_incomplete"),
 
     @SerializedName("error_if_incomplete")
     ERROR_IF_INCOMPLETE("error_if_incomplete"),

--- a/src/main/java/com/stripe/param/SubscriptionItemCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionItemCreateParams.java
@@ -50,6 +50,13 @@ public class SubscriptionItemCreateParams extends ApiRequestParams {
    * href="https://stripe.com/docs/billing/migration/strong-customer-authentication">SCA Migration
    * Guide</a> for Billing to learn more. This is the default behavior.
    *
+   * <p>Use {@code default_incomplete} to transition the subscription to {@code status=past_due}
+   * when payment is required and await explicit confirmation of the invoice's payment intent. This
+   * allows simpler management of scenarios where additional user actions are needed to pay a
+   * subscription’s invoice. Such as failed payments, <a
+   * href="https://stripe.com/docs/billing/migration/strong-customer-authentication">SCA
+   * regulation</a>, or collecting a mandate for a bank debit payment method.
+   *
    * <p>Use {@code pending_if_incomplete} to update the subscription using <a
    * href="https://stripe.com/docs/billing/subscriptions/pending-updates">pending updates</a>. When
    * you use {@code pending_if_incomplete} you can only pass the parameters <a
@@ -306,6 +313,13 @@ public class SubscriptionItemCreateParams extends ApiRequestParams {
      * require 3DS authentication to complete payment. See the <a
      * href="https://stripe.com/docs/billing/migration/strong-customer-authentication">SCA Migration
      * Guide</a> for Billing to learn more. This is the default behavior.
+     *
+     * <p>Use {@code default_incomplete} to transition the subscription to {@code status=past_due}
+     * when payment is required and await explicit confirmation of the invoice's payment intent.
+     * This allows simpler management of scenarios where additional user actions are needed to pay a
+     * subscription’s invoice. Such as failed payments, <a
+     * href="https://stripe.com/docs/billing/migration/strong-customer-authentication">SCA
+     * regulation</a>, or collecting a mandate for a bank debit payment method.
      *
      * <p>Use {@code pending_if_incomplete} to update the subscription using <a
      * href="https://stripe.com/docs/billing/subscriptions/pending-updates">pending updates</a>.
@@ -777,6 +791,9 @@ public class SubscriptionItemCreateParams extends ApiRequestParams {
   public enum PaymentBehavior implements ApiRequestParams.EnumParam {
     @SerializedName("allow_incomplete")
     ALLOW_INCOMPLETE("allow_incomplete"),
+
+    @SerializedName("default_incomplete")
+    DEFAULT_INCOMPLETE("default_incomplete"),
 
     @SerializedName("error_if_incomplete")
     ERROR_IF_INCOMPLETE("error_if_incomplete"),

--- a/src/main/java/com/stripe/param/SubscriptionItemUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionItemUpdateParams.java
@@ -54,6 +54,13 @@ public class SubscriptionItemUpdateParams extends ApiRequestParams {
    * href="https://stripe.com/docs/billing/migration/strong-customer-authentication">SCA Migration
    * Guide</a> for Billing to learn more. This is the default behavior.
    *
+   * <p>Use {@code default_incomplete} to transition the subscription to {@code status=past_due}
+   * when payment is required and await explicit confirmation of the invoice's payment intent. This
+   * allows simpler management of scenarios where additional user actions are needed to pay a
+   * subscription’s invoice. Such as failed payments, <a
+   * href="https://stripe.com/docs/billing/migration/strong-customer-authentication">SCA
+   * regulation</a>, or collecting a mandate for a bank debit payment method.
+   *
    * <p>Use {@code pending_if_incomplete} to update the subscription using <a
    * href="https://stripe.com/docs/billing/subscriptions/pending-updates">pending updates</a>. When
    * you use {@code pending_if_incomplete} you can only pass the parameters <a
@@ -336,6 +343,13 @@ public class SubscriptionItemUpdateParams extends ApiRequestParams {
      * require 3DS authentication to complete payment. See the <a
      * href="https://stripe.com/docs/billing/migration/strong-customer-authentication">SCA Migration
      * Guide</a> for Billing to learn more. This is the default behavior.
+     *
+     * <p>Use {@code default_incomplete} to transition the subscription to {@code status=past_due}
+     * when payment is required and await explicit confirmation of the invoice's payment intent.
+     * This allows simpler management of scenarios where additional user actions are needed to pay a
+     * subscription’s invoice. Such as failed payments, <a
+     * href="https://stripe.com/docs/billing/migration/strong-customer-authentication">SCA
+     * regulation</a>, or collecting a mandate for a bank debit payment method.
      *
      * <p>Use {@code pending_if_incomplete} to update the subscription using <a
      * href="https://stripe.com/docs/billing/subscriptions/pending-updates">pending updates</a>.
@@ -838,6 +852,9 @@ public class SubscriptionItemUpdateParams extends ApiRequestParams {
   public enum PaymentBehavior implements ApiRequestParams.EnumParam {
     @SerializedName("allow_incomplete")
     ALLOW_INCOMPLETE("allow_incomplete"),
+
+    @SerializedName("default_incomplete")
+    DEFAULT_INCOMPLETE("default_incomplete"),
 
     @SerializedName("error_if_incomplete")
     ERROR_IF_INCOMPLETE("error_if_incomplete"),

--- a/src/main/java/com/stripe/param/SubscriptionListParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionListParams.java
@@ -82,7 +82,8 @@ public class SubscriptionListParams extends ApiRequestParams {
    * all canceled subscriptions, including those belonging to deleted customers. Pass {@code ended}
    * to find subscriptions that are canceled and subscriptions that are expired due to <a
    * href="https://stripe.com/docs/billing/subscriptions/overview#subscription-statuses">incomplete
-   * payment</a>. Passing in a value of {@code all} will return subscriptions of all statuses.
+   * payment</a>. Passing in a value of {@code all} will return subscriptions of all statuses. If no
+   * value is supplied, all subscriptions that have not been canceled are returned.
    */
   @SerializedName("status")
   Status status;
@@ -311,7 +312,8 @@ public class SubscriptionListParams extends ApiRequestParams {
      * {@code ended} to find subscriptions that are canceled and subscriptions that are expired due
      * to <a
      * href="https://stripe.com/docs/billing/subscriptions/overview#subscription-statuses">incomplete
-     * payment</a>. Passing in a value of {@code all} will return subscriptions of all statuses.
+     * payment</a>. Passing in a value of {@code all} will return subscriptions of all statuses. If
+     * no value is supplied, all subscriptions that have not been canceled are returned.
      */
     public Builder setStatus(Status status) {
       this.status = status;

--- a/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
@@ -157,6 +157,13 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
    * href="https://stripe.com/docs/billing/migration/strong-customer-authentication">SCA Migration
    * Guide</a> for Billing to learn more. This is the default behavior.
    *
+   * <p>Use {@code default_incomplete} to transition the subscription to {@code status=past_due}
+   * when payment is required and await explicit confirmation of the invoice's payment intent. This
+   * allows simpler management of scenarios where additional user actions are needed to pay a
+   * subscription’s invoice. Such as failed payments, <a
+   * href="https://stripe.com/docs/billing/migration/strong-customer-authentication">SCA
+   * regulation</a>, or collecting a mandate for a bank debit payment method.
+   *
    * <p>Use {@code pending_if_incomplete} to update the subscription using <a
    * href="https://stripe.com/docs/billing/subscriptions/pending-updates">pending updates</a>. When
    * you use {@code pending_if_incomplete} you can only pass the parameters <a
@@ -776,6 +783,13 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
      * require 3DS authentication to complete payment. See the <a
      * href="https://stripe.com/docs/billing/migration/strong-customer-authentication">SCA Migration
      * Guide</a> for Billing to learn more. This is the default behavior.
+     *
+     * <p>Use {@code default_incomplete} to transition the subscription to {@code status=past_due}
+     * when payment is required and await explicit confirmation of the invoice's payment intent.
+     * This allows simpler management of scenarios where additional user actions are needed to pay a
+     * subscription’s invoice. Such as failed payments, <a
+     * href="https://stripe.com/docs/billing/migration/strong-customer-authentication">SCA
+     * regulation</a>, or collecting a mandate for a bank debit payment method.
      *
      * <p>Use {@code pending_if_incomplete} to update the subscription using <a
      * href="https://stripe.com/docs/billing/subscriptions/pending-updates">pending updates</a>.
@@ -2411,6 +2425,9 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
   public enum PaymentBehavior implements ApiRequestParams.EnumParam {
     @SerializedName("allow_incomplete")
     ALLOW_INCOMPLETE("allow_incomplete"),
+
+    @SerializedName("default_incomplete")
+    DEFAULT_INCOMPLETE("default_incomplete"),
 
     @SerializedName("error_if_incomplete")
     ERROR_IF_INCOMPLETE("error_if_incomplete"),

--- a/src/main/java/com/stripe/param/TokenCreateParams.java
+++ b/src/main/java/com/stripe/param/TokenCreateParams.java
@@ -1433,6 +1433,9 @@ public class TokenCreateParams extends ApiRequestParams {
         @SerializedName("public_partnership")
         PUBLIC_PARTNERSHIP("public_partnership"),
 
+        @SerializedName("single_member_llc")
+        SINGLE_MEMBER_LLC("single_member_llc"),
+
         @SerializedName("sole_proprietorship")
         SOLE_PROPRIETORSHIP("sole_proprietorship"),
 


### PR DESCRIPTION
Codegen for openapi 7cc2037.
r? @richardm-stripe
cc @stripe/api-libraries

## Changelog
* Added support for `card_present` on `PaymentIntent.payment_method_options`
* Added support for `default_incomplete` as a `payment_behavior` on `SubscriptionItemCreateParams`, `SubscriptionUpdateParams`, and `SubscriptionCreateParams`.
* Added support for `single_member_llc` as a `structure` on `AccountCreateParams.company` and `AccountUpdateParams.company`.

