### PR TITLE
Add support for auto-paginatable `SearchResult` type

### DIFF
--- a/src/main/java/com/stripe/model/SearchPagingIterable.java
+++ b/src/main/java/com/stripe/model/SearchPagingIterable.java
@@ -1,0 +1,20 @@
+package com.stripe.model;
+
+import java.util.Iterator;
+
+/**
+ * Provides an <code>{@code Iterable<T>}</code> target that automatically iterates across all API
+ * pages and which is suitable for use with a <code>{@code foreach}</code> loop.
+ */
+public class SearchPagingIterable<T> implements Iterable<T> {
+  private StripeSearchResultInterface<T> page;
+
+  SearchPagingIterable(final StripeSearchResultInterface<T> page) {
+    this.page = page;
+  }
+
+  @Override
+  public Iterator<T> iterator() {
+    return new SearchPagingIterator<>(page);
+  }
+}

--- a/src/main/java/com/stripe/model/SearchPagingIterable.java
+++ b/src/main/java/com/stripe/model/SearchPagingIterable.java
@@ -5,6 +5,8 @@ import java.util.Iterator;
 /**
  * Provides an <code>{@code Iterable<T>}</code> target that automatically iterates across all API
  * pages and which is suitable for use with a <code>{@code foreach}</code> loop.
+ *
+ * <p>Please note SearchPagingIterable is in beta and is subject to change or removal at any time.
  */
 public class SearchPagingIterable<T> implements Iterable<T> {
   private StripeSearchResultInterface<T> page;

--- a/src/main/java/com/stripe/model/SearchPagingIterator.java
+++ b/src/main/java/com/stripe/model/SearchPagingIterator.java
@@ -51,7 +51,8 @@ public class SearchPagingIterator<T> extends ApiResource implements Iterator<T> 
         // then put our new page start in
         params.put("next_page", this.nextPage);
 
-        this.currentSearchResult = list(params, currentSearchResult.getRequestOptions());
+        this.currentSearchResult = search(params, currentSearchResult.getRequestOptions());
+        this.nextPage = this.currentSearchResult.getNextPage();
 
         this.currentDataIterator = currentSearchResult.getData().iterator();
       } catch (final Exception e) {
@@ -73,7 +74,7 @@ public class SearchPagingIterator<T> extends ApiResource implements Iterator<T> 
   }
 
   @SuppressWarnings("unchecked")
-  private StripeSearchResultInterface<T> list(
+  private StripeSearchResultInterface<T> search(
       final Map<String, Object> params, final RequestOptions options) throws Exception {
     return ApiResource.requestSearchResult(url, params, collectionType, options);
   }

--- a/src/main/java/com/stripe/model/SearchPagingIterator.java
+++ b/src/main/java/com/stripe/model/SearchPagingIterator.java
@@ -1,0 +1,80 @@
+package com.stripe.model;
+
+import com.stripe.Stripe;
+import com.stripe.net.ApiResource;
+import com.stripe.net.RequestOptions;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+public class SearchPagingIterator<T> extends ApiResource implements Iterator<T> {
+  private final String url;
+
+  @SuppressWarnings("rawtypes")
+  private final Class<? extends StripeSearchResultInterface> collectionType;
+
+  private StripeSearchResultInterface<T> currentSearchResult;
+  private Iterator<T> currentDataIterator;
+
+  private String nextPage;
+
+  SearchPagingIterator(final StripeSearchResultInterface<T> stripeSearchResult) {
+    this.url = Stripe.getApiBase() + stripeSearchResult.getUrl();
+    this.nextPage = stripeSearchResult.getNextPage();
+
+    this.collectionType = stripeSearchResult.getClass();
+
+    this.currentSearchResult = stripeSearchResult;
+    this.currentDataIterator = stripeSearchResult.getData().iterator();
+  }
+
+  @Override
+  public boolean hasNext() {
+    return currentDataIterator.hasNext() || currentSearchResult.getHasMore();
+  }
+
+  @Override
+  public T next() {
+    // if we've run out of data on the current page, try to fetch another
+    // one
+    if (!currentDataIterator.hasNext() && currentSearchResult.getHasMore()) {
+      try {
+        Map<String, Object> params = new HashMap<>();
+
+        // copy all the parameters from the initial request
+        Map<String, Object> initialParams = currentSearchResult.getRequestParams();
+        if (initialParams != null) {
+          params.putAll(initialParams);
+        }
+
+        // then put our new page start in
+        params.put("next_page", this.nextPage);
+
+        this.currentSearchResult = list(params, currentSearchResult.getRequestOptions());
+
+        this.currentDataIterator = currentSearchResult.getData().iterator();
+      } catch (final Exception e) {
+        throw new RuntimeException("Unable to lazy-load stripe objects", e);
+      }
+    }
+
+    if (currentDataIterator.hasNext()) {
+      final T next = currentDataIterator.next();
+      return next;
+    }
+
+    throw new NoSuchElementException();
+  }
+
+  @Override
+  public void remove() {
+    throw new UnsupportedOperationException();
+  }
+
+  @SuppressWarnings("unchecked")
+  private StripeSearchResultInterface<T> list(
+      final Map<String, Object> params, final RequestOptions options) throws Exception {
+    return ApiResource.requestSearchResult(url, params, collectionType, options);
+  }
+}

--- a/src/main/java/com/stripe/model/SearchPagingIterator.java
+++ b/src/main/java/com/stripe/model/SearchPagingIterator.java
@@ -8,6 +8,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
+/** Please note SearchPagingIterator is in beta and is subject to change or removal at any time. */
 public class SearchPagingIterator<T> extends ApiResource implements Iterator<T> {
   private final String url;
 

--- a/src/main/java/com/stripe/model/StripeSearchResult.java
+++ b/src/main/java/com/stripe/model/StripeSearchResult.java
@@ -7,7 +7,10 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
-/** Provides a representation of a single page worth of data from a Stripe API search method. */
+/**
+ * Provides a representation of a single page worth of data from a Stripe API search method. Please
+ * note, StripeSearchResult is beta functionality and is subject to change or removal at any time.
+ */
 @Getter
 @Setter
 @EqualsAndHashCode(callSuper = false)

--- a/src/main/java/com/stripe/model/StripeSearchResult.java
+++ b/src/main/java/com/stripe/model/StripeSearchResult.java
@@ -1,0 +1,60 @@
+package com.stripe.model;
+
+import com.stripe.net.RequestOptions;
+import java.util.List;
+import java.util.Map;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+/** Provides a representation of a single page worth of data from a Stripe API search method. */
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
+public abstract class StripeSearchResult<T> extends StripeObject
+    implements StripeSearchResultInterface<T> {
+  String object;
+
+  @Getter(onMethod_ = {@Override})
+  List<T> data;
+
+  @Getter(onMethod_ = {@Override})
+  Boolean hasMore;
+
+  @Getter(onMethod_ = {@Override})
+  String url;
+
+  @Getter(onMethod_ = {@Override})
+  String nextPage;
+
+  @Getter(onMethod_ = {@Override})
+  @Setter(onMethod = @__({@Override}))
+  private transient RequestOptions requestOptions;
+
+  @Getter(onMethod_ = {@Override})
+  @Setter(onMethod = @__({@Override}))
+  private Map<String, Object> requestParams;
+
+  public Iterable<T> autoPagingIterable() {
+    return new SearchPagingIterable<>(this);
+  }
+
+  public Iterable<T> autoPagingIterable(Map<String, Object> params) {
+    this.setRequestParams(params);
+    return new SearchPagingIterable<>(this);
+  }
+
+  /**
+   * Constructs an iterable that can be used to iterate across all objects across all pages. As page
+   * boundaries are encountered, the next page will be fetched automatically for continued
+   * iteration.
+   *
+   * @param params request parameters (will override the parameters from the initial list request)
+   * @param options request options (will override the options from the initial list request)
+   */
+  public Iterable<T> autoPagingIterable(Map<String, Object> params, RequestOptions options) {
+    this.setRequestOptions(options);
+    this.setRequestParams(params);
+    return new SearchPagingIterable<>(this);
+  }
+}

--- a/src/main/java/com/stripe/model/StripeSearchResultInterface.java
+++ b/src/main/java/com/stripe/model/StripeSearchResultInterface.java
@@ -1,5 +1,9 @@
 package com.stripe.model;
 
+/**
+ * Please note, StripeSearchResultInterface is beta functionality and is subject to change or
+ * removal at any time.
+ */
 public interface StripeSearchResultInterface<T> extends StripeCollectionInterface<T> {
   String getNextPage();
 }

--- a/src/main/java/com/stripe/model/StripeSearchResultInterface.java
+++ b/src/main/java/com/stripe/model/StripeSearchResultInterface.java
@@ -1,0 +1,5 @@
+package com.stripe.model;
+
+public interface StripeSearchResultInterface<T> extends StripeCollectionInterface<T> {
+  String getNextPage();
+}

--- a/src/main/java/com/stripe/net/ApiResource.java
+++ b/src/main/java/com/stripe/net/ApiResource.java
@@ -21,6 +21,7 @@ import com.stripe.model.StripeObject;
 import com.stripe.model.StripeObjectInterface;
 import com.stripe.model.StripeRawJsonObject;
 import com.stripe.model.StripeRawJsonObjectDeserializer;
+import com.stripe.model.StripeSearchResultInterface;
 import com.stripe.util.StringUtils;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
@@ -221,6 +222,32 @@ public abstract class ApiResource extends StripeObject {
     }
 
     return collection;
+  }
+
+  public static <T extends StripeSearchResultInterface<?>> T requestSearchResult(
+      String url, ApiRequestParams params, Class<T> clazz, RequestOptions options)
+      throws StripeException {
+    checkNullTypedParams(url, params);
+    return requestSearchResult(url, params.toMap(), clazz, options);
+  }
+
+  /**
+   * Similar to #request, but specific for use with searchResult types that come from the API
+   *
+   * <p>Collections need a little extra work because we need to plumb request options and params
+   * through so that we can iterate to the next page if necessary.
+   */
+  public static <T extends StripeSearchResultInterface<?>> T requestSearchResult(
+      String url, Map<String, Object> params, Class<T> clazz, RequestOptions options)
+      throws StripeException {
+    T searchResult = request(RequestMethod.GET, url, params, clazz, options);
+
+    if (searchResult != null) {
+      searchResult.setRequestOptions(options);
+      searchResult.setRequestParams(params);
+    }
+
+    return searchResult;
   }
 
   /**

--- a/src/main/java/com/stripe/net/ApiResource.java
+++ b/src/main/java/com/stripe/net/ApiResource.java
@@ -234,8 +234,11 @@ public abstract class ApiResource extends StripeObject {
   /**
    * Similar to #request, but specific for use with searchResult types that come from the API
    *
-   * <p>Collections need a little extra work because we need to plumb request options and params
-   * through so that we can iterate to the next page if necessary.
+   * <p>SearchResults, like collections need a little extra work because we need to plumb request
+   * options and params through so that we can iterate to the next page if necessary.
+   *
+   * <p>Please note, requestSearchResult is beta functionality and is subject to charge or removal
+   * at any time.
    */
   public static <T extends StripeSearchResultInterface<?>> T requestSearchResult(
       String url, Map<String, Object> params, Class<T> clazz, RequestOptions options)


### PR DESCRIPTION
## Notify
r? @ramon-stripe 
cc @stripe/api-libraries 

## Summary
Adds support for autopaginatable `SearchResult` API response types. Implementation strategy: mostly I copied `Collection` classes/interfaces, but changed the pagination logic to use `nextPage` instead of `lastId`.

Analogous to PRs in [stripe-node](https://github.com/stripe/stripe-node/pull/1198/files) and [stripe-go](https://github.com/stripe/stripe-go/pull/1324)

See [example commit](https://github.com/stripe/stripe-java/compare/richardm-search-charges?expand=1) for how this would work in the context of a `/v1/search/charges` endpoint.

## Release Plan

Even though this functionality is not public, without a future PR adding a search method to a resource (like [my charges example](https://github.com/stripe/stripe-java/compare/richardm-search-charges?expand=1), none of these classes/interfaces are accessible, so in effect this addition does not affect the public interface of `stripe-java` and can be safely removed or changed. I intend to merge it right away. This is similar to the release pattern we followed for [streaming requests](https://github.com/stripe/stripe-java/pull/1207).

## Testing
Test strategy: took https://github.com/stripe/stripe-java/compare/richardm-search-charges?expand=1, made a .jar, added it to the `pom.xml` in my sample app, and successfully executed:
```java
    RequestOptions opts = RequestOptions.builder().setStripeVersionOverride("2020-08-27;search_api_beta=v1").build();
    ChargeSearchParams params = ChargeSearchParams
      .builder()
      .setLimit(2l)
      .setQuery("metadata[\"foo\"]:\"bar\"")
      .build();
    for (Charge ch : Charge.search(params, opts).autoPagingIterable()) {
      System.out.println(ch.getId());
    }
```
and confirmed the pagination appeared to be happening correctly (it actually wasn't, at first and I fixed a bug).