### PR TITLE
API Updates

### DIFF
--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -1677,7 +1677,10 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
       /**
        * The cardholder name as read from the card, in <a
        * href="https://en.wikipedia.org/wiki/ISO/IEC_7813">ISO 7813</a> format. May include
-       * alphanumeric characters, special characters and first/last name separator ({@code /}).
+       * alphanumeric characters, special characters and first/last name separator ({@code /}). In
+       * some cases, the cardholder name may not be available depending on how the issuer has
+       * configured the card. Cardholder name is typically not available on swipe or contactless
+       * payments, such as those made with Apple Pay and Google Pay.
        */
       @SerializedName("cardholder_name")
       String cardholderName;
@@ -2012,7 +2015,10 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
       /**
        * The cardholder name as read from the card, in <a
        * href="https://en.wikipedia.org/wiki/ISO/IEC_7813">ISO 7813</a> format. May include
-       * alphanumeric characters, special characters and first/last name separator ({@code /}).
+       * alphanumeric characters, special characters and first/last name separator ({@code /}). In
+       * some cases, the cardholder name may not be available depending on how the issuer has
+       * configured the card. Cardholder name is typically not available on swipe or contactless
+       * payments, such as those made with Apple Pay and Google Pay.
        */
       @SerializedName("cardholder_name")
       String cardholderName;

--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -1537,7 +1537,7 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
     @EqualsAndHashCode(callSuper = false)
     public static class AcssDebit extends StripeObject {
       @SerializedName("mandate_options")
-      AcssDebitMandateOptions mandateOptions;
+      MandateOptions mandateOptions;
 
       /**
        * Bank account verification method.
@@ -1550,7 +1550,7 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
       @Getter
       @Setter
       @EqualsAndHashCode(callSuper = false)
-      public static class AcssDebitMandateOptions extends StripeObject {
+      public static class MandateOptions extends StripeObject {
         /**
          * Transaction type of the mandate.
          *

--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -1512,6 +1512,13 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
   @EqualsAndHashCode(callSuper = false)
   public static class PaymentMethodOptions extends StripeObject {
     /**
+     * If paying by {@code acss_debit}, this sub-hash contains details about the Canadian
+     * pre-authorized debit payment method options to pass to the invoice’s PaymentIntent.
+     */
+    @SerializedName("acss_debit")
+    AcssDebit acssDebit;
+
+    /**
      * If paying by {@code bancontact}, this sub-hash contains details about the Bancontact payment
      * method options to pass to the invoice’s PaymentIntent.
      */
@@ -1524,6 +1531,35 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
      */
     @SerializedName("card")
     Card card;
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class AcssDebit extends StripeObject {
+      @SerializedName("mandate_options")
+      AcssDebitMandateOptions mandateOptions;
+
+      /**
+       * Bank account verification method.
+       *
+       * <p>One of {@code automatic}, {@code instant}, or {@code microdeposits}.
+       */
+      @SerializedName("verification_method")
+      String verificationMethod;
+
+      @Getter
+      @Setter
+      @EqualsAndHashCode(callSuper = false)
+      public static class AcssDebitMandateOptions extends StripeObject {
+        /**
+         * Transaction type of the mandate.
+         *
+         * <p>One of {@code business}, or {@code personal}.
+         */
+        @SerializedName("transaction_type")
+        String transactionType;
+      }
+    }
 
     @Getter
     @Setter

--- a/src/main/java/com/stripe/model/Mandate.java
+++ b/src/main/java/com/stripe/model/Mandate.java
@@ -7,6 +7,7 @@ import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 import com.stripe.param.MandateRetrieveParams;
+import java.util.List;
 import java.util.Map;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -229,6 +230,10 @@ public class Mandate extends ApiResource implements HasId {
     @Setter
     @EqualsAndHashCode(callSuper = false)
     public static class AcssDebit extends StripeObject {
+      /** List of Stripe products where this mandate can be selected automatically. */
+      @SerializedName("default_for")
+      List<String> defaultFor;
+
       /**
        * Description of the interval. Only required if the 'payment_schedule' parameter is
        * 'interval' or 'combined'.

--- a/src/main/java/com/stripe/model/SetupIntent.java
+++ b/src/main/java/com/stripe/model/SetupIntent.java
@@ -768,6 +768,10 @@ public class SetupIntent extends ApiResource implements HasId, MetadataStore<Set
         @SerializedName("custom_mandate_url")
         String customMandateUrl;
 
+        /** List of Stripe products where this mandate can be selected automatically. */
+        @SerializedName("default_for")
+        List<String> defaultFor;
+
         /**
          * Description of the interval. Only required if the 'payment_schedule' parameter is
          * 'interval' or 'combined'.

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -764,6 +764,13 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
   @EqualsAndHashCode(callSuper = false)
   public static class PaymentMethodOptions extends StripeObject {
     /**
+     * This sub-hash contains details about the Canadian pre-authorized debit payment method options
+     * to pass to invoices created by the subscription.
+     */
+    @SerializedName("acss_debit")
+    Invoice.PaymentMethodOptions.AcssDebit acssDebit;
+
+    /**
      * This sub-hash contains details about the Bancontact payment method options to pass to
      * invoices created by the subscription.
      */

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -789,7 +789,7 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
     @EqualsAndHashCode(callSuper = false)
     public static class AcssDebit extends StripeObject {
       @SerializedName("mandate_options")
-      AcssDebitMandateOptions mandateOptions;
+      MandateOptions mandateOptions;
 
       /**
        * Bank account verification method.
@@ -802,7 +802,7 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
       @Getter
       @Setter
       @EqualsAndHashCode(callSuper = false)
-      public static class AcssDebitMandateOptions extends StripeObject {
+      public static class MandateOptions extends StripeObject {
         /**
          * Transaction type of the mandate.
          *

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -768,7 +768,7 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
      * to pass to invoices created by the subscription.
      */
     @SerializedName("acss_debit")
-    Invoice.PaymentMethodOptions.AcssDebit acssDebit;
+    AcssDebit acssDebit;
 
     /**
      * This sub-hash contains details about the Bancontact payment method options to pass to
@@ -783,6 +783,35 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
      */
     @SerializedName("card")
     Card card;
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class AcssDebit extends StripeObject {
+      @SerializedName("mandate_options")
+      Invoice.PaymentMethodOptions.AcssDebit.AcssDebitMandateOptions mandateOptions;
+
+      /**
+       * Bank account verification method.
+       *
+       * <p>One of {@code automatic}, {@code instant}, or {@code microdeposits}.
+       */
+      @SerializedName("verification_method")
+      String verificationMethod;
+
+      @Getter
+      @Setter
+      @EqualsAndHashCode(callSuper = false)
+      public static class AcssDebitMandateOptions extends StripeObject {
+        /**
+         * Transaction type of the mandate.
+         *
+         * <p>One of {@code business}, or {@code personal}.
+         */
+        @SerializedName("transaction_type")
+        String transactionType;
+      }
+    }
 
     @Getter
     @Setter

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -789,7 +789,7 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
     @EqualsAndHashCode(callSuper = false)
     public static class AcssDebit extends StripeObject {
       @SerializedName("mandate_options")
-      Invoice.PaymentMethodOptions.AcssDebit.AcssDebitMandateOptions mandateOptions;
+      AcssDebitMandateOptions mandateOptions;
 
       /**
        * Bank account verification method.

--- a/src/main/java/com/stripe/model/checkout/Session.java
+++ b/src/main/java/com/stripe/model/checkout/Session.java
@@ -625,6 +625,13 @@ public class Session extends ApiResource implements HasId {
         String customMandateUrl;
 
         /**
+         * List of Stripe products where this mandate can be selected automatically. Returned when
+         * the Session is in {@code setup} mode.
+         */
+        @SerializedName("default_for")
+        List<String> defaultFor;
+
+        /**
          * Description of the interval. Only required if the 'payment_schedule' parameter is
          * 'interval' or 'combined'.
          */

--- a/src/main/java/com/stripe/model/reporting/ReportType.java
+++ b/src/main/java/com/stripe/model/reporting/ReportType.java
@@ -48,6 +48,13 @@ public class ReportType extends ApiResource implements HasId {
   @SerializedName("id")
   String id;
 
+  /**
+   * Has the value {@code true} if the object exists in live mode or the value {@code false} if the
+   * object exists in test mode.
+   */
+  @SerializedName("livemode")
+  Boolean livemode;
+
   /** Human-readable name of the Report Type. */
   @SerializedName("name")
   String name;

--- a/src/main/java/com/stripe/param/InvoiceCreateParams.java
+++ b/src/main/java/com/stripe/param/InvoiceCreateParams.java
@@ -1079,6 +1079,13 @@ public class InvoiceCreateParams extends ApiRequestParams {
     @Getter
     public static class PaymentMethodOptions {
       /**
+       * If paying by {@code acss_debit}, this sub-hash contains details about the Canadian
+       * pre-authorized debit payment method options to pass to the invoice’s PaymentIntent.
+       */
+      @SerializedName("acss_debit")
+      Object acssDebit;
+
+      /**
        * If paying by {@code bancontact}, this sub-hash contains details about the Bancontact
        * payment method options to pass to the invoice’s PaymentIntent.
        */
@@ -1102,7 +1109,8 @@ public class InvoiceCreateParams extends ApiRequestParams {
       Map<String, Object> extraParams;
 
       private PaymentMethodOptions(
-          Object bancontact, Object card, Map<String, Object> extraParams) {
+          Object acssDebit, Object bancontact, Object card, Map<String, Object> extraParams) {
+        this.acssDebit = acssDebit;
         this.bancontact = bancontact;
         this.card = card;
         this.extraParams = extraParams;
@@ -1113,6 +1121,8 @@ public class InvoiceCreateParams extends ApiRequestParams {
       }
 
       public static class Builder {
+        private Object acssDebit;
+
         private Object bancontact;
 
         private Object card;
@@ -1121,7 +1131,26 @@ public class InvoiceCreateParams extends ApiRequestParams {
 
         /** Finalize and obtain parameter instance from this builder. */
         public PaymentMethodOptions build() {
-          return new PaymentMethodOptions(this.bancontact, this.card, this.extraParams);
+          return new PaymentMethodOptions(
+              this.acssDebit, this.bancontact, this.card, this.extraParams);
+        }
+
+        /**
+         * If paying by {@code acss_debit}, this sub-hash contains details about the Canadian
+         * pre-authorized debit payment method options to pass to the invoice’s PaymentIntent.
+         */
+        public Builder setAcssDebit(AcssDebit acssDebit) {
+          this.acssDebit = acssDebit;
+          return this;
+        }
+
+        /**
+         * If paying by {@code acss_debit}, this sub-hash contains details about the Canadian
+         * pre-authorized debit payment method options to pass to the invoice’s PaymentIntent.
+         */
+        public Builder setAcssDebit(EmptyParam acssDebit) {
+          this.acssDebit = acssDebit;
+          return this;
         }
 
         /**
@@ -1186,6 +1215,201 @@ public class InvoiceCreateParams extends ApiRequestParams {
           }
           this.extraParams.putAll(map);
           return this;
+        }
+      }
+
+      @Getter
+      public static class AcssDebit {
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /** Additional fields for Mandate creation. */
+        @SerializedName("mandate_options")
+        MandateOptions mandateOptions;
+
+        /** Verification method for the intent. */
+        @SerializedName("verification_method")
+        VerificationMethod verificationMethod;
+
+        private AcssDebit(
+            Map<String, Object> extraParams,
+            MandateOptions mandateOptions,
+            VerificationMethod verificationMethod) {
+          this.extraParams = extraParams;
+          this.mandateOptions = mandateOptions;
+          this.verificationMethod = verificationMethod;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Map<String, Object> extraParams;
+
+          private MandateOptions mandateOptions;
+
+          private VerificationMethod verificationMethod;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public AcssDebit build() {
+            return new AcssDebit(this.extraParams, this.mandateOptions, this.verificationMethod);
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.AcssDebit#extraParams} for the
+           * field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.AcssDebit#extraParams} for the
+           * field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /** Additional fields for Mandate creation. */
+          public Builder setMandateOptions(MandateOptions mandateOptions) {
+            this.mandateOptions = mandateOptions;
+            return this;
+          }
+
+          /** Verification method for the intent. */
+          public Builder setVerificationMethod(VerificationMethod verificationMethod) {
+            this.verificationMethod = verificationMethod;
+            return this;
+          }
+        }
+
+        @Getter
+        public static class MandateOptions {
+          /**
+           * Map of extra parameters for custom features not available in this client library. The
+           * content in this map is not serialized under this field's {@code @SerializedName} value.
+           * Instead, each key/value pair is serialized as if the key is a root-level field
+           * (serialized) name in this param object. Effectively, this map is flattened to its
+           * parent instance.
+           */
+          @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+          Map<String, Object> extraParams;
+
+          /** Transaction type of the mandate. */
+          @SerializedName("transaction_type")
+          TransactionType transactionType;
+
+          private MandateOptions(Map<String, Object> extraParams, TransactionType transactionType) {
+            this.extraParams = extraParams;
+            this.transactionType = transactionType;
+          }
+
+          public static Builder builder() {
+            return new Builder();
+          }
+
+          public static class Builder {
+            private Map<String, Object> extraParams;
+
+            private TransactionType transactionType;
+
+            /** Finalize and obtain parameter instance from this builder. */
+            public MandateOptions build() {
+              return new MandateOptions(this.extraParams, this.transactionType);
+            }
+
+            /**
+             * Add a key/value pair to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.AcssDebit.MandateOptions#extraParams}
+             * for the field documentation.
+             */
+            public Builder putExtraParam(String key, Object value) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.put(key, value);
+              return this;
+            }
+
+            /**
+             * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.AcssDebit.MandateOptions#extraParams}
+             * for the field documentation.
+             */
+            public Builder putAllExtraParam(Map<String, Object> map) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.putAll(map);
+              return this;
+            }
+
+            /** Transaction type of the mandate. */
+            public Builder setTransactionType(TransactionType transactionType) {
+              this.transactionType = transactionType;
+              return this;
+            }
+          }
+
+          public enum TransactionType implements ApiRequestParams.EnumParam {
+            @SerializedName("business")
+            BUSINESS("business"),
+
+            @SerializedName("personal")
+            PERSONAL("personal");
+
+            @Getter(onMethod_ = {@Override})
+            private final String value;
+
+            TransactionType(String value) {
+              this.value = value;
+            }
+          }
+        }
+
+        public enum VerificationMethod implements ApiRequestParams.EnumParam {
+          @SerializedName("automatic")
+          AUTOMATIC("automatic"),
+
+          @SerializedName("instant")
+          INSTANT("instant"),
+
+          @SerializedName("microdeposits")
+          MICRODEPOSITS("microdeposits");
+
+          @Getter(onMethod_ = {@Override})
+          private final String value;
+
+          VerificationMethod(String value) {
+            this.value = value;
+          }
         }
       }
 
@@ -1402,6 +1626,9 @@ public class InvoiceCreateParams extends ApiRequestParams {
 
       @SerializedName("ach_debit")
       ACH_DEBIT("ach_debit"),
+
+      @SerializedName("acss_debit")
+      ACSS_DEBIT("acss_debit"),
 
       @SerializedName("au_becs_debit")
       AU_BECS_DEBIT("au_becs_debit"),

--- a/src/main/java/com/stripe/param/InvoiceUpdateParams.java
+++ b/src/main/java/com/stripe/param/InvoiceUpdateParams.java
@@ -1161,6 +1161,13 @@ public class InvoiceUpdateParams extends ApiRequestParams {
     @Getter
     public static class PaymentMethodOptions {
       /**
+       * If paying by {@code acss_debit}, this sub-hash contains details about the Canadian
+       * pre-authorized debit payment method options to pass to the invoice’s PaymentIntent.
+       */
+      @SerializedName("acss_debit")
+      Object acssDebit;
+
+      /**
        * If paying by {@code bancontact}, this sub-hash contains details about the Bancontact
        * payment method options to pass to the invoice’s PaymentIntent.
        */
@@ -1184,7 +1191,8 @@ public class InvoiceUpdateParams extends ApiRequestParams {
       Map<String, Object> extraParams;
 
       private PaymentMethodOptions(
-          Object bancontact, Object card, Map<String, Object> extraParams) {
+          Object acssDebit, Object bancontact, Object card, Map<String, Object> extraParams) {
+        this.acssDebit = acssDebit;
         this.bancontact = bancontact;
         this.card = card;
         this.extraParams = extraParams;
@@ -1195,6 +1203,8 @@ public class InvoiceUpdateParams extends ApiRequestParams {
       }
 
       public static class Builder {
+        private Object acssDebit;
+
         private Object bancontact;
 
         private Object card;
@@ -1203,7 +1213,26 @@ public class InvoiceUpdateParams extends ApiRequestParams {
 
         /** Finalize and obtain parameter instance from this builder. */
         public PaymentMethodOptions build() {
-          return new PaymentMethodOptions(this.bancontact, this.card, this.extraParams);
+          return new PaymentMethodOptions(
+              this.acssDebit, this.bancontact, this.card, this.extraParams);
+        }
+
+        /**
+         * If paying by {@code acss_debit}, this sub-hash contains details about the Canadian
+         * pre-authorized debit payment method options to pass to the invoice’s PaymentIntent.
+         */
+        public Builder setAcssDebit(AcssDebit acssDebit) {
+          this.acssDebit = acssDebit;
+          return this;
+        }
+
+        /**
+         * If paying by {@code acss_debit}, this sub-hash contains details about the Canadian
+         * pre-authorized debit payment method options to pass to the invoice’s PaymentIntent.
+         */
+        public Builder setAcssDebit(EmptyParam acssDebit) {
+          this.acssDebit = acssDebit;
+          return this;
         }
 
         /**
@@ -1268,6 +1297,201 @@ public class InvoiceUpdateParams extends ApiRequestParams {
           }
           this.extraParams.putAll(map);
           return this;
+        }
+      }
+
+      @Getter
+      public static class AcssDebit {
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /** Additional fields for Mandate creation. */
+        @SerializedName("mandate_options")
+        MandateOptions mandateOptions;
+
+        /** Verification method for the intent. */
+        @SerializedName("verification_method")
+        VerificationMethod verificationMethod;
+
+        private AcssDebit(
+            Map<String, Object> extraParams,
+            MandateOptions mandateOptions,
+            VerificationMethod verificationMethod) {
+          this.extraParams = extraParams;
+          this.mandateOptions = mandateOptions;
+          this.verificationMethod = verificationMethod;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Map<String, Object> extraParams;
+
+          private MandateOptions mandateOptions;
+
+          private VerificationMethod verificationMethod;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public AcssDebit build() {
+            return new AcssDebit(this.extraParams, this.mandateOptions, this.verificationMethod);
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.AcssDebit#extraParams} for the
+           * field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.AcssDebit#extraParams} for the
+           * field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /** Additional fields for Mandate creation. */
+          public Builder setMandateOptions(MandateOptions mandateOptions) {
+            this.mandateOptions = mandateOptions;
+            return this;
+          }
+
+          /** Verification method for the intent. */
+          public Builder setVerificationMethod(VerificationMethod verificationMethod) {
+            this.verificationMethod = verificationMethod;
+            return this;
+          }
+        }
+
+        @Getter
+        public static class MandateOptions {
+          /**
+           * Map of extra parameters for custom features not available in this client library. The
+           * content in this map is not serialized under this field's {@code @SerializedName} value.
+           * Instead, each key/value pair is serialized as if the key is a root-level field
+           * (serialized) name in this param object. Effectively, this map is flattened to its
+           * parent instance.
+           */
+          @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+          Map<String, Object> extraParams;
+
+          /** Transaction type of the mandate. */
+          @SerializedName("transaction_type")
+          TransactionType transactionType;
+
+          private MandateOptions(Map<String, Object> extraParams, TransactionType transactionType) {
+            this.extraParams = extraParams;
+            this.transactionType = transactionType;
+          }
+
+          public static Builder builder() {
+            return new Builder();
+          }
+
+          public static class Builder {
+            private Map<String, Object> extraParams;
+
+            private TransactionType transactionType;
+
+            /** Finalize and obtain parameter instance from this builder. */
+            public MandateOptions build() {
+              return new MandateOptions(this.extraParams, this.transactionType);
+            }
+
+            /**
+             * Add a key/value pair to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.AcssDebit.MandateOptions#extraParams}
+             * for the field documentation.
+             */
+            public Builder putExtraParam(String key, Object value) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.put(key, value);
+              return this;
+            }
+
+            /**
+             * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.AcssDebit.MandateOptions#extraParams}
+             * for the field documentation.
+             */
+            public Builder putAllExtraParam(Map<String, Object> map) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.putAll(map);
+              return this;
+            }
+
+            /** Transaction type of the mandate. */
+            public Builder setTransactionType(TransactionType transactionType) {
+              this.transactionType = transactionType;
+              return this;
+            }
+          }
+
+          public enum TransactionType implements ApiRequestParams.EnumParam {
+            @SerializedName("business")
+            BUSINESS("business"),
+
+            @SerializedName("personal")
+            PERSONAL("personal");
+
+            @Getter(onMethod_ = {@Override})
+            private final String value;
+
+            TransactionType(String value) {
+              this.value = value;
+            }
+          }
+        }
+
+        public enum VerificationMethod implements ApiRequestParams.EnumParam {
+          @SerializedName("automatic")
+          AUTOMATIC("automatic"),
+
+          @SerializedName("instant")
+          INSTANT("instant"),
+
+          @SerializedName("microdeposits")
+          MICRODEPOSITS("microdeposits");
+
+          @Getter(onMethod_ = {@Override})
+          private final String value;
+
+          VerificationMethod(String value) {
+            this.value = value;
+          }
         }
       }
 
@@ -1484,6 +1708,9 @@ public class InvoiceUpdateParams extends ApiRequestParams {
 
       @SerializedName("ach_debit")
       ACH_DEBIT("ach_debit"),
+
+      @SerializedName("acss_debit")
+      ACSS_DEBIT("acss_debit"),
 
       @SerializedName("au_becs_debit")
       AU_BECS_DEBIT("au_becs_debit"),

--- a/src/main/java/com/stripe/param/SetupIntentConfirmParams.java
+++ b/src/main/java/com/stripe/param/SetupIntentConfirmParams.java
@@ -766,6 +766,10 @@ public class SetupIntentConfirmParams extends ApiRequestParams {
         @SerializedName("custom_mandate_url")
         Object customMandateUrl;
 
+        /** List of Stripe products where this mandate can be selected automatically. */
+        @SerializedName("default_for")
+        List<DefaultFor> defaultFor;
+
         /**
          * Map of extra parameters for custom features not available in this client library. The
          * content in this map is not serialized under this field's {@code @SerializedName} value.
@@ -793,11 +797,13 @@ public class SetupIntentConfirmParams extends ApiRequestParams {
 
         private MandateOptions(
             Object customMandateUrl,
+            List<DefaultFor> defaultFor,
             Map<String, Object> extraParams,
             String intervalDescription,
             PaymentSchedule paymentSchedule,
             TransactionType transactionType) {
           this.customMandateUrl = customMandateUrl;
+          this.defaultFor = defaultFor;
           this.extraParams = extraParams;
           this.intervalDescription = intervalDescription;
           this.paymentSchedule = paymentSchedule;
@@ -811,6 +817,8 @@ public class SetupIntentConfirmParams extends ApiRequestParams {
         public static class Builder {
           private Object customMandateUrl;
 
+          private List<DefaultFor> defaultFor;
+
           private Map<String, Object> extraParams;
 
           private String intervalDescription;
@@ -823,6 +831,7 @@ public class SetupIntentConfirmParams extends ApiRequestParams {
           public MandateOptions build() {
             return new MandateOptions(
                 this.customMandateUrl,
+                this.defaultFor,
                 this.extraParams,
                 this.intervalDescription,
                 this.paymentSchedule,
@@ -848,6 +857,34 @@ public class SetupIntentConfirmParams extends ApiRequestParams {
            */
           public Builder setCustomMandateUrl(EmptyParam customMandateUrl) {
             this.customMandateUrl = customMandateUrl;
+            return this;
+          }
+
+          /**
+           * Add an element to `defaultFor` list. A list is initialized for the first `add/addAll`
+           * call, and subsequent calls adds additional elements to the original list. See {@link
+           * SetupIntentConfirmParams.PaymentMethodOptions.AcssDebit.MandateOptions#defaultFor} for
+           * the field documentation.
+           */
+          public Builder addDefaultFor(DefaultFor element) {
+            if (this.defaultFor == null) {
+              this.defaultFor = new ArrayList<>();
+            }
+            this.defaultFor.add(element);
+            return this;
+          }
+
+          /**
+           * Add all elements to `defaultFor` list. A list is initialized for the first `add/addAll`
+           * call, and subsequent calls adds additional elements to the original list. See {@link
+           * SetupIntentConfirmParams.PaymentMethodOptions.AcssDebit.MandateOptions#defaultFor} for
+           * the field documentation.
+           */
+          public Builder addAllDefaultFor(List<DefaultFor> elements) {
+            if (this.defaultFor == null) {
+              this.defaultFor = new ArrayList<>();
+            }
+            this.defaultFor.addAll(elements);
             return this;
           }
 
@@ -900,6 +937,21 @@ public class SetupIntentConfirmParams extends ApiRequestParams {
           public Builder setTransactionType(TransactionType transactionType) {
             this.transactionType = transactionType;
             return this;
+          }
+        }
+
+        public enum DefaultFor implements ApiRequestParams.EnumParam {
+          @SerializedName("invoice")
+          INVOICE("invoice"),
+
+          @SerializedName("subscription")
+          SUBSCRIPTION("subscription");
+
+          @Getter(onMethod_ = {@Override})
+          private final String value;
+
+          DefaultFor(String value) {
+            this.value = value;
           }
         }
 

--- a/src/main/java/com/stripe/param/SetupIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/SetupIntentCreateParams.java
@@ -971,6 +971,10 @@ public class SetupIntentCreateParams extends ApiRequestParams {
         @SerializedName("custom_mandate_url")
         Object customMandateUrl;
 
+        /** List of Stripe products where this mandate can be selected automatically. */
+        @SerializedName("default_for")
+        List<DefaultFor> defaultFor;
+
         /**
          * Map of extra parameters for custom features not available in this client library. The
          * content in this map is not serialized under this field's {@code @SerializedName} value.
@@ -998,11 +1002,13 @@ public class SetupIntentCreateParams extends ApiRequestParams {
 
         private MandateOptions(
             Object customMandateUrl,
+            List<DefaultFor> defaultFor,
             Map<String, Object> extraParams,
             String intervalDescription,
             PaymentSchedule paymentSchedule,
             TransactionType transactionType) {
           this.customMandateUrl = customMandateUrl;
+          this.defaultFor = defaultFor;
           this.extraParams = extraParams;
           this.intervalDescription = intervalDescription;
           this.paymentSchedule = paymentSchedule;
@@ -1016,6 +1022,8 @@ public class SetupIntentCreateParams extends ApiRequestParams {
         public static class Builder {
           private Object customMandateUrl;
 
+          private List<DefaultFor> defaultFor;
+
           private Map<String, Object> extraParams;
 
           private String intervalDescription;
@@ -1028,6 +1036,7 @@ public class SetupIntentCreateParams extends ApiRequestParams {
           public MandateOptions build() {
             return new MandateOptions(
                 this.customMandateUrl,
+                this.defaultFor,
                 this.extraParams,
                 this.intervalDescription,
                 this.paymentSchedule,
@@ -1053,6 +1062,34 @@ public class SetupIntentCreateParams extends ApiRequestParams {
            */
           public Builder setCustomMandateUrl(EmptyParam customMandateUrl) {
             this.customMandateUrl = customMandateUrl;
+            return this;
+          }
+
+          /**
+           * Add an element to `defaultFor` list. A list is initialized for the first `add/addAll`
+           * call, and subsequent calls adds additional elements to the original list. See {@link
+           * SetupIntentCreateParams.PaymentMethodOptions.AcssDebit.MandateOptions#defaultFor} for
+           * the field documentation.
+           */
+          public Builder addDefaultFor(DefaultFor element) {
+            if (this.defaultFor == null) {
+              this.defaultFor = new ArrayList<>();
+            }
+            this.defaultFor.add(element);
+            return this;
+          }
+
+          /**
+           * Add all elements to `defaultFor` list. A list is initialized for the first `add/addAll`
+           * call, and subsequent calls adds additional elements to the original list. See {@link
+           * SetupIntentCreateParams.PaymentMethodOptions.AcssDebit.MandateOptions#defaultFor} for
+           * the field documentation.
+           */
+          public Builder addAllDefaultFor(List<DefaultFor> elements) {
+            if (this.defaultFor == null) {
+              this.defaultFor = new ArrayList<>();
+            }
+            this.defaultFor.addAll(elements);
             return this;
           }
 
@@ -1105,6 +1142,21 @@ public class SetupIntentCreateParams extends ApiRequestParams {
           public Builder setTransactionType(TransactionType transactionType) {
             this.transactionType = transactionType;
             return this;
+          }
+        }
+
+        public enum DefaultFor implements ApiRequestParams.EnumParam {
+          @SerializedName("invoice")
+          INVOICE("invoice"),
+
+          @SerializedName("subscription")
+          SUBSCRIPTION("subscription");
+
+          @Getter(onMethod_ = {@Override})
+          private final String value;
+
+          DefaultFor(String value) {
+            this.value = value;
           }
         }
 

--- a/src/main/java/com/stripe/param/SetupIntentUpdateParams.java
+++ b/src/main/java/com/stripe/param/SetupIntentUpdateParams.java
@@ -534,6 +534,10 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
         @SerializedName("custom_mandate_url")
         Object customMandateUrl;
 
+        /** List of Stripe products where this mandate can be selected automatically. */
+        @SerializedName("default_for")
+        List<DefaultFor> defaultFor;
+
         /**
          * Map of extra parameters for custom features not available in this client library. The
          * content in this map is not serialized under this field's {@code @SerializedName} value.
@@ -561,11 +565,13 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
 
         private MandateOptions(
             Object customMandateUrl,
+            List<DefaultFor> defaultFor,
             Map<String, Object> extraParams,
             Object intervalDescription,
             PaymentSchedule paymentSchedule,
             TransactionType transactionType) {
           this.customMandateUrl = customMandateUrl;
+          this.defaultFor = defaultFor;
           this.extraParams = extraParams;
           this.intervalDescription = intervalDescription;
           this.paymentSchedule = paymentSchedule;
@@ -579,6 +585,8 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
         public static class Builder {
           private Object customMandateUrl;
 
+          private List<DefaultFor> defaultFor;
+
           private Map<String, Object> extraParams;
 
           private Object intervalDescription;
@@ -591,6 +599,7 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
           public MandateOptions build() {
             return new MandateOptions(
                 this.customMandateUrl,
+                this.defaultFor,
                 this.extraParams,
                 this.intervalDescription,
                 this.paymentSchedule,
@@ -616,6 +625,34 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
            */
           public Builder setCustomMandateUrl(EmptyParam customMandateUrl) {
             this.customMandateUrl = customMandateUrl;
+            return this;
+          }
+
+          /**
+           * Add an element to `defaultFor` list. A list is initialized for the first `add/addAll`
+           * call, and subsequent calls adds additional elements to the original list. See {@link
+           * SetupIntentUpdateParams.PaymentMethodOptions.AcssDebit.MandateOptions#defaultFor} for
+           * the field documentation.
+           */
+          public Builder addDefaultFor(DefaultFor element) {
+            if (this.defaultFor == null) {
+              this.defaultFor = new ArrayList<>();
+            }
+            this.defaultFor.add(element);
+            return this;
+          }
+
+          /**
+           * Add all elements to `defaultFor` list. A list is initialized for the first `add/addAll`
+           * call, and subsequent calls adds additional elements to the original list. See {@link
+           * SetupIntentUpdateParams.PaymentMethodOptions.AcssDebit.MandateOptions#defaultFor} for
+           * the field documentation.
+           */
+          public Builder addAllDefaultFor(List<DefaultFor> elements) {
+            if (this.defaultFor == null) {
+              this.defaultFor = new ArrayList<>();
+            }
+            this.defaultFor.addAll(elements);
             return this;
           }
 
@@ -677,6 +714,21 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
           public Builder setTransactionType(TransactionType transactionType) {
             this.transactionType = transactionType;
             return this;
+          }
+        }
+
+        public enum DefaultFor implements ApiRequestParams.EnumParam {
+          @SerializedName("invoice")
+          INVOICE("invoice"),
+
+          @SerializedName("subscription")
+          SUBSCRIPTION("subscription");
+
+          @Getter(onMethod_ = {@Override})
+          private final String value;
+
+          DefaultFor(String value) {
+            this.value = value;
           }
         }
 

--- a/src/main/java/com/stripe/param/SubscriptionCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionCreateParams.java
@@ -2190,6 +2190,13 @@ public class SubscriptionCreateParams extends ApiRequestParams {
     @Getter
     public static class PaymentMethodOptions {
       /**
+       * This sub-hash contains details about the Canadian pre-authorized debit payment method
+       * options to pass to the invoice’s PaymentIntent.
+       */
+      @SerializedName("acss_debit")
+      Object acssDebit;
+
+      /**
        * This sub-hash contains details about the Bancontact payment method options to pass to the
        * invoice’s PaymentIntent.
        */
@@ -2213,7 +2220,8 @@ public class SubscriptionCreateParams extends ApiRequestParams {
       Map<String, Object> extraParams;
 
       private PaymentMethodOptions(
-          Object bancontact, Object card, Map<String, Object> extraParams) {
+          Object acssDebit, Object bancontact, Object card, Map<String, Object> extraParams) {
+        this.acssDebit = acssDebit;
         this.bancontact = bancontact;
         this.card = card;
         this.extraParams = extraParams;
@@ -2224,6 +2232,8 @@ public class SubscriptionCreateParams extends ApiRequestParams {
       }
 
       public static class Builder {
+        private Object acssDebit;
+
         private Object bancontact;
 
         private Object card;
@@ -2232,7 +2242,26 @@ public class SubscriptionCreateParams extends ApiRequestParams {
 
         /** Finalize and obtain parameter instance from this builder. */
         public PaymentMethodOptions build() {
-          return new PaymentMethodOptions(this.bancontact, this.card, this.extraParams);
+          return new PaymentMethodOptions(
+              this.acssDebit, this.bancontact, this.card, this.extraParams);
+        }
+
+        /**
+         * This sub-hash contains details about the Canadian pre-authorized debit payment method
+         * options to pass to the invoice’s PaymentIntent.
+         */
+        public Builder setAcssDebit(AcssDebit acssDebit) {
+          this.acssDebit = acssDebit;
+          return this;
+        }
+
+        /**
+         * This sub-hash contains details about the Canadian pre-authorized debit payment method
+         * options to pass to the invoice’s PaymentIntent.
+         */
+        public Builder setAcssDebit(EmptyParam acssDebit) {
+          this.acssDebit = acssDebit;
+          return this;
         }
 
         /**
@@ -2299,6 +2328,201 @@ public class SubscriptionCreateParams extends ApiRequestParams {
           }
           this.extraParams.putAll(map);
           return this;
+        }
+      }
+
+      @Getter
+      public static class AcssDebit {
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /** Additional fields for Mandate creation. */
+        @SerializedName("mandate_options")
+        MandateOptions mandateOptions;
+
+        /** Verification method for the intent. */
+        @SerializedName("verification_method")
+        VerificationMethod verificationMethod;
+
+        private AcssDebit(
+            Map<String, Object> extraParams,
+            MandateOptions mandateOptions,
+            VerificationMethod verificationMethod) {
+          this.extraParams = extraParams;
+          this.mandateOptions = mandateOptions;
+          this.verificationMethod = verificationMethod;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Map<String, Object> extraParams;
+
+          private MandateOptions mandateOptions;
+
+          private VerificationMethod verificationMethod;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public AcssDebit build() {
+            return new AcssDebit(this.extraParams, this.mandateOptions, this.verificationMethod);
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.AcssDebit#extraParams}
+           * for the field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.AcssDebit#extraParams}
+           * for the field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /** Additional fields for Mandate creation. */
+          public Builder setMandateOptions(MandateOptions mandateOptions) {
+            this.mandateOptions = mandateOptions;
+            return this;
+          }
+
+          /** Verification method for the intent. */
+          public Builder setVerificationMethod(VerificationMethod verificationMethod) {
+            this.verificationMethod = verificationMethod;
+            return this;
+          }
+        }
+
+        @Getter
+        public static class MandateOptions {
+          /**
+           * Map of extra parameters for custom features not available in this client library. The
+           * content in this map is not serialized under this field's {@code @SerializedName} value.
+           * Instead, each key/value pair is serialized as if the key is a root-level field
+           * (serialized) name in this param object. Effectively, this map is flattened to its
+           * parent instance.
+           */
+          @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+          Map<String, Object> extraParams;
+
+          /** Transaction type of the mandate. */
+          @SerializedName("transaction_type")
+          TransactionType transactionType;
+
+          private MandateOptions(Map<String, Object> extraParams, TransactionType transactionType) {
+            this.extraParams = extraParams;
+            this.transactionType = transactionType;
+          }
+
+          public static Builder builder() {
+            return new Builder();
+          }
+
+          public static class Builder {
+            private Map<String, Object> extraParams;
+
+            private TransactionType transactionType;
+
+            /** Finalize and obtain parameter instance from this builder. */
+            public MandateOptions build() {
+              return new MandateOptions(this.extraParams, this.transactionType);
+            }
+
+            /**
+             * Add a key/value pair to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.AcssDebit.MandateOptions#extraParams}
+             * for the field documentation.
+             */
+            public Builder putExtraParam(String key, Object value) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.put(key, value);
+              return this;
+            }
+
+            /**
+             * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.AcssDebit.MandateOptions#extraParams}
+             * for the field documentation.
+             */
+            public Builder putAllExtraParam(Map<String, Object> map) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.putAll(map);
+              return this;
+            }
+
+            /** Transaction type of the mandate. */
+            public Builder setTransactionType(TransactionType transactionType) {
+              this.transactionType = transactionType;
+              return this;
+            }
+          }
+
+          public enum TransactionType implements ApiRequestParams.EnumParam {
+            @SerializedName("business")
+            BUSINESS("business"),
+
+            @SerializedName("personal")
+            PERSONAL("personal");
+
+            @Getter(onMethod_ = {@Override})
+            private final String value;
+
+            TransactionType(String value) {
+              this.value = value;
+            }
+          }
+        }
+
+        public enum VerificationMethod implements ApiRequestParams.EnumParam {
+          @SerializedName("automatic")
+          AUTOMATIC("automatic"),
+
+          @SerializedName("instant")
+          INSTANT("instant"),
+
+          @SerializedName("microdeposits")
+          MICRODEPOSITS("microdeposits");
+
+          @Getter(onMethod_ = {@Override})
+          private final String value;
+
+          VerificationMethod(String value) {
+            this.value = value;
+          }
         }
       }
 
@@ -2515,6 +2739,9 @@ public class SubscriptionCreateParams extends ApiRequestParams {
 
       @SerializedName("ach_debit")
       ACH_DEBIT("ach_debit"),
+
+      @SerializedName("acss_debit")
+      ACSS_DEBIT("acss_debit"),
 
       @SerializedName("au_becs_debit")
       AU_BECS_DEBIT("au_becs_debit"),

--- a/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
@@ -2520,6 +2520,13 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
     @Getter
     public static class PaymentMethodOptions {
       /**
+       * This sub-hash contains details about the Canadian pre-authorized debit payment method
+       * options to pass to the invoice’s PaymentIntent.
+       */
+      @SerializedName("acss_debit")
+      Object acssDebit;
+
+      /**
        * This sub-hash contains details about the Bancontact payment method options to pass to the
        * invoice’s PaymentIntent.
        */
@@ -2543,7 +2550,8 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
       Map<String, Object> extraParams;
 
       private PaymentMethodOptions(
-          Object bancontact, Object card, Map<String, Object> extraParams) {
+          Object acssDebit, Object bancontact, Object card, Map<String, Object> extraParams) {
+        this.acssDebit = acssDebit;
         this.bancontact = bancontact;
         this.card = card;
         this.extraParams = extraParams;
@@ -2554,6 +2562,8 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
       }
 
       public static class Builder {
+        private Object acssDebit;
+
         private Object bancontact;
 
         private Object card;
@@ -2562,7 +2572,26 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
 
         /** Finalize and obtain parameter instance from this builder. */
         public PaymentMethodOptions build() {
-          return new PaymentMethodOptions(this.bancontact, this.card, this.extraParams);
+          return new PaymentMethodOptions(
+              this.acssDebit, this.bancontact, this.card, this.extraParams);
+        }
+
+        /**
+         * This sub-hash contains details about the Canadian pre-authorized debit payment method
+         * options to pass to the invoice’s PaymentIntent.
+         */
+        public Builder setAcssDebit(AcssDebit acssDebit) {
+          this.acssDebit = acssDebit;
+          return this;
+        }
+
+        /**
+         * This sub-hash contains details about the Canadian pre-authorized debit payment method
+         * options to pass to the invoice’s PaymentIntent.
+         */
+        public Builder setAcssDebit(EmptyParam acssDebit) {
+          this.acssDebit = acssDebit;
+          return this;
         }
 
         /**
@@ -2629,6 +2658,201 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
           }
           this.extraParams.putAll(map);
           return this;
+        }
+      }
+
+      @Getter
+      public static class AcssDebit {
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /** Additional fields for Mandate creation. */
+        @SerializedName("mandate_options")
+        MandateOptions mandateOptions;
+
+        /** Verification method for the intent. */
+        @SerializedName("verification_method")
+        VerificationMethod verificationMethod;
+
+        private AcssDebit(
+            Map<String, Object> extraParams,
+            MandateOptions mandateOptions,
+            VerificationMethod verificationMethod) {
+          this.extraParams = extraParams;
+          this.mandateOptions = mandateOptions;
+          this.verificationMethod = verificationMethod;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Map<String, Object> extraParams;
+
+          private MandateOptions mandateOptions;
+
+          private VerificationMethod verificationMethod;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public AcssDebit build() {
+            return new AcssDebit(this.extraParams, this.mandateOptions, this.verificationMethod);
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.AcssDebit#extraParams}
+           * for the field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.AcssDebit#extraParams}
+           * for the field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /** Additional fields for Mandate creation. */
+          public Builder setMandateOptions(MandateOptions mandateOptions) {
+            this.mandateOptions = mandateOptions;
+            return this;
+          }
+
+          /** Verification method for the intent. */
+          public Builder setVerificationMethod(VerificationMethod verificationMethod) {
+            this.verificationMethod = verificationMethod;
+            return this;
+          }
+        }
+
+        @Getter
+        public static class MandateOptions {
+          /**
+           * Map of extra parameters for custom features not available in this client library. The
+           * content in this map is not serialized under this field's {@code @SerializedName} value.
+           * Instead, each key/value pair is serialized as if the key is a root-level field
+           * (serialized) name in this param object. Effectively, this map is flattened to its
+           * parent instance.
+           */
+          @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+          Map<String, Object> extraParams;
+
+          /** Transaction type of the mandate. */
+          @SerializedName("transaction_type")
+          TransactionType transactionType;
+
+          private MandateOptions(Map<String, Object> extraParams, TransactionType transactionType) {
+            this.extraParams = extraParams;
+            this.transactionType = transactionType;
+          }
+
+          public static Builder builder() {
+            return new Builder();
+          }
+
+          public static class Builder {
+            private Map<String, Object> extraParams;
+
+            private TransactionType transactionType;
+
+            /** Finalize and obtain parameter instance from this builder. */
+            public MandateOptions build() {
+              return new MandateOptions(this.extraParams, this.transactionType);
+            }
+
+            /**
+             * Add a key/value pair to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.AcssDebit.MandateOptions#extraParams}
+             * for the field documentation.
+             */
+            public Builder putExtraParam(String key, Object value) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.put(key, value);
+              return this;
+            }
+
+            /**
+             * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.AcssDebit.MandateOptions#extraParams}
+             * for the field documentation.
+             */
+            public Builder putAllExtraParam(Map<String, Object> map) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.putAll(map);
+              return this;
+            }
+
+            /** Transaction type of the mandate. */
+            public Builder setTransactionType(TransactionType transactionType) {
+              this.transactionType = transactionType;
+              return this;
+            }
+          }
+
+          public enum TransactionType implements ApiRequestParams.EnumParam {
+            @SerializedName("business")
+            BUSINESS("business"),
+
+            @SerializedName("personal")
+            PERSONAL("personal");
+
+            @Getter(onMethod_ = {@Override})
+            private final String value;
+
+            TransactionType(String value) {
+              this.value = value;
+            }
+          }
+        }
+
+        public enum VerificationMethod implements ApiRequestParams.EnumParam {
+          @SerializedName("automatic")
+          AUTOMATIC("automatic"),
+
+          @SerializedName("instant")
+          INSTANT("instant"),
+
+          @SerializedName("microdeposits")
+          MICRODEPOSITS("microdeposits");
+
+          @Getter(onMethod_ = {@Override})
+          private final String value;
+
+          VerificationMethod(String value) {
+            this.value = value;
+          }
         }
       }
 
@@ -2845,6 +3069,9 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
 
       @SerializedName("ach_debit")
       ACH_DEBIT("ach_debit"),
+
+      @SerializedName("acss_debit")
+      ACSS_DEBIT("acss_debit"),
 
       @SerializedName("au_becs_debit")
       AU_BECS_DEBIT("au_becs_debit"),

--- a/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
+++ b/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
@@ -3338,6 +3338,13 @@ public class SessionCreateParams extends ApiRequestParams {
         Object customMandateUrl;
 
         /**
+         * List of Stripe products where this mandate can be selected automatically. Only usable in
+         * {@code setup} mode.
+         */
+        @SerializedName("default_for")
+        List<DefaultFor> defaultFor;
+
+        /**
          * Map of extra parameters for custom features not available in this client library. The
          * content in this map is not serialized under this field's {@code @SerializedName} value.
          * Instead, each key/value pair is serialized as if the key is a root-level field
@@ -3364,11 +3371,13 @@ public class SessionCreateParams extends ApiRequestParams {
 
         private MandateOptions(
             Object customMandateUrl,
+            List<DefaultFor> defaultFor,
             Map<String, Object> extraParams,
             String intervalDescription,
             PaymentSchedule paymentSchedule,
             TransactionType transactionType) {
           this.customMandateUrl = customMandateUrl;
+          this.defaultFor = defaultFor;
           this.extraParams = extraParams;
           this.intervalDescription = intervalDescription;
           this.paymentSchedule = paymentSchedule;
@@ -3382,6 +3391,8 @@ public class SessionCreateParams extends ApiRequestParams {
         public static class Builder {
           private Object customMandateUrl;
 
+          private List<DefaultFor> defaultFor;
+
           private Map<String, Object> extraParams;
 
           private String intervalDescription;
@@ -3394,6 +3405,7 @@ public class SessionCreateParams extends ApiRequestParams {
           public MandateOptions build() {
             return new MandateOptions(
                 this.customMandateUrl,
+                this.defaultFor,
                 this.extraParams,
                 this.intervalDescription,
                 this.paymentSchedule,
@@ -3419,6 +3431,34 @@ public class SessionCreateParams extends ApiRequestParams {
            */
           public Builder setCustomMandateUrl(EmptyParam customMandateUrl) {
             this.customMandateUrl = customMandateUrl;
+            return this;
+          }
+
+          /**
+           * Add an element to `defaultFor` list. A list is initialized for the first `add/addAll`
+           * call, and subsequent calls adds additional elements to the original list. See {@link
+           * SessionCreateParams.PaymentMethodOptions.AcssDebit.MandateOptions#defaultFor} for the
+           * field documentation.
+           */
+          public Builder addDefaultFor(DefaultFor element) {
+            if (this.defaultFor == null) {
+              this.defaultFor = new ArrayList<>();
+            }
+            this.defaultFor.add(element);
+            return this;
+          }
+
+          /**
+           * Add all elements to `defaultFor` list. A list is initialized for the first `add/addAll`
+           * call, and subsequent calls adds additional elements to the original list. See {@link
+           * SessionCreateParams.PaymentMethodOptions.AcssDebit.MandateOptions#defaultFor} for the
+           * field documentation.
+           */
+          public Builder addAllDefaultFor(List<DefaultFor> elements) {
+            if (this.defaultFor == null) {
+              this.defaultFor = new ArrayList<>();
+            }
+            this.defaultFor.addAll(elements);
             return this;
           }
 
@@ -3471,6 +3511,21 @@ public class SessionCreateParams extends ApiRequestParams {
           public Builder setTransactionType(TransactionType transactionType) {
             this.transactionType = transactionType;
             return this;
+          }
+        }
+
+        public enum DefaultFor implements ApiRequestParams.EnumParam {
+          @SerializedName("invoice")
+          INVOICE("invoice"),
+
+          @SerializedName("subscription")
+          SUBSCRIPTION("subscription");
+
+          @Getter(onMethod_ = {@Override})
+          private final String value;
+
+          DefaultFor(String value) {
+            this.value = value;
           }
         }
 


### PR DESCRIPTION
Codegen for openapi 95a1ab8.
r? @dcr-stripe
cc @stripe/api-libraries

## Changelog
* Add support for `default_for` on `CheckoutSessionCreateParams.payment_method_options.acss_debit.mandate_options`, `Checkout.Session.payment_method_options.acss_debit.mandate_options`, `Mandate.payment_method_details.acss_debit`, `SetupIntentCreateParams.payment_method_options.acss_debit.mandate_options`, `SetupIntentUpdateParams.payment_method_options.acss_debit.mandate_options`, `SetupIntentConfirmParams.payment_method_options.acss_debit.mandate_options`, and `SetupIntent.payment_method_options.acss_debit.mandate_options`
* Add support for `acss_debit` on `InvoiceCreateParams.payment_settings.payment_method_options`, `InvoiceUpdateParams.payment_settings.payment_method_options`, `Invoice.payment_settings.payment_method_options`, `SubscriptionCreateParams.payment_settings.payment_method_options`, `SubscriptionUpdateParams.payment_settings.payment_method_options`, and `Subscription.payment_settings.payment_method_options`
* Add support for new value `acss_debit` on enums `InvoiceCreateParams.payment_settings.payment_method_types[]`, `InvoiceUpdateParams.payment_settings.payment_method_types[]`, `SubscriptionCreateParams.payment_settings.payment_method_types[]`, and `SubscriptionUpdateParams.payment_settings.payment_method_types[]`
* Add support for `livemode` on `Reporting.ReportType`

