### PR TITLE
API Updates

### DIFF
--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -314,7 +314,11 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
   @SerializedName("statement_descriptor_suffix")
   String statementDescriptorSuffix;
 
-  /** The status of the payment is either {@code succeeded}, {@code pending}, or {@code failed}. */
+  /**
+   * The status of the payment is either {@code succeeded}, {@code pending}, or {@code failed}.
+   *
+   * <p>One of {@code failed}, {@code pending}, or {@code succeeded}.
+   */
   @SerializedName("status")
   String status;
 

--- a/src/main/java/com/stripe/model/PaymentIntent.java
+++ b/src/main/java/com/stripe/model/PaymentIntent.java
@@ -1141,6 +1141,20 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
       /** The base64 image data for a pre-generated QR code. */
       @SerializedName("image_data_url")
       String imageDataUrl;
+
+      /**
+       * The image_url_png string used to render QR code, can be used as &lt;img src=&quot;…&quot;
+       * /&gt;.
+       */
+      @SerializedName("image_url_png")
+      String imageUrlPng;
+
+      /**
+       * The image_url_svg string used to render QR code, can be used as &lt;img src=&quot;…&quot;
+       * /&gt;.
+       */
+      @SerializedName("image_url_svg")
+      String imageUrlSvg;
     }
 
     @Getter
@@ -1301,6 +1315,9 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
     @SerializedName("au_becs_debit")
     AuBecsDebit auBecsDebit;
 
+    @SerializedName("bacs_debit")
+    BacsDebit bacsDebit;
+
     @SerializedName("bancontact")
     Bancontact bancontact;
 
@@ -1312,6 +1329,9 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
 
     @SerializedName("card_present")
     CardPresent cardPresent;
+
+    @SerializedName("eps")
+    Eps eps;
 
     @SerializedName("fpx")
     Fpx fpx;
@@ -1417,6 +1437,11 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
     @Setter
     @EqualsAndHashCode(callSuper = false)
     public static class AuBecsDebit extends StripeObject {}
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class BacsDebit extends StripeObject {}
 
     @Getter
     @Setter
@@ -1545,6 +1570,11 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
     @Setter
     @EqualsAndHashCode(callSuper = false)
     public static class CardPresent extends StripeObject {}
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class Eps extends StripeObject {}
 
     @Getter
     @Setter

--- a/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
@@ -3448,6 +3448,13 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
     Object auBecsDebit;
 
     /**
+     * If this is a {@code bacs_debit} PaymentMethod, this sub-hash contains details about the BACS
+     * Debit payment method options.
+     */
+    @SerializedName("bacs_debit")
+    Object bacsDebit;
+
+    /**
      * If this is a {@code bancontact} PaymentMethod, this sub-hash contains details about the
      * Bancontact payment method options.
      */
@@ -3471,6 +3478,13 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
      */
     @SerializedName("card_present")
     Object cardPresent;
+
+    /**
+     * If this is a {@code eps} PaymentMethod, this sub-hash contains details about the EPS payment
+     * method options.
+     */
+    @SerializedName("eps")
+    Object eps;
 
     /**
      * Map of extra parameters for custom features not available in this client library. The content
@@ -3563,10 +3577,12 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
         Object afterpayClearpay,
         Object alipay,
         Object auBecsDebit,
+        Object bacsDebit,
         Object bancontact,
         Object boleto,
         Object card,
         Object cardPresent,
+        Object eps,
         Map<String, Object> extraParams,
         Object fpx,
         Object giropay,
@@ -3583,10 +3599,12 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       this.afterpayClearpay = afterpayClearpay;
       this.alipay = alipay;
       this.auBecsDebit = auBecsDebit;
+      this.bacsDebit = bacsDebit;
       this.bancontact = bancontact;
       this.boleto = boleto;
       this.card = card;
       this.cardPresent = cardPresent;
+      this.eps = eps;
       this.extraParams = extraParams;
       this.fpx = fpx;
       this.giropay = giropay;
@@ -3614,6 +3632,8 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
 
       private Object auBecsDebit;
 
+      private Object bacsDebit;
+
       private Object bancontact;
 
       private Object boleto;
@@ -3621,6 +3641,8 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       private Object card;
 
       private Object cardPresent;
+
+      private Object eps;
 
       private Map<String, Object> extraParams;
 
@@ -3653,10 +3675,12 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
             this.afterpayClearpay,
             this.alipay,
             this.auBecsDebit,
+            this.bacsDebit,
             this.bancontact,
             this.boleto,
             this.card,
             this.cardPresent,
+            this.eps,
             this.extraParams,
             this.fpx,
             this.giropay,
@@ -3744,6 +3768,24 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       }
 
       /**
+       * If this is a {@code bacs_debit} PaymentMethod, this sub-hash contains details about the
+       * BACS Debit payment method options.
+       */
+      public Builder setBacsDebit(BacsDebit bacsDebit) {
+        this.bacsDebit = bacsDebit;
+        return this;
+      }
+
+      /**
+       * If this is a {@code bacs_debit} PaymentMethod, this sub-hash contains details about the
+       * BACS Debit payment method options.
+       */
+      public Builder setBacsDebit(EmptyParam bacsDebit) {
+        this.bacsDebit = bacsDebit;
+        return this;
+      }
+
+      /**
        * If this is a {@code bancontact} PaymentMethod, this sub-hash contains details about the
        * Bancontact payment method options.
        */
@@ -3806,6 +3848,24 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
        */
       public Builder setCardPresent(EmptyParam cardPresent) {
         this.cardPresent = cardPresent;
+        return this;
+      }
+
+      /**
+       * If this is a {@code eps} PaymentMethod, this sub-hash contains details about the EPS
+       * payment method options.
+       */
+      public Builder setEps(Eps eps) {
+        this.eps = eps;
+        return this;
+      }
+
+      /**
+       * If this is a {@code eps} PaymentMethod, this sub-hash contains details about the EPS
+       * payment method options.
+       */
+      public Builder setEps(EmptyParam eps) {
+        this.eps = eps;
         return this;
       }
 
@@ -4505,6 +4565,63 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
          * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
          * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
          * map. See {@link PaymentIntentConfirmParams.PaymentMethodOptions.AuBecsDebit#extraParams}
+         * for the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+      }
+    }
+
+    @Getter
+    public static class BacsDebit {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private BacsDebit(Map<String, Object> extraParams) {
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public BacsDebit build() {
+          return new BacsDebit(this.extraParams);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentConfirmParams.PaymentMethodOptions.BacsDebit#extraParams}
+         * for the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentConfirmParams.PaymentMethodOptions.BacsDebit#extraParams}
          * for the field documentation.
          */
         public Builder putAllExtraParam(Map<String, Object> map) {
@@ -5316,6 +5433,63 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
          * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
          * map. See {@link PaymentIntentConfirmParams.PaymentMethodOptions.CardPresent#extraParams}
          * for the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+      }
+    }
+
+    @Getter
+    public static class Eps {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private Eps(Map<String, Object> extraParams) {
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Eps build() {
+          return new Eps(this.extraParams);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentConfirmParams.PaymentMethodOptions.Eps#extraParams} for the
+         * field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentConfirmParams.PaymentMethodOptions.Eps#extraParams} for the
+         * field documentation.
          */
         public Builder putAllExtraParam(Map<String, Object> map) {
           if (this.extraParams == null) {

--- a/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
@@ -3910,6 +3910,13 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     Object auBecsDebit;
 
     /**
+     * If this is a {@code bacs_debit} PaymentMethod, this sub-hash contains details about the BACS
+     * Debit payment method options.
+     */
+    @SerializedName("bacs_debit")
+    Object bacsDebit;
+
+    /**
      * If this is a {@code bancontact} PaymentMethod, this sub-hash contains details about the
      * Bancontact payment method options.
      */
@@ -3933,6 +3940,13 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
      */
     @SerializedName("card_present")
     Object cardPresent;
+
+    /**
+     * If this is a {@code eps} PaymentMethod, this sub-hash contains details about the EPS payment
+     * method options.
+     */
+    @SerializedName("eps")
+    Object eps;
 
     /**
      * Map of extra parameters for custom features not available in this client library. The content
@@ -4025,10 +4039,12 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
         Object afterpayClearpay,
         Object alipay,
         Object auBecsDebit,
+        Object bacsDebit,
         Object bancontact,
         Object boleto,
         Object card,
         Object cardPresent,
+        Object eps,
         Map<String, Object> extraParams,
         Object fpx,
         Object giropay,
@@ -4045,10 +4061,12 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       this.afterpayClearpay = afterpayClearpay;
       this.alipay = alipay;
       this.auBecsDebit = auBecsDebit;
+      this.bacsDebit = bacsDebit;
       this.bancontact = bancontact;
       this.boleto = boleto;
       this.card = card;
       this.cardPresent = cardPresent;
+      this.eps = eps;
       this.extraParams = extraParams;
       this.fpx = fpx;
       this.giropay = giropay;
@@ -4076,6 +4094,8 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
 
       private Object auBecsDebit;
 
+      private Object bacsDebit;
+
       private Object bancontact;
 
       private Object boleto;
@@ -4083,6 +4103,8 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       private Object card;
 
       private Object cardPresent;
+
+      private Object eps;
 
       private Map<String, Object> extraParams;
 
@@ -4115,10 +4137,12 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
             this.afterpayClearpay,
             this.alipay,
             this.auBecsDebit,
+            this.bacsDebit,
             this.bancontact,
             this.boleto,
             this.card,
             this.cardPresent,
+            this.eps,
             this.extraParams,
             this.fpx,
             this.giropay,
@@ -4206,6 +4230,24 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       }
 
       /**
+       * If this is a {@code bacs_debit} PaymentMethod, this sub-hash contains details about the
+       * BACS Debit payment method options.
+       */
+      public Builder setBacsDebit(BacsDebit bacsDebit) {
+        this.bacsDebit = bacsDebit;
+        return this;
+      }
+
+      /**
+       * If this is a {@code bacs_debit} PaymentMethod, this sub-hash contains details about the
+       * BACS Debit payment method options.
+       */
+      public Builder setBacsDebit(EmptyParam bacsDebit) {
+        this.bacsDebit = bacsDebit;
+        return this;
+      }
+
+      /**
        * If this is a {@code bancontact} PaymentMethod, this sub-hash contains details about the
        * Bancontact payment method options.
        */
@@ -4268,6 +4310,24 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
        */
       public Builder setCardPresent(EmptyParam cardPresent) {
         this.cardPresent = cardPresent;
+        return this;
+      }
+
+      /**
+       * If this is a {@code eps} PaymentMethod, this sub-hash contains details about the EPS
+       * payment method options.
+       */
+      public Builder setEps(Eps eps) {
+        this.eps = eps;
+        return this;
+      }
+
+      /**
+       * If this is a {@code eps} PaymentMethod, this sub-hash contains details about the EPS
+       * payment method options.
+       */
+      public Builder setEps(EmptyParam eps) {
+        this.eps = eps;
         return this;
       }
 
@@ -4968,6 +5028,63 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
          * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
          * map. See {@link PaymentIntentCreateParams.PaymentMethodOptions.AuBecsDebit#extraParams}
          * for the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+      }
+    }
+
+    @Getter
+    public static class BacsDebit {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private BacsDebit(Map<String, Object> extraParams) {
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public BacsDebit build() {
+          return new BacsDebit(this.extraParams);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentCreateParams.PaymentMethodOptions.BacsDebit#extraParams} for
+         * the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentCreateParams.PaymentMethodOptions.BacsDebit#extraParams} for
+         * the field documentation.
          */
         public Builder putAllExtraParam(Map<String, Object> map) {
           if (this.extraParams == null) {
@@ -5778,6 +5895,63 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
          * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
          * map. See {@link PaymentIntentCreateParams.PaymentMethodOptions.CardPresent#extraParams}
          * for the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+      }
+    }
+
+    @Getter
+    public static class Eps {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private Eps(Map<String, Object> extraParams) {
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Eps build() {
+          return new Eps(this.extraParams);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentCreateParams.PaymentMethodOptions.Eps#extraParams} for the
+         * field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentCreateParams.PaymentMethodOptions.Eps#extraParams} for the
+         * field documentation.
          */
         public Builder putAllExtraParam(Map<String, Object> map) {
           if (this.extraParams == null) {

--- a/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
@@ -3458,6 +3458,13 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     Object auBecsDebit;
 
     /**
+     * If this is a {@code bacs_debit} PaymentMethod, this sub-hash contains details about the BACS
+     * Debit payment method options.
+     */
+    @SerializedName("bacs_debit")
+    Object bacsDebit;
+
+    /**
      * If this is a {@code bancontact} PaymentMethod, this sub-hash contains details about the
      * Bancontact payment method options.
      */
@@ -3481,6 +3488,13 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
      */
     @SerializedName("card_present")
     Object cardPresent;
+
+    /**
+     * If this is a {@code eps} PaymentMethod, this sub-hash contains details about the EPS payment
+     * method options.
+     */
+    @SerializedName("eps")
+    Object eps;
 
     /**
      * Map of extra parameters for custom features not available in this client library. The content
@@ -3573,10 +3587,12 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
         Object afterpayClearpay,
         Object alipay,
         Object auBecsDebit,
+        Object bacsDebit,
         Object bancontact,
         Object boleto,
         Object card,
         Object cardPresent,
+        Object eps,
         Map<String, Object> extraParams,
         Object fpx,
         Object giropay,
@@ -3593,10 +3609,12 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       this.afterpayClearpay = afterpayClearpay;
       this.alipay = alipay;
       this.auBecsDebit = auBecsDebit;
+      this.bacsDebit = bacsDebit;
       this.bancontact = bancontact;
       this.boleto = boleto;
       this.card = card;
       this.cardPresent = cardPresent;
+      this.eps = eps;
       this.extraParams = extraParams;
       this.fpx = fpx;
       this.giropay = giropay;
@@ -3624,6 +3642,8 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
 
       private Object auBecsDebit;
 
+      private Object bacsDebit;
+
       private Object bancontact;
 
       private Object boleto;
@@ -3631,6 +3651,8 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       private Object card;
 
       private Object cardPresent;
+
+      private Object eps;
 
       private Map<String, Object> extraParams;
 
@@ -3663,10 +3685,12 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
             this.afterpayClearpay,
             this.alipay,
             this.auBecsDebit,
+            this.bacsDebit,
             this.bancontact,
             this.boleto,
             this.card,
             this.cardPresent,
+            this.eps,
             this.extraParams,
             this.fpx,
             this.giropay,
@@ -3754,6 +3778,24 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       }
 
       /**
+       * If this is a {@code bacs_debit} PaymentMethod, this sub-hash contains details about the
+       * BACS Debit payment method options.
+       */
+      public Builder setBacsDebit(BacsDebit bacsDebit) {
+        this.bacsDebit = bacsDebit;
+        return this;
+      }
+
+      /**
+       * If this is a {@code bacs_debit} PaymentMethod, this sub-hash contains details about the
+       * BACS Debit payment method options.
+       */
+      public Builder setBacsDebit(EmptyParam bacsDebit) {
+        this.bacsDebit = bacsDebit;
+        return this;
+      }
+
+      /**
        * If this is a {@code bancontact} PaymentMethod, this sub-hash contains details about the
        * Bancontact payment method options.
        */
@@ -3816,6 +3858,24 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
        */
       public Builder setCardPresent(EmptyParam cardPresent) {
         this.cardPresent = cardPresent;
+        return this;
+      }
+
+      /**
+       * If this is a {@code eps} PaymentMethod, this sub-hash contains details about the EPS
+       * payment method options.
+       */
+      public Builder setEps(Eps eps) {
+        this.eps = eps;
+        return this;
+      }
+
+      /**
+       * If this is a {@code eps} PaymentMethod, this sub-hash contains details about the EPS
+       * payment method options.
+       */
+      public Builder setEps(EmptyParam eps) {
+        this.eps = eps;
         return this;
       }
 
@@ -4536,6 +4596,63 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
          * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
          * map. See {@link PaymentIntentUpdateParams.PaymentMethodOptions.AuBecsDebit#extraParams}
          * for the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+      }
+    }
+
+    @Getter
+    public static class BacsDebit {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private BacsDebit(Map<String, Object> extraParams) {
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public BacsDebit build() {
+          return new BacsDebit(this.extraParams);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentUpdateParams.PaymentMethodOptions.BacsDebit#extraParams} for
+         * the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentUpdateParams.PaymentMethodOptions.BacsDebit#extraParams} for
+         * the field documentation.
          */
         public Builder putAllExtraParam(Map<String, Object> map) {
           if (this.extraParams == null) {
@@ -5356,6 +5473,63 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
          * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
          * map. See {@link PaymentIntentUpdateParams.PaymentMethodOptions.CardPresent#extraParams}
          * for the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+      }
+    }
+
+    @Getter
+    public static class Eps {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private Eps(Map<String, Object> extraParams) {
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Eps build() {
+          return new Eps(this.extraParams);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentUpdateParams.PaymentMethodOptions.Eps#extraParams} for the
+         * field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentUpdateParams.PaymentMethodOptions.Eps#extraParams} for the
+         * field documentation.
          */
         public Builder putAllExtraParam(Map<String, Object> map) {
           if (this.extraParams == null) {


### PR DESCRIPTION
Codegen for openapi 7734045.
r? @yejia-stripe
cc @stripe/api-libraries

## Changelog
* Add support for `bacs_debit` and `eps` on `PaymentIntentCreateParams.payment_method_options`, `PaymentIntentUpdateParams.payment_method_options`, `PaymentIntentConfirmParams.payment_method_options`, and `PaymentIntent.payment_method_options`
* Add support for `image_url_png` and `image_url_svg` on `PaymentIntent.next_action.wechat_pay_display_qr_code`

