### PR TITLE
API Updates

### DIFF
--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -1496,8 +1496,8 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
      * jp_cn}, {@code jp_rn}, {@code li_uid}, {@code my_itn}, {@code us_ein}, {@code kr_brn}, {@code
      * ca_qst}, {@code ca_gst_hst}, {@code ca_pst_bc}, {@code ca_pst_mb}, {@code ca_pst_sk}, {@code
      * my_sst}, {@code sg_gst}, {@code ae_trn}, {@code cl_tin}, {@code sa_vat}, {@code id_npwp},
-     * {@code my_frp}, {@code il_vat}, {@code ge_vat}, {@code ua_vat}, {@code is_vat}, or {@code
-     * unknown}.
+     * {@code my_frp}, {@code il_vat}, {@code ge_vat}, {@code ua_vat}, {@code is_vat}, {@code
+     * bg_uic}, {@code hu_tin}, {@code si_tin}, or {@code unknown}.
      */
     @SerializedName("type")
     String type;

--- a/src/main/java/com/stripe/model/Refund.java
+++ b/src/main/java/com/stripe/model/Refund.java
@@ -6,6 +6,7 @@ import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
+import com.stripe.param.RefundCancelParams;
 import com.stripe.param.RefundCreateParams;
 import com.stripe.param.RefundListParams;
 import com.stripe.param.RefundRetrieveParams;
@@ -401,6 +402,76 @@ public class Refund extends ApiResource implements MetadataStore<Refund>, Balanc
             "%s%s",
             Stripe.getApiBase(),
             String.format("/v1/refunds/%s", ApiResource.urlEncodeId(this.getId())));
+    return ApiResource.request(ApiResource.RequestMethod.POST, url, params, Refund.class, options);
+  }
+
+  /**
+   * Cancels a refund with a status of <code>requires_action</code>.
+   *
+   * <p>Refunds in other states cannot be canceled, and only refunds for payment methods that
+   * require customer action will enter the <code>requires_action</code> state.
+   */
+  public Refund cancel() throws StripeException {
+    return cancel((Map<String, Object>) null, (RequestOptions) null);
+  }
+
+  /**
+   * Cancels a refund with a status of <code>requires_action</code>.
+   *
+   * <p>Refunds in other states cannot be canceled, and only refunds for payment methods that
+   * require customer action will enter the <code>requires_action</code> state.
+   */
+  public Refund cancel(RequestOptions options) throws StripeException {
+    return cancel((Map<String, Object>) null, options);
+  }
+
+  /**
+   * Cancels a refund with a status of <code>requires_action</code>.
+   *
+   * <p>Refunds in other states cannot be canceled, and only refunds for payment methods that
+   * require customer action will enter the <code>requires_action</code> state.
+   */
+  public Refund cancel(Map<String, Object> params) throws StripeException {
+    return cancel(params, (RequestOptions) null);
+  }
+
+  /**
+   * Cancels a refund with a status of <code>requires_action</code>.
+   *
+   * <p>Refunds in other states cannot be canceled, and only refunds for payment methods that
+   * require customer action will enter the <code>requires_action</code> state.
+   */
+  public Refund cancel(Map<String, Object> params, RequestOptions options) throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/refunds/%s/cancel", ApiResource.urlEncodeId(this.getId())));
+    return ApiResource.request(ApiResource.RequestMethod.POST, url, params, Refund.class, options);
+  }
+
+  /**
+   * Cancels a refund with a status of <code>requires_action</code>.
+   *
+   * <p>Refunds in other states cannot be canceled, and only refunds for payment methods that
+   * require customer action will enter the <code>requires_action</code> state.
+   */
+  public Refund cancel(RefundCancelParams params) throws StripeException {
+    return cancel(params, (RequestOptions) null);
+  }
+
+  /**
+   * Cancels a refund with a status of <code>requires_action</code>.
+   *
+   * <p>Refunds in other states cannot be canceled, and only refunds for payment methods that
+   * require customer action will enter the <code>requires_action</code> state.
+   */
+  public Refund cancel(RefundCancelParams params, RequestOptions options) throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/refunds/%s/cancel", ApiResource.urlEncodeId(this.getId())));
     return ApiResource.request(ApiResource.RequestMethod.POST, url, params, Refund.class, options);
   }
 

--- a/src/main/java/com/stripe/model/TaxId.java
+++ b/src/main/java/com/stripe/model/TaxId.java
@@ -54,15 +54,15 @@ public class TaxId extends ApiResource implements HasId {
   String object;
 
   /**
-   * Type of the tax ID, one of {@code ae_trn}, {@code au_abn}, {@code au_arn}, {@code br_cnpj},
-   * {@code br_cpf}, {@code ca_bn}, {@code ca_gst_hst}, {@code ca_pst_bc}, {@code ca_pst_mb}, {@code
-   * ca_pst_sk}, {@code ca_qst}, {@code ch_vat}, {@code cl_tin}, {@code es_cif}, {@code eu_vat},
-   * {@code gb_vat}, {@code ge_vat}, {@code hk_br}, {@code id_npwp}, {@code il_vat}, {@code in_gst},
-   * {@code is_vat}, {@code jp_cn}, {@code jp_rn}, {@code kr_brn}, {@code li_uid}, {@code mx_rfc},
-   * {@code my_frp}, {@code my_itn}, {@code my_sst}, {@code no_vat}, {@code nz_gst}, {@code ru_inn},
-   * {@code ru_kpp}, {@code sa_vat}, {@code sg_gst}, {@code sg_uen}, {@code th_vat}, {@code tw_vat},
-   * {@code ua_vat}, {@code us_ein}, or {@code za_vat}. Note that some legacy tax IDs have type
-   * {@code unknown}
+   * Type of the tax ID, one of {@code ae_trn}, {@code au_abn}, {@code au_arn}, {@code bg_uic},
+   * {@code br_cnpj}, {@code br_cpf}, {@code ca_bn}, {@code ca_gst_hst}, {@code ca_pst_bc}, {@code
+   * ca_pst_mb}, {@code ca_pst_sk}, {@code ca_qst}, {@code ch_vat}, {@code cl_tin}, {@code es_cif},
+   * {@code eu_vat}, {@code gb_vat}, {@code ge_vat}, {@code hk_br}, {@code hu_tin}, {@code id_npwp},
+   * {@code il_vat}, {@code in_gst}, {@code is_vat}, {@code jp_cn}, {@code jp_rn}, {@code kr_brn},
+   * {@code li_uid}, {@code mx_rfc}, {@code my_frp}, {@code my_itn}, {@code my_sst}, {@code no_vat},
+   * {@code nz_gst}, {@code ru_inn}, {@code ru_kpp}, {@code sa_vat}, {@code sg_gst}, {@code sg_uen},
+   * {@code si_tin}, {@code th_vat}, {@code tw_vat}, {@code ua_vat}, {@code us_ein}, or {@code
+   * za_vat}. Note that some legacy tax IDs have type {@code unknown}
    */
   @SerializedName("type")
   String type;

--- a/src/main/java/com/stripe/model/checkout/Session.java
+++ b/src/main/java/com/stripe/model/checkout/Session.java
@@ -719,7 +719,7 @@ public class Session extends ApiResource implements HasId {
        * kr_brn}, {@code ca_qst}, {@code ca_gst_hst}, {@code ca_pst_bc}, {@code ca_pst_mb}, {@code
        * ca_pst_sk}, {@code my_sst}, {@code sg_gst}, {@code ae_trn}, {@code cl_tin}, {@code sa_vat},
        * {@code id_npwp}, {@code my_frp}, {@code il_vat}, {@code ge_vat}, {@code ua_vat}, {@code
-       * is_vat}, or {@code unknown}.
+       * is_vat}, {@code bg_uic}, {@code hu_tin}, {@code si_tin}, or {@code unknown}.
        */
       @SerializedName("type")
       String type;

--- a/src/main/java/com/stripe/param/CustomerCreateParams.java
+++ b/src/main/java/com/stripe/param/CustomerCreateParams.java
@@ -1272,14 +1272,15 @@ public class CustomerCreateParams extends ApiRequestParams {
     Map<String, Object> extraParams;
 
     /**
-     * Type of the tax ID, one of {@code ae_trn}, {@code au_abn}, {@code au_arn}, {@code br_cnpj},
-     * {@code br_cpf}, {@code ca_bn}, {@code ca_gst_hst}, {@code ca_pst_bc}, {@code ca_pst_mb},
-     * {@code ca_pst_sk}, {@code ca_qst}, {@code ch_vat}, {@code cl_tin}, {@code es_cif}, {@code
-     * eu_vat}, {@code gb_vat}, {@code ge_vat}, {@code hk_br}, {@code id_npwp}, {@code il_vat},
-     * {@code in_gst}, {@code is_vat}, {@code jp_cn}, {@code jp_rn}, {@code kr_brn}, {@code li_uid},
-     * {@code mx_rfc}, {@code my_frp}, {@code my_itn}, {@code my_sst}, {@code no_vat}, {@code
-     * nz_gst}, {@code ru_inn}, {@code ru_kpp}, {@code sa_vat}, {@code sg_gst}, {@code sg_uen},
-     * {@code th_vat}, {@code tw_vat}, {@code ua_vat}, {@code us_ein}, or {@code za_vat}.
+     * Type of the tax ID, one of {@code ae_trn}, {@code au_abn}, {@code au_arn}, {@code bg_uic},
+     * {@code br_cnpj}, {@code br_cpf}, {@code ca_bn}, {@code ca_gst_hst}, {@code ca_pst_bc}, {@code
+     * ca_pst_mb}, {@code ca_pst_sk}, {@code ca_qst}, {@code ch_vat}, {@code cl_tin}, {@code
+     * es_cif}, {@code eu_vat}, {@code gb_vat}, {@code ge_vat}, {@code hk_br}, {@code hu_tin},
+     * {@code id_npwp}, {@code il_vat}, {@code in_gst}, {@code is_vat}, {@code jp_cn}, {@code
+     * jp_rn}, {@code kr_brn}, {@code li_uid}, {@code mx_rfc}, {@code my_frp}, {@code my_itn},
+     * {@code my_sst}, {@code no_vat}, {@code nz_gst}, {@code ru_inn}, {@code ru_kpp}, {@code
+     * sa_vat}, {@code sg_gst}, {@code sg_uen}, {@code si_tin}, {@code th_vat}, {@code tw_vat},
+     * {@code ua_vat}, {@code us_ein}, or {@code za_vat}.
      */
     @SerializedName("type")
     Type type;
@@ -1337,14 +1338,15 @@ public class CustomerCreateParams extends ApiRequestParams {
       }
 
       /**
-       * Type of the tax ID, one of {@code ae_trn}, {@code au_abn}, {@code au_arn}, {@code br_cnpj},
-       * {@code br_cpf}, {@code ca_bn}, {@code ca_gst_hst}, {@code ca_pst_bc}, {@code ca_pst_mb},
-       * {@code ca_pst_sk}, {@code ca_qst}, {@code ch_vat}, {@code cl_tin}, {@code es_cif}, {@code
-       * eu_vat}, {@code gb_vat}, {@code ge_vat}, {@code hk_br}, {@code id_npwp}, {@code il_vat},
-       * {@code in_gst}, {@code is_vat}, {@code jp_cn}, {@code jp_rn}, {@code kr_brn}, {@code
-       * li_uid}, {@code mx_rfc}, {@code my_frp}, {@code my_itn}, {@code my_sst}, {@code no_vat},
-       * {@code nz_gst}, {@code ru_inn}, {@code ru_kpp}, {@code sa_vat}, {@code sg_gst}, {@code
-       * sg_uen}, {@code th_vat}, {@code tw_vat}, {@code ua_vat}, {@code us_ein}, or {@code za_vat}.
+       * Type of the tax ID, one of {@code ae_trn}, {@code au_abn}, {@code au_arn}, {@code bg_uic},
+       * {@code br_cnpj}, {@code br_cpf}, {@code ca_bn}, {@code ca_gst_hst}, {@code ca_pst_bc},
+       * {@code ca_pst_mb}, {@code ca_pst_sk}, {@code ca_qst}, {@code ch_vat}, {@code cl_tin},
+       * {@code es_cif}, {@code eu_vat}, {@code gb_vat}, {@code ge_vat}, {@code hk_br}, {@code
+       * hu_tin}, {@code id_npwp}, {@code il_vat}, {@code in_gst}, {@code is_vat}, {@code jp_cn},
+       * {@code jp_rn}, {@code kr_brn}, {@code li_uid}, {@code mx_rfc}, {@code my_frp}, {@code
+       * my_itn}, {@code my_sst}, {@code no_vat}, {@code nz_gst}, {@code ru_inn}, {@code ru_kpp},
+       * {@code sa_vat}, {@code sg_gst}, {@code sg_uen}, {@code si_tin}, {@code th_vat}, {@code
+       * tw_vat}, {@code ua_vat}, {@code us_ein}, or {@code za_vat}.
        */
       public Builder setType(Type type) {
         this.type = type;
@@ -1367,6 +1369,9 @@ public class CustomerCreateParams extends ApiRequestParams {
 
       @SerializedName("au_arn")
       AU_ARN("au_arn"),
+
+      @SerializedName("bg_uic")
+      BG_UIC("bg_uic"),
 
       @SerializedName("br_cnpj")
       BR_CNPJ("br_cnpj"),
@@ -1412,6 +1417,9 @@ public class CustomerCreateParams extends ApiRequestParams {
 
       @SerializedName("hk_br")
       HK_BR("hk_br"),
+
+      @SerializedName("hu_tin")
+      HU_TIN("hu_tin"),
 
       @SerializedName("id_npwp")
       ID_NPWP("id_npwp"),
@@ -1469,6 +1477,9 @@ public class CustomerCreateParams extends ApiRequestParams {
 
       @SerializedName("sg_uen")
       SG_UEN("sg_uen"),
+
+      @SerializedName("si_tin")
+      SI_TIN("si_tin"),
 
       @SerializedName("th_vat")
       TH_VAT("th_vat"),

--- a/src/main/java/com/stripe/param/InvoiceUpcomingParams.java
+++ b/src/main/java/com/stripe/param/InvoiceUpcomingParams.java
@@ -1415,14 +1415,15 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
       Map<String, Object> extraParams;
 
       /**
-       * Type of the tax ID, one of {@code ae_trn}, {@code au_abn}, {@code au_arn}, {@code br_cnpj},
-       * {@code br_cpf}, {@code ca_bn}, {@code ca_gst_hst}, {@code ca_pst_bc}, {@code ca_pst_mb},
-       * {@code ca_pst_sk}, {@code ca_qst}, {@code ch_vat}, {@code cl_tin}, {@code es_cif}, {@code
-       * eu_vat}, {@code gb_vat}, {@code ge_vat}, {@code hk_br}, {@code id_npwp}, {@code il_vat},
-       * {@code in_gst}, {@code is_vat}, {@code jp_cn}, {@code jp_rn}, {@code kr_brn}, {@code
-       * li_uid}, {@code mx_rfc}, {@code my_frp}, {@code my_itn}, {@code my_sst}, {@code no_vat},
-       * {@code nz_gst}, {@code ru_inn}, {@code ru_kpp}, {@code sa_vat}, {@code sg_gst}, {@code
-       * sg_uen}, {@code th_vat}, {@code tw_vat}, {@code ua_vat}, {@code us_ein}, or {@code za_vat}.
+       * Type of the tax ID, one of {@code ae_trn}, {@code au_abn}, {@code au_arn}, {@code bg_uic},
+       * {@code br_cnpj}, {@code br_cpf}, {@code ca_bn}, {@code ca_gst_hst}, {@code ca_pst_bc},
+       * {@code ca_pst_mb}, {@code ca_pst_sk}, {@code ca_qst}, {@code ch_vat}, {@code cl_tin},
+       * {@code es_cif}, {@code eu_vat}, {@code gb_vat}, {@code ge_vat}, {@code hk_br}, {@code
+       * hu_tin}, {@code id_npwp}, {@code il_vat}, {@code in_gst}, {@code is_vat}, {@code jp_cn},
+       * {@code jp_rn}, {@code kr_brn}, {@code li_uid}, {@code mx_rfc}, {@code my_frp}, {@code
+       * my_itn}, {@code my_sst}, {@code no_vat}, {@code nz_gst}, {@code ru_inn}, {@code ru_kpp},
+       * {@code sa_vat}, {@code sg_gst}, {@code sg_uen}, {@code si_tin}, {@code th_vat}, {@code
+       * tw_vat}, {@code ua_vat}, {@code us_ein}, or {@code za_vat}.
        */
       @SerializedName("type")
       Type type;
@@ -1483,14 +1484,14 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
 
         /**
          * Type of the tax ID, one of {@code ae_trn}, {@code au_abn}, {@code au_arn}, {@code
-         * br_cnpj}, {@code br_cpf}, {@code ca_bn}, {@code ca_gst_hst}, {@code ca_pst_bc}, {@code
-         * ca_pst_mb}, {@code ca_pst_sk}, {@code ca_qst}, {@code ch_vat}, {@code cl_tin}, {@code
-         * es_cif}, {@code eu_vat}, {@code gb_vat}, {@code ge_vat}, {@code hk_br}, {@code id_npwp},
-         * {@code il_vat}, {@code in_gst}, {@code is_vat}, {@code jp_cn}, {@code jp_rn}, {@code
-         * kr_brn}, {@code li_uid}, {@code mx_rfc}, {@code my_frp}, {@code my_itn}, {@code my_sst},
-         * {@code no_vat}, {@code nz_gst}, {@code ru_inn}, {@code ru_kpp}, {@code sa_vat}, {@code
-         * sg_gst}, {@code sg_uen}, {@code th_vat}, {@code tw_vat}, {@code ua_vat}, {@code us_ein},
-         * or {@code za_vat}.
+         * bg_uic}, {@code br_cnpj}, {@code br_cpf}, {@code ca_bn}, {@code ca_gst_hst}, {@code
+         * ca_pst_bc}, {@code ca_pst_mb}, {@code ca_pst_sk}, {@code ca_qst}, {@code ch_vat}, {@code
+         * cl_tin}, {@code es_cif}, {@code eu_vat}, {@code gb_vat}, {@code ge_vat}, {@code hk_br},
+         * {@code hu_tin}, {@code id_npwp}, {@code il_vat}, {@code in_gst}, {@code is_vat}, {@code
+         * jp_cn}, {@code jp_rn}, {@code kr_brn}, {@code li_uid}, {@code mx_rfc}, {@code my_frp},
+         * {@code my_itn}, {@code my_sst}, {@code no_vat}, {@code nz_gst}, {@code ru_inn}, {@code
+         * ru_kpp}, {@code sa_vat}, {@code sg_gst}, {@code sg_uen}, {@code si_tin}, {@code th_vat},
+         * {@code tw_vat}, {@code ua_vat}, {@code us_ein}, or {@code za_vat}.
          */
         public Builder setType(Type type) {
           this.type = type;
@@ -1513,6 +1514,9 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
 
         @SerializedName("au_arn")
         AU_ARN("au_arn"),
+
+        @SerializedName("bg_uic")
+        BG_UIC("bg_uic"),
 
         @SerializedName("br_cnpj")
         BR_CNPJ("br_cnpj"),
@@ -1558,6 +1562,9 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
 
         @SerializedName("hk_br")
         HK_BR("hk_br"),
+
+        @SerializedName("hu_tin")
+        HU_TIN("hu_tin"),
 
         @SerializedName("id_npwp")
         ID_NPWP("id_npwp"),
@@ -1615,6 +1622,9 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
 
         @SerializedName("sg_uen")
         SG_UEN("sg_uen"),
+
+        @SerializedName("si_tin")
+        SI_TIN("si_tin"),
 
         @SerializedName("th_vat")
         TH_VAT("th_vat"),

--- a/src/main/java/com/stripe/param/QuoteListParams.java
+++ b/src/main/java/com/stripe/param/QuoteListParams.java
@@ -57,6 +57,13 @@ public class QuoteListParams extends ApiRequestParams {
   @SerializedName("status")
   Status status;
 
+  /**
+   * Provides a list of quotes that are associated with the specified test clock. The response will
+   * not include quotes with test clocks if this and the customer parameter is not set.
+   */
+  @SerializedName("test_clock")
+  String testClock;
+
   private QuoteListParams(
       String customer,
       String endingBefore,
@@ -64,7 +71,8 @@ public class QuoteListParams extends ApiRequestParams {
       Map<String, Object> extraParams,
       Long limit,
       String startingAfter,
-      Status status) {
+      Status status,
+      String testClock) {
     this.customer = customer;
     this.endingBefore = endingBefore;
     this.expand = expand;
@@ -72,6 +80,7 @@ public class QuoteListParams extends ApiRequestParams {
     this.limit = limit;
     this.startingAfter = startingAfter;
     this.status = status;
+    this.testClock = testClock;
   }
 
   public static Builder builder() {
@@ -93,6 +102,8 @@ public class QuoteListParams extends ApiRequestParams {
 
     private Status status;
 
+    private String testClock;
+
     /** Finalize and obtain parameter instance from this builder. */
     public QuoteListParams build() {
       return new QuoteListParams(
@@ -102,7 +113,8 @@ public class QuoteListParams extends ApiRequestParams {
           this.extraParams,
           this.limit,
           this.startingAfter,
-          this.status);
+          this.status,
+          this.testClock);
     }
 
     /** The ID of the customer whose quotes will be retrieved. */
@@ -197,6 +209,15 @@ public class QuoteListParams extends ApiRequestParams {
     /** The status of the quote. */
     public Builder setStatus(Status status) {
       this.status = status;
+      return this;
+    }
+
+    /**
+     * Provides a list of quotes that are associated with the specified test clock. The response
+     * will not include quotes with test clocks if this and the customer parameter is not set.
+     */
+    public Builder setTestClock(String testClock) {
+      this.testClock = testClock;
       return this;
     }
   }

--- a/src/main/java/com/stripe/param/RefundCancelParams.java
+++ b/src/main/java/com/stripe/param/RefundCancelParams.java
@@ -1,0 +1,98 @@
+// File generated from our OpenAPI spec
+package com.stripe.param;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class RefundCancelParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  private RefundCancelParams(List<String> expand, Map<String, Object> extraParams) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public RefundCancelParams build() {
+      return new RefundCancelParams(this.expand, this.extraParams);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * RefundCancelParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * RefundCancelParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * RefundCancelParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link RefundCancelParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/TaxIdCollectionCreateParams.java
+++ b/src/main/java/com/stripe/param/TaxIdCollectionCreateParams.java
@@ -25,14 +25,15 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
   Map<String, Object> extraParams;
 
   /**
-   * Type of the tax ID, one of {@code ae_trn}, {@code au_abn}, {@code au_arn}, {@code br_cnpj},
-   * {@code br_cpf}, {@code ca_bn}, {@code ca_gst_hst}, {@code ca_pst_bc}, {@code ca_pst_mb}, {@code
-   * ca_pst_sk}, {@code ca_qst}, {@code ch_vat}, {@code cl_tin}, {@code es_cif}, {@code eu_vat},
-   * {@code gb_vat}, {@code ge_vat}, {@code hk_br}, {@code id_npwp}, {@code il_vat}, {@code in_gst},
-   * {@code is_vat}, {@code jp_cn}, {@code jp_rn}, {@code kr_brn}, {@code li_uid}, {@code mx_rfc},
-   * {@code my_frp}, {@code my_itn}, {@code my_sst}, {@code no_vat}, {@code nz_gst}, {@code ru_inn},
-   * {@code ru_kpp}, {@code sa_vat}, {@code sg_gst}, {@code sg_uen}, {@code th_vat}, {@code tw_vat},
-   * {@code ua_vat}, {@code us_ein}, or {@code za_vat}.
+   * Type of the tax ID, one of {@code ae_trn}, {@code au_abn}, {@code au_arn}, {@code bg_uic},
+   * {@code br_cnpj}, {@code br_cpf}, {@code ca_bn}, {@code ca_gst_hst}, {@code ca_pst_bc}, {@code
+   * ca_pst_mb}, {@code ca_pst_sk}, {@code ca_qst}, {@code ch_vat}, {@code cl_tin}, {@code es_cif},
+   * {@code eu_vat}, {@code gb_vat}, {@code ge_vat}, {@code hk_br}, {@code hu_tin}, {@code id_npwp},
+   * {@code il_vat}, {@code in_gst}, {@code is_vat}, {@code jp_cn}, {@code jp_rn}, {@code kr_brn},
+   * {@code li_uid}, {@code mx_rfc}, {@code my_frp}, {@code my_itn}, {@code my_sst}, {@code no_vat},
+   * {@code nz_gst}, {@code ru_inn}, {@code ru_kpp}, {@code sa_vat}, {@code sg_gst}, {@code sg_uen},
+   * {@code si_tin}, {@code th_vat}, {@code tw_vat}, {@code ua_vat}, {@code us_ein}, or {@code
+   * za_vat}.
    */
   @SerializedName("type")
   Type type;
@@ -120,14 +121,15 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
     }
 
     /**
-     * Type of the tax ID, one of {@code ae_trn}, {@code au_abn}, {@code au_arn}, {@code br_cnpj},
-     * {@code br_cpf}, {@code ca_bn}, {@code ca_gst_hst}, {@code ca_pst_bc}, {@code ca_pst_mb},
-     * {@code ca_pst_sk}, {@code ca_qst}, {@code ch_vat}, {@code cl_tin}, {@code es_cif}, {@code
-     * eu_vat}, {@code gb_vat}, {@code ge_vat}, {@code hk_br}, {@code id_npwp}, {@code il_vat},
-     * {@code in_gst}, {@code is_vat}, {@code jp_cn}, {@code jp_rn}, {@code kr_brn}, {@code li_uid},
-     * {@code mx_rfc}, {@code my_frp}, {@code my_itn}, {@code my_sst}, {@code no_vat}, {@code
-     * nz_gst}, {@code ru_inn}, {@code ru_kpp}, {@code sa_vat}, {@code sg_gst}, {@code sg_uen},
-     * {@code th_vat}, {@code tw_vat}, {@code ua_vat}, {@code us_ein}, or {@code za_vat}.
+     * Type of the tax ID, one of {@code ae_trn}, {@code au_abn}, {@code au_arn}, {@code bg_uic},
+     * {@code br_cnpj}, {@code br_cpf}, {@code ca_bn}, {@code ca_gst_hst}, {@code ca_pst_bc}, {@code
+     * ca_pst_mb}, {@code ca_pst_sk}, {@code ca_qst}, {@code ch_vat}, {@code cl_tin}, {@code
+     * es_cif}, {@code eu_vat}, {@code gb_vat}, {@code ge_vat}, {@code hk_br}, {@code hu_tin},
+     * {@code id_npwp}, {@code il_vat}, {@code in_gst}, {@code is_vat}, {@code jp_cn}, {@code
+     * jp_rn}, {@code kr_brn}, {@code li_uid}, {@code mx_rfc}, {@code my_frp}, {@code my_itn},
+     * {@code my_sst}, {@code no_vat}, {@code nz_gst}, {@code ru_inn}, {@code ru_kpp}, {@code
+     * sa_vat}, {@code sg_gst}, {@code sg_uen}, {@code si_tin}, {@code th_vat}, {@code tw_vat},
+     * {@code ua_vat}, {@code us_ein}, or {@code za_vat}.
      */
     public Builder setType(Type type) {
       this.type = type;
@@ -150,6 +152,9 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
 
     @SerializedName("au_arn")
     AU_ARN("au_arn"),
+
+    @SerializedName("bg_uic")
+    BG_UIC("bg_uic"),
 
     @SerializedName("br_cnpj")
     BR_CNPJ("br_cnpj"),
@@ -195,6 +200,9 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
 
     @SerializedName("hk_br")
     HK_BR("hk_br"),
+
+    @SerializedName("hu_tin")
+    HU_TIN("hu_tin"),
 
     @SerializedName("id_npwp")
     ID_NPWP("id_npwp"),
@@ -252,6 +260,9 @@ public class TaxIdCollectionCreateParams extends ApiRequestParams {
 
     @SerializedName("sg_uen")
     SG_UEN("sg_uen"),
+
+    @SerializedName("si_tin")
+    SI_TIN("si_tin"),
 
     @SerializedName("th_vat")
     TH_VAT("th_vat"),

--- a/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
+++ b/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
@@ -1083,6 +1083,21 @@ public class WebhookEndpointCreateParams extends ApiRequestParams {
     @SerializedName("tax_rate.updated")
     TAX_RATE__UPDATED("tax_rate.updated"),
 
+    @SerializedName("test_helpers.test_clock.advancing")
+    TEST_HELPERS__TEST_CLOCK__ADVANCING("test_helpers.test_clock.advancing"),
+
+    @SerializedName("test_helpers.test_clock.created")
+    TEST_HELPERS__TEST_CLOCK__CREATED("test_helpers.test_clock.created"),
+
+    @SerializedName("test_helpers.test_clock.deleted")
+    TEST_HELPERS__TEST_CLOCK__DELETED("test_helpers.test_clock.deleted"),
+
+    @SerializedName("test_helpers.test_clock.internal_failure")
+    TEST_HELPERS__TEST_CLOCK__INTERNAL_FAILURE("test_helpers.test_clock.internal_failure"),
+
+    @SerializedName("test_helpers.test_clock.ready")
+    TEST_HELPERS__TEST_CLOCK__READY("test_helpers.test_clock.ready"),
+
     @SerializedName("topup.canceled")
     TOPUP__CANCELED("topup.canceled"),
 

--- a/src/main/java/com/stripe/param/WebhookEndpointUpdateParams.java
+++ b/src/main/java/com/stripe/param/WebhookEndpointUpdateParams.java
@@ -771,6 +771,21 @@ public class WebhookEndpointUpdateParams extends ApiRequestParams {
     @SerializedName("tax_rate.updated")
     TAX_RATE__UPDATED("tax_rate.updated"),
 
+    @SerializedName("test_helpers.test_clock.advancing")
+    TEST_HELPERS__TEST_CLOCK__ADVANCING("test_helpers.test_clock.advancing"),
+
+    @SerializedName("test_helpers.test_clock.created")
+    TEST_HELPERS__TEST_CLOCK__CREATED("test_helpers.test_clock.created"),
+
+    @SerializedName("test_helpers.test_clock.deleted")
+    TEST_HELPERS__TEST_CLOCK__DELETED("test_helpers.test_clock.deleted"),
+
+    @SerializedName("test_helpers.test_clock.internal_failure")
+    TEST_HELPERS__TEST_CLOCK__INTERNAL_FAILURE("test_helpers.test_clock.internal_failure"),
+
+    @SerializedName("test_helpers.test_clock.ready")
+    TEST_HELPERS__TEST_CLOCK__READY("test_helpers.test_clock.ready"),
+
     @SerializedName("topup.canceled")
     TOPUP__CANCELED("topup.canceled"),
 


### PR DESCRIPTION
Codegen for openapi 9664a38.
r? @richardm-stripe
cc @stripe/api-libraries

## Changelog
* Add support for `cancel` method on resource `Refund`
* Add support for new values `bg_uic`, `hu_tin`, and `si_tin` on enums `CustomerCreateParams.tax_id_data[].type`, `InvoiceUpcomingLinesParams.customer_details.tax_ids[].type`, `InvoiceUpcomingParams.customer_details.tax_ids[].type`, and `TaxIdCreateParams.type`
* Change `InvoiceCreateParams.customer` to be optional
* Add support for `test_clock` on `QuoteListParams`
* Add support for new values `test_helpers.test_clock.advancing`, `test_helpers.test_clock.created`, `test_helpers.test_clock.deleted`, `test_helpers.test_clock.internal_failure`, and `test_helpers.test_clock.ready` on enums `WebhookEndpointCreateParams.enabled_events[]` and `WebhookEndpointUpdateParams.enabled_events[]`

