### PR TITLE
search-beta: API Updates

### DIFF
--- a/src/main/java/com/stripe/model/PaymentIntent.java
+++ b/src/main/java/com/stripe/model/PaymentIntent.java
@@ -1058,7 +1058,8 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
    * Search for PaymentIntents you’ve previously created using Stripe’s <a
    * href="https://stripe.com/docs/search-api#search-query-language">Search Query Language</a>.
    */
-  public PaymentIntentSearchResult search(Map<String, Object> params) throws StripeException {
+  public static PaymentIntentSearchResult search(Map<String, Object> params)
+      throws StripeException {
     return search(params, (RequestOptions) null);
   }
 
@@ -1066,7 +1067,7 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
    * Search for PaymentIntents you’ve previously created using Stripe’s <a
    * href="https://stripe.com/docs/search-api#search-query-language">Search Query Language</a>.
    */
-  public PaymentIntentSearchResult search(Map<String, Object> params, RequestOptions options)
+  public static PaymentIntentSearchResult search(Map<String, Object> params, RequestOptions options)
       throws StripeException {
     String url = String.format("%s%s", Stripe.getApiBase(), "/v1/search/payment_intents");
     return ApiResource.requestSearchResult(url, params, PaymentIntentSearchResult.class, options);
@@ -1076,7 +1077,8 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
    * Search for PaymentIntents you’ve previously created using Stripe’s <a
    * href="https://stripe.com/docs/search-api#search-query-language">Search Query Language</a>.
    */
-  public PaymentIntentSearchResult search(PaymentIntentSearchParams params) throws StripeException {
+  public static PaymentIntentSearchResult search(PaymentIntentSearchParams params)
+      throws StripeException {
     return search(params, (RequestOptions) null);
   }
 
@@ -1084,8 +1086,8 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
    * Search for PaymentIntents you’ve previously created using Stripe’s <a
    * href="https://stripe.com/docs/search-api#search-query-language">Search Query Language</a>.
    */
-  public PaymentIntentSearchResult search(PaymentIntentSearchParams params, RequestOptions options)
-      throws StripeException {
+  public static PaymentIntentSearchResult search(
+      PaymentIntentSearchParams params, RequestOptions options) throws StripeException {
     String url = String.format("%s%s", Stripe.getApiBase(), "/v1/search/payment_intents");
     return ApiResource.requestSearchResult(url, params, PaymentIntentSearchResult.class, options);
   }

--- a/src/main/java/com/stripe/model/Price.java
+++ b/src/main/java/com/stripe/model/Price.java
@@ -9,6 +9,7 @@ import com.stripe.net.RequestOptions;
 import com.stripe.param.PriceCreateParams;
 import com.stripe.param.PriceListParams;
 import com.stripe.param.PriceRetrieveParams;
+import com.stripe.param.PriceSearchParams;
 import com.stripe.param.PriceUpdateParams;
 import java.math.BigDecimal;
 import java.util.List;
@@ -291,6 +292,42 @@ public class Price extends ApiResource implements HasId, MetadataStore<Price> {
             Stripe.getApiBase(),
             String.format("/v1/prices/%s", ApiResource.urlEncodeId(this.getId())));
     return ApiResource.request(ApiResource.RequestMethod.POST, url, params, Price.class, options);
+  }
+
+  /**
+   * Search for prices you’ve previously created using Stripe’s <a
+   * href="https://stripe.com/docs/search-api#search-query-language">Search Query Language</a>.
+   */
+  public static PriceSearchResult search(Map<String, Object> params) throws StripeException {
+    return search(params, (RequestOptions) null);
+  }
+
+  /**
+   * Search for prices you’ve previously created using Stripe’s <a
+   * href="https://stripe.com/docs/search-api#search-query-language">Search Query Language</a>.
+   */
+  public static PriceSearchResult search(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/search/prices");
+    return ApiResource.requestSearchResult(url, params, PriceSearchResult.class, options);
+  }
+
+  /**
+   * Search for prices you’ve previously created using Stripe’s <a
+   * href="https://stripe.com/docs/search-api#search-query-language">Search Query Language</a>.
+   */
+  public static PriceSearchResult search(PriceSearchParams params) throws StripeException {
+    return search(params, (RequestOptions) null);
+  }
+
+  /**
+   * Search for prices you’ve previously created using Stripe’s <a
+   * href="https://stripe.com/docs/search-api#search-query-language">Search Query Language</a>.
+   */
+  public static PriceSearchResult search(PriceSearchParams params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/search/prices");
+    return ApiResource.requestSearchResult(url, params, PriceSearchResult.class, options);
   }
 
   @Getter

--- a/src/main/java/com/stripe/model/PriceSearchResult.java
+++ b/src/main/java/com/stripe/model/PriceSearchResult.java
@@ -1,0 +1,4 @@
+// File generated from our OpenAPI spec
+package com.stripe.model;
+
+public class PriceSearchResult extends StripeSearchResult<Price> {}

--- a/src/main/java/com/stripe/model/Product.java
+++ b/src/main/java/com/stripe/model/Product.java
@@ -9,6 +9,7 @@ import com.stripe.net.RequestOptions;
 import com.stripe.param.ProductCreateParams;
 import com.stripe.param.ProductListParams;
 import com.stripe.param.ProductRetrieveParams;
+import com.stripe.param.ProductSearchParams;
 import com.stripe.param.ProductUpdateParams;
 import java.util.List;
 import java.util.Map;
@@ -356,5 +357,41 @@ public class Product extends ApiResource implements HasId, MetadataStore<Product
             String.format("/v1/products/%s", ApiResource.urlEncodeId(this.getId())));
     return ApiResource.request(
         ApiResource.RequestMethod.DELETE, url, params, Product.class, options);
+  }
+
+  /**
+   * Search for products you’ve previously created using Stripe’s <a
+   * href="https://stripe.com/docs/search-api#search-query-language">Search Query Language</a>.
+   */
+  public static ProductSearchResult search(Map<String, Object> params) throws StripeException {
+    return search(params, (RequestOptions) null);
+  }
+
+  /**
+   * Search for products you’ve previously created using Stripe’s <a
+   * href="https://stripe.com/docs/search-api#search-query-language">Search Query Language</a>.
+   */
+  public static ProductSearchResult search(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/search/products");
+    return ApiResource.requestSearchResult(url, params, ProductSearchResult.class, options);
+  }
+
+  /**
+   * Search for products you’ve previously created using Stripe’s <a
+   * href="https://stripe.com/docs/search-api#search-query-language">Search Query Language</a>.
+   */
+  public static ProductSearchResult search(ProductSearchParams params) throws StripeException {
+    return search(params, (RequestOptions) null);
+  }
+
+  /**
+   * Search for products you’ve previously created using Stripe’s <a
+   * href="https://stripe.com/docs/search-api#search-query-language">Search Query Language</a>.
+   */
+  public static ProductSearchResult search(ProductSearchParams params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/search/products");
+    return ApiResource.requestSearchResult(url, params, ProductSearchResult.class, options);
   }
 }

--- a/src/main/java/com/stripe/model/ProductSearchResult.java
+++ b/src/main/java/com/stripe/model/ProductSearchResult.java
@@ -1,0 +1,4 @@
+// File generated from our OpenAPI spec
+package com.stripe.model;
+
+public class ProductSearchResult extends StripeSearchResult<Product> {}

--- a/src/main/java/com/stripe/param/PriceSearchParams.java
+++ b/src/main/java/com/stripe/param/PriceSearchParams.java
@@ -1,0 +1,246 @@
+// File generated from our OpenAPI spec
+package com.stripe.param;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class PriceSearchParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  /**
+   * Whether to include {@code total_count} in the results. Note that counts max out at 10,000
+   * results and searches with greater than 10,000 results will return {@code total_count: 10000}
+   */
+  @SerializedName("include_count")
+  Boolean includeCount;
+
+  /**
+   * A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+   * default is 10.
+   */
+  @SerializedName("limit")
+  Long limit;
+
+  /**
+   * A cursor for pagination across multiple pages of results. Do not include this parameter on the
+   * first call. Use the next_page value returned in a response to request subsequent results.
+   */
+  @SerializedName("next_page")
+  String nextPage;
+
+  /**
+   * The search query string. See <a
+   * href="https://stripe.com/docs/search-api#search-query-language">search query language</a>
+   */
+  @SerializedName("query")
+  String query;
+
+  /** The trailing window to search over. */
+  @SerializedName("search_window")
+  SearchWindow searchWindow;
+
+  /** The order (ascending or descending) that results are listed in. Default: {@code desc} */
+  @SerializedName("sort_order")
+  SortOrder sortOrder;
+
+  private PriceSearchParams(
+      List<String> expand,
+      Map<String, Object> extraParams,
+      Boolean includeCount,
+      Long limit,
+      String nextPage,
+      String query,
+      SearchWindow searchWindow,
+      SortOrder sortOrder) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+    this.includeCount = includeCount;
+    this.limit = limit;
+    this.nextPage = nextPage;
+    this.query = query;
+    this.searchWindow = searchWindow;
+    this.sortOrder = sortOrder;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    private Boolean includeCount;
+
+    private Long limit;
+
+    private String nextPage;
+
+    private String query;
+
+    private SearchWindow searchWindow;
+
+    private SortOrder sortOrder;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public PriceSearchParams build() {
+      return new PriceSearchParams(
+          this.expand,
+          this.extraParams,
+          this.includeCount,
+          this.limit,
+          this.nextPage,
+          this.query,
+          this.searchWindow,
+          this.sortOrder);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * PriceSearchParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * PriceSearchParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * PriceSearchParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link PriceSearchParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /**
+     * Whether to include {@code total_count} in the results. Note that counts max out at 10,000
+     * results and searches with greater than 10,000 results will return {@code total_count: 10000}
+     */
+    public Builder setIncludeCount(Boolean includeCount) {
+      this.includeCount = includeCount;
+      return this;
+    }
+
+    /**
+     * A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+     * default is 10.
+     */
+    public Builder setLimit(Long limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    /**
+     * A cursor for pagination across multiple pages of results. Do not include this parameter on
+     * the first call. Use the next_page value returned in a response to request subsequent results.
+     */
+    public Builder setNextPage(String nextPage) {
+      this.nextPage = nextPage;
+      return this;
+    }
+
+    /**
+     * The search query string. See <a
+     * href="https://stripe.com/docs/search-api#search-query-language">search query language</a>
+     */
+    public Builder setQuery(String query) {
+      this.query = query;
+      return this;
+    }
+
+    /** The trailing window to search over. */
+    public Builder setSearchWindow(SearchWindow searchWindow) {
+      this.searchWindow = searchWindow;
+      return this;
+    }
+
+    /** The order (ascending or descending) that results are listed in. Default: {@code desc} */
+    public Builder setSortOrder(SortOrder sortOrder) {
+      this.sortOrder = sortOrder;
+      return this;
+    }
+  }
+
+  public enum SearchWindow implements ApiRequestParams.EnumParam {
+    @SerializedName("all_time")
+    ALL_TIME("all_time"),
+
+    @SerializedName("last_year")
+    LAST_YEAR("last_year");
+
+    @Getter(onMethod_ = {@Override})
+    private final String value;
+
+    SearchWindow(String value) {
+      this.value = value;
+    }
+  }
+
+  public enum SortOrder implements ApiRequestParams.EnumParam {
+    @SerializedName("asc")
+    ASC("asc"),
+
+    @SerializedName("desc")
+    DESC("desc");
+
+    @Getter(onMethod_ = {@Override})
+    private final String value;
+
+    SortOrder(String value) {
+      this.value = value;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/ProductSearchParams.java
+++ b/src/main/java/com/stripe/param/ProductSearchParams.java
@@ -1,0 +1,246 @@
+// File generated from our OpenAPI spec
+package com.stripe.param;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class ProductSearchParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  /**
+   * Whether to include {@code total_count} in the results. Note that counts max out at 10,000
+   * results and searches with greater than 10,000 results will return {@code total_count: 10000}
+   */
+  @SerializedName("include_count")
+  Boolean includeCount;
+
+  /**
+   * A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+   * default is 10.
+   */
+  @SerializedName("limit")
+  Long limit;
+
+  /**
+   * A cursor for pagination across multiple pages of results. Do not include this parameter on the
+   * first call. Use the next_page value returned in a response to request subsequent results.
+   */
+  @SerializedName("next_page")
+  String nextPage;
+
+  /**
+   * The search query string. See <a
+   * href="https://stripe.com/docs/search-api#search-query-language">search query language</a>
+   */
+  @SerializedName("query")
+  String query;
+
+  /** The trailing window to search over. */
+  @SerializedName("search_window")
+  SearchWindow searchWindow;
+
+  /** The order (ascending or descending) that results are listed in. Default: {@code desc} */
+  @SerializedName("sort_order")
+  SortOrder sortOrder;
+
+  private ProductSearchParams(
+      List<String> expand,
+      Map<String, Object> extraParams,
+      Boolean includeCount,
+      Long limit,
+      String nextPage,
+      String query,
+      SearchWindow searchWindow,
+      SortOrder sortOrder) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+    this.includeCount = includeCount;
+    this.limit = limit;
+    this.nextPage = nextPage;
+    this.query = query;
+    this.searchWindow = searchWindow;
+    this.sortOrder = sortOrder;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    private Boolean includeCount;
+
+    private Long limit;
+
+    private String nextPage;
+
+    private String query;
+
+    private SearchWindow searchWindow;
+
+    private SortOrder sortOrder;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public ProductSearchParams build() {
+      return new ProductSearchParams(
+          this.expand,
+          this.extraParams,
+          this.includeCount,
+          this.limit,
+          this.nextPage,
+          this.query,
+          this.searchWindow,
+          this.sortOrder);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * ProductSearchParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * ProductSearchParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * ProductSearchParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link ProductSearchParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /**
+     * Whether to include {@code total_count} in the results. Note that counts max out at 10,000
+     * results and searches with greater than 10,000 results will return {@code total_count: 10000}
+     */
+    public Builder setIncludeCount(Boolean includeCount) {
+      this.includeCount = includeCount;
+      return this;
+    }
+
+    /**
+     * A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+     * default is 10.
+     */
+    public Builder setLimit(Long limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    /**
+     * A cursor for pagination across multiple pages of results. Do not include this parameter on
+     * the first call. Use the next_page value returned in a response to request subsequent results.
+     */
+    public Builder setNextPage(String nextPage) {
+      this.nextPage = nextPage;
+      return this;
+    }
+
+    /**
+     * The search query string. See <a
+     * href="https://stripe.com/docs/search-api#search-query-language">search query language</a>
+     */
+    public Builder setQuery(String query) {
+      this.query = query;
+      return this;
+    }
+
+    /** The trailing window to search over. */
+    public Builder setSearchWindow(SearchWindow searchWindow) {
+      this.searchWindow = searchWindow;
+      return this;
+    }
+
+    /** The order (ascending or descending) that results are listed in. Default: {@code desc} */
+    public Builder setSortOrder(SortOrder sortOrder) {
+      this.sortOrder = sortOrder;
+      return this;
+    }
+  }
+
+  public enum SearchWindow implements ApiRequestParams.EnumParam {
+    @SerializedName("all_time")
+    ALL_TIME("all_time"),
+
+    @SerializedName("last_year")
+    LAST_YEAR("last_year");
+
+    @Getter(onMethod_ = {@Override})
+    private final String value;
+
+    SearchWindow(String value) {
+      this.value = value;
+    }
+  }
+
+  public enum SortOrder implements ApiRequestParams.EnumParam {
+    @SerializedName("asc")
+    ASC("asc"),
+
+    @SerializedName("desc")
+    DESC("desc");
+
+    @Getter(onMethod_ = {@Override})
+    private final String value;
+
+    SortOrder(String value) {
+      this.value = value;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
+++ b/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
@@ -222,8 +222,9 @@ public class SessionCreateParams extends ApiRequestParams {
 
   /**
    * The URL to which Stripe should send customers when payment or setup is complete. If you’d like
-   * access to the Checkout Session for the successful payment, read more about it in the guide on
-   * <a href="https://stripe.com/docs/payments/checkout/fulfill-orders">fulfilling orders</a>.
+   * to use information from the successful Checkout Session on your page, read the guide on <a
+   * href="https://stripe.com/docs/payments/checkout/custom-success-page">customizing your success
+   * page</a>.
    */
   @SerializedName("success_url")
   String successUrl;
@@ -764,9 +765,9 @@ public class SessionCreateParams extends ApiRequestParams {
 
     /**
      * The URL to which Stripe should send customers when payment or setup is complete. If you’d
-     * like access to the Checkout Session for the successful payment, read more about it in the
-     * guide on <a href="https://stripe.com/docs/payments/checkout/fulfill-orders">fulfilling
-     * orders</a>.
+     * like to use information from the successful Checkout Session on your page, read the guide on
+     * <a href="https://stripe.com/docs/payments/checkout/custom-success-page">customizing your
+     * success page</a>.
      */
     public Builder setSuccessUrl(String successUrl) {
       this.successUrl = successUrl;
@@ -1715,7 +1716,7 @@ public class SessionCreateParams extends ApiRequestParams {
 
       /**
        * The maximum quantity the customer can purchase for the Checkout Session. By default this
-       * value is 99.
+       * value is 99. You can specify a value up to 999.
        */
       @SerializedName("maximum")
       Long maximum;
@@ -1792,7 +1793,7 @@ public class SessionCreateParams extends ApiRequestParams {
 
         /**
          * The maximum quantity the customer can purchase for the Checkout Session. By default this
-         * value is 99.
+         * value is 99. You can specify a value up to 999.
          */
         public Builder setMaximum(Long maximum) {
           this.maximum = maximum;

--- a/src/test/java/com/stripe/functional/GeneratedExamples.java
+++ b/src/test/java/com/stripe/functional/GeneratedExamples.java
@@ -937,20 +937,6 @@ class GeneratedExamples extends BaseStripeTest {
   }
 
   @Test
-  public void testCustomerBalanceTransactionList() throws StripeException {
-    Customer customer = Customer.retrieve("cus_xxxxxxxxxxxxx");
-    CustomerBalanceTransactionCollectionListParams params =
-        CustomerBalanceTransactionCollectionListParams.builder().setLimit(3L).build();
-    CustomerBalanceTransactionCollection customerBalanceTransactions =
-        customer.balanceTransactions().list(params);
-    assertNotNull(customerBalanceTransactions);
-    verifyRequest(
-        ApiResource.RequestMethod.GET,
-        "/v1/customers/cus_xxxxxxxxxxxxx/balance_transactions",
-        params.toMap());
-  }
-
-  @Test
   public void testSessionCreate2() throws StripeException {
     com.stripe.param.billingportal.SessionCreateParams params =
         com.stripe.param.billingportal.SessionCreateParams.builder()


### PR DESCRIPTION
Codegen for openapi beba931.
r? @dcr-stripe 
cc @stripe/api-libraries

Note: includes a breaking change. This is on the `search-beta` branch so it should be peaceful to push this without any ceremony. I will add the changelog below to CHANGELOG.md at the top, similarly to how [the changelog is organized in `stripe-node-search-beta`](https://github.com/stripe/stripe-node/blob/search-beta/CHANGELOG.md)

## Changelog

* Bugfix (breaking type change): moves `PaymentIntent.search` from an instance method to a static method.
* Add support for `search` on Price
* Add support for `search` on Product