### PR TITLE
Pass credentials to nexusStaging rule.

### DIFF
--- a/deploy.gradle
+++ b/deploy.gradle
@@ -10,12 +10,6 @@ apply plugin: "maven-publish"
 apply plugin: "signing"
 apply plugin: "io.codearte.nexus-staging"
 
-nexusStaging {
-    packageGroup = GROUP
-    numberOfRetries = 40
-    delayBetweenRetriesInMillis = 4000
-}
-
 def isReleaseBuild() {
     return VERSION_NAME.contains("SNAPSHOT") == false
 }
@@ -57,6 +51,14 @@ afterEvaluate { project ->
         required { isReleaseBuild() && gradle.taskGraph.hasTask("publish") }
         useGpgCmd()
         sign publishing.publications
+    }
+
+    nexusStaging {
+        packageGroup = GROUP
+        numberOfRetries = 40
+        delayBetweenRetriesInMillis = 4000
+        username = getRepositoryUsername()
+        password = getRepositoryPassword()
     }
 
     publishing {


### PR DESCRIPTION
r? @richardm-stripe 

## Summary

Starts providing the credentials to the `nexusStaging` rule as well as the maven repository. The `io.codearte.nexus-staging` pulls the credentials from this object when trying to get the staging profile, which is needed to close the repository. Before this would fail with a 401 as no credentials were being passed in.

## Test plan

Before:

```
 λ ./gradlew getStagingProfile

> Task :getStagingProfile FAILED
GET request failed. 401: , body: <empty>

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':getStagingProfile'.
> 401: , body: <empty>
```

After:

```
 λ ./gradlew getStagingProfile 

> Task :getStagingProfile
Received staging profile id: <snip>

BUILD SUCCESSFUL in 2s
1 actionable task: 1 executed
```