### PR TITLE
Add missing constant for `account_requirement` as a `purpose` on File create and List APIs

### DIFF
--- a/src/main/java/com/stripe/param/FileCreateParams.java
+++ b/src/main/java/com/stripe/param/FileCreateParams.java
@@ -207,6 +207,9 @@ public class FileCreateParams extends ApiRequestParams {
   }
 
   public enum Purpose implements ApiRequestParams.EnumParam {
+    @SerializedName("account_requirement")
+    ACCOUNT_REQUIREMENT("account_requirement"),
+
     @SerializedName("additional_verification")
     ADDITIONAL_VERIFICATION("additional_verification"),
 

--- a/src/main/java/com/stripe/param/FileListParams.java
+++ b/src/main/java/com/stripe/param/FileListParams.java
@@ -235,6 +235,9 @@ public class FileListParams extends ApiRequestParams {
   }
 
   public enum Purpose implements ApiRequestParams.EnumParam {
+    @SerializedName("account_requirement")
+    ACCOUNT_REQUIREMENT("account_requirement"),
+
     @SerializedName("additional_verification")
     ADDITIONAL_VERIFICATION("additional_verification"),
 


### PR DESCRIPTION
r? @richardm-stripe 
cc @stripe/api-libraries 

Fixes https://github.com/stripe/stripe-java/issues/1258