### PR TITLE
API Updates

### DIFF
--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -365,6 +365,13 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
   Boolean paid;
 
   /**
+   * Returns true if the invoice was manually marked paid, returns false if the invoice hasn't been
+   * paid yet or was paid on Stripe.
+   */
+  @SerializedName("paid_out_of_band")
+  Boolean paidOutOfBand;
+
+  /**
    * The PaymentIntent associated with this invoice. The PaymentIntent is generated when the invoice
    * is finalized, and can then be used to pay the invoice. Note that voiding an invoice will cancel
    * the PaymentIntent.

--- a/src/main/java/com/stripe/model/PaymentIntent.java
+++ b/src/main/java/com/stripe/model/PaymentIntent.java
@@ -1313,8 +1313,14 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
     @SerializedName("card_present")
     CardPresent cardPresent;
 
+    @SerializedName("fpx")
+    Fpx fpx;
+
     @SerializedName("giropay")
     Giropay giropay;
+
+    @SerializedName("grabpay")
+    Grabpay grabpay;
 
     @SerializedName("ideal")
     Ideal ideal;
@@ -1543,7 +1549,17 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
     @Getter
     @Setter
     @EqualsAndHashCode(callSuper = false)
+    public static class Fpx extends StripeObject {}
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
     public static class Giropay extends StripeObject {}
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class Grabpay extends StripeObject {}
 
     @Getter
     @Setter

--- a/src/main/java/com/stripe/model/checkout/Session.java
+++ b/src/main/java/com/stripe/model/checkout/Session.java
@@ -102,6 +102,14 @@ public class Session extends ApiResource implements HasId {
   ExpandableField<Customer> customer;
 
   /**
+   * Configure whether a Checkout Session creates a Customer when the Checkout Session completes.
+   *
+   * <p>One of {@code always}, or {@code if_required}.
+   */
+  @SerializedName("customer_creation")
+  String customerCreation;
+
+  /**
    * The customer details including the customer's tax exempt status and the customer's tax IDs.
    * Only present on Sessions in {@code payment} or {@code subscription} mode.
    */

--- a/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
@@ -3482,11 +3482,25 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
     Map<String, Object> extraParams;
 
     /**
+     * If this is a {@code fpx} PaymentMethod, this sub-hash contains details about the FPX payment
+     * method options.
+     */
+    @SerializedName("fpx")
+    Object fpx;
+
+    /**
      * If this is a {@code giropay} PaymentMethod, this sub-hash contains details about the Giropay
      * payment method options.
      */
     @SerializedName("giropay")
     Object giropay;
+
+    /**
+     * If this is a {@code grabpay} PaymentMethod, this sub-hash contains details about the Grabpay
+     * payment method options.
+     */
+    @SerializedName("grabpay")
+    Object grabpay;
 
     /**
      * If this is a {@code ideal} PaymentMethod, this sub-hash contains details about the Ideal
@@ -3554,7 +3568,9 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
         Object card,
         Object cardPresent,
         Map<String, Object> extraParams,
+        Object fpx,
         Object giropay,
+        Object grabpay,
         Object ideal,
         Object interacPresent,
         Object klarna,
@@ -3572,7 +3588,9 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       this.card = card;
       this.cardPresent = cardPresent;
       this.extraParams = extraParams;
+      this.fpx = fpx;
       this.giropay = giropay;
+      this.grabpay = grabpay;
       this.ideal = ideal;
       this.interacPresent = interacPresent;
       this.klarna = klarna;
@@ -3606,7 +3624,11 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
 
       private Map<String, Object> extraParams;
 
+      private Object fpx;
+
       private Object giropay;
+
+      private Object grabpay;
 
       private Object ideal;
 
@@ -3636,7 +3658,9 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
             this.card,
             this.cardPresent,
             this.extraParams,
+            this.fpx,
             this.giropay,
+            this.grabpay,
             this.ideal,
             this.interacPresent,
             this.klarna,
@@ -3813,6 +3837,24 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       }
 
       /**
+       * If this is a {@code fpx} PaymentMethod, this sub-hash contains details about the FPX
+       * payment method options.
+       */
+      public Builder setFpx(Fpx fpx) {
+        this.fpx = fpx;
+        return this;
+      }
+
+      /**
+       * If this is a {@code fpx} PaymentMethod, this sub-hash contains details about the FPX
+       * payment method options.
+       */
+      public Builder setFpx(EmptyParam fpx) {
+        this.fpx = fpx;
+        return this;
+      }
+
+      /**
        * If this is a {@code giropay} PaymentMethod, this sub-hash contains details about the
        * Giropay payment method options.
        */
@@ -3827,6 +3869,24 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
        */
       public Builder setGiropay(EmptyParam giropay) {
         this.giropay = giropay;
+        return this;
+      }
+
+      /**
+       * If this is a {@code grabpay} PaymentMethod, this sub-hash contains details about the
+       * Grabpay payment method options.
+       */
+      public Builder setGrabpay(Grabpay grabpay) {
+        this.grabpay = grabpay;
+        return this;
+      }
+
+      /**
+       * If this is a {@code grabpay} PaymentMethod, this sub-hash contains details about the
+       * Grabpay payment method options.
+       */
+      public Builder setGrabpay(EmptyParam grabpay) {
+        this.grabpay = grabpay;
         return this;
       }
 
@@ -5268,6 +5328,63 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
     }
 
     @Getter
+    public static class Fpx {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private Fpx(Map<String, Object> extraParams) {
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Fpx build() {
+          return new Fpx(this.extraParams);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentConfirmParams.PaymentMethodOptions.Fpx#extraParams} for the
+         * field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentConfirmParams.PaymentMethodOptions.Fpx#extraParams} for the
+         * field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+      }
+    }
+
+    @Getter
     public static class Giropay {
       /**
        * Map of extra parameters for custom features not available in this client library. The
@@ -5312,6 +5429,63 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
          * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
          * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
          * map. See {@link PaymentIntentConfirmParams.PaymentMethodOptions.Giropay#extraParams} for
+         * the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+      }
+    }
+
+    @Getter
+    public static class Grabpay {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private Grabpay(Map<String, Object> extraParams) {
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Grabpay build() {
+          return new Grabpay(this.extraParams);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentConfirmParams.PaymentMethodOptions.Grabpay#extraParams} for
+         * the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentConfirmParams.PaymentMethodOptions.Grabpay#extraParams} for
          * the field documentation.
          */
         public Builder putAllExtraParam(Map<String, Object> map) {

--- a/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
@@ -3944,11 +3944,25 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     Map<String, Object> extraParams;
 
     /**
+     * If this is a {@code fpx} PaymentMethod, this sub-hash contains details about the FPX payment
+     * method options.
+     */
+    @SerializedName("fpx")
+    Object fpx;
+
+    /**
      * If this is a {@code giropay} PaymentMethod, this sub-hash contains details about the Giropay
      * payment method options.
      */
     @SerializedName("giropay")
     Object giropay;
+
+    /**
+     * If this is a {@code grabpay} PaymentMethod, this sub-hash contains details about the Grabpay
+     * payment method options.
+     */
+    @SerializedName("grabpay")
+    Object grabpay;
 
     /**
      * If this is a {@code ideal} PaymentMethod, this sub-hash contains details about the Ideal
@@ -4016,7 +4030,9 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
         Object card,
         Object cardPresent,
         Map<String, Object> extraParams,
+        Object fpx,
         Object giropay,
+        Object grabpay,
         Object ideal,
         Object interacPresent,
         Object klarna,
@@ -4034,7 +4050,9 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       this.card = card;
       this.cardPresent = cardPresent;
       this.extraParams = extraParams;
+      this.fpx = fpx;
       this.giropay = giropay;
+      this.grabpay = grabpay;
       this.ideal = ideal;
       this.interacPresent = interacPresent;
       this.klarna = klarna;
@@ -4068,7 +4086,11 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
 
       private Map<String, Object> extraParams;
 
+      private Object fpx;
+
       private Object giropay;
+
+      private Object grabpay;
 
       private Object ideal;
 
@@ -4098,7 +4120,9 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
             this.card,
             this.cardPresent,
             this.extraParams,
+            this.fpx,
             this.giropay,
+            this.grabpay,
             this.ideal,
             this.interacPresent,
             this.klarna,
@@ -4275,6 +4299,24 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       }
 
       /**
+       * If this is a {@code fpx} PaymentMethod, this sub-hash contains details about the FPX
+       * payment method options.
+       */
+      public Builder setFpx(Fpx fpx) {
+        this.fpx = fpx;
+        return this;
+      }
+
+      /**
+       * If this is a {@code fpx} PaymentMethod, this sub-hash contains details about the FPX
+       * payment method options.
+       */
+      public Builder setFpx(EmptyParam fpx) {
+        this.fpx = fpx;
+        return this;
+      }
+
+      /**
        * If this is a {@code giropay} PaymentMethod, this sub-hash contains details about the
        * Giropay payment method options.
        */
@@ -4289,6 +4331,24 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
        */
       public Builder setGiropay(EmptyParam giropay) {
         this.giropay = giropay;
+        return this;
+      }
+
+      /**
+       * If this is a {@code grabpay} PaymentMethod, this sub-hash contains details about the
+       * Grabpay payment method options.
+       */
+      public Builder setGrabpay(Grabpay grabpay) {
+        this.grabpay = grabpay;
+        return this;
+      }
+
+      /**
+       * If this is a {@code grabpay} PaymentMethod, this sub-hash contains details about the
+       * Grabpay payment method options.
+       */
+      public Builder setGrabpay(EmptyParam grabpay) {
+        this.grabpay = grabpay;
         return this;
       }
 
@@ -5730,6 +5790,63 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     }
 
     @Getter
+    public static class Fpx {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private Fpx(Map<String, Object> extraParams) {
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Fpx build() {
+          return new Fpx(this.extraParams);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentCreateParams.PaymentMethodOptions.Fpx#extraParams} for the
+         * field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentCreateParams.PaymentMethodOptions.Fpx#extraParams} for the
+         * field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+      }
+    }
+
+    @Getter
     public static class Giropay {
       /**
        * Map of extra parameters for custom features not available in this client library. The
@@ -5774,6 +5891,63 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
          * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
          * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
          * map. See {@link PaymentIntentCreateParams.PaymentMethodOptions.Giropay#extraParams} for
+         * the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+      }
+    }
+
+    @Getter
+    public static class Grabpay {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private Grabpay(Map<String, Object> extraParams) {
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Grabpay build() {
+          return new Grabpay(this.extraParams);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentCreateParams.PaymentMethodOptions.Grabpay#extraParams} for
+         * the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentCreateParams.PaymentMethodOptions.Grabpay#extraParams} for
          * the field documentation.
          */
         public Builder putAllExtraParam(Map<String, Object> map) {

--- a/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
@@ -3492,11 +3492,25 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     Map<String, Object> extraParams;
 
     /**
+     * If this is a {@code fpx} PaymentMethod, this sub-hash contains details about the FPX payment
+     * method options.
+     */
+    @SerializedName("fpx")
+    Object fpx;
+
+    /**
      * If this is a {@code giropay} PaymentMethod, this sub-hash contains details about the Giropay
      * payment method options.
      */
     @SerializedName("giropay")
     Object giropay;
+
+    /**
+     * If this is a {@code grabpay} PaymentMethod, this sub-hash contains details about the Grabpay
+     * payment method options.
+     */
+    @SerializedName("grabpay")
+    Object grabpay;
 
     /**
      * If this is a {@code ideal} PaymentMethod, this sub-hash contains details about the Ideal
@@ -3564,7 +3578,9 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
         Object card,
         Object cardPresent,
         Map<String, Object> extraParams,
+        Object fpx,
         Object giropay,
+        Object grabpay,
         Object ideal,
         Object interacPresent,
         Object klarna,
@@ -3582,7 +3598,9 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       this.card = card;
       this.cardPresent = cardPresent;
       this.extraParams = extraParams;
+      this.fpx = fpx;
       this.giropay = giropay;
+      this.grabpay = grabpay;
       this.ideal = ideal;
       this.interacPresent = interacPresent;
       this.klarna = klarna;
@@ -3616,7 +3634,11 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
 
       private Map<String, Object> extraParams;
 
+      private Object fpx;
+
       private Object giropay;
+
+      private Object grabpay;
 
       private Object ideal;
 
@@ -3646,7 +3668,9 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
             this.card,
             this.cardPresent,
             this.extraParams,
+            this.fpx,
             this.giropay,
+            this.grabpay,
             this.ideal,
             this.interacPresent,
             this.klarna,
@@ -3823,6 +3847,24 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       }
 
       /**
+       * If this is a {@code fpx} PaymentMethod, this sub-hash contains details about the FPX
+       * payment method options.
+       */
+      public Builder setFpx(Fpx fpx) {
+        this.fpx = fpx;
+        return this;
+      }
+
+      /**
+       * If this is a {@code fpx} PaymentMethod, this sub-hash contains details about the FPX
+       * payment method options.
+       */
+      public Builder setFpx(EmptyParam fpx) {
+        this.fpx = fpx;
+        return this;
+      }
+
+      /**
        * If this is a {@code giropay} PaymentMethod, this sub-hash contains details about the
        * Giropay payment method options.
        */
@@ -3837,6 +3879,24 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
        */
       public Builder setGiropay(EmptyParam giropay) {
         this.giropay = giropay;
+        return this;
+      }
+
+      /**
+       * If this is a {@code grabpay} PaymentMethod, this sub-hash contains details about the
+       * Grabpay payment method options.
+       */
+      public Builder setGrabpay(Grabpay grabpay) {
+        this.grabpay = grabpay;
+        return this;
+      }
+
+      /**
+       * If this is a {@code grabpay} PaymentMethod, this sub-hash contains details about the
+       * Grabpay payment method options.
+       */
+      public Builder setGrabpay(EmptyParam grabpay) {
+        this.grabpay = grabpay;
         return this;
       }
 
@@ -5308,6 +5368,63 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     }
 
     @Getter
+    public static class Fpx {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private Fpx(Map<String, Object> extraParams) {
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Fpx build() {
+          return new Fpx(this.extraParams);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentUpdateParams.PaymentMethodOptions.Fpx#extraParams} for the
+         * field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentUpdateParams.PaymentMethodOptions.Fpx#extraParams} for the
+         * field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+      }
+    }
+
+    @Getter
     public static class Giropay {
       /**
        * Map of extra parameters for custom features not available in this client library. The
@@ -5352,6 +5469,63 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
          * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
          * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
          * map. See {@link PaymentIntentUpdateParams.PaymentMethodOptions.Giropay#extraParams} for
+         * the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+      }
+    }
+
+    @Getter
+    public static class Grabpay {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private Grabpay(Map<String, Object> extraParams) {
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Grabpay build() {
+          return new Grabpay(this.extraParams);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentUpdateParams.PaymentMethodOptions.Grabpay#extraParams} for
+         * the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentUpdateParams.PaymentMethodOptions.Grabpay#extraParams} for
          * the field documentation.
          */
         public Builder putAllExtraParam(Map<String, Object> map) {

--- a/src/main/java/com/stripe/param/PaymentMethodListParams.java
+++ b/src/main/java/com/stripe/param/PaymentMethodListParams.java
@@ -11,7 +11,10 @@ import lombok.Getter;
 
 @Getter
 public class PaymentMethodListParams extends ApiRequestParams {
-  /** The ID of the customer whose PaymentMethods will be retrieved. */
+  /**
+   * The ID of the customer whose PaymentMethods will be retrieved. If not provided, the response
+   * list will be empty.
+   */
   @SerializedName("customer")
   String customer;
 
@@ -105,7 +108,10 @@ public class PaymentMethodListParams extends ApiRequestParams {
           this.type);
     }
 
-    /** The ID of the customer whose PaymentMethods will be retrieved. */
+    /**
+     * The ID of the customer whose PaymentMethods will be retrieved. If not provided, the response
+     * list will be empty.
+     */
     public Builder setCustomer(String customer) {
       this.customer = customer;
       return this;

--- a/src/main/java/com/stripe/param/billingportal/ConfigurationCreateParams.java
+++ b/src/main/java/com/stripe/param/billingportal/ConfigurationCreateParams.java
@@ -1386,7 +1386,7 @@ public class ConfigurationCreateParams extends ApiRequestParams {
         @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
         Map<String, Object> extraParams;
 
-        /** The list of prices IDs that a subscription can be updated to. */
+        /** The list of price IDs for the product that a subscription can be updated to. */
         @SerializedName("prices")
         List<String> prices;
 

--- a/src/main/java/com/stripe/param/billingportal/ConfigurationUpdateParams.java
+++ b/src/main/java/com/stripe/param/billingportal/ConfigurationUpdateParams.java
@@ -1443,7 +1443,7 @@ public class ConfigurationUpdateParams extends ApiRequestParams {
         @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
         Map<String, Object> extraParams;
 
-        /** The list of prices IDs that a subscription can be updated to. */
+        /** The list of price IDs for the product that a subscription can be updated to. */
         @SerializedName("prices")
         List<String> prices;
 


### PR DESCRIPTION
Codegen for openapi 31569c9 and 28e1e6d.
r? @yejia-stripe
cc @stripe/api-libraries

## Changelog
* Add support for `customer_creation` on `CheckoutSessionCreateParams` and `Checkout.Session`
* Add support for `fpx` and `grabpay` on `PaymentIntentCreateParams.payment_method_options`, `PaymentIntentUpdateParams.payment_method_options`, `PaymentIntentConfirmParams.payment_method_options`, and `PaymentIntent.payment_method_options`
* Add support for `PaidOutOfBand` on `Invoice`