### PR TITLE
API Updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,10 +3,6 @@ buildscript {
         mavenCentral()
         //Add only for SNAPSHOT versions
         //maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
-        maven {
-          name = 'ajoberstar-backup'
-          url = 'https://ajoberstar.org/bintray-backup/'
-        }
     }
     dependencies {
         classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.30.0"
@@ -62,6 +58,10 @@ configurations.all {
 
 repositories {
      mavenCentral()
+     maven {
+       name = 'ajoberstar-backup'
+       url = 'https://ajoberstar.org/bintray-backup/'
+     }
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,10 @@ buildscript {
         mavenCentral()
         //Add only for SNAPSHOT versions
         //maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
+        maven {
+          name = 'ajoberstar-backup'
+          url = 'https://ajoberstar.org/bintray-backup/'
+        }
     }
     dependencies {
         classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.30.0"

--- a/build.gradle
+++ b/build.gradle
@@ -57,11 +57,7 @@ configurations.all {
 }
 
 repositories {
-     mavenCentral()
-     maven {
-       name = 'ajoberstar-backup'
-       url = 'https://ajoberstar.org/bintray-backup/'
-     }
+    mavenCentral()
 }
 
 dependencies {

--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -1592,6 +1592,30 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
        */
       @SerializedName("request_three_d_secure")
       String requestThreeDSecure;
+
+      @Getter
+      @Setter
+      @EqualsAndHashCode(callSuper = false)
+      public static class MandateOptions extends StripeObject {
+        /** Amount to be charged for future payments. */
+        @SerializedName("amount")
+        Long amount;
+
+        /**
+         * One of {@code fixed} or {@code maximum}. If {@code fixed}, the {@code amount} param
+         * refers to the exact amount to be charged in future payments. If {@code maximum}, the
+         * amount charged can be up to the value passed for the {@code amount} param.
+         */
+        @SerializedName("amount_type")
+        String amountType;
+
+        /**
+         * A description of the mandate or subscription that is meant to be displayed to the
+         * customer.
+         */
+        @SerializedName("description")
+        String description;
+      }
     }
   }
 

--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -1592,30 +1592,6 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
        */
       @SerializedName("request_three_d_secure")
       String requestThreeDSecure;
-
-      @Getter
-      @Setter
-      @EqualsAndHashCode(callSuper = false)
-      public static class MandateOptions extends StripeObject {
-        /** Amount to be charged for future payments. */
-        @SerializedName("amount")
-        Long amount;
-
-        /**
-         * One of {@code fixed} or {@code maximum}. If {@code fixed}, the {@code amount} param
-         * refers to the exact amount to be charged in future payments. If {@code maximum}, the
-         * amount charged can be up to the value passed for the {@code amount} param.
-         */
-        @SerializedName("amount_type")
-        String amountType;
-
-        /**
-         * A description of the mandate or subscription that is meant to be displayed to the
-         * customer.
-         */
-        @SerializedName("description")
-        String description;
-      }
     }
   }
 

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -844,6 +844,30 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
        */
       @SerializedName("request_three_d_secure")
       String requestThreeDSecure;
+
+      @Getter
+      @Setter
+      @EqualsAndHashCode(callSuper = false)
+      public static class MandateOptions extends StripeObject {
+        /** Amount to be charged for future payments. */
+        @SerializedName("amount")
+        Long amount;
+
+        /**
+         * One of {@code fixed} or {@code maximum}. If {@code fixed}, the {@code amount} param
+         * refers to the exact amount to be charged in future payments. If {@code maximum}, the
+         * amount charged can be up to the value passed for the {@code amount} param.
+         */
+        @SerializedName("amount_type")
+        String amountType;
+
+        /**
+         * A description of the mandate or subscription that is meant to be displayed to the
+         * customer.
+         */
+        @SerializedName("description")
+        String description;
+      }
     }
   }
 

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -830,6 +830,9 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
     @Setter
     @EqualsAndHashCode(callSuper = false)
     public static class Card extends StripeObject {
+      @SerializedName("mandate_options")
+      MandateOptions mandateOptions;
+
       /**
        * We strongly recommend that you rely on our SCA Engine to automatically prompt your
        * customers for authentication based on risk level and <a

--- a/src/main/java/com/stripe/param/InvoiceUpcomingParams.java
+++ b/src/main/java/com/stripe/param/InvoiceUpcomingParams.java
@@ -38,9 +38,10 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
 
   /**
    * The coupons to redeem into discounts for the invoice preview. If not specified, inherits the
-   * discount from the customer or subscription. Pass an empty string to avoid inheriting any
-   * discounts. To preview the upcoming invoice for a subscription that hasn't been created, use
-   * {@code coupon} instead.
+   * discount from the customer or subscription. This only works for coupons directly applied to the
+   * invoice. To apply a coupon to a subscription, you must use the {@code coupon} parameter
+   * instead. Pass an empty string to avoid inheriting any discounts. To preview the upcoming
+   * invoice for a subscription that hasn't been created, use {@code coupon} instead.
    */
   @SerializedName("discounts")
   Object discounts;
@@ -346,9 +347,10 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
 
     /**
      * The coupons to redeem into discounts for the invoice preview. If not specified, inherits the
-     * discount from the customer or subscription. Pass an empty string to avoid inheriting any
-     * discounts. To preview the upcoming invoice for a subscription that hasn't been created, use
-     * {@code coupon} instead.
+     * discount from the customer or subscription. This only works for coupons directly applied to
+     * the invoice. To apply a coupon to a subscription, you must use the {@code coupon} parameter
+     * instead. Pass an empty string to avoid inheriting any discounts. To preview the upcoming
+     * invoice for a subscription that hasn't been created, use {@code coupon} instead.
      */
     public Builder setDiscounts(EmptyParam discounts) {
       this.discounts = discounts;
@@ -357,9 +359,10 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
 
     /**
      * The coupons to redeem into discounts for the invoice preview. If not specified, inherits the
-     * discount from the customer or subscription. Pass an empty string to avoid inheriting any
-     * discounts. To preview the upcoming invoice for a subscription that hasn't been created, use
-     * {@code coupon} instead.
+     * discount from the customer or subscription. This only works for coupons directly applied to
+     * the invoice. To apply a coupon to a subscription, you must use the {@code coupon} parameter
+     * instead. Pass an empty string to avoid inheriting any discounts. To preview the upcoming
+     * invoice for a subscription that hasn't been created, use {@code coupon} instead.
      */
     public Builder setDiscounts(List<Discount> discounts) {
       this.discounts = discounts;

--- a/src/main/java/com/stripe/param/SubscriptionCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionCreateParams.java
@@ -2652,6 +2652,10 @@ public class SubscriptionCreateParams extends ApiRequestParams {
         @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
         Map<String, Object> extraParams;
 
+        /** Configuration options for setting up an eMandate for cards issued in India. */
+        @SerializedName("mandate_options")
+        MandateOptions mandateOptions;
+
         /**
          * We strongly recommend that you rely on our SCA Engine to automatically prompt your
          * customers for authentication based on risk level and <a
@@ -2665,8 +2669,12 @@ public class SubscriptionCreateParams extends ApiRequestParams {
         @SerializedName("request_three_d_secure")
         RequestThreeDSecure requestThreeDSecure;
 
-        private Card(Map<String, Object> extraParams, RequestThreeDSecure requestThreeDSecure) {
+        private Card(
+            Map<String, Object> extraParams,
+            MandateOptions mandateOptions,
+            RequestThreeDSecure requestThreeDSecure) {
           this.extraParams = extraParams;
+          this.mandateOptions = mandateOptions;
           this.requestThreeDSecure = requestThreeDSecure;
         }
 
@@ -2677,11 +2685,13 @@ public class SubscriptionCreateParams extends ApiRequestParams {
         public static class Builder {
           private Map<String, Object> extraParams;
 
+          private MandateOptions mandateOptions;
+
           private RequestThreeDSecure requestThreeDSecure;
 
           /** Finalize and obtain parameter instance from this builder. */
           public Card build() {
-            return new Card(this.extraParams, this.requestThreeDSecure);
+            return new Card(this.extraParams, this.mandateOptions, this.requestThreeDSecure);
           }
 
           /**
@@ -2714,6 +2724,12 @@ public class SubscriptionCreateParams extends ApiRequestParams {
             return this;
           }
 
+          /** Configuration options for setting up an eMandate for cards issued in India. */
+          public Builder setMandateOptions(MandateOptions mandateOptions) {
+            this.mandateOptions = mandateOptions;
+            return this;
+          }
+
           /**
            * We strongly recommend that you rely on our SCA Engine to automatically prompt your
            * customers for authentication based on risk level and <a
@@ -2727,6 +2743,139 @@ public class SubscriptionCreateParams extends ApiRequestParams {
           public Builder setRequestThreeDSecure(RequestThreeDSecure requestThreeDSecure) {
             this.requestThreeDSecure = requestThreeDSecure;
             return this;
+          }
+        }
+
+        @Getter
+        public static class MandateOptions {
+          /** Amount to be charged for future payments. */
+          @SerializedName("amount")
+          Long amount;
+
+          /**
+           * One of {@code fixed} or {@code maximum}. If {@code fixed}, the {@code amount} param
+           * refers to the exact amount to be charged in future payments. If {@code maximum}, the
+           * amount charged can be up to the value passed for the {@code amount} param.
+           */
+          @SerializedName("amount_type")
+          AmountType amountType;
+
+          /**
+           * A description of the mandate or subscription that is meant to be displayed to the
+           * customer.
+           */
+          @SerializedName("description")
+          String description;
+
+          /**
+           * Map of extra parameters for custom features not available in this client library. The
+           * content in this map is not serialized under this field's {@code @SerializedName} value.
+           * Instead, each key/value pair is serialized as if the key is a root-level field
+           * (serialized) name in this param object. Effectively, this map is flattened to its
+           * parent instance.
+           */
+          @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+          Map<String, Object> extraParams;
+
+          private MandateOptions(
+              Long amount,
+              AmountType amountType,
+              String description,
+              Map<String, Object> extraParams) {
+            this.amount = amount;
+            this.amountType = amountType;
+            this.description = description;
+            this.extraParams = extraParams;
+          }
+
+          public static Builder builder() {
+            return new Builder();
+          }
+
+          public static class Builder {
+            private Long amount;
+
+            private AmountType amountType;
+
+            private String description;
+
+            private Map<String, Object> extraParams;
+
+            /** Finalize and obtain parameter instance from this builder. */
+            public MandateOptions build() {
+              return new MandateOptions(
+                  this.amount, this.amountType, this.description, this.extraParams);
+            }
+
+            /** Amount to be charged for future payments. */
+            public Builder setAmount(Long amount) {
+              this.amount = amount;
+              return this;
+            }
+
+            /**
+             * One of {@code fixed} or {@code maximum}. If {@code fixed}, the {@code amount} param
+             * refers to the exact amount to be charged in future payments. If {@code maximum}, the
+             * amount charged can be up to the value passed for the {@code amount} param.
+             */
+            public Builder setAmountType(AmountType amountType) {
+              this.amountType = amountType;
+              return this;
+            }
+
+            /**
+             * A description of the mandate or subscription that is meant to be displayed to the
+             * customer.
+             */
+            public Builder setDescription(String description) {
+              this.description = description;
+              return this;
+            }
+
+            /**
+             * Add a key/value pair to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.Card.MandateOptions#extraParams}
+             * for the field documentation.
+             */
+            public Builder putExtraParam(String key, Object value) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.put(key, value);
+              return this;
+            }
+
+            /**
+             * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.Card.MandateOptions#extraParams}
+             * for the field documentation.
+             */
+            public Builder putAllExtraParam(Map<String, Object> map) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.putAll(map);
+              return this;
+            }
+          }
+
+          public enum AmountType implements ApiRequestParams.EnumParam {
+            @SerializedName("fixed")
+            FIXED("fixed"),
+
+            @SerializedName("maximum")
+            MAXIMUM("maximum");
+
+            @Getter(onMethod_ = {@Override})
+            private final String value;
+
+            AmountType(String value) {
+              this.value = value;
+            }
           }
         }
 

--- a/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
@@ -2972,6 +2972,10 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
         @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
         Map<String, Object> extraParams;
 
+        /** Configuration options for setting up an eMandate for cards issued in India. */
+        @SerializedName("mandate_options")
+        MandateOptions mandateOptions;
+
         /**
          * We strongly recommend that you rely on our SCA Engine to automatically prompt your
          * customers for authentication based on risk level and <a
@@ -2985,8 +2989,12 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
         @SerializedName("request_three_d_secure")
         RequestThreeDSecure requestThreeDSecure;
 
-        private Card(Map<String, Object> extraParams, RequestThreeDSecure requestThreeDSecure) {
+        private Card(
+            Map<String, Object> extraParams,
+            MandateOptions mandateOptions,
+            RequestThreeDSecure requestThreeDSecure) {
           this.extraParams = extraParams;
+          this.mandateOptions = mandateOptions;
           this.requestThreeDSecure = requestThreeDSecure;
         }
 
@@ -2997,11 +3005,13 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
         public static class Builder {
           private Map<String, Object> extraParams;
 
+          private MandateOptions mandateOptions;
+
           private RequestThreeDSecure requestThreeDSecure;
 
           /** Finalize and obtain parameter instance from this builder. */
           public Card build() {
-            return new Card(this.extraParams, this.requestThreeDSecure);
+            return new Card(this.extraParams, this.mandateOptions, this.requestThreeDSecure);
           }
 
           /**
@@ -3034,6 +3044,12 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
             return this;
           }
 
+          /** Configuration options for setting up an eMandate for cards issued in India. */
+          public Builder setMandateOptions(MandateOptions mandateOptions) {
+            this.mandateOptions = mandateOptions;
+            return this;
+          }
+
           /**
            * We strongly recommend that you rely on our SCA Engine to automatically prompt your
            * customers for authentication based on risk level and <a
@@ -3047,6 +3063,148 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
           public Builder setRequestThreeDSecure(RequestThreeDSecure requestThreeDSecure) {
             this.requestThreeDSecure = requestThreeDSecure;
             return this;
+          }
+        }
+
+        @Getter
+        public static class MandateOptions {
+          /** Amount to be charged for future payments. */
+          @SerializedName("amount")
+          Long amount;
+
+          /**
+           * One of {@code fixed} or {@code maximum}. If {@code fixed}, the {@code amount} param
+           * refers to the exact amount to be charged in future payments. If {@code maximum}, the
+           * amount charged can be up to the value passed for the {@code amount} param.
+           */
+          @SerializedName("amount_type")
+          AmountType amountType;
+
+          /**
+           * A description of the mandate or subscription that is meant to be displayed to the
+           * customer.
+           */
+          @SerializedName("description")
+          Object description;
+
+          /**
+           * Map of extra parameters for custom features not available in this client library. The
+           * content in this map is not serialized under this field's {@code @SerializedName} value.
+           * Instead, each key/value pair is serialized as if the key is a root-level field
+           * (serialized) name in this param object. Effectively, this map is flattened to its
+           * parent instance.
+           */
+          @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+          Map<String, Object> extraParams;
+
+          private MandateOptions(
+              Long amount,
+              AmountType amountType,
+              Object description,
+              Map<String, Object> extraParams) {
+            this.amount = amount;
+            this.amountType = amountType;
+            this.description = description;
+            this.extraParams = extraParams;
+          }
+
+          public static Builder builder() {
+            return new Builder();
+          }
+
+          public static class Builder {
+            private Long amount;
+
+            private AmountType amountType;
+
+            private Object description;
+
+            private Map<String, Object> extraParams;
+
+            /** Finalize and obtain parameter instance from this builder. */
+            public MandateOptions build() {
+              return new MandateOptions(
+                  this.amount, this.amountType, this.description, this.extraParams);
+            }
+
+            /** Amount to be charged for future payments. */
+            public Builder setAmount(Long amount) {
+              this.amount = amount;
+              return this;
+            }
+
+            /**
+             * One of {@code fixed} or {@code maximum}. If {@code fixed}, the {@code amount} param
+             * refers to the exact amount to be charged in future payments. If {@code maximum}, the
+             * amount charged can be up to the value passed for the {@code amount} param.
+             */
+            public Builder setAmountType(AmountType amountType) {
+              this.amountType = amountType;
+              return this;
+            }
+
+            /**
+             * A description of the mandate or subscription that is meant to be displayed to the
+             * customer.
+             */
+            public Builder setDescription(String description) {
+              this.description = description;
+              return this;
+            }
+
+            /**
+             * A description of the mandate or subscription that is meant to be displayed to the
+             * customer.
+             */
+            public Builder setDescription(EmptyParam description) {
+              this.description = description;
+              return this;
+            }
+
+            /**
+             * Add a key/value pair to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.Card.MandateOptions#extraParams}
+             * for the field documentation.
+             */
+            public Builder putExtraParam(String key, Object value) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.put(key, value);
+              return this;
+            }
+
+            /**
+             * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.Card.MandateOptions#extraParams}
+             * for the field documentation.
+             */
+            public Builder putAllExtraParam(Map<String, Object> map) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.putAll(map);
+              return this;
+            }
+          }
+
+          public enum AmountType implements ApiRequestParams.EnumParam {
+            @SerializedName("fixed")
+            FIXED("fixed"),
+
+            @SerializedName("maximum")
+            MAXIMUM("maximum");
+
+            @Getter(onMethod_ = {@Override})
+            private final String value;
+
+            AmountType(String value) {
+              this.value = value;
+            }
           }
         }
 


### PR DESCRIPTION
Codegen for openapi d70de34.
r? @richardm-stripe
cc @stripe/api-libraries

## Changelog
* Add support for `mandate_options` on `SubscriptionCreateParams.payment_settings.payment_method_options.card`, `SubscriptionUpdateParams.payment_settings.payment_method_options.card`, and `Subscription.payment_settings.payment_method_options.card`

