### PR TITLE
[wip] stripe-java Services interface prototype.

### DIFF
--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -721,6 +721,7 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
    */
   @Override
   public Charge update(Map<String, Object> params, RequestOptions options) throws StripeException {
+    checkRequestMethodsEnabled();
     String url =
         String.format(
             "%s%s",
@@ -742,6 +743,7 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
    * provided will be left unchanged.
    */
   public Charge update(ChargeUpdateParams params, RequestOptions options) throws StripeException {
+    checkRequestMethodsEnabled();
     String url =
         String.format(
             "%s%s",
@@ -760,6 +762,7 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
    * capturable.
    */
   public Charge capture() throws StripeException {
+    checkRequestMethodsEnabled();
     return capture((Map<String, Object>) null, (RequestOptions) null);
   }
 
@@ -799,6 +802,7 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
    * capturable.
    */
   public Charge capture(Map<String, Object> params, RequestOptions options) throws StripeException {
+    checkRequestMethodsEnabled();
     String url =
         String.format(
             "%s%s",
@@ -830,6 +834,7 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
    * capturable.
    */
   public Charge capture(ChargeCaptureParams params, RequestOptions options) throws StripeException {
+    checkRequestMethodsEnabled();
     String url =
         String.format(
             "%s%s",

--- a/src/main/java/com/stripe/model/PaymentSourceCollection.java
+++ b/src/main/java/com/stripe/model/PaymentSourceCollection.java
@@ -19,6 +19,7 @@ public class PaymentSourceCollection extends StripeCollection<PaymentSource> {
   /** List sources for a specified customer. */
   public PaymentSourceCollection list(Map<String, Object> params, RequestOptions options)
       throws StripeException {
+    checkRequestMethodsEnabled();
     String url = String.format("%s%s", Stripe.getApiBase(), this.getUrl());
     return ApiResource.requestCollection(url, params, PaymentSourceCollection.class, options);
   }
@@ -32,6 +33,7 @@ public class PaymentSourceCollection extends StripeCollection<PaymentSource> {
   /** List sources for a specified customer. */
   public PaymentSourceCollection list(
       PaymentSourceCollectionListParams params, RequestOptions options) throws StripeException {
+    checkRequestMethodsEnabled();
     String url = String.format("%s%s", Stripe.getApiBase(), this.getUrl());
     return ApiResource.requestCollection(url, params, PaymentSourceCollection.class, options);
   }
@@ -49,6 +51,7 @@ public class PaymentSourceCollection extends StripeCollection<PaymentSource> {
   /** Retrieve a specified source for a given customer. */
   public PaymentSource retrieve(String id, Map<String, Object> params, RequestOptions options)
       throws StripeException {
+    checkRequestMethodsEnabled();
     String url =
         String.format(
             "%s%s",
@@ -62,6 +65,7 @@ public class PaymentSourceCollection extends StripeCollection<PaymentSource> {
   public PaymentSource retrieve(
       String id, PaymentSourceCollectionRetrieveParams params, RequestOptions options)
       throws StripeException {
+    checkRequestMethodsEnabled();
     String url =
         String.format(
             "%s%s",
@@ -95,6 +99,7 @@ public class PaymentSourceCollection extends StripeCollection<PaymentSource> {
    */
   public PaymentSource create(Map<String, Object> params, RequestOptions options)
       throws StripeException {
+    checkRequestMethodsEnabled();
     String url = String.format("%s%s", Stripe.getApiBase(), this.getUrl());
     return ApiResource.request(
         ApiResource.RequestMethod.POST, url, params, PaymentSource.class, options);
@@ -124,6 +129,7 @@ public class PaymentSourceCollection extends StripeCollection<PaymentSource> {
    */
   public PaymentSource create(PaymentSourceCollectionCreateParams params, RequestOptions options)
       throws StripeException {
+    checkRequestMethodsEnabled();
     String url = String.format("%s%s", Stripe.getApiBase(), this.getUrl());
     return ApiResource.request(
         ApiResource.RequestMethod.POST, url, params, PaymentSource.class, options);

--- a/src/main/java/com/stripe/model/StripeCollection.java
+++ b/src/main/java/com/stripe/model/StripeCollection.java
@@ -35,7 +35,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @EqualsAndHashCode(callSuper = false)
-public abstract class StripeCollection<T extends HasId> extends StripeObject
+public class StripeCollection<T extends HasId> extends StripeObject
     implements StripeCollectionInterface<T> {
   String object;
 
@@ -57,10 +57,12 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject
   private Map<String, Object> requestParams;
 
   public Iterable<T> autoPagingIterable() {
+    checkRequestMethodsEnabled();
     return new PagingIterable<>(this);
   }
 
   public Iterable<T> autoPagingIterable(Map<String, Object> params) {
+    checkRequestMethodsEnabled();
     this.setRequestParams(params);
     return new PagingIterable<>(this);
   }
@@ -74,6 +76,7 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject
    * @param options request options (will override the options from the initial list request)
    */
   public Iterable<T> autoPagingIterable(Map<String, Object> params, RequestOptions options) {
+  checkRequestMethodsEnabled();
     this.setRequestOptions(options);
     this.setRequestParams(params);
     return new PagingIterable<>(this);

--- a/src/main/java/com/stripe/model/StripeObject.java
+++ b/src/main/java/com/stripe/model/StripeObject.java
@@ -21,6 +21,18 @@ public abstract class StripeObject implements StripeObjectInterface {
 
   private transient JsonObject rawJsonObject;
 
+  private transient boolean enableRequestMethods = true;
+
+  public void disableRequestMethods() {
+    this.enableRequestMethods = false;
+  }
+
+  protected void checkRequestMethodsEnabled() {
+    if (!this.enableRequestMethods) {
+      throw new UnsupportedOperationException();
+    }
+  }
+
   @Override
   public String toString() {
     return String.format(

--- a/src/main/java/com/stripe/net/FormEncoder.java
+++ b/src/main/java/com/stripe/net/FormEncoder.java
@@ -1,12 +1,10 @@
 package com.stripe.net;
 
+import com.stripe.util.StringUtils;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Array;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -73,7 +71,7 @@ public final class FormEncoder {
     return String.join(
         "&",
         nameValueCollection.stream()
-            .map(kvp -> String.format("%s=%s", urlEncode(kvp.getKey()), urlEncode(kvp.getValue())))
+            .map(kvp -> String.format("%s=%s", StringUtils.urlEncode(kvp.getKey()), StringUtils.urlEncode(kvp.getValue())))
             .collect(Collectors.toList()));
   }
 
@@ -109,31 +107,6 @@ public final class FormEncoder {
    */
   public static List<KeyValuePair<String, Object>> flattenParams(Map<String, Object> params) {
     return flattenParamsValue(params, null);
-  }
-
-  /**
-   * URL-encodes a string.
-   *
-   * @param value The string to URL-encode.
-   * @return The URL-encoded string.
-   */
-  private static String urlEncode(String value) {
-    if (value == null) {
-      return null;
-    }
-
-    try {
-      // Don't use strict form encoding by changing the square bracket control
-      // characters back to their literals. This is fine by the server, and
-      // makes these parameter strings easier to read.
-      return URLEncoder.encode(value, StandardCharsets.UTF_8.name())
-          .replaceAll("%5B", "[")
-          .replaceAll("%5D", "]");
-    } catch (UnsupportedEncodingException e) {
-      // This can literally never happen, and lets us avoid having to catch
-      // UnsupportedEncodingException in callers.
-      throw new AssertionError("UTF-8 is unknown");
-    }
   }
 
   /**

--- a/src/main/java/com/stripe/net/RequestOptions.java
+++ b/src/main/java/com/stripe/net/RequestOptions.java
@@ -5,6 +5,7 @@ import java.net.PasswordAuthentication;
 import java.net.Proxy;
 import java.util.Map;
 import lombok.EqualsAndHashCode;
+import lombok.With;
 
 @EqualsAndHashCode(callSuper = false)
 public class RequestOptions {
@@ -27,6 +28,9 @@ public class RequestOptions {
   private final Proxy connectionProxy;
   private final PasswordAuthentication proxyCredential;
 
+  @With(onMethod = @__({@SuppressWarnings("ReferenceEquality")}))
+  private final String baseUrl;
+
   public static RequestOptions getDefault() {
     return new RequestOptions(
         Stripe.apiKey,
@@ -38,7 +42,8 @@ public class RequestOptions {
         Stripe.getReadTimeout(),
         Stripe.getMaxNetworkRetries(),
         Stripe.getConnectionProxy(),
-        Stripe.getProxyCredential());
+        Stripe.getProxyCredential(),
+        null);
   }
 
   private RequestOptions(
@@ -51,7 +56,8 @@ public class RequestOptions {
       int readTimeout,
       int maxNetworkRetries,
       Proxy connectionProxy,
-      PasswordAuthentication proxyCredential) {
+      PasswordAuthentication proxyCredential,
+      String baseUrl) {
     this.apiKey = apiKey;
     this.clientId = clientId;
     this.idempotencyKey = idempotencyKey;
@@ -62,6 +68,7 @@ public class RequestOptions {
     this.maxNetworkRetries = maxNetworkRetries;
     this.connectionProxy = connectionProxy;
     this.proxyCredential = proxyCredential;
+    this.baseUrl = baseUrl;
   }
 
   public String getApiKey() {
@@ -108,6 +115,10 @@ public class RequestOptions {
     return proxyCredential;
   }
 
+  public String getBaseUrl() {
+    return baseUrl;
+  }
+
   public static RequestOptionsBuilder builder() {
     return new RequestOptionsBuilder();
   }
@@ -132,6 +143,7 @@ public class RequestOptions {
     private int maxNetworkRetries;
     private Proxy connectionProxy;
     private PasswordAuthentication proxyCredential;
+    private String baseUrl;
 
     /**
      * Constructs a request options builder with the global parameters (API key and client ID) as
@@ -145,6 +157,7 @@ public class RequestOptions {
       this.maxNetworkRetries = Stripe.getMaxNetworkRetries();
       this.connectionProxy = Stripe.getConnectionProxy();
       this.proxyCredential = Stripe.getProxyCredential();
+      this.baseUrl = null;
     }
 
     public String getApiKey() {
@@ -292,6 +305,14 @@ public class RequestOptions {
       return setStripeVersionOverride(null);
     }
 
+    public String getBaseUrl() {
+      return this.baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+      this.baseUrl = baseUrl;
+    }
+
     /** Constructs a {@link RequestOptions} with the specified values. */
     public RequestOptions build() {
       return new RequestOptions(
@@ -304,7 +325,8 @@ public class RequestOptions {
           readTimeout,
           maxNetworkRetries,
           connectionProxy,
-          proxyCredential);
+          proxyCredential,
+          baseUrl);
     }
   }
 

--- a/src/main/java/com/stripe/net/StripeClient.java
+++ b/src/main/java/com/stripe/net/StripeClient.java
@@ -1,0 +1,152 @@
+package com.stripe.net;
+
+import com.google.gson.JsonSyntaxException;
+import com.stripe.exception.StripeException;
+import com.stripe.exception.oauth.InvalidRequestException;
+import com.stripe.model.StripeObjectInterface;
+import com.stripe.model.StripeObject;
+import com.stripe.service.ChargeService;
+import com.stripe.service.CouponService;
+import com.stripe.service.CustomerService;
+import com.stripe.service.FileService;
+import com.stripe.service.RootServices;
+import com.stripe.service.checkout.CheckoutServices;
+import com.stripe.service.issuing.IssuingServices;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.Map;
+import lombok.Getter;
+
+public class StripeClient {
+  /** Default base URL for Stripe's API. */
+  public static final String DEFAULT_API_BASE = "https://api.stripe.com";
+
+  /** Default base URL for Stripe's OAuth API. */
+  public static final String DEFAULT_CONNECT_BASE = "https://connect.stripe.com";
+
+  /** Default base URL for Stripe's Files API. */
+  public static final String DEFAULT_FILES_BASE = "https://files.stripe.com";
+
+  @Getter private final String apiBase;
+
+  @Getter private final String apiKey;
+
+  @Getter private final String clientId;
+
+  @Getter private final String connectBase;
+
+  @Getter private final String filesBase;
+
+  @Getter private final HttpClient httpClient;
+
+  // --- GENERATED CODE STARTS HERE ---
+  // Also imports for services need to be generated too.
+
+  private final RootServices rootServices = new RootServices(this);
+
+  private final CheckoutServices checkoutServices = new CheckoutServices(this);
+
+  private final IssuingServices issuingServices = new IssuingServices(this);
+
+  public ChargeService charges() {
+    return this.rootServices.charges();
+  }
+
+  public CheckoutServices checkout() {
+    return this.checkoutServices;
+  }
+
+  public CouponService coupons() {
+    return this.rootServices.coupons();
+  }
+
+  public CustomerService customers() {
+    return this.rootServices.customers();
+  }
+
+  public FileService files() {
+    return this.rootServices.files();
+  }
+
+  public IssuingServices issuing() {
+    return this.issuingServices;
+  }
+
+  // --- GENERATED CODE ENDS HERE ---
+
+  public StripeClient(String apiKey) {
+    this(apiKey, null, null);
+  }
+
+  public StripeClient(String apiKey, String clientId, HttpClient client) {
+    this(apiKey, clientId, client, DEFAULT_API_BASE, DEFAULT_CONNECT_BASE, DEFAULT_FILES_BASE);
+  }
+
+  public StripeClient(
+      String apiKey,
+      String clientId,
+      HttpClient client,
+      String apiBase,
+      String connectBase,
+      String filesBase) {
+    this.apiKey = apiKey;
+    this.clientId = clientId;
+    this.httpClient = (client != null) ? client : buildDefaultHttpClient();
+    this.apiBase = apiBase;
+    this.connectBase = connectBase;
+    this.filesBase = filesBase;
+  }
+
+  @SuppressWarnings("TypeParameterUnusedInFormals")
+  public <T extends StripeObjectInterface> T request(
+      Type typeOfT,
+      ApiResource.RequestMethod method,
+      String path,
+      ApiRequestParams params,
+      RequestOptions options)
+      throws StripeException {
+    Map<String, Object> paramMap = (params != null) ? params.toMap() : Collections.emptyMap();
+    StripeRequest request = new StripeRequest(this, method, path, paramMap, options);
+
+    StripeResponse response = this.httpClient.request(request);
+
+    return processResponse(typeOfT, response);
+  }
+
+  private static HttpClient buildDefaultHttpClient() {
+    return new HttpURLConnectionClient();
+  }
+
+  @SuppressWarnings("TypeParameterUnusedInFormals")
+  private static <T extends StripeObjectInterface> T processResponse(
+      Type typeOfT, StripeResponse response) throws StripeException {
+    if (response.code() != 200) {
+      throw buildStripeException(response);
+    }
+
+    T resource = null;
+    try {
+      resource = ApiResource.GSON.fromJson(response.body(), typeOfT);
+    } catch (JsonSyntaxException e) {
+      throw buildInvalidResponseException(response);
+    }
+
+    // This should be on the interface instead of the object, but for the sake of prototyping taking
+    // a shortcut.
+    if (resource instanceof StripeObject) {
+      ((StripeObject) resource).disableRequestMethods();
+    }
+
+    return resource;
+  }
+
+  private static StripeException buildStripeException(StripeResponse response) {
+    return new InvalidRequestException(
+        "foo", response.body(), response.requestId(), response.code(), null);
+  }
+
+  private static StripeException buildInvalidResponseException(StripeResponse response) {
+    return new InvalidRequestException(
+        "foo", response.body(), response.requestId(), response.code(), null);
+  }
+}

--- a/src/main/java/com/stripe/service/ChargeService.java
+++ b/src/main/java/com/stripe/service/ChargeService.java
@@ -1,0 +1,225 @@
+package com.stripe.service;
+
+import com.google.gson.reflect.TypeToken;
+import com.stripe.exception.StripeException;
+import com.stripe.model.Charge;
+import com.stripe.model.ChargeCollection;
+import com.stripe.model.StripeCollection;
+import com.stripe.net.ApiResource;
+import com.stripe.net.RequestOptions;
+import com.stripe.net.StripeClient;
+import com.stripe.param.ChargeCaptureParams;
+import com.stripe.param.ChargeCreateParams;
+import com.stripe.param.ChargeListParams;
+import com.stripe.param.ChargeRetrieveParams;
+import com.stripe.param.ChargeUpdateParams;
+import com.stripe.util.StringUtils;
+import java.lang.reflect.Type;
+
+public class ChargeService extends Service<Charge> {
+  public ChargeService(StripeClient client) {
+    super(client);
+  }
+
+  /**
+   * Capture the payment of an existing, uncaptured, charge. This is the second
+   * half of the two-step payment flow, where first you
+   * <a href="#create_charge">created a charge</a> with the capture option set to
+   * false.
+   *
+   * <p>
+   * Uncaptured payments expire exactly seven days after they are created. If they
+   * are not captured by that point in time, they will be marked as refunded and
+   * will no longer be capturable.
+   *
+   * @param id the ID of the charge to update
+   * @return the captured charge
+   * @throws StripeException if the request fails
+   */
+  public Charge capture(String id) throws StripeException {
+    return this.capture(id, null, null);
+  }
+
+  /**
+   * Capture the payment of an existing, uncaptured, charge. This is the second
+   * half of the two-step payment flow, where first you
+   * <a href="#create_charge">created a charge</a> with the capture option set to
+   * false.
+   *
+   * <p>
+   * Uncaptured payments expire exactly seven days after they are created. If they
+   * are not captured by that point in time, they will be marked as refunded and
+   * will no longer be capturable.
+   *
+   * @param id     the ID of the charge to update
+   * @param params the request parameters
+   * @return the captured charge
+   * @throws StripeException if the request fails
+   */
+  public Charge capture(String id, ChargeCaptureParams params) throws StripeException {
+    return this.capture(id, params, null);
+  }
+
+  /**
+   * Capture the payment of an existing, uncaptured, charge. This is the second
+   * half of the two-step payment flow, where first you
+   * <a href="#create_charge">created a charge</a> with the capture option set to
+   * false.
+   *
+   * <p>
+   * Uncaptured payments expire exactly seven days after they are created. If they
+   * are not captured by that point in time, they will be marked as refunded and
+   * will no longer be capturable.
+   *
+   * @param id      the ID of the charge to capture
+   * @param params  the request parameters
+   * @param options the special options for the request
+   * @return the captured charge
+   * @throws StripeException if the request fails
+   */
+  public Charge capture(String id, ChargeCaptureParams params, RequestOptions options) throws StripeException {
+    return this.request(Charge.class, ApiResource.RequestMethod.POST,
+        String.format("/v1/charges/%s/capture", StringUtils.urlEncode(id)), params, options);
+  }
+
+  /**
+   * To charge a credit card or other payment source, you create a
+   * <code>Charge</code> object. If your API key is in test mode, the supplied
+   * payment source (e.g., card) won’t actually be charged, although everything
+   * else will occur as if in live mode. (Stripe assumes that the charge would
+   * have completed successfully).
+   *
+   * @param params the request parameters
+   * @return the created charge
+   * @throws StripeException if the request fails
+   */
+  public Charge create(ChargeCreateParams params) throws StripeException {
+    return this.create(params, null);
+  }
+
+  /**
+   * To charge a credit card or other payment source, you create a
+   * <code>Charge</code> object. If your API key is in test mode, the supplied
+   * payment source (e.g., card) won’t actually be charged, although everything
+   * else will occur as if in live mode. (Stripe assumes that the charge would
+   * have completed successfully).
+   *
+   * @param params  the request parameters
+   * @param options the special options for the request
+   * @return the created charge
+   * @throws StripeException if the request fails
+   */
+  public Charge create(ChargeCreateParams params, RequestOptions options) throws StripeException {
+    return this.request(Charge.class, ApiResource.RequestMethod.POST, "/v1/charges", params, options);
+  }
+
+  /**
+   * Returns a list of charges you’ve previously created. The charges are returned
+   * in sorted order, with the most recent charges appearing first.
+   *
+   * @return the list of charges
+   * @throws StripeException if the request fails
+   */
+  public ChargeCollection list() throws StripeException {
+    return this.list(null, null);
+  }
+
+  /**
+   * Returns a list of charges you’ve previously created. The charges are returned
+   * in sorted order, with the most recent charges appearing first.
+   *
+   * @param params the request parameters
+   * @return the list of charges
+   * @throws StripeException if the request fails
+   */
+  public ChargeCollection list(ChargeListParams params) throws StripeException {
+    return this.list(params, null);
+  }
+
+  /**
+   * Returns a list of charges you’ve previously created. The charges are returned
+   * in sorted order, with the most recent charges appearing first.
+   *
+   * @param params  the request parameters
+   * @param options the special options for the request
+   * @return the list of charges
+   * @throws StripeException if the request fails
+   */
+  public ChargeCollection list(ChargeListParams params, RequestOptions options) throws StripeException {
+    return this.request(ChargeCollection.class, ApiResource.RequestMethod.GET, "/v1/charges", params, options);
+  }
+
+  /**
+   * Retrieves the details of a charge that has previously been created. Supply
+   * the unique charge ID that was returned from your previous request, and Stripe
+   * will return the corresponding charge information. The same information is
+   * returned when creating or refunding the charge.
+   *
+   * @param id the ID of the charge to retrieve
+   * @return the retrieved charge
+   * @throws StripeException if the request fails
+   */
+  public Charge retrieve(String id) throws StripeException {
+    return this.retrieve(id, null, null);
+  }
+
+  /**
+   * Retrieves the details of a charge that has previously been created. Supply
+   * the unique charge ID that was returned from your previous request, and Stripe
+   * will return the corresponding charge information. The same information is
+   * returned when creating or refunding the charge.
+   *
+   * @param id     the ID of the charge to retrieve
+   * @param params the request parameters
+   * @return the retrieved charge
+   * @throws StripeException if the request fails
+   */
+  public Charge retrieve(String id, ChargeRetrieveParams params) throws StripeException {
+    return this.retrieve(id, params, null);
+  }
+
+  /**
+   * Retrieves the details of a charge that has previously been created. Supply
+   * the unique charge ID that was returned from your previous request, and Stripe
+   * will return the corresponding charge information. The same information is
+   * returned when creating or refunding the charge.
+   *
+   * @param id      the ID of the charge to retrieve
+   * @param params  the request parameters
+   * @param options the special options for the request
+   * @return the retrieved charge
+   * @throws StripeException if the request fails
+   */
+  public Charge retrieve(String id, ChargeRetrieveParams params, RequestOptions options) throws StripeException {
+    return this.request(Charge.class, ApiResource.RequestMethod.GET,
+        String.format("/v1/charges/%s", StringUtils.urlEncode(id)), params, options);
+  }
+
+  /**
+   * Updates the specified charge by setting the values of the parameters passed.
+   * Any parameters not provided will be left unchanged.
+   *
+   * @param id     the ID of the charge to update
+   * @param params the request parameters
+   * @return the updated charge
+   * @throws StripeException if the request fails
+   */
+  public Charge update(String id, ChargeUpdateParams params) throws StripeException {
+    return this.update(id, params, null);
+  }
+
+  /**
+   * Updates the specified charge by setting the values of the parameters passed.
+   * Any parameters not provided will be left unchanged.
+   *
+   * @param id      the ID of the charge to update
+   * @param params  the request parameters
+   * @param options the special options for the request
+   * @return the updated charge
+   * @throws StripeException if the request fails
+   */
+  public Charge update(String id, ChargeUpdateParams params, RequestOptions options) throws StripeException {
+    return this.request(Charge.class, ApiResource.RequestMethod.POST,
+        String.format("/v1/charges/%s", StringUtils.urlEncode(id)), params, options);
+  }
+}

--- a/src/main/java/com/stripe/service/CouponService.java
+++ b/src/main/java/com/stripe/service/CouponService.java
@@ -1,0 +1,204 @@
+package com.stripe.service;
+
+import com.google.gson.reflect.TypeToken;
+import com.stripe.exception.StripeException;
+import com.stripe.model.Coupon;
+import com.stripe.model.StripeCollection;
+import com.stripe.net.ApiResource;
+import com.stripe.net.RequestOptions;
+import com.stripe.net.StripeClient;
+import com.stripe.param.CouponCreateParams;
+import com.stripe.param.CouponListParams;
+import com.stripe.param.CouponRetrieveParams;
+import com.stripe.param.CouponUpdateParams;
+import com.stripe.util.StringUtils;
+import java.lang.reflect.Type;
+
+public class CouponService extends Service<Coupon> {
+  public CouponService(StripeClient client) {
+    super(client);
+  }
+
+  /**
+   * You can create coupons easily via the
+   * <a href="https://dashboard.stripe.com/coupons">coupon management</a> page of
+   * the Stripe dashboard. Coupon creation is also accessible via the API if you
+   * need to create coupons on the fly.
+   *
+   * <p>
+   * A coupon has either a <code>percent_off</code> or an <code>amount_off</code>
+   * and <code>
+   * currency</code>. If you set an <code>amount_off</code>, that amount will be
+   * subtracted from any invoice’s subtotal. For example, an invoice with a
+   * subtotal of 100 will have a final total of 0 if a coupon with an
+   * <code>amount_off</code> of 200 is applied to it and an invoice with a
+   * subtotal of 300 will have a final total of 100 if a coupon with an
+   * <code>amount_off</code> of 200 is applied to it.
+   *
+   * @param params the request parameters
+   * @return the created coupon
+   * @throws StripeException if the request fails
+   */
+  public Coupon create(CouponCreateParams params) throws StripeException {
+    return this.create(params, null);
+  }
+
+  /**
+   * You can create coupons easily via the
+   * <a href="https://dashboard.stripe.com/coupons">coupon management</a> page of
+   * the Stripe dashboard. Coupon creation is also accessible via the API if you
+   * need to create coupons on the fly.
+   *
+   * <p>
+   * A coupon has either a <code>percent_off</code> or an <code>amount_off</code>
+   * and <code>
+   * currency</code>. If you set an <code>amount_off</code>, that amount will be
+   * subtracted from any invoice’s subtotal. For example, an invoice with a
+   * subtotal of 100 will have a final total of 0 if a coupon with an
+   * <code>amount_off</code> of 200 is applied to it and an invoice with a
+   * subtotal of 300 will have a final total of 100 if a coupon with an
+   * <code>amount_off</code> of 200 is applied to it.
+   *
+   * @param params  the request parameters
+   * @param options the special options for the request
+   * @return the created coupon
+   * @throws StripeException if the request fails
+   */
+  public Coupon create(CouponCreateParams params, RequestOptions options) throws StripeException {
+    return this.request(Coupon.class, ApiResource.RequestMethod.POST, "/v1/coupons", params, options);
+  }
+
+  /**
+   * You can delete coupons via the
+   * <a href="https://dashboard.stripe.com/coupons">coupon management</a> page of
+   * the Stripe dashboard. However, deleting a coupon does not affect any
+   * customers who have already applied the coupon; it means that new customers
+   * can’t redeem the coupon. You can also delete coupons via the API.
+   *
+   * @param id the ID of the coupon to delete
+   * @return the deleted coupon
+   * @throws StripeException if the request fails
+   */
+  public Coupon delete(String id) throws StripeException {
+    return this.delete(id, null);
+  }
+
+  // TODO we should have a CouponDeleteParams class even if there are no
+  // parameters
+  /**
+   * You can delete coupons via the
+   * <a href="https://dashboard.stripe.com/coupons">coupon management</a> page of
+   * the Stripe dashboard. However, deleting a coupon does not affect any
+   * customers who have already applied the coupon; it means that new customers
+   * can’t redeem the coupon. You can also delete coupons via the API.
+   *
+   * @param id      the ID of the coupon to delete
+   * @param options the special options for the request
+   * @return the deleted coupon
+   * @throws StripeException if the request fails
+   */
+  public Coupon delete(String id, RequestOptions options) throws StripeException {
+    return this.request(Coupon.class, ApiResource.RequestMethod.DELETE,
+        String.format("/v1/coupons/%s", StringUtils.urlEncode(id)), null, options);
+  }
+
+  /**
+   * Returns a list of your coupons.
+   *
+   * @return the list of coupons
+   * @throws StripeException if the request fails
+   */
+  public StripeCollection<Coupon> list() throws StripeException {
+    return this.list(null, null);
+  }
+
+  /**
+   * Returns a list of your coupons.
+   *
+   * @param params the request parameters
+   * @return the list of coupons
+   * @throws StripeException if the request fails
+   */
+  public StripeCollection<Coupon> list(CouponListParams params) throws StripeException {
+    return this.list(params, null);
+  }
+
+  /**
+   * Returns a list of your coupons.
+   *
+   * @param params  the request parameters
+   * @param options the special options for the request
+   * @return the list of coupons
+   * @throws StripeException if the request fails
+   */
+  public StripeCollection<Coupon> list(CouponListParams params, RequestOptions options) throws StripeException {
+    Type type = new TypeToken<StripeCollection<Coupon>>() {
+    }.getType();
+    return this.request(type, ApiResource.RequestMethod.GET, "/v1/coupons", params, options);
+  }
+
+  /**
+   * Retrieves the coupon with the given ID.
+   *
+   * @param id the ID of the coupon to retrieve
+   * @return the retrieved coupon
+   * @throws StripeException if the request fails
+   */
+  public Coupon retrieve(String id) throws StripeException {
+    return this.retrieve(id, null, null);
+  }
+
+  /**
+   * Retrieves the coupon with the given ID.
+   *
+   * @param id     the ID of the coupon to retrieve
+   * @param params the request parameters
+   * @return the retrieved coupon
+   * @throws StripeException if the request fails
+   */
+  public Coupon retrieve(String id, CouponRetrieveParams params) throws StripeException {
+    return this.retrieve(id, params, null);
+  }
+
+  /**
+   * Retrieves the coupon with the given ID.
+   *
+   * @param id      the ID of the coupon to retrieve
+   * @param params  the request parameters
+   * @param options the special options for the request
+   * @return the retrieved coupon
+   * @throws StripeException if the request fails
+   */
+  public Coupon retrieve(String id, CouponRetrieveParams params, RequestOptions options) throws StripeException {
+    return this.request(Coupon.class, ApiResource.RequestMethod.GET,
+        String.format("/v1/coupons/%s", StringUtils.urlEncode(id)), params, options);
+  }
+
+  /**
+   * Updates the metadata of a coupon. Other coupon details (currency, duration,
+   * amount_off) are, by design, not editable.
+   *
+   * @param id     the ID of the coupon to update
+   * @param params the request parameters
+   * @return the updated coupon
+   * @throws StripeException if the request fails
+   */
+  public Coupon update(String id, CouponUpdateParams params) throws StripeException {
+    return this.update(id, params, null);
+  }
+
+  /**
+   * Updates the metadata of a coupon. Other coupon details (currency, duration,
+   * amount_off) are, by design, not editable.
+   *
+   * @param id      the ID of the coupon to update
+   * @param params  the request parameters
+   * @param options the special options for the request
+   * @return the updated coupon
+   * @throws StripeException if the request fails
+   */
+  public Coupon update(String id, CouponUpdateParams params, RequestOptions options) throws StripeException {
+    return this.request(Coupon.class, ApiResource.RequestMethod.POST,
+        String.format("/v1/coupons/%s", StringUtils.urlEncode(id)), params, options);
+  }
+}

--- a/src/main/java/com/stripe/service/CustomerService.java
+++ b/src/main/java/com/stripe/service/CustomerService.java
@@ -1,0 +1,48 @@
+package com.stripe.service;
+
+import com.google.gson.reflect.TypeToken;
+import com.stripe.exception.StripeException;
+import com.stripe.model.Customer;
+import com.stripe.model.PaymentSourceCollection;
+import com.stripe.model.PaymentSource;
+import com.stripe.net.ApiResource;
+import com.stripe.net.RequestOptions;
+import com.stripe.net.StripeClient;
+import com.stripe.param.PaymentSourceCollectionListParams;
+import com.stripe.param.SourceRetrieveParams;
+import com.stripe.util.StringUtils;
+import java.lang.reflect.Type;
+
+public class CustomerService extends Service<Customer> {
+  public CustomerService(StripeClient client) {
+    super(client);
+  }
+
+  /** Returns a list of Line Items */
+  public PaymentSourceCollection listSources(String parentId, PaymentSourceCollectionListParams params)
+      throws StripeException {
+    return listSources(parentId, params, (RequestOptions) null);
+  }
+
+  /** Returns a list of Line Items */
+  public PaymentSourceCollection listSources(String parentId, PaymentSourceCollectionListParams params,
+      RequestOptions options) throws StripeException {
+    return this.request(PaymentSourceCollection.class, ApiResource.RequestMethod.GET,
+        String.format("/v1/customers/%s/sources", StringUtils.urlEncode(parentId)), params, options);
+  }
+
+  public PaymentSource retrieveSource(String parentId, String id) throws StripeException {
+    return this.retrieveSource(parentId, id, null, null);
+  }
+
+  public PaymentSource retrieveSource(String parentId, String id, SourceRetrieveParams params) throws StripeException {
+    return this.retrieveSource(parentId, id, params, null);
+  }
+
+  public PaymentSource retrieveSource(String parentId, String id, SourceRetrieveParams params, RequestOptions options)
+      throws StripeException {
+    return this.request(PaymentSource.class, ApiResource.RequestMethod.GET,
+        String.format("/v1/customers/%s/sources/%s", StringUtils.urlEncode(parentId), StringUtils.urlEncode(id)),
+        params, options);
+  }
+}

--- a/src/main/java/com/stripe/service/FileService.java
+++ b/src/main/java/com/stripe/service/FileService.java
@@ -1,0 +1,132 @@
+package com.stripe.service;
+
+import com.google.gson.reflect.TypeToken;
+import com.stripe.exception.StripeException;
+import com.stripe.model.File;
+import com.stripe.model.StripeCollection;
+import com.stripe.net.ApiResource;
+import com.stripe.net.RequestOptions;
+import com.stripe.net.StripeClient;
+import com.stripe.param.FileCreateParams;
+import com.stripe.param.FileListParams;
+import com.stripe.util.StringUtils;
+import java.lang.reflect.Type;
+
+public class FileService extends Service<File> {
+  public FileService(StripeClient client) {
+    super(client);
+  }
+
+  /**
+   * To upload a file to Stripe, you’ll need to send a request of type {@code multipart/form-data}.
+   * The request should contain the file you would like to upload, as well as the parameters for
+   * creating a file.
+   *
+   * @param params the request parameters
+   * @return the created file
+   * @throws StripeException if the request fails
+   */
+  public File create(FileCreateParams params) throws StripeException {
+    return this.create(params, null);
+  }
+
+  /**
+   * To upload a file to Stripe, you’ll need to send a request of type {@code multipart/form-data}.
+   * The request should contain the file you would like to upload, as well as the parameters for
+   * creating a file.
+   *
+   * @param params the request parameters
+   * @param options the special options for the request
+   * @return the created file
+   * @throws StripeException if the request fails
+   */
+  public File create(FileCreateParams params, RequestOptions options) throws StripeException {
+    options = this.setupRequestOptionsForFilesRequest(options);
+    return this.request(File.class, ApiResource.RequestMethod.POST, "/v1/files", params, options);
+  }
+
+  /**
+   * Returns a list of the files that your account has access to. The files are returned sorted by
+   * creation date, with the most recently created files appearing first.
+   *
+   * @return the list of files
+   * @throws StripeException if the request fails
+   */
+  public StripeCollection<File> list() throws StripeException {
+    return this.list(null, null);
+  }
+
+  /**
+   * Returns a list of the files that your account has access to. The files are returned sorted by
+   * creation date, with the most recently created files appearing first.
+   *
+   * @param params the request parameters
+   * @return the list of files
+   * @throws StripeException if the request fails
+   */
+  public StripeCollection<File> list(FileListParams params) throws StripeException {
+    return this.list(params, null);
+  }
+
+  /**
+   * Returns a list of the files that your account has access to. The files are returned sorted by
+   * creation date, with the most recently created files appearing first.
+   *
+   * @param params the request parameters
+   * @param options the special options for the request
+   * @return the list of files
+   * @throws StripeException if the request fails
+   */
+  public StripeCollection<File> list(FileListParams params, RequestOptions options)
+      throws StripeException {
+    Type type = new TypeToken<StripeCollection<File>>() {}.getType();
+    return this.request(type, ApiResource.RequestMethod.GET, "/v1/files", params, options);
+  }
+
+  /**
+   * Retrieves the details of an existing file object. Supply the unique file ID from a file, and
+   * Stripe will return the corresponding file object.
+   *
+   * @param id the ID of the file to retrieve
+   * @return the retrieved file
+   * @throws StripeException if the request fails
+   */
+  public File retrieve(String id) throws StripeException {
+    return this.retrieve(id, null);
+  }
+
+  // TODO we should have a FileRetrieveParams class even if there are no parameters
+  /**
+   * Retrieves the details of an existing file object. Supply the unique file ID from a file, and
+   * Stripe will return the corresponding file object.
+   *
+   * @param id the ID of the file to retrieve
+   * @param options the special options for the request
+   * @return the retrieved file
+   * @throws StripeException if the request fails
+   */
+  public File retrieve(String id, RequestOptions options) throws StripeException {
+    return this.request(
+        File.class,
+        ApiResource.RequestMethod.GET,
+        String.format("/v1/files/%s", StringUtils.urlEncode(id)),
+        null,
+        options);
+  }
+
+  private RequestOptions setupRequestOptionsForFilesRequest(RequestOptions options) {
+    if (options == null) {
+      options =
+          RequestOptions.builder()
+              .setApiKey(this.getClient().getApiKey())
+              .setClientId(this.getClient().getClientId())
+              .build();
+    }
+
+    if (options.getBaseUrl() == null) {
+      options = options.withBaseUrl(this.getClient().getFilesBase());
+    }
+
+    return options;
+  }
+}

--- a/src/main/java/com/stripe/service/RootServices.java
+++ b/src/main/java/com/stripe/service/RootServices.java
@@ -1,0 +1,36 @@
+package com.stripe.service;
+
+import com.stripe.net.StripeClient;
+import com.stripe.util.Lazy;
+
+public class RootServices {
+  private StripeClient client = null;
+
+  public RootServices(StripeClient client) {
+    this.client = client;
+  }
+
+  private final Lazy<ChargeService> chargeService = new Lazy<>(() -> new ChargeService(this.client));
+
+  private final Lazy<CouponService> couponService = new Lazy<>(() -> new CouponService(this.client));
+
+  private final Lazy<CustomerService> customerService = new Lazy<>(() -> new CustomerService(this.client));
+
+  private final Lazy<FileService> fileService = new Lazy<>(() -> new FileService(this.client));
+
+  public ChargeService charges() {
+    return this.chargeService.get();
+  }
+
+  public CouponService coupons() {
+    return this.couponService.get();
+  }
+
+  public CustomerService customers() {
+    return this.customerService.get();
+  }
+
+  public FileService files() {
+    return this.fileService.get();
+  }
+}

--- a/src/main/java/com/stripe/service/Service.java
+++ b/src/main/java/com/stripe/service/Service.java
@@ -1,0 +1,45 @@
+package com.stripe.service;
+
+import com.stripe.exception.StripeException;
+import com.stripe.model.StripeObjectInterface;
+import com.stripe.net.ApiRequestParams;
+import com.stripe.net.ApiResource;
+import com.stripe.net.RequestOptions;
+import com.stripe.net.StripeClient;
+import java.lang.reflect.Type;
+
+public abstract class Service<TObjectReturned extends StripeObjectInterface> {
+  private final StripeClient client;
+
+  protected Service(StripeClient client) {
+    this.client = client;
+  }
+
+  public String getBaseUrl() {
+    return this.getClient().getApiBase();
+  }
+
+  public StripeClient getClient() {
+    return this.client;
+  }
+
+  @SuppressWarnings("TypeParameterUnusedInFormals")
+  public <T extends StripeObjectInterface> T request(Type typeOfT, ApiResource.RequestMethod method, String path,
+      ApiRequestParams params, RequestOptions options) throws StripeException {
+    options = this.setupRequestOptions(options);
+    return this.getClient().request(typeOfT, method, path, params, options);
+  }
+
+  protected RequestOptions setupRequestOptions(RequestOptions options) {
+    if (options == null) {
+      options = RequestOptions.builder().setApiKey(this.getClient().getApiKey())
+          .setClientId(this.getClient().getClientId()).build();
+    }
+
+    if (options.getBaseUrl() == null) {
+      options = options.withBaseUrl(this.getBaseUrl());
+    }
+
+    return options;
+  }
+}

--- a/src/main/java/com/stripe/service/checkout/CheckoutServices.java
+++ b/src/main/java/com/stripe/service/checkout/CheckoutServices.java
@@ -1,0 +1,19 @@
+
+package com.stripe.service.checkout;
+
+import com.stripe.net.StripeClient;
+import com.stripe.util.Lazy;
+
+public class CheckoutServices {
+  private StripeClient client = null;
+
+  public CheckoutServices(StripeClient client) {
+    this.client = client;
+  }
+
+  private final Lazy<SessionService> sessionService = new Lazy<>(() -> new SessionService(this.client));
+
+  public SessionService sessions() {
+    return this.sessionService.get();
+  }
+}

--- a/src/main/java/com/stripe/service/checkout/SessionService.java
+++ b/src/main/java/com/stripe/service/checkout/SessionService.java
@@ -1,0 +1,53 @@
+package com.stripe.service.checkout;
+
+import com.google.gson.reflect.TypeToken;
+import com.stripe.exception.StripeException;
+import com.stripe.model.StripeCollection;
+import com.stripe.model.checkout.Session;
+import com.stripe.model.LineItem;
+import com.stripe.model.LineItemCollection;
+import com.stripe.net.ApiResource;
+import com.stripe.net.RequestOptions;
+import com.stripe.net.StripeClient;
+import com.stripe.param.checkout.SessionRetrieveParams;
+import com.stripe.param.checkout.SessionListLineItemsParams;
+import com.stripe.service.Service;
+import com.stripe.util.StringUtils;
+
+public class SessionService extends Service<Session> {
+  public SessionService(StripeClient client) {
+    super(client);
+  }
+
+  /** Retrieves a Session object. */
+  public Session retrieve(String session) throws StripeException {
+    return this.retrieve(session, null, null);
+  }
+
+  /** Retrieves a Session object. */
+  public Session retrieve(String session, SessionRetrieveParams params) throws StripeException {
+    return this.retrieve(session, params, null);
+  }
+
+  /** Retrieves a Session object. */
+  public Session retrieve(String session, SessionRetrieveParams params, RequestOptions options) throws StripeException {
+
+    return this.request(Session.class, ApiResource.RequestMethod.GET,
+        String.format("/v1/checkout/sessions/%s", StringUtils.urlEncode(session)), params, options);
+  }
+
+  /** Returns a list of Line Items */
+  public LineItemCollection listLineItems(String session, SessionListLineItemsParams params) throws StripeException {
+    return listLineItems(session, params, (RequestOptions) null);
+  }
+
+  /** Returns a list of Line Items */
+  public LineItemCollection listLineItems(String session, SessionListLineItemsParams params, RequestOptions options)
+      throws StripeException {
+    return this.request(LineItemCollection.class, ApiResource.RequestMethod.GET,
+        String.format("/v1/checkout/sessions/%s/line_items", StringUtils.urlEncode(session)), params, options);
+  }
+
+  // Other session methods...
+
+}

--- a/src/main/java/com/stripe/service/issuing/CardService.java
+++ b/src/main/java/com/stripe/service/issuing/CardService.java
@@ -1,0 +1,159 @@
+package com.stripe.service.issuing;
+
+import com.google.gson.reflect.TypeToken;
+import com.stripe.exception.StripeException;
+import com.stripe.model.StripeCollection;
+import com.stripe.model.issuing.Card;
+import com.stripe.net.ApiResource;
+import com.stripe.net.RequestOptions;
+import com.stripe.net.StripeClient;
+import com.stripe.param.issuing.CardCreateParams;
+import com.stripe.param.issuing.CardListParams;
+import com.stripe.param.issuing.CardRetrieveParams;
+import com.stripe.param.issuing.CardUpdateParams;
+import com.stripe.service.Service;
+import com.stripe.util.StringUtils;
+import java.lang.reflect.Type;
+
+public class CardService extends Service<Card> {
+  public CardService(StripeClient client) {
+    super(client);
+  }
+
+  /**
+   * Creates an Issuing <code>Card</code> object.
+   *
+   * @param params the request parameters
+   * @return the created card
+   * @throws StripeException if the request fails
+   */
+  public Card create(CardCreateParams params) throws StripeException {
+    return this.create(params, null);
+  }
+
+  /**
+   * Creates an Issuing <code>Card</code> object.
+   *
+   * @param params the request parameters
+   * @param options the special options for the request
+   * @return the created card
+   * @throws StripeException if the request fails
+   */
+  public Card create(CardCreateParams params, RequestOptions options) throws StripeException {
+    return this.request(
+        Card.class, ApiResource.RequestMethod.POST, "/v1/issuing/cards", params, options);
+  }
+
+  /**
+   * Returns a list of Issuing <code>Card</code> objects. The objects are sorted in descending order
+   * by creation date, with the most recently created object appearing first.
+   *
+   * @return the list of cards
+   * @throws StripeException if the request fails
+   */
+  public StripeCollection<Card> list() throws StripeException {
+    return this.list(null, null);
+  }
+
+  /**
+   * Returns a list of Issuing <code>Card</code> objects. The objects are sorted in descending order
+   * by creation date, with the most recently created object appearing first.
+   *
+   * @param params the request parameters
+   * @return the list of cards
+   * @throws StripeException if the request fails
+   */
+  public StripeCollection<Card> list(CardListParams params) throws StripeException {
+    return this.list(params, null);
+  }
+
+  /**
+   * Returns a list of Issuing <code>Card</code> objects. The objects are sorted in descending order
+   * by creation date, with the most recently created object appearing first.
+   *
+   * @param params the request parameters
+   * @param options the special options for the request
+   * @return the list of cards
+   * @throws StripeException if the request fails
+   */
+  public StripeCollection<Card> list(CardListParams params, RequestOptions options)
+      throws StripeException {
+    Type type = new TypeToken<StripeCollection<Card>>() {}.getType();
+    return this.request(type, ApiResource.RequestMethod.GET, "/v1/issuing/cards", params, options);
+  }
+
+  /**
+   * Retrieves an Issuing <code>Card</code> object.
+   *
+   * @param id the ID of the card to retrieve
+   * @return the retrieved card
+   * @throws StripeException if the request fails
+   */
+  public Card retrieve(String id) throws StripeException {
+    return this.retrieve(id, null, null);
+  }
+
+  /**
+   * Retrieves an Issuing <code>Card</code> object.
+   *
+   * @param id the ID of the card to retrieve
+   * @param params the request parameters
+   * @return the retrieved card
+   * @throws StripeException if the request fails
+   */
+  public Card retrieve(String id, CardRetrieveParams params) throws StripeException {
+    return this.retrieve(id, params, null);
+  }
+
+  /**
+   * Retrieves an Issuing <code>Card</code> object.
+   *
+   * @param id the ID of the card to retrieve
+   * @param params the request parameters
+   * @param options the special options for the request
+   * @return the retrieved card
+   * @throws StripeException if the request fails
+   */
+  public Card retrieve(String id, CardRetrieveParams params, RequestOptions options)
+      throws StripeException {
+    return this.request(
+        Card.class,
+        ApiResource.RequestMethod.GET,
+        String.format("/v1/issuing/cards/%s", StringUtils.urlEncode(id)),
+        params,
+        options);
+  }
+
+  /**
+   * Updates the specified Issuing <code>Card</code> object by setting the values of the parameters
+   * passed. Any parameters not provided will be left unchanged.
+   *
+   * @param id the ID of the card to update
+   * @param params the request parameters
+   * @return the updated card
+   * @throws StripeException if the request fails
+   */
+  public Card update(String id, CardUpdateParams params) throws StripeException {
+    return this.update(id, params, null);
+  }
+
+  /**
+   * Updates the specified Issuing <code>Card</code> object by setting the values of the parameters
+   * passed. Any parameters not provided will be left unchanged.
+   *
+   * @param id the ID of the card to update
+   * @param params the request parameters
+   * @param options the special options for the request
+   * @return the updated card
+   * @throws StripeException if the request fails
+   */
+  public Card update(String id, CardUpdateParams params, RequestOptions options)
+      throws StripeException {
+    return this.request(
+        Card.class,
+        ApiResource.RequestMethod.POST,
+        String.format("/v1/issuing/cards/%s", StringUtils.urlEncode(id)),
+        params,
+        options);
+  }
+}

--- a/src/main/java/com/stripe/service/issuing/IssuingServices.java
+++ b/src/main/java/com/stripe/service/issuing/IssuingServices.java
@@ -1,0 +1,19 @@
+
+package com.stripe.service.issuing;
+
+import com.stripe.net.StripeClient;
+import com.stripe.util.Lazy;
+
+public class IssuingServices {
+  private StripeClient client = null;
+
+  public IssuingServices(StripeClient client) {
+    this.client = client;
+  }
+
+  private final Lazy<CardService> cardService = new Lazy<>(() -> new CardService(this.client));
+
+  public CardService cards() {
+    return this.cardService.get();
+  }
+}

--- a/src/main/java/com/stripe/util/Lazy.java
+++ b/src/main/java/com/stripe/util/Lazy.java
@@ -1,0 +1,50 @@
+package com.stripe.util;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+/**
+ * This class provides a generic implementation of the lazy initialization pattern.
+ *
+ * @param <T> the type of the object wrapped by this class
+ */
+public class Lazy<T> {
+  private final AtomicReference<Object> cached = new AtomicReference<>();
+
+  private final Supplier<? extends T> ctor;
+
+  /**
+   * Initializes a new instance of the {@link Lazy} class.
+   *
+   * @param ctor the {@link Supplier} used to initialize the object
+   * @throws NullPointerException if {@code ctor} is {@code null}
+   */
+  public Lazy(Supplier<? extends T> ctor) {
+    requireNonNull(ctor);
+    this.ctor = ctor;
+  }
+
+  /**
+   * Returns the object wrapped by this instance. The object will be initialized and cached the
+   * first time this method is called, and the cached version is returned on subsequent calls.
+   *
+   * @return the lazily-initialized object
+   */
+  @SuppressWarnings("unchecked")
+  public T get() {
+    Object value = this.cached.get();
+    if (value == null) {
+      synchronized (this.cached) {
+        value = this.cached.get();
+        if (value == null) {
+          final T actualValue = this.ctor.get();
+          value = actualValue == null ? this.cached : actualValue;
+          this.cached.set(value);
+        }
+      }
+    }
+    return (T) (value == this.cached ? null : value);
+  }
+}

--- a/src/main/java/com/stripe/util/StringUtils.java
+++ b/src/main/java/com/stripe/util/StringUtils.java
@@ -2,6 +2,8 @@ package com.stripe.util;
 
 import static java.util.Objects.requireNonNull;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.regex.Pattern;
@@ -47,4 +49,30 @@ public final class StringUtils {
         .replaceAll("([a-z0-9])([A-Z])", "$1_$2")
         .toLowerCase();
   }
+
+  /**
+   * URL-encodes a string.
+   *
+   * @param value The string to URL-encode.
+   * @return The URL-encoded string.
+   */
+  public static String urlEncode(String value) {
+    if (value == null) {
+      return null;
+    }
+
+    try {
+      // Don't use strict form encoding by changing the square bracket control
+      // characters back to their literals. This is fine by the server, and
+      // makes these parameter strings easier to read.
+      return URLEncoder.encode(value, StandardCharsets.UTF_8.name())
+          .replaceAll("%5B", "[")
+          .replaceAll("%5D", "]");
+    } catch (UnsupportedEncodingException e) {
+      // This can literally never happen, and lets us avoid having to catch
+      // UnsupportedEncodingException in callers.
+      throw new AssertionError("UTF-8 is unknown");
+    }
+  }
+
 }

--- a/src/test/java/com/stripe/service/BaseServiceTest.java
+++ b/src/test/java/com/stripe/service/BaseServiceTest.java
@@ -1,0 +1,46 @@
+package com.stripe.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.stripe.exception.StripeException;
+import com.stripe.net.ApiRequestParams;
+import com.stripe.net.ApiResource;
+import com.stripe.net.HttpClient;
+import com.stripe.net.HttpURLConnectionClient;
+import com.stripe.net.StripeClient;
+import com.stripe.net.StripeRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+public class BaseServiceTest {
+  protected StripeClient client;
+
+  @BeforeEach
+  public void setUpClient() {
+    HttpClient httpClient = Mockito.spy(new HttpURLConnectionClient());
+    this.client =
+        new StripeClient(
+            "sk_test_123",
+            null,
+            httpClient,
+            "http://localhost:12111",
+            "http://localhost:12111",
+            "http://localhost:12111");
+  }
+
+  public void verifyRequest(ApiResource.RequestMethod method, String path) throws StripeException {
+    verifyRequest(method, path, null);
+  }
+
+  public void verifyRequest(ApiResource.RequestMethod method, String path, ApiRequestParams params)
+      throws StripeException {
+    ArgumentCaptor<StripeRequest> argument = ArgumentCaptor.forClass(StripeRequest.class);
+    Mockito.verify(this.client.getHttpClient()).request(argument.capture());
+    StripeRequest request = argument.getValue();
+
+    assertEquals(method, request.method());
+    assertEquals(path, request.url().getPath());
+    // TODO check params
+  }
+}

--- a/src/test/java/com/stripe/service/ChargeServiceTest.java
+++ b/src/test/java/com/stripe/service/ChargeServiceTest.java
@@ -1,0 +1,82 @@
+
+package com.stripe.service;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.stripe.exception.StripeException;
+import com.stripe.model.Charge;
+import com.stripe.model.ChargeCollection;
+import com.stripe.model.StripeCollection;
+import com.stripe.net.ApiResource;
+import com.stripe.param.ChargeCreateParams;
+import com.stripe.param.ChargeListParams;
+import com.stripe.param.ChargeUpdateParams;
+import org.junit.jupiter.api.Test;
+
+public class ChargeServiceTest extends BaseServiceTest {
+  @Test
+  public void testCapture() throws StripeException {
+    Charge charge = this.client.charges().capture("ch_123");
+    assertNotNull(charge);
+    this.verifyRequest(ApiResource.RequestMethod.POST, "/v1/charges/ch_123/capture");
+  }
+
+  @Test
+  public void testCreate() throws StripeException {
+    ChargeCreateParams params = ChargeCreateParams.builder().setAmount(123L).setCurrency("usd").setSource("tok_visa")
+        .build();
+    Charge charge = this.client.charges().create(params);
+    assertNotNull(charge);
+    this.verifyRequest(ApiResource.RequestMethod.POST, "/v1/charges");
+  }
+
+  @Test
+  public void testList() throws StripeException {
+    ChargeListParams params = ChargeListParams.builder().setLimit(1L).build();
+    StripeCollection<Charge> charges = this.client.charges().list(params);
+    assertNotNull(charges);
+    assertNotNull(charges.getData());
+    assertEquals(1, charges.getData().size());
+    Charge charge = charges.getData().get(0);
+    assertNotNull(charge);
+    assertEquals("charge", charge.getObject());
+    this.verifyRequest(ApiResource.RequestMethod.GET, "/v1/charges");
+  }
+
+  @Test
+  public void testRetrieve() throws StripeException {
+    Charge charge = this.client.charges().retrieve("ch_123");
+    assertNotNull(charge);
+    this.verifyRequest(ApiResource.RequestMethod.GET, "/v1/charges/ch_123");
+  }
+
+  @Test
+  public void testUpdate() throws StripeException {
+    ChargeUpdateParams params = ChargeUpdateParams.builder().putMetadata("key", "value").build();
+    Charge charge = this.client.charges().update("ch_123", params);
+    assertNotNull(charge);
+    this.verifyRequest(ApiResource.RequestMethod.POST, "/v1/charges/ch_123");
+  }
+
+  // Test that request methods are disabled.
+
+  @Test
+  public void testRequestMethodsDisabled_update() throws StripeException {
+    Charge charge = this.client.charges().capture("ch_123");
+    ChargeUpdateParams params = ChargeUpdateParams.builder().build();
+    assertThrows(UnsupportedOperationException.class, () -> {
+      charge.update(params);
+    });
+  }
+
+  @Test
+  public void testRequestMethodsDisabled_listIterator() throws StripeException {
+    ChargeCollection collection = this.client.charges().list();
+    assertThrows(UnsupportedOperationException.class, () -> {
+      collection.autoPagingIterable();
+    });
+  }
+
+}

--- a/src/test/java/com/stripe/service/CouponServiceTest.java
+++ b/src/test/java/com/stripe/service/CouponServiceTest.java
@@ -1,0 +1,64 @@
+package com.stripe.service;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.stripe.exception.StripeException;
+import com.stripe.model.Coupon;
+import com.stripe.model.StripeCollection;
+import com.stripe.net.ApiResource;
+import com.stripe.param.CouponCreateParams;
+import com.stripe.param.CouponCreateParams.Duration;
+import com.stripe.param.CouponListParams;
+import com.stripe.param.CouponUpdateParams;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Test;
+
+public class CouponServiceTest extends BaseServiceTest {
+  @Test
+  public void testCreate() throws StripeException {
+    CouponCreateParams params =
+        CouponCreateParams.builder()
+            .setPercentOff(BigDecimal.valueOf(25))
+            .setDuration(Duration.FOREVER)
+            .build();
+    Coupon coupon = this.client.coupons().create(params);
+    assertNotNull(coupon);
+    this.verifyRequest(ApiResource.RequestMethod.POST, "/v1/coupons");
+  }
+
+  @Test
+  public void testDelete() throws StripeException {
+    Coupon coupon = this.client.coupons().delete("mycoupon");
+    assertNotNull(coupon);
+    this.verifyRequest(ApiResource.RequestMethod.DELETE, "/v1/coupons/mycoupon");
+  }
+
+  @Test
+  public void testList() throws StripeException {
+    CouponListParams params = CouponListParams.builder().setLimit(1L).build();
+    StripeCollection<Coupon> coupons = this.client.coupons().list(params);
+    assertNotNull(coupons);
+    assertNotNull(coupons.getData());
+    assertEquals(1, coupons.getData().size());
+    Coupon coupon = coupons.getData().get(0);
+    assertNotNull(coupon);
+    assertEquals("coupon", coupon.getObject());
+    this.verifyRequest(ApiResource.RequestMethod.GET, "/v1/coupons");
+  }
+
+  @Test
+  public void testRetrieve() throws StripeException {
+    Coupon coupon = this.client.coupons().retrieve("mycoupon");
+    assertNotNull(coupon);
+    this.verifyRequest(ApiResource.RequestMethod.GET, "/v1/coupons/mycoupon");
+  }
+
+  @Test
+  public void testUpdate() throws StripeException {
+    CouponUpdateParams params = CouponUpdateParams.builder().putMetadata("key", "value").build();
+    Coupon coupon = this.client.coupons().update("mycoupon", params);
+    assertNotNull(coupon);
+    this.verifyRequest(ApiResource.RequestMethod.POST, "/v1/coupons/mycoupon");
+  }
+}

--- a/src/test/java/com/stripe/service/CustomerServiceTest.java
+++ b/src/test/java/com/stripe/service/CustomerServiceTest.java
@@ -1,0 +1,38 @@
+package com.stripe.service;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.stripe.exception.StripeException;
+import com.stripe.model.LineItemCollection;
+import com.stripe.model.PaymentSourceCollection;
+import com.stripe.model.PaymentSource;
+import com.stripe.net.ApiResource;
+import com.stripe.param.PaymentSourceCollectionListParams;
+
+import org.junit.jupiter.api.Test;
+
+public class CustomerServiceTest extends BaseServiceTest {
+
+  @Test
+  public void testListSources() throws StripeException {
+    PaymentSourceCollection sources = this.client.customers().listSources(
+      "acct_123",
+      PaymentSourceCollectionListParams.builder().setLimit(5L).build()
+    );
+
+    assertNotNull(sources);
+    assertEquals("list", sources.getObject());
+    this.verifyRequest(ApiResource.RequestMethod.GET, "/v1/customers/acct_123/sources");
+  }
+
+  @Test
+  public void testRetrieveSource() throws StripeException {
+    PaymentSource source = this.client.customers().retrieveSource(
+      "acct_123",
+      "card_123");
+
+    assertNotNull(source);
+    this.verifyRequest(ApiResource.RequestMethod.GET, "/v1/customers/acct_123/sources/card_123");
+  }
+}

--- a/src/test/java/com/stripe/service/FileServiceTest.java
+++ b/src/test/java/com/stripe/service/FileServiceTest.java
@@ -1,0 +1,50 @@
+package com.stripe.service;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.stripe.exception.StripeException;
+import com.stripe.model.File;
+import com.stripe.model.StripeCollection;
+import com.stripe.net.ApiResource;
+import com.stripe.param.FileCreateParams;
+import com.stripe.param.FileCreateParams.Purpose;
+import com.stripe.param.FileListParams;
+import org.junit.jupiter.api.Test;
+
+public class FileServiceTest extends BaseServiceTest {
+  @Test
+  public void testCreate() throws StripeException {
+    FileCreateParams params =
+        FileCreateParams.builder()
+            .setPurpose(Purpose.BUSINESS_ICON)
+            .setFile(new java.io.File(getClass().getResource("/test.png").getFile()))
+            .build();
+    File file = this.client.files().create(params);
+    assertNotNull(file);
+    this.verifyRequest(ApiResource.RequestMethod.POST, "/v1/files");
+    // TODO assert files.stripe.com
+  }
+
+  @Test
+  public void testList() throws StripeException {
+    FileListParams params = FileListParams.builder().setLimit(1L).build();
+    StripeCollection<File> files = this.client.files().list(params);
+    assertNotNull(files);
+    assertNotNull(files.getData());
+    assertEquals(1, files.getData().size());
+    File file = files.getData().get(0);
+    assertNotNull(file);
+    assertEquals("file", file.getObject());
+    this.verifyRequest(ApiResource.RequestMethod.GET, "/v1/files");
+    // TODO assert files.stripe.com
+  }
+
+  @Test
+  public void testRetrieve() throws StripeException {
+    File file = this.client.files().retrieve("file_123");
+    assertNotNull(file);
+    this.verifyRequest(ApiResource.RequestMethod.GET, "/v1/files/file_123");
+    // TODO assert files.stripe.com
+  }
+}

--- a/src/test/java/com/stripe/service/checkout/SessionServiceTest.java
+++ b/src/test/java/com/stripe/service/checkout/SessionServiceTest.java
@@ -1,0 +1,35 @@
+package com.stripe.service.checkout;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.stripe.exception.StripeException;
+import com.stripe.model.LineItemCollection;
+import com.stripe.model.StripeCollection;
+import com.stripe.model.checkout.Session;
+import com.stripe.net.ApiResource;
+import com.stripe.param.checkout.SessionListLineItemsParams;
+
+import com.stripe.service.BaseServiceTest;
+import org.junit.jupiter.api.Test;
+
+public class SessionServiceTest extends BaseServiceTest {
+  @Test
+  public void testRetrieve() throws StripeException {
+    Session session = this.client.checkout().sessions().retrieve("cs_123");
+    assertNotNull(session);
+    assertEquals("checkout.session", session.getObject());
+    this.verifyRequest(ApiResource.RequestMethod.GET, "/v1/checkout/sessions/cs_123");
+  }
+
+  @Test
+  public void testListLineItems() throws StripeException {
+    LineItemCollection collection = this.client.checkout().sessions().listLineItems(
+      "cs_123",
+      SessionListLineItemsParams.builder().setLimit(5L).build()
+    );
+    assertNotNull(collection);
+    assertEquals("list", collection.getObject());
+    this.verifyRequest(ApiResource.RequestMethod.GET, "/v1/checkout/sessions/cs_123/line_items");
+  }
+}

--- a/src/test/java/com/stripe/service/issuing/CardServiceTest.java
+++ b/src/test/java/com/stripe/service/issuing/CardServiceTest.java
@@ -1,0 +1,57 @@
+package com.stripe.service.issuing;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.stripe.exception.StripeException;
+import com.stripe.model.StripeCollection;
+import com.stripe.model.issuing.Card;
+import com.stripe.net.ApiResource;
+import com.stripe.param.issuing.CardCreateParams;
+import com.stripe.param.issuing.CardCreateParams.Type;
+import com.stripe.param.issuing.CardListParams;
+import com.stripe.param.issuing.CardUpdateParams;
+import com.stripe.service.BaseServiceTest;
+import org.junit.jupiter.api.Test;
+
+public class CardServiceTest extends BaseServiceTest {
+  @Test
+  public void testCreate() throws StripeException {
+    CardCreateParams params =
+        CardCreateParams.builder().setCurrency("usd").setType(CardCreateParams.Type.PHYSICAL).build();
+    Card card = this.client.issuing().cards().create(params);
+    assertNotNull(card);
+    assertEquals("issuing.card", card.getObject());
+    this.verifyRequest(ApiResource.RequestMethod.POST, "/v1/issuing/cards");
+  }
+
+  @Test
+  public void testList() throws StripeException {
+    CardListParams params = CardListParams.builder().setLimit(1L).build();
+    StripeCollection<Card> cards = this.client.issuing().cards().list(params);
+    assertNotNull(cards);
+    assertNotNull(cards.getData());
+    assertEquals(1, cards.getData().size());
+    Card card = cards.getData().get(0);
+    assertNotNull(card);
+    assertEquals("issuing.card", card.getObject());
+    this.verifyRequest(ApiResource.RequestMethod.GET, "/v1/issuing/cards");
+  }
+
+  @Test
+  public void testRetrieve() throws StripeException {
+    Card card = this.client.issuing().cards().retrieve("ic_123");
+    assertNotNull(card);
+    assertEquals("issuing.card", card.getObject());
+    this.verifyRequest(ApiResource.RequestMethod.GET, "/v1/issuing/cards/ic_123");
+  }
+
+  @Test
+  public void testUpdate() throws StripeException {
+    CardUpdateParams params = CardUpdateParams.builder().putMetadata("key", "value").build();
+    Card card = this.client.issuing().cards().update("ic_123", params);
+    assertNotNull(card);
+    assertEquals("issuing.card", card.getObject());
+    this.verifyRequest(ApiResource.RequestMethod.POST, "/v1/issuing/cards/ic_123");
+  }
+}


### PR DESCRIPTION
# Summary

This is a continuation of https://github.com/stripe/stripe-java/pull/942.

It is meant to prototype what the structure would look like for a services architecture. 

The goal is to enable changing code from the form

```
Stripe.apiKey = "sk_test_xyz";
Customer customer = Customer.retrieve("cus_123");
Customer deletedCustomer = customer.delete();
```

to

```
StripeClient client = new StripeClient("sk_test_xyz");
Customer deletedCustomer = client.customers().delete("cus_123");
```

This has a number of benefits:
1. Removes unnecessary API requests. As an example, in the above use case we have to first issue an API request to retrieve the customer, and then issue a second an API request to delete it. In the new interface, only one API request is sent. 
1. Brings the library in line with other libraries, such as stripe-dotnet and stripe-php, which now offer a `*Service` interface.
1. More flexibility around client configuration (eg. could have multiple clients) and reduced global state.

# What does this include?

- An example `StripeClient` showing how we may issue requests and transform them into results.
- Sample partial services, including some that use a nested resource (eg. `SessionService.listLineItems`) as well as some that use a polymorphic resource (eg. `CustomerService.{list|retrieve}Source`).
- Example code as to how we can re-use the model objects for the services interface but avoid confusing instance-level calls. This should be unsupported for objects generated through services to avoid confusion if a user were to write a call like `client.customers().retrieve("cs_123").update(...)`. In this case, the `#update` call would be relying on the global `Stripe` object and not issue its request correctly. This is just an example approach - there are others (eg. break up a model into `<Model>` and `<Model>Lite`/`<Model>Base` where base includes just the data fields and `<Model>` includes methods).

# What is missing

- Likely a new set of `<...>Params` classes will need to be created for the service interface to match the service naming convention (eg. `param.CardUpdateOnCustomerParams` -> `service.param.CustomerUpdateSourceParams`).
- A general approach for migrating exiting code to this new interface.
- A general approach for testing these across the board to ensure no regressions.