### PR TITLE
Update Javadoc task to not use module directories.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,11 @@ coveralls {
 
 javadoc {
   doFirst {
+    // We should remove this once we start using module-info.java.
+    // Without that file, Javadoc will fall back to "undefined" as the module
+    // name resulting in broken search links. This option explicitly declares
+    // that we are not currently using modules and the module name should be
+    // omitted from Javadoc.
     options.addBooleanOption('-no-module-directories', true)
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -122,6 +122,12 @@ coveralls {
     jacocoReportPath "build/reports/jacoco/test/jacocoTestReport.xml"
 }
 
+javadoc {
+  doFirst {
+    options.addBooleanOption('-no-module-directories', true)
+  }
+}
+
 gitPublish {
     repoUri = 'git@github.com:stripe/stripe-java.git'
     branch = 'gh-pages'


### PR DESCRIPTION
r? @richardm-stripe 
cc @stripe/api-libraries 

### Summary
Updates the `javadoc` task to explicitly specify we're not using module directories. By default the task attempts to use them, searching for `module-info.java` files.

Since we don't use these currently, the end result is we had broken links in our Javadoc where clicking on a search result tried going to the `undefined` module, resulting in a URL such as: https://stripe.dev/stripe-java/undefined/com/stripe/model/Account.html

### Test plan

I build Javadoc before and after this change using `./gradlew javadoc` and then tried opening the locally built index.html (`build/docs/javadoc/index.html`) in my browser and searching.