### PR TITLE
Replace `maven` plugin with `maven-publish`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,13 +5,14 @@ buildscript {
         //maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
     }
     dependencies {
-        classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.21.1"
+        classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.30.0"
     }
 }
 
 plugins {
     id "java"
-    id "maven"
+    id "maven-publish"
+    id "signing"
     id "jacoco"
     id "io.freefair.lombok" version "5.3.3.3" // 5.3 branch is the last branch compatible with Gradle 6
     id "com.diffplug.spotless" version "5.14.3"

--- a/deploy.gradle
+++ b/deploy.gradle
@@ -6,7 +6,7 @@
  * https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle
  */
 
-apply plugin: "maven"
+apply plugin: "maven-publish"
 apply plugin: "signing"
 apply plugin: "io.codearte.nexus-staging"
 
@@ -39,67 +39,6 @@ def getRepositoryPassword() {
 }
 
 afterEvaluate { project ->
-    uploadArchives {
-        repositories {
-            mavenDeployer {
-                beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-
-                pom.groupId = GROUP
-                pom.artifactId = POM_ARTIFACT_ID
-                pom.version = VERSION_NAME
-
-                repository(url: getReleaseRepositoryUrl()) {
-                    authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
-                }
-
-                snapshotRepository(url: getSnapshotRepositoryUrl()) {
-                    authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
-                }
-
-                pom.project {
-                    name POM_NAME
-                    description POM_DESCRIPTION
-                    url POM_URL
-                    packaging POM_PACKAGING
-
-                    scm {
-                        url POM_SCM_URL
-                        connection POM_SCM_CONNECTION
-                        developerConnection POM_SCM_DEV_CONNECTION
-                    }
-
-                    licenses {
-                        license {
-                            name POM_LICENCE_NAME
-                            url POM_LICENCE_URL
-                            distribution POM_LICENCE_DIST
-                        }
-                    }
-
-                    developers {
-                        developer {
-                            id POM_DEVELOPER_ID
-                            name POM_DEVELOPER_NAME
-                            email POM_DEVELOPER_EMAIL
-                        }
-                    }
-
-                    organization {
-                        name POM_DEVELOPER_NAME
-                        url POM_ORGANIZATION_URL
-                    }
-                }
-            }
-        }
-    }
-
-    signing {
-        required { isReleaseBuild() &&
-        (gradle.taskGraph.hasTask("uploadArchives") || gradle.taskGraph.hasTask("publish"))}
-        useGpgCmd()
-        sign configurations.archives
-    }
-
     tasks.withType(Sign) {
         onlyIf { isReleaseBuild() && project.hasProperty("signing.gnupg.keyName") }
     }
@@ -114,8 +53,63 @@ afterEvaluate { project ->
         from javadoc.destinationDir
     }
 
-    artifacts {
-        archives sourcesJar
-        archives javadocJar
+    signing {
+        required { isReleaseBuild() && gradle.taskGraph.hasTask("publish") }
+        useGpgCmd()
+        sign publishing.publications
+    }
+
+    publishing {
+        publications {
+            mavenJava(MavenPublication) {
+                groupId = GROUP
+                artifactId = POM_ARTIFACT_ID
+                version = VERSION_NAME
+                from components.java
+                artifact sourcesJar
+                artifact javadocJar
+                pom {
+                    name = POM_NAME
+                    description = POM_DESCRIPTION
+                    url = POM_URL
+                    packaging = POM_PACKAGING
+                    licenses {
+                        license {
+                            name = POM_LICENCE_NAME
+                            url = POM_LICENCE_URL
+                            distribution = POM_LICENCE_DIST
+                        }
+                    }
+                    developers {
+                        developer {
+                            id = POM_DEVELOPER_ID
+                            name = POM_DEVELOPER_NAME
+                            email = POM_DEVELOPER_EMAIL
+                        }
+                    }
+                    organization {
+                        name = POM_DEVELOPER_NAME
+                        url = POM_ORGANIZATION_URL
+                    }
+                    scm {
+                        connection = POM_SCM_CONNECTION
+                        developerConnection = POM_SCM_DEV_CONNECTION
+                        url = POM_SCM_URL
+                    }
+                }
+            }
+        }
+        repositories {
+            maven {
+                name = "nexus"
+                def releasesRepoUrl = getReleaseRepositoryUrl()
+                def snapshotsRepoUrl = getSnapshotRepositoryUrl()
+                url = isReleaseBuild() ? releasesRepoUrl : snapshotsRepoUrl
+                credentials {
+                    username = getRepositoryUsername()
+                    password = getRepositoryPassword()
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
r? @stripe/api-library-reviewers 
cc @stripe/api-libraries 

This PR replaces the `maven` plugin with `maven-publish`.

The `maven` plugin is deprecated and has been removed from Gradle 7: https://docs.gradle.org/current/userguide/upgrading_version_6.html#removal_of_the_legacy_maven_plugin. This PR is a prerequisite for upgrading to Gradle 7, which is itself necessary for testing the library with Java 16+.

Unfortunately this change is kind of hard to test. I was able to use the [`publishToMavenLocal`](https://docs.gradle.org/current/userguide/publishing_maven.html#publishing_maven:install) task to publish to my local repository and ensure that all artifacts are present and signed using GnuPG:
```
$ rm -rf build/

$ ./gradlew clean publishToMavenLocal -Dorg.gradle.project.signing.gnupg.keyName=<my GnuPG key fingerprint>
...
BUILD SUCCESSFUL in 2m 7s
12 actionable tasks: 12 executed

$ ls -l ~/.m2/repository/com/stripe/stripe-java/20.74.0
total 34696
-rw-r--r--  1 ob  staff  11479369 Sep  9 11:35 stripe-java-20.74.0-javadoc.jar
-rw-r--r--  1 ob  staff       853 Sep  9 11:35 stripe-java-20.74.0-javadoc.jar.asc
-rw-r--r--  1 ob  staff   1710559 Sep  9 11:35 stripe-java-20.74.0-sources.jar
-rw-r--r--  1 ob  staff       853 Sep  9 11:35 stripe-java-20.74.0-sources.jar.asc
-rw-r--r--  1 ob  staff   4540350 Sep  9 11:35 stripe-java-20.74.0.jar
-rw-r--r--  1 ob  staff       853 Sep  9 11:35 stripe-java-20.74.0.jar.asc
-rw-r--r--  1 ob  staff      2141 Sep  9 11:35 stripe-java-20.74.0.module
-rw-r--r--  1 ob  staff       853 Sep  9 11:35 stripe-java-20.74.0.module.asc
-rw-r--r--  1 ob  staff      1765 Sep  9 11:35 stripe-java-20.74.0.pom
-rw-r--r--  1 ob  staff       853 Sep  9 11:35 stripe-java-20.74.0.pom.asc

$ gpg --verify ~/.m2/repository/com/stripe/stripe-java/20.74.0/stripe-java-20.74.0.jar.asc ~/.m2/repository/com/stripe/stripe-java/20.74.0/stripe-java-20.74.0.jar
gpg: Signature made Thu Sep  9 11:35:07 2021 CEST
gpg:                using RSA key <my GnuPG key fingerprint>
gpg: Good signature from "Olivier Bellone <ob@stripe.com>" [ultimate]
```

In order to actually test publishing a new release to Sonatype OSS, I think we'll need to proceed as such:
1. merge this PR
2. update the bindings release tool to use `./gradlew publish` instead of `./gradlew uploadArchives`
3. try releasing a new version

and revert 1. and 2. if the release fails.
