### PR TITLE
API Updates

### DIFF
--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -2212,7 +2212,7 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
        * de-DE}, {@code en-DE}, {@code da-DK}, {@code en-DK}, {@code es-ES}, {@code en-ES}, {@code
        * fi-FI}, {@code sv-FI}, {@code en-FI}, {@code en-GB}, {@code en-IE}, {@code it-IT}, {@code
        * en-IT}, {@code nl-NL}, {@code en-NL}, {@code nb-NO}, {@code en-NO}, {@code sv-SE}, {@code
-       * en-SE}, {@code en-US}, {@code fr-FR}, or {@code en-FR}
+       * en-SE}, {@code en-US}, {@code es-US}, {@code fr-FR}, or {@code en-FR}
        */
       @SerializedName("preferred_locale")
       String preferredLocale;

--- a/src/main/java/com/stripe/model/PaymentIntent.java
+++ b/src/main/java/com/stripe/model/PaymentIntent.java
@@ -1626,7 +1626,10 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
     @SerializedName("card")
     Card card;
 
-    /** Type of the next action to perform, one of {@code card}. */
+    /**
+     * Type of the payment method for which payment is in {@code processing} state, one of {@code
+     * card}.
+     */
     @SerializedName("type")
     String type;
 

--- a/src/main/java/com/stripe/model/SetupAttempt.java
+++ b/src/main/java/com/stripe/model/SetupAttempt.java
@@ -236,6 +236,9 @@ public class SetupAttempt extends ApiResource implements HasId {
     @SerializedName("bancontact")
     Bancontact bancontact;
 
+    @SerializedName("boleto")
+    Boleto boleto;
+
     @SerializedName("card")
     Card card;
 
@@ -366,6 +369,11 @@ public class SetupAttempt extends ApiResource implements HasId {
             new ExpandableField<Mandate>(expandableObject.getId(), expandableObject);
       }
     }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class Boleto extends StripeObject {}
 
     @Getter
     @Setter

--- a/src/main/java/com/stripe/param/InvoiceFinalizeInvoiceParams.java
+++ b/src/main/java/com/stripe/param/InvoiceFinalizeInvoiceParams.java
@@ -13,9 +13,9 @@ import lombok.Getter;
 public class InvoiceFinalizeInvoiceParams extends ApiRequestParams {
   /**
    * Controls whether Stripe will perform <a
-   * href="https://stripe.com/docs/billing/invoices/overview#auto-advance">automatic collection</a>
-   * of the invoice. When {@code false}, the invoice's state will not automatically advance without
-   * an explicit action.
+   * href="https://stripe.com/docs/invoicing/automatic-charging">automatic collection</a> of the
+   * invoice. When {@code false}, the invoice's state will not automatically advance without an
+   * explicit action.
    */
   @SerializedName("auto_advance")
   Boolean autoAdvance;
@@ -58,9 +58,9 @@ public class InvoiceFinalizeInvoiceParams extends ApiRequestParams {
 
     /**
      * Controls whether Stripe will perform <a
-     * href="https://stripe.com/docs/billing/invoices/overview#auto-advance">automatic
-     * collection</a> of the invoice. When {@code false}, the invoice's state will not automatically
-     * advance without an explicit action.
+     * href="https://stripe.com/docs/invoicing/automatic-charging">automatic collection</a> of the
+     * invoice. When {@code false}, the invoice's state will not automatically advance without an
+     * explicit action.
      */
     public Builder setAutoAdvance(Boolean autoAdvance) {
       this.autoAdvance = autoAdvance;

--- a/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
@@ -5452,6 +5452,9 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
         @SerializedName("en-FI")
         EN_FI("en-FI"),
 
+        @SerializedName("en-FR")
+        EN_FR("en-FR"),
+
         @SerializedName("en-GB")
         EN_GB("en-GB"),
 
@@ -5476,11 +5479,17 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
         @SerializedName("es-ES")
         ES_ES("es-ES"),
 
+        @SerializedName("es-US")
+        ES_US("es-US"),
+
         @SerializedName("fi-FI")
         FI_FI("fi-FI"),
 
         @SerializedName("fr-BE")
         FR_BE("fr-BE"),
+
+        @SerializedName("fr-FR")
+        FR_FR("fr-FR"),
 
         @SerializedName("it-IT")
         IT_IT("it-IT"),

--- a/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
@@ -5914,6 +5914,9 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
         @SerializedName("en-FI")
         EN_FI("en-FI"),
 
+        @SerializedName("en-FR")
+        EN_FR("en-FR"),
+
         @SerializedName("en-GB")
         EN_GB("en-GB"),
 
@@ -5938,11 +5941,17 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
         @SerializedName("es-ES")
         ES_ES("es-ES"),
 
+        @SerializedName("es-US")
+        ES_US("es-US"),
+
         @SerializedName("fi-FI")
         FI_FI("fi-FI"),
 
         @SerializedName("fr-BE")
         FR_BE("fr-BE"),
+
+        @SerializedName("fr-FR")
+        FR_FR("fr-FR"),
 
         @SerializedName("it-IT")
         IT_IT("it-IT"),

--- a/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
@@ -5492,6 +5492,9 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
         @SerializedName("en-FI")
         EN_FI("en-FI"),
 
+        @SerializedName("en-FR")
+        EN_FR("en-FR"),
+
         @SerializedName("en-GB")
         EN_GB("en-GB"),
 
@@ -5516,11 +5519,17 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
         @SerializedName("es-ES")
         ES_ES("es-ES"),
 
+        @SerializedName("es-US")
+        ES_US("es-US"),
+
         @SerializedName("fi-FI")
         FI_FI("fi-FI"),
 
         @SerializedName("fr-BE")
         FR_BE("fr-BE"),
+
+        @SerializedName("fr-FR")
+        FR_FR("fr-FR"),
 
         @SerializedName("it-IT")
         IT_IT("it-IT"),

--- a/src/main/java/com/stripe/param/issuing/CardholderCreateParams.java
+++ b/src/main/java/com/stripe/param/issuing/CardholderCreateParams.java
@@ -49,7 +49,10 @@ public class CardholderCreateParams extends ApiRequestParams {
   @SerializedName("metadata")
   Map<String, String> metadata;
 
-  /** The cardholder's name. This will be printed on cards issued to them. */
+  /**
+   * The cardholder's name. This will be printed on cards issued to them. The maximum length of this
+   * field is 24 characters.
+   */
   @SerializedName("name")
   String name;
 
@@ -257,7 +260,10 @@ public class CardholderCreateParams extends ApiRequestParams {
       return this;
     }
 
-    /** The cardholder's name. This will be printed on cards issued to them. */
+    /**
+     * The cardholder's name. This will be printed on cards issued to them. The maximum length of
+     * this field is 24 characters.
+     */
     public Builder setName(String name) {
       this.name = name;
       return this;


### PR DESCRIPTION
Codegen for openapi 628e7c2.
r? @yejia-stripe
cc @stripe/api-libraries

## Changelog
* Add support for new values `en-FR`, `es-US`, and `fr-FR` on enums `PaymentIntentCreateParams.payment_method_options.klarna.preferred_locale`, `PaymentIntentUpdateParams.payment_method_options.klarna.preferred_locale`, and `PaymentIntentConfirmParams.payment_method_options.klarna.preferred_locale`
* Add support for `boleto` on `SetupAttempt.payment_method_details`

