### PR TITLE
Pin grgit version to 4.1.1.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,13 @@ buildscript {
     }
     dependencies {
         classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.30.0"
+
+        // Explicitly pin grgit to 4.1.1. This is a dependencdy of git-publish,
+        // but git-publish pins to grgit-core:latest. Unfortunately grgit 5+
+        // no longer support Java 8, but we still support Java 8.
+        classpath ("org.ajoberstar.grgit:grgit-core:4.1.1") {
+            force = true
+        }
     }
 }
 


### PR DESCRIPTION
r? @yejia-stripe 
cc @richardm-stripe 

## Summary

Pins the grgit-core version to 4.1.1 (latest v4 release). The git-publish package depends on this, but uses `release.latest` as its version. grgit just released v5.0.0 which no longer supports Java 8. We want to continue supporting Java 8 so this pin is necessary.

## Test plan

Java 8 tests pass again 🎉 