### PR TITLE
API Updates

### DIFF
--- a/src/main/java/com/stripe/model/TaxRate.java
+++ b/src/main/java/com/stripe/model/TaxRate.java
@@ -107,8 +107,8 @@ public class TaxRate extends ApiResource implements HasId, MetadataStore<TaxRate
   /**
    * The high-level tax type, such as {@code vat} or {@code sales_tax}.
    *
-   * <p>One of {@code gst}, {@code hst}, {@code pst}, {@code qst}, {@code sales_tax}, or {@code
-   * vat}.
+   * <p>One of {@code gst}, {@code hst}, {@code pst}, {@code qst}, {@code rst}, {@code sales_tax},
+   * or {@code vat}.
    */
   @SerializedName("tax_type")
   String taxType;

--- a/src/main/java/com/stripe/model/checkout/Session.java
+++ b/src/main/java/com/stripe/model/checkout/Session.java
@@ -536,7 +536,12 @@ public class Session extends ApiResource implements HasId {
   @Setter
   @EqualsAndHashCode(callSuper = false)
   public static class CustomerDetails extends StripeObject {
-    /** The customer’s email at time of checkout. */
+    /**
+     * The email associated with the Customer, if one exists, on the Checkout Session at the time of
+     * checkout or at time of session expiry. Otherwise, if the customer has consented to
+     * promotional content, this value is the most recent valid email provided by the customer on
+     * the Checkout form.
+     */
     @SerializedName("email")
     String email;
 

--- a/src/main/java/com/stripe/param/TaxRateCreateParams.java
+++ b/src/main/java/com/stripe/param/TaxRateCreateParams.java
@@ -321,6 +321,9 @@ public class TaxRateCreateParams extends ApiRequestParams {
     @SerializedName("qst")
     QST("qst"),
 
+    @SerializedName("rst")
+    RST("rst"),
+
     @SerializedName("sales_tax")
     SALES_TAX("sales_tax"),
 

--- a/src/main/java/com/stripe/param/TaxRateUpdateParams.java
+++ b/src/main/java/com/stripe/param/TaxRateUpdateParams.java
@@ -357,6 +357,9 @@ public class TaxRateUpdateParams extends ApiRequestParams {
     @SerializedName("qst")
     QST("qst"),
 
+    @SerializedName("rst")
+    RST("rst"),
+
     @SerializedName("sales_tax")
     SALES_TAX("sales_tax"),
 

--- a/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
+++ b/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
@@ -663,6 +663,9 @@ public class WebhookEndpointCreateParams extends ApiRequestParams {
     @SerializedName("checkout.session.completed")
     CHECKOUT__SESSION__COMPLETED("checkout.session.completed"),
 
+    @SerializedName("checkout.session.expired")
+    CHECKOUT__SESSION__EXPIRED("checkout.session.expired"),
+
     @SerializedName("coupon.created")
     COUPON__CREATED("coupon.created"),
 

--- a/src/main/java/com/stripe/param/WebhookEndpointUpdateParams.java
+++ b/src/main/java/com/stripe/param/WebhookEndpointUpdateParams.java
@@ -351,6 +351,9 @@ public class WebhookEndpointUpdateParams extends ApiRequestParams {
     @SerializedName("checkout.session.completed")
     CHECKOUT__SESSION__COMPLETED("checkout.session.completed"),
 
+    @SerializedName("checkout.session.expired")
+    CHECKOUT__SESSION__EXPIRED("checkout.session.expired"),
+
     @SerializedName("coupon.created")
     COUPON__CREATED("coupon.created"),
 


### PR DESCRIPTION
Codegen for openapi ad7d382.
r? @dcr-stripe
cc @stripe/api-libraries

## Changelog
* Add support for new value `rst` on enums `TaxRateCreateParams.tax_type` and `TaxRateUpdateParams.tax_type`
* Add support for new value `checkout.session.expired` on enums `WebhookEndpointCreateParams.enabled_events[]` and `WebhookEndpointUpdateParams.enabled_events[]`

