### PR TITLE
API Updates

### DIFF
--- a/src/main/java/com/stripe/model/Account.java
+++ b/src/main/java/com/stripe/model/Account.java
@@ -53,7 +53,7 @@ public class Account extends ApiResource implements MetadataStore<Account>, Paym
   @SerializedName("country")
   String country;
 
-  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  /** Time at which the account was connected. Measured in seconds since the Unix epoch. */
   @SerializedName("created")
   Long created;
 
@@ -811,6 +811,15 @@ public class Account extends ApiResource implements MetadataStore<Account>, Paym
     String p24Payments;
 
     /**
+     * The status of the paynow payments capability of the account, or whether the account can
+     * directly process paynow charges.
+     *
+     * <p>One of {@code active}, {@code inactive}, or {@code pending}.
+     */
+    @SerializedName("paynow_payments")
+    String paynowPayments;
+
+    /**
      * The status of the SEPA Direct Debits payments capability of the account, or whether the
      * account can directly process SEPA Direct Debits charges.
      *
@@ -852,6 +861,15 @@ public class Account extends ApiResource implements MetadataStore<Account>, Paym
      */
     @SerializedName("transfers")
     String transfers;
+
+    /**
+     * The status of the US bank account ACH payments capability of the account, or whether the
+     * account can directly process US bank account charges.
+     *
+     * <p>One of {@code active}, {@code inactive}, or {@code pending}.
+     */
+    @SerializedName("us_bank_account_ach_payments")
+    String usBankAccountAchPayments;
   }
 
   @Getter

--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -147,6 +147,15 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
   Boolean disputed;
 
   /**
+   * ID of the balance transaction that describes the reversal of the balance on your account due to
+   * payment failure.
+   */
+  @SerializedName("failure_balance_transaction")
+  @Getter(lombok.AccessLevel.NONE)
+  @Setter(lombok.AccessLevel.NONE)
+  ExpandableField<BalanceTransaction> failureBalanceTransaction;
+
+  /**
    * Error code explaining reason for charge failure if available (see <a
    * href="https://stripe.com/docs/api#errors">the errors section</a> for a list of codes).
    */
@@ -455,6 +464,28 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
 
   public void setDisputeObject(Dispute expandableObject) {
     this.dispute = new ExpandableField<Dispute>(expandableObject.getId(), expandableObject);
+  }
+
+  /** Get ID of expandable {@code failureBalanceTransaction} object. */
+  public String getFailureBalanceTransaction() {
+    return (this.failureBalanceTransaction != null) ? this.failureBalanceTransaction.getId() : null;
+  }
+
+  public void setFailureBalanceTransaction(String id) {
+    this.failureBalanceTransaction =
+        ApiResource.setExpandableFieldId(id, this.failureBalanceTransaction);
+  }
+
+  /** Get expanded {@code failureBalanceTransaction}. */
+  public BalanceTransaction getFailureBalanceTransactionObject() {
+    return (this.failureBalanceTransaction != null)
+        ? this.failureBalanceTransaction.getExpanded()
+        : null;
+  }
+
+  public void setFailureBalanceTransactionObject(BalanceTransaction expandableObject) {
+    this.failureBalanceTransaction =
+        new ExpandableField<BalanceTransaction>(expandableObject.getId(), expandableObject);
   }
 
   /** Get ID of expandable {@code invoice} object. */
@@ -1078,6 +1109,9 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
     @SerializedName("p24")
     P24 p24;
 
+    @SerializedName("paynow")
+    Paynow paynow;
+
     @SerializedName("sepa_credit_transfer")
     SepaCreditTransfer sepaCreditTransfer;
 
@@ -1101,6 +1135,9 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
      */
     @SerializedName("type")
     String type;
+
+    @SerializedName("us_bank_account")
+    UsBankAccount usBankAccount;
 
     @SerializedName("wechat")
     Wechat wechat;
@@ -2295,6 +2332,15 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
     @Getter
     @Setter
     @EqualsAndHashCode(callSuper = false)
+    public static class Paynow extends StripeObject {
+      /** Reference number associated with this PayNow payment. */
+      @SerializedName("reference")
+      String reference;
+    }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
     public static class SepaCreditTransfer extends StripeObject {
       /** Name of the bank associated with the bank account. */
       @SerializedName("bank_name")
@@ -2453,6 +2499,46 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
     @Setter
     @EqualsAndHashCode(callSuper = false)
     public static class StripeAccount extends StripeObject {}
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class UsBankAccount extends StripeObject {
+      /**
+       * Account holder type: individual or company.
+       *
+       * <p>One of {@code company}, or {@code individual}.
+       */
+      @SerializedName("account_holder_type")
+      String accountHolderType;
+
+      /**
+       * Account type: checkings or savings. Defaults to checking if omitted.
+       *
+       * <p>One of {@code checking}, or {@code savings}.
+       */
+      @SerializedName("account_type")
+      String accountType;
+
+      /** Name of the bank associated with the bank account. */
+      @SerializedName("bank_name")
+      String bankName;
+
+      /**
+       * Uniquely identifies this particular bank account. You can use this attribute to check
+       * whether two bank accounts are the same.
+       */
+      @SerializedName("fingerprint")
+      String fingerprint;
+
+      /** Last four digits of the bank account number. */
+      @SerializedName("last4")
+      String last4;
+
+      /** Routing number of the bank account. */
+      @SerializedName("routing_number")
+      String routingNumber;
+    }
 
     @Getter
     @Setter

--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -1572,6 +1572,13 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
     @SerializedName("konbini")
     Konbini konbini;
 
+    /**
+     * If paying by {@code us_bank_account}, this sub-hash contains details about the ACH direct
+     * debit payment method options to pass to the invoice’s PaymentIntent.
+     */
+    @SerializedName("us_bank_account")
+    UsBankAccount usBankAccount;
+
     @Getter
     @Setter
     @EqualsAndHashCode(callSuper = false)
@@ -1638,6 +1645,19 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
     @Setter
     @EqualsAndHashCode(callSuper = false)
     public static class Konbini extends StripeObject {}
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class UsBankAccount extends StripeObject {
+      /**
+       * Bank account verification method.
+       *
+       * <p>One of {@code automatic}, {@code instant}, or {@code microdeposits}.
+       */
+      @SerializedName("verification_method")
+      String verificationMethod;
+    }
   }
 
   @Getter

--- a/src/main/java/com/stripe/model/Mandate.java
+++ b/src/main/java/com/stripe/model/Mandate.java
@@ -226,6 +226,9 @@ public class Mandate extends ApiResource implements HasId {
     @SerializedName("type")
     String type;
 
+    @SerializedName("us_bank_account")
+    UsBankAccount usBankAccount;
+
     @Getter
     @Setter
     @EqualsAndHashCode(callSuper = false)
@@ -278,6 +281,11 @@ public class Mandate extends ApiResource implements HasId {
       @SerializedName("url")
       String url;
     }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class UsBankAccount extends StripeObject {}
   }
 
   @Getter

--- a/src/main/java/com/stripe/model/PaymentIntent.java
+++ b/src/main/java/com/stripe/model/PaymentIntent.java
@@ -1164,6 +1164,9 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
     @SerializedName("oxxo_display_details")
     NextActionOxxoDisplayDetails oxxoDisplayDetails;
 
+    @SerializedName("paynow_display_qr_code")
+    PaynowDisplayQrCode paynowDisplayQrCode;
+
     @SerializedName("redirect_to_url")
     NextActionRedirectToUrl redirectToUrl;
 
@@ -1198,6 +1201,26 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
     @Getter
     @Setter
     @EqualsAndHashCode(callSuper = false)
+    public static class PaynowDisplayQrCode extends StripeObject {
+      /**
+       * The raw data string used to generate QR code, it should be used together with QR code
+       * library.
+       */
+      @SerializedName("data")
+      String data;
+
+      /** The image_url_png string used to render QR code. */
+      @SerializedName("image_url_png")
+      String imageUrlPng;
+
+      /** The image_url_svg string used to render QR code. */
+      @SerializedName("image_url_svg")
+      String imageUrlSvg;
+    }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
     public static class VerifyWithMicrodeposits extends StripeObject {
       /** The timestamp when the microdeposits are expected to land. */
       @SerializedName("arrival_date")
@@ -1209,6 +1232,15 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
        */
       @SerializedName("hosted_verification_url")
       String hostedVerificationUrl;
+
+      /**
+       * The type of the microdeposit sent to the customer. Used to distinguish between different
+       * verification methods.
+       *
+       * <p>One of {@code amounts}, or {@code descriptor_code}.
+       */
+      @SerializedName("microdeposit_type")
+      String microdepositType;
     }
 
     @Getter
@@ -1546,11 +1578,17 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
     @SerializedName("p24")
     P24 p24;
 
+    @SerializedName("paynow")
+    Paynow paynow;
+
     @SerializedName("sepa_debit")
     SepaDebit sepaDebit;
 
     @SerializedName("sofort")
     Sofort sofort;
+
+    @SerializedName("us_bank_account")
+    UsBankAccount usBankAccount;
 
     @SerializedName("wechat_pay")
     WechatPay wechatPay;
@@ -1627,6 +1665,14 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
     @Setter
     @EqualsAndHashCode(callSuper = false)
     public static class AfterpayClearpay extends StripeObject {
+      /**
+       * Controls when the funds will be captured from the customer's account.
+       *
+       * <p>Equal to {@code manual}.
+       */
+      @SerializedName("capture_method")
+      String captureMethod;
+
       /**
        * Order identifier shown to the customer in Afterpay’s online portal. We recommend using a
        * value that helps you answer any questions a customer might have about the payment. The
@@ -1802,6 +1848,14 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
     @Setter
     @EqualsAndHashCode(callSuper = false)
     public static class Card extends StripeObject {
+      /**
+       * Controls when the funds will be captured from the customer's account.
+       *
+       * <p>Equal to {@code manual}.
+       */
+      @SerializedName("capture_method")
+      String captureMethod;
+
       /**
        * Installment details for this payment (Mexico only).
        *
@@ -2100,6 +2154,14 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
     @Setter
     @EqualsAndHashCode(callSuper = false)
     public static class Klarna extends StripeObject {
+      /**
+       * Controls when the funds will be captured from the customer's account.
+       *
+       * <p>Equal to {@code manual}.
+       */
+      @SerializedName("capture_method")
+      String captureMethod;
+
       /** Preferred locale of the Klarna checkout page that the customer is redirected to. */
       @SerializedName("preferred_locale")
       String preferredLocale;
@@ -2241,6 +2303,31 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
     @Getter
     @Setter
     @EqualsAndHashCode(callSuper = false)
+    public static class Paynow extends StripeObject {
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * <p>Providing this parameter will <a
+       * href="https://stripe.com/docs/payments/save-during-payment">attach the payment method</a>
+       * to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any
+       * required actions from the user are complete. If no Customer was provided, the payment
+       * method can still be <a
+       * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer after
+       * the transaction completes.
+       *
+       * <p>When processing card payments, Stripe also uses {@code setup_future_usage} to
+       * dynamically optimize your payment flow and comply with regional legislation and network
+       * rules, such as <a href="https://stripe.com/docs/strong-customer-authentication">SCA</a>.
+       *
+       * <p>Equal to {@code none}.
+       */
+      @SerializedName("setup_future_usage")
+      String setupFutureUsage;
+    }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
     public static class SepaDebit extends StripeObject {
       @SerializedName("mandate_options")
       SepaDebitMandateOptions mandateOptions;
@@ -2303,6 +2390,39 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
        */
       @SerializedName("setup_future_usage")
       String setupFutureUsage;
+    }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class UsBankAccount extends StripeObject {
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * <p>Providing this parameter will <a
+       * href="https://stripe.com/docs/payments/save-during-payment">attach the payment method</a>
+       * to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any
+       * required actions from the user are complete. If no Customer was provided, the payment
+       * method can still be <a
+       * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer after
+       * the transaction completes.
+       *
+       * <p>When processing card payments, Stripe also uses {@code setup_future_usage} to
+       * dynamically optimize your payment flow and comply with regional legislation and network
+       * rules, such as <a href="https://stripe.com/docs/strong-customer-authentication">SCA</a>.
+       *
+       * <p>One of {@code none}, {@code off_session}, or {@code on_session}.
+       */
+      @SerializedName("setup_future_usage")
+      String setupFutureUsage;
+
+      /**
+       * Bank account verification method.
+       *
+       * <p>One of {@code automatic}, {@code instant}, or {@code microdeposits}.
+       */
+      @SerializedName("verification_method")
+      String verificationMethod;
     }
 
     @Getter

--- a/src/main/java/com/stripe/model/PaymentMethod.java
+++ b/src/main/java/com/stripe/model/PaymentMethod.java
@@ -124,6 +124,9 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
   @SerializedName("p24")
   P24 p24;
 
+  @SerializedName("paynow")
+  Paynow paynow;
+
   @SerializedName("sepa_debit")
   SepaDebit sepaDebit;
 
@@ -137,11 +140,14 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
    * <p>One of {@code acss_debit}, {@code afterpay_clearpay}, {@code alipay}, {@code au_becs_debit},
    * {@code bacs_debit}, {@code bancontact}, {@code boleto}, {@code card}, {@code card_present},
    * {@code eps}, {@code fpx}, {@code giropay}, {@code grabpay}, {@code ideal}, {@code
-   * interac_present}, {@code klarna}, {@code konbini}, {@code oxxo}, {@code p24}, {@code
-   * sepa_debit}, {@code sofort}, or {@code wechat_pay}.
+   * interac_present}, {@code klarna}, {@code konbini}, {@code oxxo}, {@code p24}, {@code paynow},
+   * {@code sepa_debit}, {@code sofort}, {@code us_bank_account}, or {@code wechat_pay}.
    */
   @SerializedName("type")
   String type;
+
+  @SerializedName("us_bank_account")
+  USBankAccount usBankAccount;
 
   @SerializedName("wechat_pay")
   WechatPay wechatPay;
@@ -1016,6 +1022,11 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
   @Getter
   @Setter
   @EqualsAndHashCode(callSuper = false)
+  public static class Paynow extends StripeObject {}
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
   public static class SepaDebit extends StripeObject {
     /** Bank code of bank associated with the bank account. */
     @SerializedName("bank_code")
@@ -1106,6 +1117,46 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
     /** Two-letter ISO code representing the country the bank account is located in. */
     @SerializedName("country")
     String country;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class USBankAccount extends StripeObject {
+    /**
+     * Account holder type: individual or company.
+     *
+     * <p>One of {@code company}, or {@code individual}.
+     */
+    @SerializedName("account_holder_type")
+    String accountHolderType;
+
+    /**
+     * Account type: checkings or savings. Defaults to checking if omitted.
+     *
+     * <p>One of {@code checking}, or {@code savings}.
+     */
+    @SerializedName("account_type")
+    String accountType;
+
+    /** The name of the bank. */
+    @SerializedName("bank_name")
+    String bankName;
+
+    /**
+     * Uniquely identifies this particular bank account. You can use this attribute to check whether
+     * two bank accounts are the same.
+     */
+    @SerializedName("fingerprint")
+    String fingerprint;
+
+    /** Last four digits of the bank account number. */
+    @SerializedName("last4")
+    String last4;
+
+    /** Routing number of the bank account. */
+    @SerializedName("routing_number")
+    String routingNumber;
   }
 
   @Getter

--- a/src/main/java/com/stripe/model/SetupAttempt.java
+++ b/src/main/java/com/stripe/model/SetupAttempt.java
@@ -262,6 +262,9 @@ public class SetupAttempt extends ApiResource implements HasId {
     @SerializedName("type")
     String type;
 
+    @SerializedName("us_bank_account")
+    UsBankAccount usBankAccount;
+
     @Getter
     @Setter
     @EqualsAndHashCode(callSuper = false)
@@ -604,5 +607,10 @@ public class SetupAttempt extends ApiResource implements HasId {
             new ExpandableField<Mandate>(expandableObject.getId(), expandableObject);
       }
     }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class UsBankAccount extends StripeObject {}
   }
 }

--- a/src/main/java/com/stripe/model/SetupIntent.java
+++ b/src/main/java/com/stripe/model/SetupIntent.java
@@ -756,6 +756,15 @@ public class SetupIntent extends ApiResource implements HasId, MetadataStore<Set
        */
       @SerializedName("hosted_verification_url")
       String hostedVerificationUrl;
+
+      /**
+       * The type of the microdeposit sent to the customer. Used to distinguish between different
+       * verification methods.
+       *
+       * <p>One of {@code amounts}, or {@code descriptor_code}.
+       */
+      @SerializedName("microdeposit_type")
+      String microdepositType;
     }
   }
 
@@ -787,6 +796,9 @@ public class SetupIntent extends ApiResource implements HasId, MetadataStore<Set
 
     @SerializedName("sepa_debit")
     SepaDebit sepaDebit;
+
+    @SerializedName("us_bank_account")
+    UsBankAccount usBankAccount;
 
     @Getter
     @Setter
@@ -955,5 +967,18 @@ public class SetupIntent extends ApiResource implements HasId, MetadataStore<Set
     @Setter
     @EqualsAndHashCode(callSuper = false)
     public static class SepaDebitMandateOptions extends StripeObject {}
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class UsBankAccount extends StripeObject {
+      /**
+       * Bank account verification method.
+       *
+       * <p>One of {@code automatic}, {@code instant}, or {@code microdeposits}.
+       */
+      @SerializedName("verification_method")
+      String verificationMethod;
+    }
   }
 }

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -856,6 +856,13 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
     @SerializedName("konbini")
     Konbini konbini;
 
+    /**
+     * This sub-hash contains details about the ACH direct debit payment method options to pass to
+     * invoices created by the subscription.
+     */
+    @SerializedName("us_bank_account")
+    UsBankAccount usBankAccount;
+
     @Getter
     @Setter
     @EqualsAndHashCode(callSuper = false)
@@ -949,6 +956,19 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
     @Setter
     @EqualsAndHashCode(callSuper = false)
     public static class Konbini extends StripeObject {}
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class UsBankAccount extends StripeObject {
+      /**
+       * Bank account verification method.
+       *
+       * <p>One of {@code automatic}, {@code instant}, or {@code microdeposits}.
+       */
+      @SerializedName("verification_method")
+      String verificationMethod;
+    }
   }
 
   @Getter

--- a/src/main/java/com/stripe/model/checkout/Session.java
+++ b/src/main/java/com/stripe/model/checkout/Session.java
@@ -746,6 +746,9 @@ public class Session extends ApiResource implements HasId {
     @SerializedName("oxxo")
     Oxxo oxxo;
 
+    @SerializedName("us_bank_account")
+    UsBankAccount usBankAccount;
+
     @Getter
     @Setter
     @EqualsAndHashCode(callSuper = false)
@@ -887,6 +890,19 @@ public class Session extends ApiResource implements HasId {
        */
       @SerializedName("setup_future_usage")
       String setupFutureUsage;
+    }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class UsBankAccount extends StripeObject {
+      /**
+       * Bank account verification method.
+       *
+       * <p>One of {@code automatic}, or {@code instant}.
+       */
+      @SerializedName("verification_method")
+      String verificationMethod;
     }
   }
 

--- a/src/main/java/com/stripe/param/AccountCreateParams.java
+++ b/src/main/java/com/stripe/param/AccountCreateParams.java
@@ -913,6 +913,10 @@ public class AccountCreateParams extends ApiRequestParams {
     @SerializedName("p24_payments")
     P24Payments p24Payments;
 
+    /** The paynow_payments capability. */
+    @SerializedName("paynow_payments")
+    PaynowPayments paynowPayments;
+
     /** The sepa_debit_payments capability. */
     @SerializedName("sepa_debit_payments")
     SepaDebitPayments sepaDebitPayments;
@@ -932,6 +936,10 @@ public class AccountCreateParams extends ApiRequestParams {
     /** The transfers capability. */
     @SerializedName("transfers")
     Transfers transfers;
+
+    /** The us_bank_account_ach_payments capability. */
+    @SerializedName("us_bank_account_ach_payments")
+    UsBankAccountAchPayments usBankAccountAchPayments;
 
     private Capabilities(
         AcssDebitPayments acssDebitPayments,
@@ -955,11 +963,13 @@ public class AccountCreateParams extends ApiRequestParams {
         LegacyPayments legacyPayments,
         OxxoPayments oxxoPayments,
         P24Payments p24Payments,
+        PaynowPayments paynowPayments,
         SepaDebitPayments sepaDebitPayments,
         SofortPayments sofortPayments,
         TaxReportingUs1099K taxReportingUs1099K,
         TaxReportingUs1099Misc taxReportingUs1099Misc,
-        Transfers transfers) {
+        Transfers transfers,
+        UsBankAccountAchPayments usBankAccountAchPayments) {
       this.acssDebitPayments = acssDebitPayments;
       this.afterpayClearpayPayments = afterpayClearpayPayments;
       this.auBecsDebitPayments = auBecsDebitPayments;
@@ -981,11 +991,13 @@ public class AccountCreateParams extends ApiRequestParams {
       this.legacyPayments = legacyPayments;
       this.oxxoPayments = oxxoPayments;
       this.p24Payments = p24Payments;
+      this.paynowPayments = paynowPayments;
       this.sepaDebitPayments = sepaDebitPayments;
       this.sofortPayments = sofortPayments;
       this.taxReportingUs1099K = taxReportingUs1099K;
       this.taxReportingUs1099Misc = taxReportingUs1099Misc;
       this.transfers = transfers;
+      this.usBankAccountAchPayments = usBankAccountAchPayments;
     }
 
     public static Builder builder() {
@@ -1035,6 +1047,8 @@ public class AccountCreateParams extends ApiRequestParams {
 
       private P24Payments p24Payments;
 
+      private PaynowPayments paynowPayments;
+
       private SepaDebitPayments sepaDebitPayments;
 
       private SofortPayments sofortPayments;
@@ -1044,6 +1058,8 @@ public class AccountCreateParams extends ApiRequestParams {
       private TaxReportingUs1099Misc taxReportingUs1099Misc;
 
       private Transfers transfers;
+
+      private UsBankAccountAchPayments usBankAccountAchPayments;
 
       /** Finalize and obtain parameter instance from this builder. */
       public Capabilities build() {
@@ -1069,11 +1085,13 @@ public class AccountCreateParams extends ApiRequestParams {
             this.legacyPayments,
             this.oxxoPayments,
             this.p24Payments,
+            this.paynowPayments,
             this.sepaDebitPayments,
             this.sofortPayments,
             this.taxReportingUs1099K,
             this.taxReportingUs1099Misc,
-            this.transfers);
+            this.transfers,
+            this.usBankAccountAchPayments);
       }
 
       /** The acss_debit_payments capability. */
@@ -1223,6 +1241,12 @@ public class AccountCreateParams extends ApiRequestParams {
         return this;
       }
 
+      /** The paynow_payments capability. */
+      public Builder setPaynowPayments(PaynowPayments paynowPayments) {
+        this.paynowPayments = paynowPayments;
+        return this;
+      }
+
       /** The sepa_debit_payments capability. */
       public Builder setSepaDebitPayments(SepaDebitPayments sepaDebitPayments) {
         this.sepaDebitPayments = sepaDebitPayments;
@@ -1250,6 +1274,13 @@ public class AccountCreateParams extends ApiRequestParams {
       /** The transfers capability. */
       public Builder setTransfers(Transfers transfers) {
         this.transfers = transfers;
+        return this;
+      }
+
+      /** The us_bank_account_ach_payments capability. */
+      public Builder setUsBankAccountAchPayments(
+          UsBankAccountAchPayments usBankAccountAchPayments) {
+        this.usBankAccountAchPayments = usBankAccountAchPayments;
         return this;
       }
     }
@@ -2815,6 +2846,84 @@ public class AccountCreateParams extends ApiRequestParams {
     }
 
     @Getter
+    public static class PaynowPayments {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /**
+       * Passing true requests the capability for the account, if it is not already requested. A
+       * requested capability may not immediately become active. Any requirements to activate the
+       * capability are returned in the {@code requirements} arrays.
+       */
+      @SerializedName("requested")
+      Boolean requested;
+
+      private PaynowPayments(Map<String, Object> extraParams, Boolean requested) {
+        this.extraParams = extraParams;
+        this.requested = requested;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private Boolean requested;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public PaynowPayments build() {
+          return new PaynowPayments(this.extraParams, this.requested);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link AccountCreateParams.Capabilities.PaynowPayments#extraParams} for the
+         * field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link AccountCreateParams.Capabilities.PaynowPayments#extraParams} for the
+         * field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /**
+         * Passing true requests the capability for the account, if it is not already requested. A
+         * requested capability may not immediately become active. Any requirements to activate the
+         * capability are returned in the {@code requirements} arrays.
+         */
+        public Builder setRequested(Boolean requested) {
+          this.requested = requested;
+          return this;
+        }
+      }
+    }
+
+    @Getter
     public static class SepaDebitPayments {
       /**
        * Map of extra parameters for custom features not available in this client library. The
@@ -3183,6 +3292,84 @@ public class AccountCreateParams extends ApiRequestParams {
          * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
          * map. See {@link AccountCreateParams.Capabilities.Transfers#extraParams} for the field
          * documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /**
+         * Passing true requests the capability for the account, if it is not already requested. A
+         * requested capability may not immediately become active. Any requirements to activate the
+         * capability are returned in the {@code requirements} arrays.
+         */
+        public Builder setRequested(Boolean requested) {
+          this.requested = requested;
+          return this;
+        }
+      }
+    }
+
+    @Getter
+    public static class UsBankAccountAchPayments {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /**
+       * Passing true requests the capability for the account, if it is not already requested. A
+       * requested capability may not immediately become active. Any requirements to activate the
+       * capability are returned in the {@code requirements} arrays.
+       */
+      @SerializedName("requested")
+      Boolean requested;
+
+      private UsBankAccountAchPayments(Map<String, Object> extraParams, Boolean requested) {
+        this.extraParams = extraParams;
+        this.requested = requested;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private Boolean requested;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public UsBankAccountAchPayments build() {
+          return new UsBankAccountAchPayments(this.extraParams, this.requested);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link AccountCreateParams.Capabilities.UsBankAccountAchPayments#extraParams}
+         * for the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link AccountCreateParams.Capabilities.UsBankAccountAchPayments#extraParams}
+         * for the field documentation.
          */
         public Builder putAllExtraParam(Map<String, Object> map) {
           if (this.extraParams == null) {

--- a/src/main/java/com/stripe/param/AccountUpdateParams.java
+++ b/src/main/java/com/stripe/param/AccountUpdateParams.java
@@ -1000,6 +1000,10 @@ public class AccountUpdateParams extends ApiRequestParams {
     @SerializedName("p24_payments")
     P24Payments p24Payments;
 
+    /** The paynow_payments capability. */
+    @SerializedName("paynow_payments")
+    PaynowPayments paynowPayments;
+
     /** The sepa_debit_payments capability. */
     @SerializedName("sepa_debit_payments")
     SepaDebitPayments sepaDebitPayments;
@@ -1019,6 +1023,10 @@ public class AccountUpdateParams extends ApiRequestParams {
     /** The transfers capability. */
     @SerializedName("transfers")
     Transfers transfers;
+
+    /** The us_bank_account_ach_payments capability. */
+    @SerializedName("us_bank_account_ach_payments")
+    UsBankAccountAchPayments usBankAccountAchPayments;
 
     private Capabilities(
         AcssDebitPayments acssDebitPayments,
@@ -1042,11 +1050,13 @@ public class AccountUpdateParams extends ApiRequestParams {
         LegacyPayments legacyPayments,
         OxxoPayments oxxoPayments,
         P24Payments p24Payments,
+        PaynowPayments paynowPayments,
         SepaDebitPayments sepaDebitPayments,
         SofortPayments sofortPayments,
         TaxReportingUs1099K taxReportingUs1099K,
         TaxReportingUs1099Misc taxReportingUs1099Misc,
-        Transfers transfers) {
+        Transfers transfers,
+        UsBankAccountAchPayments usBankAccountAchPayments) {
       this.acssDebitPayments = acssDebitPayments;
       this.afterpayClearpayPayments = afterpayClearpayPayments;
       this.auBecsDebitPayments = auBecsDebitPayments;
@@ -1068,11 +1078,13 @@ public class AccountUpdateParams extends ApiRequestParams {
       this.legacyPayments = legacyPayments;
       this.oxxoPayments = oxxoPayments;
       this.p24Payments = p24Payments;
+      this.paynowPayments = paynowPayments;
       this.sepaDebitPayments = sepaDebitPayments;
       this.sofortPayments = sofortPayments;
       this.taxReportingUs1099K = taxReportingUs1099K;
       this.taxReportingUs1099Misc = taxReportingUs1099Misc;
       this.transfers = transfers;
+      this.usBankAccountAchPayments = usBankAccountAchPayments;
     }
 
     public static Builder builder() {
@@ -1122,6 +1134,8 @@ public class AccountUpdateParams extends ApiRequestParams {
 
       private P24Payments p24Payments;
 
+      private PaynowPayments paynowPayments;
+
       private SepaDebitPayments sepaDebitPayments;
 
       private SofortPayments sofortPayments;
@@ -1131,6 +1145,8 @@ public class AccountUpdateParams extends ApiRequestParams {
       private TaxReportingUs1099Misc taxReportingUs1099Misc;
 
       private Transfers transfers;
+
+      private UsBankAccountAchPayments usBankAccountAchPayments;
 
       /** Finalize and obtain parameter instance from this builder. */
       public Capabilities build() {
@@ -1156,11 +1172,13 @@ public class AccountUpdateParams extends ApiRequestParams {
             this.legacyPayments,
             this.oxxoPayments,
             this.p24Payments,
+            this.paynowPayments,
             this.sepaDebitPayments,
             this.sofortPayments,
             this.taxReportingUs1099K,
             this.taxReportingUs1099Misc,
-            this.transfers);
+            this.transfers,
+            this.usBankAccountAchPayments);
       }
 
       /** The acss_debit_payments capability. */
@@ -1310,6 +1328,12 @@ public class AccountUpdateParams extends ApiRequestParams {
         return this;
       }
 
+      /** The paynow_payments capability. */
+      public Builder setPaynowPayments(PaynowPayments paynowPayments) {
+        this.paynowPayments = paynowPayments;
+        return this;
+      }
+
       /** The sepa_debit_payments capability. */
       public Builder setSepaDebitPayments(SepaDebitPayments sepaDebitPayments) {
         this.sepaDebitPayments = sepaDebitPayments;
@@ -1337,6 +1361,13 @@ public class AccountUpdateParams extends ApiRequestParams {
       /** The transfers capability. */
       public Builder setTransfers(Transfers transfers) {
         this.transfers = transfers;
+        return this;
+      }
+
+      /** The us_bank_account_ach_payments capability. */
+      public Builder setUsBankAccountAchPayments(
+          UsBankAccountAchPayments usBankAccountAchPayments) {
+        this.usBankAccountAchPayments = usBankAccountAchPayments;
         return this;
       }
     }
@@ -2902,6 +2933,84 @@ public class AccountUpdateParams extends ApiRequestParams {
     }
 
     @Getter
+    public static class PaynowPayments {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /**
+       * Passing true requests the capability for the account, if it is not already requested. A
+       * requested capability may not immediately become active. Any requirements to activate the
+       * capability are returned in the {@code requirements} arrays.
+       */
+      @SerializedName("requested")
+      Boolean requested;
+
+      private PaynowPayments(Map<String, Object> extraParams, Boolean requested) {
+        this.extraParams = extraParams;
+        this.requested = requested;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private Boolean requested;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public PaynowPayments build() {
+          return new PaynowPayments(this.extraParams, this.requested);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link AccountUpdateParams.Capabilities.PaynowPayments#extraParams} for the
+         * field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link AccountUpdateParams.Capabilities.PaynowPayments#extraParams} for the
+         * field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /**
+         * Passing true requests the capability for the account, if it is not already requested. A
+         * requested capability may not immediately become active. Any requirements to activate the
+         * capability are returned in the {@code requirements} arrays.
+         */
+        public Builder setRequested(Boolean requested) {
+          this.requested = requested;
+          return this;
+        }
+      }
+    }
+
+    @Getter
     public static class SepaDebitPayments {
       /**
        * Map of extra parameters for custom features not available in this client library. The
@@ -3270,6 +3379,84 @@ public class AccountUpdateParams extends ApiRequestParams {
          * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
          * map. See {@link AccountUpdateParams.Capabilities.Transfers#extraParams} for the field
          * documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /**
+         * Passing true requests the capability for the account, if it is not already requested. A
+         * requested capability may not immediately become active. Any requirements to activate the
+         * capability are returned in the {@code requirements} arrays.
+         */
+        public Builder setRequested(Boolean requested) {
+          this.requested = requested;
+          return this;
+        }
+      }
+    }
+
+    @Getter
+    public static class UsBankAccountAchPayments {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /**
+       * Passing true requests the capability for the account, if it is not already requested. A
+       * requested capability may not immediately become active. Any requirements to activate the
+       * capability are returned in the {@code requirements} arrays.
+       */
+      @SerializedName("requested")
+      Boolean requested;
+
+      private UsBankAccountAchPayments(Map<String, Object> extraParams, Boolean requested) {
+        this.extraParams = extraParams;
+        this.requested = requested;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private Boolean requested;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public UsBankAccountAchPayments build() {
+          return new UsBankAccountAchPayments(this.extraParams, this.requested);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link AccountUpdateParams.Capabilities.UsBankAccountAchPayments#extraParams}
+         * for the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link AccountUpdateParams.Capabilities.UsBankAccountAchPayments#extraParams}
+         * for the field documentation.
          */
         public Builder putAllExtraParam(Map<String, Object> map) {
           if (this.extraParams == null) {

--- a/src/main/java/com/stripe/param/CustomerListPaymentMethodsParams.java
+++ b/src/main/java/com/stripe/param/CustomerListPaymentMethodsParams.java
@@ -241,11 +241,17 @@ public class CustomerListPaymentMethodsParams extends ApiRequestParams {
     @SerializedName("p24")
     P24("p24"),
 
+    @SerializedName("paynow")
+    PAYNOW("paynow"),
+
     @SerializedName("sepa_debit")
     SEPA_DEBIT("sepa_debit"),
 
     @SerializedName("sofort")
     SOFORT("sofort"),
+
+    @SerializedName("us_bank_account")
+    US_BANK_ACCOUNT("us_bank_account"),
 
     @SerializedName("wechat_pay")
     WECHAT_PAY("wechat_pay");

--- a/src/main/java/com/stripe/param/InvoiceCreateParams.java
+++ b/src/main/java/com/stripe/param/InvoiceCreateParams.java
@@ -1147,17 +1147,26 @@ public class InvoiceCreateParams extends ApiRequestParams {
       @SerializedName("konbini")
       Object konbini;
 
+      /**
+       * If paying by {@code us_bank_account}, this sub-hash contains details about the ACH direct
+       * debit payment method options to pass to the invoice’s PaymentIntent.
+       */
+      @SerializedName("us_bank_account")
+      Object usBankAccount;
+
       private PaymentMethodOptions(
           Object acssDebit,
           Object bancontact,
           Object card,
           Map<String, Object> extraParams,
-          Object konbini) {
+          Object konbini,
+          Object usBankAccount) {
         this.acssDebit = acssDebit;
         this.bancontact = bancontact;
         this.card = card;
         this.extraParams = extraParams;
         this.konbini = konbini;
+        this.usBankAccount = usBankAccount;
       }
 
       public static Builder builder() {
@@ -1175,10 +1184,17 @@ public class InvoiceCreateParams extends ApiRequestParams {
 
         private Object konbini;
 
+        private Object usBankAccount;
+
         /** Finalize and obtain parameter instance from this builder. */
         public PaymentMethodOptions build() {
           return new PaymentMethodOptions(
-              this.acssDebit, this.bancontact, this.card, this.extraParams, this.konbini);
+              this.acssDebit,
+              this.bancontact,
+              this.card,
+              this.extraParams,
+              this.konbini,
+              this.usBankAccount);
         }
 
         /**
@@ -1278,6 +1294,24 @@ public class InvoiceCreateParams extends ApiRequestParams {
          */
         public Builder setKonbini(EmptyParam konbini) {
           this.konbini = konbini;
+          return this;
+        }
+
+        /**
+         * If paying by {@code us_bank_account}, this sub-hash contains details about the ACH direct
+         * debit payment method options to pass to the invoice’s PaymentIntent.
+         */
+        public Builder setUsBankAccount(UsBankAccount usBankAccount) {
+          this.usBankAccount = usBankAccount;
+          return this;
+        }
+
+        /**
+         * If paying by {@code us_bank_account}, this sub-hash contains details about the ACH direct
+         * debit payment method options to pass to the invoice’s PaymentIntent.
+         */
+        public Builder setUsBankAccount(EmptyParam usBankAccount) {
+          this.usBankAccount = usBankAccount;
           return this;
         }
       }
@@ -1742,6 +1776,98 @@ public class InvoiceCreateParams extends ApiRequestParams {
           }
         }
       }
+
+      @Getter
+      public static class UsBankAccount {
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /** Verification method for the intent. */
+        @SerializedName("verification_method")
+        VerificationMethod verificationMethod;
+
+        private UsBankAccount(
+            Map<String, Object> extraParams, VerificationMethod verificationMethod) {
+          this.extraParams = extraParams;
+          this.verificationMethod = verificationMethod;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Map<String, Object> extraParams;
+
+          private VerificationMethod verificationMethod;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public UsBankAccount build() {
+            return new UsBankAccount(this.extraParams, this.verificationMethod);
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount#extraParams} for
+           * the field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount#extraParams} for
+           * the field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /** Verification method for the intent. */
+          public Builder setVerificationMethod(VerificationMethod verificationMethod) {
+            this.verificationMethod = verificationMethod;
+            return this;
+          }
+        }
+
+        public enum VerificationMethod implements ApiRequestParams.EnumParam {
+          @SerializedName("automatic")
+          AUTOMATIC("automatic"),
+
+          @SerializedName("instant")
+          INSTANT("instant"),
+
+          @SerializedName("microdeposits")
+          MICRODEPOSITS("microdeposits");
+
+          @Getter(onMethod_ = {@Override})
+          private final String value;
+
+          VerificationMethod(String value) {
+            this.value = value;
+          }
+        }
+      }
     }
 
     public enum PaymentMethodType implements ApiRequestParams.EnumParam {
@@ -1784,6 +1910,9 @@ public class InvoiceCreateParams extends ApiRequestParams {
       @SerializedName("konbini")
       KONBINI("konbini"),
 
+      @SerializedName("paynow")
+      PAYNOW("paynow"),
+
       @SerializedName("sepa_credit_transfer")
       SEPA_CREDIT_TRANSFER("sepa_credit_transfer"),
 
@@ -1792,6 +1921,9 @@ public class InvoiceCreateParams extends ApiRequestParams {
 
       @SerializedName("sofort")
       SOFORT("sofort"),
+
+      @SerializedName("us_bank_account")
+      US_BANK_ACCOUNT("us_bank_account"),
 
       @SerializedName("wechat_pay")
       WECHAT_PAY("wechat_pay");

--- a/src/main/java/com/stripe/param/InvoiceUpdateParams.java
+++ b/src/main/java/com/stripe/param/InvoiceUpdateParams.java
@@ -1197,17 +1197,26 @@ public class InvoiceUpdateParams extends ApiRequestParams {
       @SerializedName("konbini")
       Object konbini;
 
+      /**
+       * If paying by {@code us_bank_account}, this sub-hash contains details about the ACH direct
+       * debit payment method options to pass to the invoice’s PaymentIntent.
+       */
+      @SerializedName("us_bank_account")
+      Object usBankAccount;
+
       private PaymentMethodOptions(
           Object acssDebit,
           Object bancontact,
           Object card,
           Map<String, Object> extraParams,
-          Object konbini) {
+          Object konbini,
+          Object usBankAccount) {
         this.acssDebit = acssDebit;
         this.bancontact = bancontact;
         this.card = card;
         this.extraParams = extraParams;
         this.konbini = konbini;
+        this.usBankAccount = usBankAccount;
       }
 
       public static Builder builder() {
@@ -1225,10 +1234,17 @@ public class InvoiceUpdateParams extends ApiRequestParams {
 
         private Object konbini;
 
+        private Object usBankAccount;
+
         /** Finalize and obtain parameter instance from this builder. */
         public PaymentMethodOptions build() {
           return new PaymentMethodOptions(
-              this.acssDebit, this.bancontact, this.card, this.extraParams, this.konbini);
+              this.acssDebit,
+              this.bancontact,
+              this.card,
+              this.extraParams,
+              this.konbini,
+              this.usBankAccount);
         }
 
         /**
@@ -1328,6 +1344,24 @@ public class InvoiceUpdateParams extends ApiRequestParams {
          */
         public Builder setKonbini(EmptyParam konbini) {
           this.konbini = konbini;
+          return this;
+        }
+
+        /**
+         * If paying by {@code us_bank_account}, this sub-hash contains details about the ACH direct
+         * debit payment method options to pass to the invoice’s PaymentIntent.
+         */
+        public Builder setUsBankAccount(UsBankAccount usBankAccount) {
+          this.usBankAccount = usBankAccount;
+          return this;
+        }
+
+        /**
+         * If paying by {@code us_bank_account}, this sub-hash contains details about the ACH direct
+         * debit payment method options to pass to the invoice’s PaymentIntent.
+         */
+        public Builder setUsBankAccount(EmptyParam usBankAccount) {
+          this.usBankAccount = usBankAccount;
           return this;
         }
       }
@@ -1792,6 +1826,98 @@ public class InvoiceUpdateParams extends ApiRequestParams {
           }
         }
       }
+
+      @Getter
+      public static class UsBankAccount {
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /** Verification method for the intent. */
+        @SerializedName("verification_method")
+        VerificationMethod verificationMethod;
+
+        private UsBankAccount(
+            Map<String, Object> extraParams, VerificationMethod verificationMethod) {
+          this.extraParams = extraParams;
+          this.verificationMethod = verificationMethod;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Map<String, Object> extraParams;
+
+          private VerificationMethod verificationMethod;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public UsBankAccount build() {
+            return new UsBankAccount(this.extraParams, this.verificationMethod);
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount#extraParams} for
+           * the field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount#extraParams} for
+           * the field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /** Verification method for the intent. */
+          public Builder setVerificationMethod(VerificationMethod verificationMethod) {
+            this.verificationMethod = verificationMethod;
+            return this;
+          }
+        }
+
+        public enum VerificationMethod implements ApiRequestParams.EnumParam {
+          @SerializedName("automatic")
+          AUTOMATIC("automatic"),
+
+          @SerializedName("instant")
+          INSTANT("instant"),
+
+          @SerializedName("microdeposits")
+          MICRODEPOSITS("microdeposits");
+
+          @Getter(onMethod_ = {@Override})
+          private final String value;
+
+          VerificationMethod(String value) {
+            this.value = value;
+          }
+        }
+      }
     }
 
     public enum PaymentMethodType implements ApiRequestParams.EnumParam {
@@ -1834,6 +1960,9 @@ public class InvoiceUpdateParams extends ApiRequestParams {
       @SerializedName("konbini")
       KONBINI("konbini"),
 
+      @SerializedName("paynow")
+      PAYNOW("paynow"),
+
       @SerializedName("sepa_credit_transfer")
       SEPA_CREDIT_TRANSFER("sepa_credit_transfer"),
 
@@ -1842,6 +1971,9 @@ public class InvoiceUpdateParams extends ApiRequestParams {
 
       @SerializedName("sofort")
       SOFORT("sofort"),
+
+      @SerializedName("us_bank_account")
+      US_BANK_ACCOUNT("us_bank_account"),
 
       @SerializedName("wechat_pay")
       WECHAT_PAY("wechat_pay");

--- a/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
@@ -938,6 +938,13 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
     P24 p24;
 
     /**
+     * If this is a {@code paynow} PaymentMethod, this hash contains details about the PayNow
+     * payment method.
+     */
+    @SerializedName("paynow")
+    Paynow paynow;
+
+    /**
      * If this is a {@code sepa_debit} PaymentMethod, this hash contains details about the SEPA
      * debit bank account.
      */
@@ -958,6 +965,13 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
      */
     @SerializedName("type")
     Type type;
+
+    /**
+     * If this is an {@code us_bank_account} PaymentMethod, this hash contains details about the US
+     * bank account payment method.
+     */
+    @SerializedName("us_bank_account")
+    UsBankAccount usBankAccount;
 
     /**
      * If this is an {@code wechat_pay} PaymentMethod, this hash contains details about the
@@ -987,9 +1001,11 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
         Map<String, String> metadata,
         Oxxo oxxo,
         P24 p24,
+        Paynow paynow,
         SepaDebit sepaDebit,
         Sofort sofort,
         Type type,
+        UsBankAccount usBankAccount,
         WechatPay wechatPay) {
       this.acssDebit = acssDebit;
       this.afterpayClearpay = afterpayClearpay;
@@ -1011,9 +1027,11 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       this.metadata = metadata;
       this.oxxo = oxxo;
       this.p24 = p24;
+      this.paynow = paynow;
       this.sepaDebit = sepaDebit;
       this.sofort = sofort;
       this.type = type;
+      this.usBankAccount = usBankAccount;
       this.wechatPay = wechatPay;
     }
 
@@ -1062,11 +1080,15 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
 
       private P24 p24;
 
+      private Paynow paynow;
+
       private SepaDebit sepaDebit;
 
       private Sofort sofort;
 
       private Type type;
+
+      private UsBankAccount usBankAccount;
 
       private WechatPay wechatPay;
 
@@ -1093,9 +1115,11 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
             this.metadata,
             this.oxxo,
             this.p24,
+            this.paynow,
             this.sepaDebit,
             this.sofort,
             this.type,
+            this.usBankAccount,
             this.wechatPay);
       }
 
@@ -1316,6 +1340,15 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       }
 
       /**
+       * If this is a {@code paynow} PaymentMethod, this hash contains details about the PayNow
+       * payment method.
+       */
+      public Builder setPaynow(Paynow paynow) {
+        this.paynow = paynow;
+        return this;
+      }
+
+      /**
        * If this is a {@code sepa_debit} PaymentMethod, this hash contains details about the SEPA
        * debit bank account.
        */
@@ -1340,6 +1373,15 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
        */
       public Builder setType(Type type) {
         this.type = type;
+        return this;
+      }
+
+      /**
+       * If this is an {@code us_bank_account} PaymentMethod, this hash contains details about the
+       * US bank account payment method.
+       */
+      public Builder setUsBankAccount(UsBankAccount usBankAccount) {
+        this.usBankAccount = usBankAccount;
         return this;
       }
 
@@ -3208,6 +3250,63 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
     }
 
     @Getter
+    public static class Paynow {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private Paynow(Map<String, Object> extraParams) {
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Paynow build() {
+          return new Paynow(this.extraParams);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentConfirmParams.PaymentMethodData.Paynow#extraParams} for the
+         * field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentConfirmParams.PaymentMethodData.Paynow#extraParams} for the
+         * field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+      }
+    }
+
+    @Getter
     public static class SepaDebit {
       /**
        * Map of extra parameters for custom features not available in this client library. The
@@ -3375,6 +3474,155 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
     }
 
     @Getter
+    public static class UsBankAccount {
+      /** Account holder type: individual or company. */
+      @SerializedName("account_holder_type")
+      AccountHolderType accountHolderType;
+
+      /** Account number of the bank account. */
+      @SerializedName("account_number")
+      String accountNumber;
+
+      /** Account type: checkings or savings. Defaults to checking if omitted. */
+      @SerializedName("account_type")
+      AccountType accountType;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Routing number of the bank account. */
+      @SerializedName("routing_number")
+      String routingNumber;
+
+      private UsBankAccount(
+          AccountHolderType accountHolderType,
+          String accountNumber,
+          AccountType accountType,
+          Map<String, Object> extraParams,
+          String routingNumber) {
+        this.accountHolderType = accountHolderType;
+        this.accountNumber = accountNumber;
+        this.accountType = accountType;
+        this.extraParams = extraParams;
+        this.routingNumber = routingNumber;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private AccountHolderType accountHolderType;
+
+        private String accountNumber;
+
+        private AccountType accountType;
+
+        private Map<String, Object> extraParams;
+
+        private String routingNumber;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public UsBankAccount build() {
+          return new UsBankAccount(
+              this.accountHolderType,
+              this.accountNumber,
+              this.accountType,
+              this.extraParams,
+              this.routingNumber);
+        }
+
+        /** Account holder type: individual or company. */
+        public Builder setAccountHolderType(AccountHolderType accountHolderType) {
+          this.accountHolderType = accountHolderType;
+          return this;
+        }
+
+        /** Account number of the bank account. */
+        public Builder setAccountNumber(String accountNumber) {
+          this.accountNumber = accountNumber;
+          return this;
+        }
+
+        /** Account type: checkings or savings. Defaults to checking if omitted. */
+        public Builder setAccountType(AccountType accountType) {
+          this.accountType = accountType;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentConfirmParams.PaymentMethodData.UsBankAccount#extraParams}
+         * for the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentConfirmParams.PaymentMethodData.UsBankAccount#extraParams}
+         * for the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Routing number of the bank account. */
+        public Builder setRoutingNumber(String routingNumber) {
+          this.routingNumber = routingNumber;
+          return this;
+        }
+      }
+
+      public enum AccountHolderType implements ApiRequestParams.EnumParam {
+        @SerializedName("company")
+        COMPANY("company"),
+
+        @SerializedName("individual")
+        INDIVIDUAL("individual");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        AccountHolderType(String value) {
+          this.value = value;
+        }
+      }
+
+      public enum AccountType implements ApiRequestParams.EnumParam {
+        @SerializedName("checking")
+        CHECKING("checking"),
+
+        @SerializedName("savings")
+        SAVINGS("savings");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        AccountType(String value) {
+          this.value = value;
+        }
+      }
+    }
+
+    @Getter
     public static class WechatPay {
       /**
        * Map of extra parameters for custom features not available in this client library. The
@@ -3480,11 +3728,17 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       @SerializedName("p24")
       P24("p24"),
 
+      @SerializedName("paynow")
+      PAYNOW("paynow"),
+
       @SerializedName("sepa_debit")
       SEPA_DEBIT("sepa_debit"),
 
       @SerializedName("sofort")
       SOFORT("sofort"),
+
+      @SerializedName("us_bank_account")
+      US_BANK_ACCOUNT("us_bank_account"),
 
       @SerializedName("wechat_pay")
       WECHAT_PAY("wechat_pay");
@@ -3640,6 +3894,13 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
     Object p24;
 
     /**
+     * If this is a {@code paynow} PaymentMethod, this sub-hash contains details about the PayNow
+     * payment method options.
+     */
+    @SerializedName("paynow")
+    Object paynow;
+
+    /**
      * If this is a {@code sepa_debit} PaymentIntent, this sub-hash contains details about the SEPA
      * Debit payment method options.
      */
@@ -3652,6 +3913,13 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
      */
     @SerializedName("sofort")
     Object sofort;
+
+    /**
+     * If this is a {@code us_bank_account} PaymentMethod, this sub-hash contains details about the
+     * US bank account payment method options.
+     */
+    @SerializedName("us_bank_account")
+    Object usBankAccount;
 
     /**
      * If this is a {@code wechat_pay} PaymentMethod, this sub-hash contains details about the
@@ -3681,8 +3949,10 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
         Object konbini,
         Object oxxo,
         Object p24,
+        Object paynow,
         Object sepaDebit,
         Object sofort,
+        Object usBankAccount,
         Object wechatPay) {
       this.acssDebit = acssDebit;
       this.afterpayClearpay = afterpayClearpay;
@@ -3704,8 +3974,10 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       this.konbini = konbini;
       this.oxxo = oxxo;
       this.p24 = p24;
+      this.paynow = paynow;
       this.sepaDebit = sepaDebit;
       this.sofort = sofort;
+      this.usBankAccount = usBankAccount;
       this.wechatPay = wechatPay;
     }
 
@@ -3754,9 +4026,13 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
 
       private Object p24;
 
+      private Object paynow;
+
       private Object sepaDebit;
 
       private Object sofort;
+
+      private Object usBankAccount;
 
       private Object wechatPay;
 
@@ -3783,8 +4059,10 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
             this.konbini,
             this.oxxo,
             this.p24,
+            this.paynow,
             this.sepaDebit,
             this.sofort,
+            this.usBankAccount,
             this.wechatPay);
       }
 
@@ -4152,6 +4430,24 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       }
 
       /**
+       * If this is a {@code paynow} PaymentMethod, this sub-hash contains details about the PayNow
+       * payment method options.
+       */
+      public Builder setPaynow(Paynow paynow) {
+        this.paynow = paynow;
+        return this;
+      }
+
+      /**
+       * If this is a {@code paynow} PaymentMethod, this sub-hash contains details about the PayNow
+       * payment method options.
+       */
+      public Builder setPaynow(EmptyParam paynow) {
+        this.paynow = paynow;
+        return this;
+      }
+
+      /**
        * If this is a {@code sepa_debit} PaymentIntent, this sub-hash contains details about the
        * SEPA Debit payment method options.
        */
@@ -4184,6 +4480,24 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
        */
       public Builder setSofort(EmptyParam sofort) {
         this.sofort = sofort;
+        return this;
+      }
+
+      /**
+       * If this is a {@code us_bank_account} PaymentMethod, this sub-hash contains details about
+       * the US bank account payment method options.
+       */
+      public Builder setUsBankAccount(UsBankAccount usBankAccount) {
+        this.usBankAccount = usBankAccount;
+        return this;
+      }
+
+      /**
+       * If this is a {@code us_bank_account} PaymentMethod, this sub-hash contains details about
+       * the US bank account payment method options.
+       */
+      public Builder setUsBankAccount(EmptyParam usBankAccount) {
+        this.usBankAccount = usBankAccount;
         return this;
       }
 
@@ -4593,6 +4907,18 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
     @Getter
     public static class AfterpayClearpay {
       /**
+       * Controls when the funds will be captured from the customer's account.
+       *
+       * <p>If provided, this parameter will override the top-level {@code capture_method} when
+       * finalizing the payment with this payment method type.
+       *
+       * <p>If {@code capture_method} is already set on the PaymentIntent, providing an empty value
+       * for this parameter will unset the stored value for this payment method type.
+       */
+      @SerializedName("capture_method")
+      EnumParam captureMethod;
+
+      /**
        * Map of extra parameters for custom features not available in this client library. The
        * content in this map is not serialized under this field's {@code @SerializedName} value.
        * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
@@ -4633,7 +4959,11 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       SetupFutureUsage setupFutureUsage;
 
       private AfterpayClearpay(
-          Map<String, Object> extraParams, String reference, SetupFutureUsage setupFutureUsage) {
+          EnumParam captureMethod,
+          Map<String, Object> extraParams,
+          String reference,
+          SetupFutureUsage setupFutureUsage) {
+        this.captureMethod = captureMethod;
         this.extraParams = extraParams;
         this.reference = reference;
         this.setupFutureUsage = setupFutureUsage;
@@ -4644,6 +4974,8 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       }
 
       public static class Builder {
+        private EnumParam captureMethod;
+
         private Map<String, Object> extraParams;
 
         private String reference;
@@ -4652,7 +4984,36 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
 
         /** Finalize and obtain parameter instance from this builder. */
         public AfterpayClearpay build() {
-          return new AfterpayClearpay(this.extraParams, this.reference, this.setupFutureUsage);
+          return new AfterpayClearpay(
+              this.captureMethod, this.extraParams, this.reference, this.setupFutureUsage);
+        }
+
+        /**
+         * Controls when the funds will be captured from the customer's account.
+         *
+         * <p>If provided, this parameter will override the top-level {@code capture_method} when
+         * finalizing the payment with this payment method type.
+         *
+         * <p>If {@code capture_method} is already set on the PaymentIntent, providing an empty
+         * value for this parameter will unset the stored value for this payment method type.
+         */
+        public Builder setCaptureMethod(CaptureMethod captureMethod) {
+          this.captureMethod = captureMethod;
+          return this;
+        }
+
+        /**
+         * Controls when the funds will be captured from the customer's account.
+         *
+         * <p>If provided, this parameter will override the top-level {@code capture_method} when
+         * finalizing the payment with this payment method type.
+         *
+         * <p>If {@code capture_method} is already set on the PaymentIntent, providing an empty
+         * value for this parameter will unset the stored value for this payment method type.
+         */
+        public Builder setCaptureMethod(EmptyParam captureMethod) {
+          this.captureMethod = captureMethod;
+          return this;
         }
 
         /**
@@ -4719,6 +5080,18 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
         public Builder setSetupFutureUsage(SetupFutureUsage setupFutureUsage) {
           this.setupFutureUsage = setupFutureUsage;
           return this;
+        }
+      }
+
+      public enum CaptureMethod implements ApiRequestParams.EnumParam {
+        @SerializedName("manual")
+        MANUAL("manual");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        CaptureMethod(String value) {
+          this.value = value;
         }
       }
 
@@ -5546,6 +5919,18 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
     @Getter
     public static class Card {
       /**
+       * Controls when the funds will be captured from the customer's account.
+       *
+       * <p>If provided, this parameter will override the top-level {@code capture_method} when
+       * finalizing the payment with this payment method type.
+       *
+       * <p>If {@code capture_method} is already set on the PaymentIntent, providing an empty value
+       * for this parameter will unset the stored value for this payment method type.
+       */
+      @SerializedName("capture_method")
+      EnumParam captureMethod;
+
+      /**
        * A single-use {@code cvc_update} Token that represents a card CVC value. When provided, the
        * CVC value will be verified during the card payment attempt. This parameter can only be
        * provided during confirmation.
@@ -5627,6 +6012,7 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       EnumParam setupFutureUsage;
 
       private Card(
+          EnumParam captureMethod,
           String cvcToken,
           Map<String, Object> extraParams,
           Installments installments,
@@ -5635,6 +6021,7 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
           Network network,
           RequestThreeDSecure requestThreeDSecure,
           EnumParam setupFutureUsage) {
+        this.captureMethod = captureMethod;
         this.cvcToken = cvcToken;
         this.extraParams = extraParams;
         this.installments = installments;
@@ -5650,6 +6037,8 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       }
 
       public static class Builder {
+        private EnumParam captureMethod;
+
         private String cvcToken;
 
         private Map<String, Object> extraParams;
@@ -5669,6 +6058,7 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
         /** Finalize and obtain parameter instance from this builder. */
         public Card build() {
           return new Card(
+              this.captureMethod,
               this.cvcToken,
               this.extraParams,
               this.installments,
@@ -5677,6 +6067,34 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
               this.network,
               this.requestThreeDSecure,
               this.setupFutureUsage);
+        }
+
+        /**
+         * Controls when the funds will be captured from the customer's account.
+         *
+         * <p>If provided, this parameter will override the top-level {@code capture_method} when
+         * finalizing the payment with this payment method type.
+         *
+         * <p>If {@code capture_method} is already set on the PaymentIntent, providing an empty
+         * value for this parameter will unset the stored value for this payment method type.
+         */
+        public Builder setCaptureMethod(CaptureMethod captureMethod) {
+          this.captureMethod = captureMethod;
+          return this;
+        }
+
+        /**
+         * Controls when the funds will be captured from the customer's account.
+         *
+         * <p>If provided, this parameter will override the top-level {@code capture_method} when
+         * finalizing the payment with this payment method type.
+         *
+         * <p>If {@code capture_method} is already set on the PaymentIntent, providing an empty
+         * value for this parameter will unset the stored value for this payment method type.
+         */
+        public Builder setCaptureMethod(EmptyParam captureMethod) {
+          this.captureMethod = captureMethod;
+          return this;
         }
 
         /**
@@ -6375,6 +6793,18 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
           SupportedType(String value) {
             this.value = value;
           }
+        }
+      }
+
+      public enum CaptureMethod implements ApiRequestParams.EnumParam {
+        @SerializedName("manual")
+        MANUAL("manual");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        CaptureMethod(String value) {
+          this.value = value;
         }
       }
 
@@ -7193,6 +7623,18 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
     @Getter
     public static class Klarna {
       /**
+       * Controls when the funds will be captured from the customer's account.
+       *
+       * <p>If provided, this parameter will override the top-level {@code capture_method} when
+       * finalizing the payment with this payment method type.
+       *
+       * <p>If {@code capture_method} is already set on the PaymentIntent, providing an empty value
+       * for this parameter will unset the stored value for this payment method type.
+       */
+      @SerializedName("capture_method")
+      EnumParam captureMethod;
+
+      /**
        * Map of extra parameters for custom features not available in this client library. The
        * content in this map is not serialized under this field's {@code @SerializedName} value.
        * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
@@ -7228,9 +7670,11 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       SetupFutureUsage setupFutureUsage;
 
       private Klarna(
+          EnumParam captureMethod,
           Map<String, Object> extraParams,
           PreferredLocale preferredLocale,
           SetupFutureUsage setupFutureUsage) {
+        this.captureMethod = captureMethod;
         this.extraParams = extraParams;
         this.preferredLocale = preferredLocale;
         this.setupFutureUsage = setupFutureUsage;
@@ -7241,6 +7685,8 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       }
 
       public static class Builder {
+        private EnumParam captureMethod;
+
         private Map<String, Object> extraParams;
 
         private PreferredLocale preferredLocale;
@@ -7249,7 +7695,36 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
 
         /** Finalize and obtain parameter instance from this builder. */
         public Klarna build() {
-          return new Klarna(this.extraParams, this.preferredLocale, this.setupFutureUsage);
+          return new Klarna(
+              this.captureMethod, this.extraParams, this.preferredLocale, this.setupFutureUsage);
+        }
+
+        /**
+         * Controls when the funds will be captured from the customer's account.
+         *
+         * <p>If provided, this parameter will override the top-level {@code capture_method} when
+         * finalizing the payment with this payment method type.
+         *
+         * <p>If {@code capture_method} is already set on the PaymentIntent, providing an empty
+         * value for this parameter will unset the stored value for this payment method type.
+         */
+        public Builder setCaptureMethod(CaptureMethod captureMethod) {
+          this.captureMethod = captureMethod;
+          return this;
+        }
+
+        /**
+         * Controls when the funds will be captured from the customer's account.
+         *
+         * <p>If provided, this parameter will override the top-level {@code capture_method} when
+         * finalizing the payment with this payment method type.
+         *
+         * <p>If {@code capture_method} is already set on the PaymentIntent, providing an empty
+         * value for this parameter will unset the stored value for this payment method type.
+         */
+        public Builder setCaptureMethod(EmptyParam captureMethod) {
+          this.captureMethod = captureMethod;
+          return this;
         }
 
         /**
@@ -7311,6 +7786,18 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
         public Builder setSetupFutureUsage(SetupFutureUsage setupFutureUsage) {
           this.setupFutureUsage = setupFutureUsage;
           return this;
+        }
+      }
+
+      public enum CaptureMethod implements ApiRequestParams.EnumParam {
+        @SerializedName("manual")
+        MANUAL("manual");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        CaptureMethod(String value) {
+          this.value = value;
         }
       }
 
@@ -7932,6 +8419,125 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
     }
 
     @Getter
+    public static class Paynow {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * <p>Providing this parameter will <a
+       * href="https://stripe.com/docs/payments/save-during-payment">attach the payment method</a>
+       * to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any
+       * required actions from the user are complete. If no Customer was provided, the payment
+       * method can still be <a
+       * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer after
+       * the transaction completes.
+       *
+       * <p>When processing card payments, Stripe also uses {@code setup_future_usage} to
+       * dynamically optimize your payment flow and comply with regional legislation and network
+       * rules, such as <a href="https://stripe.com/docs/strong-customer-authentication">SCA</a>.
+       *
+       * <p>If {@code setup_future_usage} is already set and you are performing a request using a
+       * publishable key, you may only update the value from {@code on_session} to {@code
+       * off_session}.
+       */
+      @SerializedName("setup_future_usage")
+      SetupFutureUsage setupFutureUsage;
+
+      private Paynow(Map<String, Object> extraParams, SetupFutureUsage setupFutureUsage) {
+        this.extraParams = extraParams;
+        this.setupFutureUsage = setupFutureUsage;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private SetupFutureUsage setupFutureUsage;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Paynow build() {
+          return new Paynow(this.extraParams, this.setupFutureUsage);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentConfirmParams.PaymentMethodOptions.Paynow#extraParams} for
+         * the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentConfirmParams.PaymentMethodOptions.Paynow#extraParams} for
+         * the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /**
+         * Indicates that you intend to make future payments with this PaymentIntent's payment
+         * method.
+         *
+         * <p>Providing this parameter will <a
+         * href="https://stripe.com/docs/payments/save-during-payment">attach the payment method</a>
+         * to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any
+         * required actions from the user are complete. If no Customer was provided, the payment
+         * method can still be <a
+         * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer
+         * after the transaction completes.
+         *
+         * <p>When processing card payments, Stripe also uses {@code setup_future_usage} to
+         * dynamically optimize your payment flow and comply with regional legislation and network
+         * rules, such as <a href="https://stripe.com/docs/strong-customer-authentication">SCA</a>.
+         *
+         * <p>If {@code setup_future_usage} is already set and you are performing a request using a
+         * publishable key, you may only update the value from {@code on_session} to {@code
+         * off_session}.
+         */
+        public Builder setSetupFutureUsage(SetupFutureUsage setupFutureUsage) {
+          this.setupFutureUsage = setupFutureUsage;
+          return this;
+        }
+      }
+
+      public enum SetupFutureUsage implements ApiRequestParams.EnumParam {
+        @SerializedName("none")
+        NONE("none");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        SetupFutureUsage(String value) {
+          this.value = value;
+        }
+      }
+    }
+
+    @Getter
     public static class SepaDebit {
       /**
        * Map of extra parameters for custom features not available in this client library. The
@@ -8351,6 +8957,193 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
         private final String value;
 
         SetupFutureUsage(String value) {
+          this.value = value;
+        }
+      }
+    }
+
+    @Getter
+    public static class UsBankAccount {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * <p>Providing this parameter will <a
+       * href="https://stripe.com/docs/payments/save-during-payment">attach the payment method</a>
+       * to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any
+       * required actions from the user are complete. If no Customer was provided, the payment
+       * method can still be <a
+       * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer after
+       * the transaction completes.
+       *
+       * <p>When processing card payments, Stripe also uses {@code setup_future_usage} to
+       * dynamically optimize your payment flow and comply with regional legislation and network
+       * rules, such as <a href="https://stripe.com/docs/strong-customer-authentication">SCA</a>.
+       *
+       * <p>If {@code setup_future_usage} is already set and you are performing a request using a
+       * publishable key, you may only update the value from {@code on_session} to {@code
+       * off_session}.
+       */
+      @SerializedName("setup_future_usage")
+      EnumParam setupFutureUsage;
+
+      /** Verification method for the intent. */
+      @SerializedName("verification_method")
+      VerificationMethod verificationMethod;
+
+      private UsBankAccount(
+          Map<String, Object> extraParams,
+          EnumParam setupFutureUsage,
+          VerificationMethod verificationMethod) {
+        this.extraParams = extraParams;
+        this.setupFutureUsage = setupFutureUsage;
+        this.verificationMethod = verificationMethod;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private EnumParam setupFutureUsage;
+
+        private VerificationMethod verificationMethod;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public UsBankAccount build() {
+          return new UsBankAccount(
+              this.extraParams, this.setupFutureUsage, this.verificationMethod);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * PaymentIntentConfirmParams.PaymentMethodOptions.UsBankAccount#extraParams} for the field
+         * documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * PaymentIntentConfirmParams.PaymentMethodOptions.UsBankAccount#extraParams} for the field
+         * documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /**
+         * Indicates that you intend to make future payments with this PaymentIntent's payment
+         * method.
+         *
+         * <p>Providing this parameter will <a
+         * href="https://stripe.com/docs/payments/save-during-payment">attach the payment method</a>
+         * to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any
+         * required actions from the user are complete. If no Customer was provided, the payment
+         * method can still be <a
+         * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer
+         * after the transaction completes.
+         *
+         * <p>When processing card payments, Stripe also uses {@code setup_future_usage} to
+         * dynamically optimize your payment flow and comply with regional legislation and network
+         * rules, such as <a href="https://stripe.com/docs/strong-customer-authentication">SCA</a>.
+         *
+         * <p>If {@code setup_future_usage} is already set and you are performing a request using a
+         * publishable key, you may only update the value from {@code on_session} to {@code
+         * off_session}.
+         */
+        public Builder setSetupFutureUsage(SetupFutureUsage setupFutureUsage) {
+          this.setupFutureUsage = setupFutureUsage;
+          return this;
+        }
+
+        /**
+         * Indicates that you intend to make future payments with this PaymentIntent's payment
+         * method.
+         *
+         * <p>Providing this parameter will <a
+         * href="https://stripe.com/docs/payments/save-during-payment">attach the payment method</a>
+         * to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any
+         * required actions from the user are complete. If no Customer was provided, the payment
+         * method can still be <a
+         * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer
+         * after the transaction completes.
+         *
+         * <p>When processing card payments, Stripe also uses {@code setup_future_usage} to
+         * dynamically optimize your payment flow and comply with regional legislation and network
+         * rules, such as <a href="https://stripe.com/docs/strong-customer-authentication">SCA</a>.
+         *
+         * <p>If {@code setup_future_usage} is already set and you are performing a request using a
+         * publishable key, you may only update the value from {@code on_session} to {@code
+         * off_session}.
+         */
+        public Builder setSetupFutureUsage(EmptyParam setupFutureUsage) {
+          this.setupFutureUsage = setupFutureUsage;
+          return this;
+        }
+
+        /** Verification method for the intent. */
+        public Builder setVerificationMethod(VerificationMethod verificationMethod) {
+          this.verificationMethod = verificationMethod;
+          return this;
+        }
+      }
+
+      public enum SetupFutureUsage implements ApiRequestParams.EnumParam {
+        @SerializedName("none")
+        NONE("none"),
+
+        @SerializedName("off_session")
+        OFF_SESSION("off_session"),
+
+        @SerializedName("on_session")
+        ON_SESSION("on_session");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        SetupFutureUsage(String value) {
+          this.value = value;
+        }
+      }
+
+      public enum VerificationMethod implements ApiRequestParams.EnumParam {
+        @SerializedName("automatic")
+        AUTOMATIC("automatic"),
+
+        @SerializedName("instant")
+        INSTANT("instant"),
+
+        @SerializedName("microdeposits")
+        MICRODEPOSITS("microdeposits");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        VerificationMethod(String value) {
           this.value = value;
         }
       }

--- a/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
@@ -1402,6 +1402,13 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     P24 p24;
 
     /**
+     * If this is a {@code paynow} PaymentMethod, this hash contains details about the PayNow
+     * payment method.
+     */
+    @SerializedName("paynow")
+    Paynow paynow;
+
+    /**
      * If this is a {@code sepa_debit} PaymentMethod, this hash contains details about the SEPA
      * debit bank account.
      */
@@ -1422,6 +1429,13 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
      */
     @SerializedName("type")
     Type type;
+
+    /**
+     * If this is an {@code us_bank_account} PaymentMethod, this hash contains details about the US
+     * bank account payment method.
+     */
+    @SerializedName("us_bank_account")
+    UsBankAccount usBankAccount;
 
     /**
      * If this is an {@code wechat_pay} PaymentMethod, this hash contains details about the
@@ -1451,9 +1465,11 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
         Map<String, String> metadata,
         Oxxo oxxo,
         P24 p24,
+        Paynow paynow,
         SepaDebit sepaDebit,
         Sofort sofort,
         Type type,
+        UsBankAccount usBankAccount,
         WechatPay wechatPay) {
       this.acssDebit = acssDebit;
       this.afterpayClearpay = afterpayClearpay;
@@ -1475,9 +1491,11 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       this.metadata = metadata;
       this.oxxo = oxxo;
       this.p24 = p24;
+      this.paynow = paynow;
       this.sepaDebit = sepaDebit;
       this.sofort = sofort;
       this.type = type;
+      this.usBankAccount = usBankAccount;
       this.wechatPay = wechatPay;
     }
 
@@ -1526,11 +1544,15 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
 
       private P24 p24;
 
+      private Paynow paynow;
+
       private SepaDebit sepaDebit;
 
       private Sofort sofort;
 
       private Type type;
+
+      private UsBankAccount usBankAccount;
 
       private WechatPay wechatPay;
 
@@ -1557,9 +1579,11 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
             this.metadata,
             this.oxxo,
             this.p24,
+            this.paynow,
             this.sepaDebit,
             this.sofort,
             this.type,
+            this.usBankAccount,
             this.wechatPay);
       }
 
@@ -1780,6 +1804,15 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       }
 
       /**
+       * If this is a {@code paynow} PaymentMethod, this hash contains details about the PayNow
+       * payment method.
+       */
+      public Builder setPaynow(Paynow paynow) {
+        this.paynow = paynow;
+        return this;
+      }
+
+      /**
        * If this is a {@code sepa_debit} PaymentMethod, this hash contains details about the SEPA
        * debit bank account.
        */
@@ -1804,6 +1837,15 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
        */
       public Builder setType(Type type) {
         this.type = type;
+        return this;
+      }
+
+      /**
+       * If this is an {@code us_bank_account} PaymentMethod, this hash contains details about the
+       * US bank account payment method.
+       */
+      public Builder setUsBankAccount(UsBankAccount usBankAccount) {
+        this.usBankAccount = usBankAccount;
         return this;
       }
 
@@ -3670,6 +3712,63 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     }
 
     @Getter
+    public static class Paynow {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private Paynow(Map<String, Object> extraParams) {
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Paynow build() {
+          return new Paynow(this.extraParams);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentCreateParams.PaymentMethodData.Paynow#extraParams} for the
+         * field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentCreateParams.PaymentMethodData.Paynow#extraParams} for the
+         * field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+      }
+    }
+
+    @Getter
     public static class SepaDebit {
       /**
        * Map of extra parameters for custom features not available in this client library. The
@@ -3837,6 +3936,155 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     }
 
     @Getter
+    public static class UsBankAccount {
+      /** Account holder type: individual or company. */
+      @SerializedName("account_holder_type")
+      AccountHolderType accountHolderType;
+
+      /** Account number of the bank account. */
+      @SerializedName("account_number")
+      String accountNumber;
+
+      /** Account type: checkings or savings. Defaults to checking if omitted. */
+      @SerializedName("account_type")
+      AccountType accountType;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Routing number of the bank account. */
+      @SerializedName("routing_number")
+      String routingNumber;
+
+      private UsBankAccount(
+          AccountHolderType accountHolderType,
+          String accountNumber,
+          AccountType accountType,
+          Map<String, Object> extraParams,
+          String routingNumber) {
+        this.accountHolderType = accountHolderType;
+        this.accountNumber = accountNumber;
+        this.accountType = accountType;
+        this.extraParams = extraParams;
+        this.routingNumber = routingNumber;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private AccountHolderType accountHolderType;
+
+        private String accountNumber;
+
+        private AccountType accountType;
+
+        private Map<String, Object> extraParams;
+
+        private String routingNumber;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public UsBankAccount build() {
+          return new UsBankAccount(
+              this.accountHolderType,
+              this.accountNumber,
+              this.accountType,
+              this.extraParams,
+              this.routingNumber);
+        }
+
+        /** Account holder type: individual or company. */
+        public Builder setAccountHolderType(AccountHolderType accountHolderType) {
+          this.accountHolderType = accountHolderType;
+          return this;
+        }
+
+        /** Account number of the bank account. */
+        public Builder setAccountNumber(String accountNumber) {
+          this.accountNumber = accountNumber;
+          return this;
+        }
+
+        /** Account type: checkings or savings. Defaults to checking if omitted. */
+        public Builder setAccountType(AccountType accountType) {
+          this.accountType = accountType;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentCreateParams.PaymentMethodData.UsBankAccount#extraParams}
+         * for the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentCreateParams.PaymentMethodData.UsBankAccount#extraParams}
+         * for the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Routing number of the bank account. */
+        public Builder setRoutingNumber(String routingNumber) {
+          this.routingNumber = routingNumber;
+          return this;
+        }
+      }
+
+      public enum AccountHolderType implements ApiRequestParams.EnumParam {
+        @SerializedName("company")
+        COMPANY("company"),
+
+        @SerializedName("individual")
+        INDIVIDUAL("individual");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        AccountHolderType(String value) {
+          this.value = value;
+        }
+      }
+
+      public enum AccountType implements ApiRequestParams.EnumParam {
+        @SerializedName("checking")
+        CHECKING("checking"),
+
+        @SerializedName("savings")
+        SAVINGS("savings");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        AccountType(String value) {
+          this.value = value;
+        }
+      }
+    }
+
+    @Getter
     public static class WechatPay {
       /**
        * Map of extra parameters for custom features not available in this client library. The
@@ -3942,11 +4190,17 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       @SerializedName("p24")
       P24("p24"),
 
+      @SerializedName("paynow")
+      PAYNOW("paynow"),
+
       @SerializedName("sepa_debit")
       SEPA_DEBIT("sepa_debit"),
 
       @SerializedName("sofort")
       SOFORT("sofort"),
+
+      @SerializedName("us_bank_account")
+      US_BANK_ACCOUNT("us_bank_account"),
 
       @SerializedName("wechat_pay")
       WECHAT_PAY("wechat_pay");
@@ -4102,6 +4356,13 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     Object p24;
 
     /**
+     * If this is a {@code paynow} PaymentMethod, this sub-hash contains details about the PayNow
+     * payment method options.
+     */
+    @SerializedName("paynow")
+    Object paynow;
+
+    /**
      * If this is a {@code sepa_debit} PaymentIntent, this sub-hash contains details about the SEPA
      * Debit payment method options.
      */
@@ -4114,6 +4375,13 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
      */
     @SerializedName("sofort")
     Object sofort;
+
+    /**
+     * If this is a {@code us_bank_account} PaymentMethod, this sub-hash contains details about the
+     * US bank account payment method options.
+     */
+    @SerializedName("us_bank_account")
+    Object usBankAccount;
 
     /**
      * If this is a {@code wechat_pay} PaymentMethod, this sub-hash contains details about the
@@ -4143,8 +4411,10 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
         Object konbini,
         Object oxxo,
         Object p24,
+        Object paynow,
         Object sepaDebit,
         Object sofort,
+        Object usBankAccount,
         Object wechatPay) {
       this.acssDebit = acssDebit;
       this.afterpayClearpay = afterpayClearpay;
@@ -4166,8 +4436,10 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       this.konbini = konbini;
       this.oxxo = oxxo;
       this.p24 = p24;
+      this.paynow = paynow;
       this.sepaDebit = sepaDebit;
       this.sofort = sofort;
+      this.usBankAccount = usBankAccount;
       this.wechatPay = wechatPay;
     }
 
@@ -4216,9 +4488,13 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
 
       private Object p24;
 
+      private Object paynow;
+
       private Object sepaDebit;
 
       private Object sofort;
+
+      private Object usBankAccount;
 
       private Object wechatPay;
 
@@ -4245,8 +4521,10 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
             this.konbini,
             this.oxxo,
             this.p24,
+            this.paynow,
             this.sepaDebit,
             this.sofort,
+            this.usBankAccount,
             this.wechatPay);
       }
 
@@ -4614,6 +4892,24 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       }
 
       /**
+       * If this is a {@code paynow} PaymentMethod, this sub-hash contains details about the PayNow
+       * payment method options.
+       */
+      public Builder setPaynow(Paynow paynow) {
+        this.paynow = paynow;
+        return this;
+      }
+
+      /**
+       * If this is a {@code paynow} PaymentMethod, this sub-hash contains details about the PayNow
+       * payment method options.
+       */
+      public Builder setPaynow(EmptyParam paynow) {
+        this.paynow = paynow;
+        return this;
+      }
+
+      /**
        * If this is a {@code sepa_debit} PaymentIntent, this sub-hash contains details about the
        * SEPA Debit payment method options.
        */
@@ -4646,6 +4942,24 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
        */
       public Builder setSofort(EmptyParam sofort) {
         this.sofort = sofort;
+        return this;
+      }
+
+      /**
+       * If this is a {@code us_bank_account} PaymentMethod, this sub-hash contains details about
+       * the US bank account payment method options.
+       */
+      public Builder setUsBankAccount(UsBankAccount usBankAccount) {
+        this.usBankAccount = usBankAccount;
+        return this;
+      }
+
+      /**
+       * If this is a {@code us_bank_account} PaymentMethod, this sub-hash contains details about
+       * the US bank account payment method options.
+       */
+      public Builder setUsBankAccount(EmptyParam usBankAccount) {
+        this.usBankAccount = usBankAccount;
         return this;
       }
 
@@ -5055,6 +5369,18 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     @Getter
     public static class AfterpayClearpay {
       /**
+       * Controls when the funds will be captured from the customer's account.
+       *
+       * <p>If provided, this parameter will override the top-level {@code capture_method} when
+       * finalizing the payment with this payment method type.
+       *
+       * <p>If {@code capture_method} is already set on the PaymentIntent, providing an empty value
+       * for this parameter will unset the stored value for this payment method type.
+       */
+      @SerializedName("capture_method")
+      EnumParam captureMethod;
+
+      /**
        * Map of extra parameters for custom features not available in this client library. The
        * content in this map is not serialized under this field's {@code @SerializedName} value.
        * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
@@ -5095,7 +5421,11 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       SetupFutureUsage setupFutureUsage;
 
       private AfterpayClearpay(
-          Map<String, Object> extraParams, String reference, SetupFutureUsage setupFutureUsage) {
+          EnumParam captureMethod,
+          Map<String, Object> extraParams,
+          String reference,
+          SetupFutureUsage setupFutureUsage) {
+        this.captureMethod = captureMethod;
         this.extraParams = extraParams;
         this.reference = reference;
         this.setupFutureUsage = setupFutureUsage;
@@ -5106,6 +5436,8 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       }
 
       public static class Builder {
+        private EnumParam captureMethod;
+
         private Map<String, Object> extraParams;
 
         private String reference;
@@ -5114,7 +5446,36 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
 
         /** Finalize and obtain parameter instance from this builder. */
         public AfterpayClearpay build() {
-          return new AfterpayClearpay(this.extraParams, this.reference, this.setupFutureUsage);
+          return new AfterpayClearpay(
+              this.captureMethod, this.extraParams, this.reference, this.setupFutureUsage);
+        }
+
+        /**
+         * Controls when the funds will be captured from the customer's account.
+         *
+         * <p>If provided, this parameter will override the top-level {@code capture_method} when
+         * finalizing the payment with this payment method type.
+         *
+         * <p>If {@code capture_method} is already set on the PaymentIntent, providing an empty
+         * value for this parameter will unset the stored value for this payment method type.
+         */
+        public Builder setCaptureMethod(CaptureMethod captureMethod) {
+          this.captureMethod = captureMethod;
+          return this;
+        }
+
+        /**
+         * Controls when the funds will be captured from the customer's account.
+         *
+         * <p>If provided, this parameter will override the top-level {@code capture_method} when
+         * finalizing the payment with this payment method type.
+         *
+         * <p>If {@code capture_method} is already set on the PaymentIntent, providing an empty
+         * value for this parameter will unset the stored value for this payment method type.
+         */
+        public Builder setCaptureMethod(EmptyParam captureMethod) {
+          this.captureMethod = captureMethod;
+          return this;
         }
 
         /**
@@ -5181,6 +5542,18 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
         public Builder setSetupFutureUsage(SetupFutureUsage setupFutureUsage) {
           this.setupFutureUsage = setupFutureUsage;
           return this;
+        }
+      }
+
+      public enum CaptureMethod implements ApiRequestParams.EnumParam {
+        @SerializedName("manual")
+        MANUAL("manual");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        CaptureMethod(String value) {
+          this.value = value;
         }
       }
 
@@ -6008,6 +6381,18 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     @Getter
     public static class Card {
       /**
+       * Controls when the funds will be captured from the customer's account.
+       *
+       * <p>If provided, this parameter will override the top-level {@code capture_method} when
+       * finalizing the payment with this payment method type.
+       *
+       * <p>If {@code capture_method} is already set on the PaymentIntent, providing an empty value
+       * for this parameter will unset the stored value for this payment method type.
+       */
+      @SerializedName("capture_method")
+      EnumParam captureMethod;
+
+      /**
        * A single-use {@code cvc_update} Token that represents a card CVC value. When provided, the
        * CVC value will be verified during the card payment attempt. This parameter can only be
        * provided during confirmation.
@@ -6089,6 +6474,7 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       EnumParam setupFutureUsage;
 
       private Card(
+          EnumParam captureMethod,
           String cvcToken,
           Map<String, Object> extraParams,
           Installments installments,
@@ -6097,6 +6483,7 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
           Network network,
           RequestThreeDSecure requestThreeDSecure,
           EnumParam setupFutureUsage) {
+        this.captureMethod = captureMethod;
         this.cvcToken = cvcToken;
         this.extraParams = extraParams;
         this.installments = installments;
@@ -6112,6 +6499,8 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       }
 
       public static class Builder {
+        private EnumParam captureMethod;
+
         private String cvcToken;
 
         private Map<String, Object> extraParams;
@@ -6131,6 +6520,7 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
         /** Finalize and obtain parameter instance from this builder. */
         public Card build() {
           return new Card(
+              this.captureMethod,
               this.cvcToken,
               this.extraParams,
               this.installments,
@@ -6139,6 +6529,34 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
               this.network,
               this.requestThreeDSecure,
               this.setupFutureUsage);
+        }
+
+        /**
+         * Controls when the funds will be captured from the customer's account.
+         *
+         * <p>If provided, this parameter will override the top-level {@code capture_method} when
+         * finalizing the payment with this payment method type.
+         *
+         * <p>If {@code capture_method} is already set on the PaymentIntent, providing an empty
+         * value for this parameter will unset the stored value for this payment method type.
+         */
+        public Builder setCaptureMethod(CaptureMethod captureMethod) {
+          this.captureMethod = captureMethod;
+          return this;
+        }
+
+        /**
+         * Controls when the funds will be captured from the customer's account.
+         *
+         * <p>If provided, this parameter will override the top-level {@code capture_method} when
+         * finalizing the payment with this payment method type.
+         *
+         * <p>If {@code capture_method} is already set on the PaymentIntent, providing an empty
+         * value for this parameter will unset the stored value for this payment method type.
+         */
+        public Builder setCaptureMethod(EmptyParam captureMethod) {
+          this.captureMethod = captureMethod;
+          return this;
         }
 
         /**
@@ -6837,6 +7255,18 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
           SupportedType(String value) {
             this.value = value;
           }
+        }
+      }
+
+      public enum CaptureMethod implements ApiRequestParams.EnumParam {
+        @SerializedName("manual")
+        MANUAL("manual");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        CaptureMethod(String value) {
+          this.value = value;
         }
       }
 
@@ -7655,6 +8085,18 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     @Getter
     public static class Klarna {
       /**
+       * Controls when the funds will be captured from the customer's account.
+       *
+       * <p>If provided, this parameter will override the top-level {@code capture_method} when
+       * finalizing the payment with this payment method type.
+       *
+       * <p>If {@code capture_method} is already set on the PaymentIntent, providing an empty value
+       * for this parameter will unset the stored value for this payment method type.
+       */
+      @SerializedName("capture_method")
+      EnumParam captureMethod;
+
+      /**
        * Map of extra parameters for custom features not available in this client library. The
        * content in this map is not serialized under this field's {@code @SerializedName} value.
        * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
@@ -7690,9 +8132,11 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       SetupFutureUsage setupFutureUsage;
 
       private Klarna(
+          EnumParam captureMethod,
           Map<String, Object> extraParams,
           PreferredLocale preferredLocale,
           SetupFutureUsage setupFutureUsage) {
+        this.captureMethod = captureMethod;
         this.extraParams = extraParams;
         this.preferredLocale = preferredLocale;
         this.setupFutureUsage = setupFutureUsage;
@@ -7703,6 +8147,8 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       }
 
       public static class Builder {
+        private EnumParam captureMethod;
+
         private Map<String, Object> extraParams;
 
         private PreferredLocale preferredLocale;
@@ -7711,7 +8157,36 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
 
         /** Finalize and obtain parameter instance from this builder. */
         public Klarna build() {
-          return new Klarna(this.extraParams, this.preferredLocale, this.setupFutureUsage);
+          return new Klarna(
+              this.captureMethod, this.extraParams, this.preferredLocale, this.setupFutureUsage);
+        }
+
+        /**
+         * Controls when the funds will be captured from the customer's account.
+         *
+         * <p>If provided, this parameter will override the top-level {@code capture_method} when
+         * finalizing the payment with this payment method type.
+         *
+         * <p>If {@code capture_method} is already set on the PaymentIntent, providing an empty
+         * value for this parameter will unset the stored value for this payment method type.
+         */
+        public Builder setCaptureMethod(CaptureMethod captureMethod) {
+          this.captureMethod = captureMethod;
+          return this;
+        }
+
+        /**
+         * Controls when the funds will be captured from the customer's account.
+         *
+         * <p>If provided, this parameter will override the top-level {@code capture_method} when
+         * finalizing the payment with this payment method type.
+         *
+         * <p>If {@code capture_method} is already set on the PaymentIntent, providing an empty
+         * value for this parameter will unset the stored value for this payment method type.
+         */
+        public Builder setCaptureMethod(EmptyParam captureMethod) {
+          this.captureMethod = captureMethod;
+          return this;
         }
 
         /**
@@ -7773,6 +8248,18 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
         public Builder setSetupFutureUsage(SetupFutureUsage setupFutureUsage) {
           this.setupFutureUsage = setupFutureUsage;
           return this;
+        }
+      }
+
+      public enum CaptureMethod implements ApiRequestParams.EnumParam {
+        @SerializedName("manual")
+        MANUAL("manual");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        CaptureMethod(String value) {
+          this.value = value;
         }
       }
 
@@ -8394,6 +8881,125 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
     }
 
     @Getter
+    public static class Paynow {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * <p>Providing this parameter will <a
+       * href="https://stripe.com/docs/payments/save-during-payment">attach the payment method</a>
+       * to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any
+       * required actions from the user are complete. If no Customer was provided, the payment
+       * method can still be <a
+       * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer after
+       * the transaction completes.
+       *
+       * <p>When processing card payments, Stripe also uses {@code setup_future_usage} to
+       * dynamically optimize your payment flow and comply with regional legislation and network
+       * rules, such as <a href="https://stripe.com/docs/strong-customer-authentication">SCA</a>.
+       *
+       * <p>If {@code setup_future_usage} is already set and you are performing a request using a
+       * publishable key, you may only update the value from {@code on_session} to {@code
+       * off_session}.
+       */
+      @SerializedName("setup_future_usage")
+      SetupFutureUsage setupFutureUsage;
+
+      private Paynow(Map<String, Object> extraParams, SetupFutureUsage setupFutureUsage) {
+        this.extraParams = extraParams;
+        this.setupFutureUsage = setupFutureUsage;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private SetupFutureUsage setupFutureUsage;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Paynow build() {
+          return new Paynow(this.extraParams, this.setupFutureUsage);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentCreateParams.PaymentMethodOptions.Paynow#extraParams} for
+         * the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentCreateParams.PaymentMethodOptions.Paynow#extraParams} for
+         * the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /**
+         * Indicates that you intend to make future payments with this PaymentIntent's payment
+         * method.
+         *
+         * <p>Providing this parameter will <a
+         * href="https://stripe.com/docs/payments/save-during-payment">attach the payment method</a>
+         * to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any
+         * required actions from the user are complete. If no Customer was provided, the payment
+         * method can still be <a
+         * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer
+         * after the transaction completes.
+         *
+         * <p>When processing card payments, Stripe also uses {@code setup_future_usage} to
+         * dynamically optimize your payment flow and comply with regional legislation and network
+         * rules, such as <a href="https://stripe.com/docs/strong-customer-authentication">SCA</a>.
+         *
+         * <p>If {@code setup_future_usage} is already set and you are performing a request using a
+         * publishable key, you may only update the value from {@code on_session} to {@code
+         * off_session}.
+         */
+        public Builder setSetupFutureUsage(SetupFutureUsage setupFutureUsage) {
+          this.setupFutureUsage = setupFutureUsage;
+          return this;
+        }
+      }
+
+      public enum SetupFutureUsage implements ApiRequestParams.EnumParam {
+        @SerializedName("none")
+        NONE("none");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        SetupFutureUsage(String value) {
+          this.value = value;
+        }
+      }
+    }
+
+    @Getter
     public static class SepaDebit {
       /**
        * Map of extra parameters for custom features not available in this client library. The
@@ -8813,6 +9419,191 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
         private final String value;
 
         SetupFutureUsage(String value) {
+          this.value = value;
+        }
+      }
+    }
+
+    @Getter
+    public static class UsBankAccount {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * <p>Providing this parameter will <a
+       * href="https://stripe.com/docs/payments/save-during-payment">attach the payment method</a>
+       * to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any
+       * required actions from the user are complete. If no Customer was provided, the payment
+       * method can still be <a
+       * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer after
+       * the transaction completes.
+       *
+       * <p>When processing card payments, Stripe also uses {@code setup_future_usage} to
+       * dynamically optimize your payment flow and comply with regional legislation and network
+       * rules, such as <a href="https://stripe.com/docs/strong-customer-authentication">SCA</a>.
+       *
+       * <p>If {@code setup_future_usage} is already set and you are performing a request using a
+       * publishable key, you may only update the value from {@code on_session} to {@code
+       * off_session}.
+       */
+      @SerializedName("setup_future_usage")
+      EnumParam setupFutureUsage;
+
+      /** Verification method for the intent. */
+      @SerializedName("verification_method")
+      VerificationMethod verificationMethod;
+
+      private UsBankAccount(
+          Map<String, Object> extraParams,
+          EnumParam setupFutureUsage,
+          VerificationMethod verificationMethod) {
+        this.extraParams = extraParams;
+        this.setupFutureUsage = setupFutureUsage;
+        this.verificationMethod = verificationMethod;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private EnumParam setupFutureUsage;
+
+        private VerificationMethod verificationMethod;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public UsBankAccount build() {
+          return new UsBankAccount(
+              this.extraParams, this.setupFutureUsage, this.verificationMethod);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentCreateParams.PaymentMethodOptions.UsBankAccount#extraParams}
+         * for the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentCreateParams.PaymentMethodOptions.UsBankAccount#extraParams}
+         * for the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /**
+         * Indicates that you intend to make future payments with this PaymentIntent's payment
+         * method.
+         *
+         * <p>Providing this parameter will <a
+         * href="https://stripe.com/docs/payments/save-during-payment">attach the payment method</a>
+         * to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any
+         * required actions from the user are complete. If no Customer was provided, the payment
+         * method can still be <a
+         * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer
+         * after the transaction completes.
+         *
+         * <p>When processing card payments, Stripe also uses {@code setup_future_usage} to
+         * dynamically optimize your payment flow and comply with regional legislation and network
+         * rules, such as <a href="https://stripe.com/docs/strong-customer-authentication">SCA</a>.
+         *
+         * <p>If {@code setup_future_usage} is already set and you are performing a request using a
+         * publishable key, you may only update the value from {@code on_session} to {@code
+         * off_session}.
+         */
+        public Builder setSetupFutureUsage(SetupFutureUsage setupFutureUsage) {
+          this.setupFutureUsage = setupFutureUsage;
+          return this;
+        }
+
+        /**
+         * Indicates that you intend to make future payments with this PaymentIntent's payment
+         * method.
+         *
+         * <p>Providing this parameter will <a
+         * href="https://stripe.com/docs/payments/save-during-payment">attach the payment method</a>
+         * to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any
+         * required actions from the user are complete. If no Customer was provided, the payment
+         * method can still be <a
+         * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer
+         * after the transaction completes.
+         *
+         * <p>When processing card payments, Stripe also uses {@code setup_future_usage} to
+         * dynamically optimize your payment flow and comply with regional legislation and network
+         * rules, such as <a href="https://stripe.com/docs/strong-customer-authentication">SCA</a>.
+         *
+         * <p>If {@code setup_future_usage} is already set and you are performing a request using a
+         * publishable key, you may only update the value from {@code on_session} to {@code
+         * off_session}.
+         */
+        public Builder setSetupFutureUsage(EmptyParam setupFutureUsage) {
+          this.setupFutureUsage = setupFutureUsage;
+          return this;
+        }
+
+        /** Verification method for the intent. */
+        public Builder setVerificationMethod(VerificationMethod verificationMethod) {
+          this.verificationMethod = verificationMethod;
+          return this;
+        }
+      }
+
+      public enum SetupFutureUsage implements ApiRequestParams.EnumParam {
+        @SerializedName("none")
+        NONE("none"),
+
+        @SerializedName("off_session")
+        OFF_SESSION("off_session"),
+
+        @SerializedName("on_session")
+        ON_SESSION("on_session");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        SetupFutureUsage(String value) {
+          this.value = value;
+        }
+      }
+
+      public enum VerificationMethod implements ApiRequestParams.EnumParam {
+        @SerializedName("automatic")
+        AUTOMATIC("automatic"),
+
+        @SerializedName("instant")
+        INSTANT("instant"),
+
+        @SerializedName("microdeposits")
+        MICRODEPOSITS("microdeposits");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        VerificationMethod(String value) {
           this.value = value;
         }
       }

--- a/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
@@ -842,6 +842,13 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     P24 p24;
 
     /**
+     * If this is a {@code paynow} PaymentMethod, this hash contains details about the PayNow
+     * payment method.
+     */
+    @SerializedName("paynow")
+    Paynow paynow;
+
+    /**
      * If this is a {@code sepa_debit} PaymentMethod, this hash contains details about the SEPA
      * debit bank account.
      */
@@ -862,6 +869,13 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
      */
     @SerializedName("type")
     Type type;
+
+    /**
+     * If this is an {@code us_bank_account} PaymentMethod, this hash contains details about the US
+     * bank account payment method.
+     */
+    @SerializedName("us_bank_account")
+    UsBankAccount usBankAccount;
 
     /**
      * If this is an {@code wechat_pay} PaymentMethod, this hash contains details about the
@@ -891,9 +905,11 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
         Map<String, String> metadata,
         Oxxo oxxo,
         P24 p24,
+        Paynow paynow,
         SepaDebit sepaDebit,
         Sofort sofort,
         Type type,
+        UsBankAccount usBankAccount,
         WechatPay wechatPay) {
       this.acssDebit = acssDebit;
       this.afterpayClearpay = afterpayClearpay;
@@ -915,9 +931,11 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       this.metadata = metadata;
       this.oxxo = oxxo;
       this.p24 = p24;
+      this.paynow = paynow;
       this.sepaDebit = sepaDebit;
       this.sofort = sofort;
       this.type = type;
+      this.usBankAccount = usBankAccount;
       this.wechatPay = wechatPay;
     }
 
@@ -966,11 +984,15 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
 
       private P24 p24;
 
+      private Paynow paynow;
+
       private SepaDebit sepaDebit;
 
       private Sofort sofort;
 
       private Type type;
+
+      private UsBankAccount usBankAccount;
 
       private WechatPay wechatPay;
 
@@ -997,9 +1019,11 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
             this.metadata,
             this.oxxo,
             this.p24,
+            this.paynow,
             this.sepaDebit,
             this.sofort,
             this.type,
+            this.usBankAccount,
             this.wechatPay);
       }
 
@@ -1220,6 +1244,15 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       }
 
       /**
+       * If this is a {@code paynow} PaymentMethod, this hash contains details about the PayNow
+       * payment method.
+       */
+      public Builder setPaynow(Paynow paynow) {
+        this.paynow = paynow;
+        return this;
+      }
+
+      /**
        * If this is a {@code sepa_debit} PaymentMethod, this hash contains details about the SEPA
        * debit bank account.
        */
@@ -1244,6 +1277,15 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
        */
       public Builder setType(Type type) {
         this.type = type;
+        return this;
+      }
+
+      /**
+       * If this is an {@code us_bank_account} PaymentMethod, this hash contains details about the
+       * US bank account payment method.
+       */
+      public Builder setUsBankAccount(UsBankAccount usBankAccount) {
+        this.usBankAccount = usBankAccount;
         return this;
       }
 
@@ -3212,6 +3254,63 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     }
 
     @Getter
+    public static class Paynow {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private Paynow(Map<String, Object> extraParams) {
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Paynow build() {
+          return new Paynow(this.extraParams);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentUpdateParams.PaymentMethodData.Paynow#extraParams} for the
+         * field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentUpdateParams.PaymentMethodData.Paynow#extraParams} for the
+         * field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+      }
+    }
+
+    @Getter
     public static class SepaDebit {
       /**
        * Map of extra parameters for custom features not available in this client library. The
@@ -3385,6 +3484,167 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     }
 
     @Getter
+    public static class UsBankAccount {
+      /** Account holder type: individual or company. */
+      @SerializedName("account_holder_type")
+      AccountHolderType accountHolderType;
+
+      /** Account number of the bank account. */
+      @SerializedName("account_number")
+      Object accountNumber;
+
+      /** Account type: checkings or savings. Defaults to checking if omitted. */
+      @SerializedName("account_type")
+      AccountType accountType;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Routing number of the bank account. */
+      @SerializedName("routing_number")
+      Object routingNumber;
+
+      private UsBankAccount(
+          AccountHolderType accountHolderType,
+          Object accountNumber,
+          AccountType accountType,
+          Map<String, Object> extraParams,
+          Object routingNumber) {
+        this.accountHolderType = accountHolderType;
+        this.accountNumber = accountNumber;
+        this.accountType = accountType;
+        this.extraParams = extraParams;
+        this.routingNumber = routingNumber;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private AccountHolderType accountHolderType;
+
+        private Object accountNumber;
+
+        private AccountType accountType;
+
+        private Map<String, Object> extraParams;
+
+        private Object routingNumber;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public UsBankAccount build() {
+          return new UsBankAccount(
+              this.accountHolderType,
+              this.accountNumber,
+              this.accountType,
+              this.extraParams,
+              this.routingNumber);
+        }
+
+        /** Account holder type: individual or company. */
+        public Builder setAccountHolderType(AccountHolderType accountHolderType) {
+          this.accountHolderType = accountHolderType;
+          return this;
+        }
+
+        /** Account number of the bank account. */
+        public Builder setAccountNumber(String accountNumber) {
+          this.accountNumber = accountNumber;
+          return this;
+        }
+
+        /** Account number of the bank account. */
+        public Builder setAccountNumber(EmptyParam accountNumber) {
+          this.accountNumber = accountNumber;
+          return this;
+        }
+
+        /** Account type: checkings or savings. Defaults to checking if omitted. */
+        public Builder setAccountType(AccountType accountType) {
+          this.accountType = accountType;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentUpdateParams.PaymentMethodData.UsBankAccount#extraParams}
+         * for the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentUpdateParams.PaymentMethodData.UsBankAccount#extraParams}
+         * for the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Routing number of the bank account. */
+        public Builder setRoutingNumber(String routingNumber) {
+          this.routingNumber = routingNumber;
+          return this;
+        }
+
+        /** Routing number of the bank account. */
+        public Builder setRoutingNumber(EmptyParam routingNumber) {
+          this.routingNumber = routingNumber;
+          return this;
+        }
+      }
+
+      public enum AccountHolderType implements ApiRequestParams.EnumParam {
+        @SerializedName("company")
+        COMPANY("company"),
+
+        @SerializedName("individual")
+        INDIVIDUAL("individual");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        AccountHolderType(String value) {
+          this.value = value;
+        }
+      }
+
+      public enum AccountType implements ApiRequestParams.EnumParam {
+        @SerializedName("checking")
+        CHECKING("checking"),
+
+        @SerializedName("savings")
+        SAVINGS("savings");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        AccountType(String value) {
+          this.value = value;
+        }
+      }
+    }
+
+    @Getter
     public static class WechatPay {
       /**
        * Map of extra parameters for custom features not available in this client library. The
@@ -3490,11 +3750,17 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       @SerializedName("p24")
       P24("p24"),
 
+      @SerializedName("paynow")
+      PAYNOW("paynow"),
+
       @SerializedName("sepa_debit")
       SEPA_DEBIT("sepa_debit"),
 
       @SerializedName("sofort")
       SOFORT("sofort"),
+
+      @SerializedName("us_bank_account")
+      US_BANK_ACCOUNT("us_bank_account"),
 
       @SerializedName("wechat_pay")
       WECHAT_PAY("wechat_pay");
@@ -3650,6 +3916,13 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     Object p24;
 
     /**
+     * If this is a {@code paynow} PaymentMethod, this sub-hash contains details about the PayNow
+     * payment method options.
+     */
+    @SerializedName("paynow")
+    Object paynow;
+
+    /**
      * If this is a {@code sepa_debit} PaymentIntent, this sub-hash contains details about the SEPA
      * Debit payment method options.
      */
@@ -3662,6 +3935,13 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
      */
     @SerializedName("sofort")
     Object sofort;
+
+    /**
+     * If this is a {@code us_bank_account} PaymentMethod, this sub-hash contains details about the
+     * US bank account payment method options.
+     */
+    @SerializedName("us_bank_account")
+    Object usBankAccount;
 
     /**
      * If this is a {@code wechat_pay} PaymentMethod, this sub-hash contains details about the
@@ -3691,8 +3971,10 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
         Object konbini,
         Object oxxo,
         Object p24,
+        Object paynow,
         Object sepaDebit,
         Object sofort,
+        Object usBankAccount,
         Object wechatPay) {
       this.acssDebit = acssDebit;
       this.afterpayClearpay = afterpayClearpay;
@@ -3714,8 +3996,10 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       this.konbini = konbini;
       this.oxxo = oxxo;
       this.p24 = p24;
+      this.paynow = paynow;
       this.sepaDebit = sepaDebit;
       this.sofort = sofort;
+      this.usBankAccount = usBankAccount;
       this.wechatPay = wechatPay;
     }
 
@@ -3764,9 +4048,13 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
 
       private Object p24;
 
+      private Object paynow;
+
       private Object sepaDebit;
 
       private Object sofort;
+
+      private Object usBankAccount;
 
       private Object wechatPay;
 
@@ -3793,8 +4081,10 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
             this.konbini,
             this.oxxo,
             this.p24,
+            this.paynow,
             this.sepaDebit,
             this.sofort,
+            this.usBankAccount,
             this.wechatPay);
       }
 
@@ -4162,6 +4452,24 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       }
 
       /**
+       * If this is a {@code paynow} PaymentMethod, this sub-hash contains details about the PayNow
+       * payment method options.
+       */
+      public Builder setPaynow(Paynow paynow) {
+        this.paynow = paynow;
+        return this;
+      }
+
+      /**
+       * If this is a {@code paynow} PaymentMethod, this sub-hash contains details about the PayNow
+       * payment method options.
+       */
+      public Builder setPaynow(EmptyParam paynow) {
+        this.paynow = paynow;
+        return this;
+      }
+
+      /**
        * If this is a {@code sepa_debit} PaymentIntent, this sub-hash contains details about the
        * SEPA Debit payment method options.
        */
@@ -4194,6 +4502,24 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
        */
       public Builder setSofort(EmptyParam sofort) {
         this.sofort = sofort;
+        return this;
+      }
+
+      /**
+       * If this is a {@code us_bank_account} PaymentMethod, this sub-hash contains details about
+       * the US bank account payment method options.
+       */
+      public Builder setUsBankAccount(UsBankAccount usBankAccount) {
+        this.usBankAccount = usBankAccount;
+        return this;
+      }
+
+      /**
+       * If this is a {@code us_bank_account} PaymentMethod, this sub-hash contains details about
+       * the US bank account payment method options.
+       */
+      public Builder setUsBankAccount(EmptyParam usBankAccount) {
+        this.usBankAccount = usBankAccount;
         return this;
       }
 
@@ -4612,6 +4938,18 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     @Getter
     public static class AfterpayClearpay {
       /**
+       * Controls when the funds will be captured from the customer's account.
+       *
+       * <p>If provided, this parameter will override the top-level {@code capture_method} when
+       * finalizing the payment with this payment method type.
+       *
+       * <p>If {@code capture_method} is already set on the PaymentIntent, providing an empty value
+       * for this parameter will unset the stored value for this payment method type.
+       */
+      @SerializedName("capture_method")
+      EnumParam captureMethod;
+
+      /**
        * Map of extra parameters for custom features not available in this client library. The
        * content in this map is not serialized under this field's {@code @SerializedName} value.
        * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
@@ -4652,7 +4990,11 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       SetupFutureUsage setupFutureUsage;
 
       private AfterpayClearpay(
-          Map<String, Object> extraParams, Object reference, SetupFutureUsage setupFutureUsage) {
+          EnumParam captureMethod,
+          Map<String, Object> extraParams,
+          Object reference,
+          SetupFutureUsage setupFutureUsage) {
+        this.captureMethod = captureMethod;
         this.extraParams = extraParams;
         this.reference = reference;
         this.setupFutureUsage = setupFutureUsage;
@@ -4663,6 +5005,8 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       }
 
       public static class Builder {
+        private EnumParam captureMethod;
+
         private Map<String, Object> extraParams;
 
         private Object reference;
@@ -4671,7 +5015,36 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
 
         /** Finalize and obtain parameter instance from this builder. */
         public AfterpayClearpay build() {
-          return new AfterpayClearpay(this.extraParams, this.reference, this.setupFutureUsage);
+          return new AfterpayClearpay(
+              this.captureMethod, this.extraParams, this.reference, this.setupFutureUsage);
+        }
+
+        /**
+         * Controls when the funds will be captured from the customer's account.
+         *
+         * <p>If provided, this parameter will override the top-level {@code capture_method} when
+         * finalizing the payment with this payment method type.
+         *
+         * <p>If {@code capture_method} is already set on the PaymentIntent, providing an empty
+         * value for this parameter will unset the stored value for this payment method type.
+         */
+        public Builder setCaptureMethod(CaptureMethod captureMethod) {
+          this.captureMethod = captureMethod;
+          return this;
+        }
+
+        /**
+         * Controls when the funds will be captured from the customer's account.
+         *
+         * <p>If provided, this parameter will override the top-level {@code capture_method} when
+         * finalizing the payment with this payment method type.
+         *
+         * <p>If {@code capture_method} is already set on the PaymentIntent, providing an empty
+         * value for this parameter will unset the stored value for this payment method type.
+         */
+        public Builder setCaptureMethod(EmptyParam captureMethod) {
+          this.captureMethod = captureMethod;
+          return this;
         }
 
         /**
@@ -4749,6 +5122,18 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
         public Builder setSetupFutureUsage(SetupFutureUsage setupFutureUsage) {
           this.setupFutureUsage = setupFutureUsage;
           return this;
+        }
+      }
+
+      public enum CaptureMethod implements ApiRequestParams.EnumParam {
+        @SerializedName("manual")
+        MANUAL("manual");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        CaptureMethod(String value) {
+          this.value = value;
         }
       }
 
@@ -5576,6 +5961,18 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     @Getter
     public static class Card {
       /**
+       * Controls when the funds will be captured from the customer's account.
+       *
+       * <p>If provided, this parameter will override the top-level {@code capture_method} when
+       * finalizing the payment with this payment method type.
+       *
+       * <p>If {@code capture_method} is already set on the PaymentIntent, providing an empty value
+       * for this parameter will unset the stored value for this payment method type.
+       */
+      @SerializedName("capture_method")
+      EnumParam captureMethod;
+
+      /**
        * A single-use {@code cvc_update} Token that represents a card CVC value. When provided, the
        * CVC value will be verified during the card payment attempt. This parameter can only be
        * provided during confirmation.
@@ -5657,6 +6054,7 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       EnumParam setupFutureUsage;
 
       private Card(
+          EnumParam captureMethod,
           Object cvcToken,
           Map<String, Object> extraParams,
           Installments installments,
@@ -5665,6 +6063,7 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
           Network network,
           RequestThreeDSecure requestThreeDSecure,
           EnumParam setupFutureUsage) {
+        this.captureMethod = captureMethod;
         this.cvcToken = cvcToken;
         this.extraParams = extraParams;
         this.installments = installments;
@@ -5680,6 +6079,8 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       }
 
       public static class Builder {
+        private EnumParam captureMethod;
+
         private Object cvcToken;
 
         private Map<String, Object> extraParams;
@@ -5699,6 +6100,7 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
         /** Finalize and obtain parameter instance from this builder. */
         public Card build() {
           return new Card(
+              this.captureMethod,
               this.cvcToken,
               this.extraParams,
               this.installments,
@@ -5707,6 +6109,34 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
               this.network,
               this.requestThreeDSecure,
               this.setupFutureUsage);
+        }
+
+        /**
+         * Controls when the funds will be captured from the customer's account.
+         *
+         * <p>If provided, this parameter will override the top-level {@code capture_method} when
+         * finalizing the payment with this payment method type.
+         *
+         * <p>If {@code capture_method} is already set on the PaymentIntent, providing an empty
+         * value for this parameter will unset the stored value for this payment method type.
+         */
+        public Builder setCaptureMethod(CaptureMethod captureMethod) {
+          this.captureMethod = captureMethod;
+          return this;
+        }
+
+        /**
+         * Controls when the funds will be captured from the customer's account.
+         *
+         * <p>If provided, this parameter will override the top-level {@code capture_method} when
+         * finalizing the payment with this payment method type.
+         *
+         * <p>If {@code capture_method} is already set on the PaymentIntent, providing an empty
+         * value for this parameter will unset the stored value for this payment method type.
+         */
+        public Builder setCaptureMethod(EmptyParam captureMethod) {
+          this.captureMethod = captureMethod;
+          return this;
         }
 
         /**
@@ -6430,6 +6860,18 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
           SupportedType(String value) {
             this.value = value;
           }
+        }
+      }
+
+      public enum CaptureMethod implements ApiRequestParams.EnumParam {
+        @SerializedName("manual")
+        MANUAL("manual");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        CaptureMethod(String value) {
+          this.value = value;
         }
       }
 
@@ -7248,6 +7690,18 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     @Getter
     public static class Klarna {
       /**
+       * Controls when the funds will be captured from the customer's account.
+       *
+       * <p>If provided, this parameter will override the top-level {@code capture_method} when
+       * finalizing the payment with this payment method type.
+       *
+       * <p>If {@code capture_method} is already set on the PaymentIntent, providing an empty value
+       * for this parameter will unset the stored value for this payment method type.
+       */
+      @SerializedName("capture_method")
+      EnumParam captureMethod;
+
+      /**
        * Map of extra parameters for custom features not available in this client library. The
        * content in this map is not serialized under this field's {@code @SerializedName} value.
        * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
@@ -7283,9 +7737,11 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       SetupFutureUsage setupFutureUsage;
 
       private Klarna(
+          EnumParam captureMethod,
           Map<String, Object> extraParams,
           PreferredLocale preferredLocale,
           SetupFutureUsage setupFutureUsage) {
+        this.captureMethod = captureMethod;
         this.extraParams = extraParams;
         this.preferredLocale = preferredLocale;
         this.setupFutureUsage = setupFutureUsage;
@@ -7296,6 +7752,8 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       }
 
       public static class Builder {
+        private EnumParam captureMethod;
+
         private Map<String, Object> extraParams;
 
         private PreferredLocale preferredLocale;
@@ -7304,7 +7762,36 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
 
         /** Finalize and obtain parameter instance from this builder. */
         public Klarna build() {
-          return new Klarna(this.extraParams, this.preferredLocale, this.setupFutureUsage);
+          return new Klarna(
+              this.captureMethod, this.extraParams, this.preferredLocale, this.setupFutureUsage);
+        }
+
+        /**
+         * Controls when the funds will be captured from the customer's account.
+         *
+         * <p>If provided, this parameter will override the top-level {@code capture_method} when
+         * finalizing the payment with this payment method type.
+         *
+         * <p>If {@code capture_method} is already set on the PaymentIntent, providing an empty
+         * value for this parameter will unset the stored value for this payment method type.
+         */
+        public Builder setCaptureMethod(CaptureMethod captureMethod) {
+          this.captureMethod = captureMethod;
+          return this;
+        }
+
+        /**
+         * Controls when the funds will be captured from the customer's account.
+         *
+         * <p>If provided, this parameter will override the top-level {@code capture_method} when
+         * finalizing the payment with this payment method type.
+         *
+         * <p>If {@code capture_method} is already set on the PaymentIntent, providing an empty
+         * value for this parameter will unset the stored value for this payment method type.
+         */
+        public Builder setCaptureMethod(EmptyParam captureMethod) {
+          this.captureMethod = captureMethod;
+          return this;
         }
 
         /**
@@ -7366,6 +7853,18 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
         public Builder setSetupFutureUsage(SetupFutureUsage setupFutureUsage) {
           this.setupFutureUsage = setupFutureUsage;
           return this;
+        }
+      }
+
+      public enum CaptureMethod implements ApiRequestParams.EnumParam {
+        @SerializedName("manual")
+        MANUAL("manual");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        CaptureMethod(String value) {
+          this.value = value;
         }
       }
 
@@ -8006,6 +8505,125 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
     }
 
     @Getter
+    public static class Paynow {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * <p>Providing this parameter will <a
+       * href="https://stripe.com/docs/payments/save-during-payment">attach the payment method</a>
+       * to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any
+       * required actions from the user are complete. If no Customer was provided, the payment
+       * method can still be <a
+       * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer after
+       * the transaction completes.
+       *
+       * <p>When processing card payments, Stripe also uses {@code setup_future_usage} to
+       * dynamically optimize your payment flow and comply with regional legislation and network
+       * rules, such as <a href="https://stripe.com/docs/strong-customer-authentication">SCA</a>.
+       *
+       * <p>If {@code setup_future_usage} is already set and you are performing a request using a
+       * publishable key, you may only update the value from {@code on_session} to {@code
+       * off_session}.
+       */
+      @SerializedName("setup_future_usage")
+      SetupFutureUsage setupFutureUsage;
+
+      private Paynow(Map<String, Object> extraParams, SetupFutureUsage setupFutureUsage) {
+        this.extraParams = extraParams;
+        this.setupFutureUsage = setupFutureUsage;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private SetupFutureUsage setupFutureUsage;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Paynow build() {
+          return new Paynow(this.extraParams, this.setupFutureUsage);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentUpdateParams.PaymentMethodOptions.Paynow#extraParams} for
+         * the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentUpdateParams.PaymentMethodOptions.Paynow#extraParams} for
+         * the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /**
+         * Indicates that you intend to make future payments with this PaymentIntent's payment
+         * method.
+         *
+         * <p>Providing this parameter will <a
+         * href="https://stripe.com/docs/payments/save-during-payment">attach the payment method</a>
+         * to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any
+         * required actions from the user are complete. If no Customer was provided, the payment
+         * method can still be <a
+         * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer
+         * after the transaction completes.
+         *
+         * <p>When processing card payments, Stripe also uses {@code setup_future_usage} to
+         * dynamically optimize your payment flow and comply with regional legislation and network
+         * rules, such as <a href="https://stripe.com/docs/strong-customer-authentication">SCA</a>.
+         *
+         * <p>If {@code setup_future_usage} is already set and you are performing a request using a
+         * publishable key, you may only update the value from {@code on_session} to {@code
+         * off_session}.
+         */
+        public Builder setSetupFutureUsage(SetupFutureUsage setupFutureUsage) {
+          this.setupFutureUsage = setupFutureUsage;
+          return this;
+        }
+      }
+
+      public enum SetupFutureUsage implements ApiRequestParams.EnumParam {
+        @SerializedName("none")
+        NONE("none");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        SetupFutureUsage(String value) {
+          this.value = value;
+        }
+      }
+    }
+
+    @Getter
     public static class SepaDebit {
       /**
        * Map of extra parameters for custom features not available in this client library. The
@@ -8425,6 +9043,191 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
         private final String value;
 
         SetupFutureUsage(String value) {
+          this.value = value;
+        }
+      }
+    }
+
+    @Getter
+    public static class UsBankAccount {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * <p>Providing this parameter will <a
+       * href="https://stripe.com/docs/payments/save-during-payment">attach the payment method</a>
+       * to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any
+       * required actions from the user are complete. If no Customer was provided, the payment
+       * method can still be <a
+       * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer after
+       * the transaction completes.
+       *
+       * <p>When processing card payments, Stripe also uses {@code setup_future_usage} to
+       * dynamically optimize your payment flow and comply with regional legislation and network
+       * rules, such as <a href="https://stripe.com/docs/strong-customer-authentication">SCA</a>.
+       *
+       * <p>If {@code setup_future_usage} is already set and you are performing a request using a
+       * publishable key, you may only update the value from {@code on_session} to {@code
+       * off_session}.
+       */
+      @SerializedName("setup_future_usage")
+      EnumParam setupFutureUsage;
+
+      /** Verification method for the intent. */
+      @SerializedName("verification_method")
+      VerificationMethod verificationMethod;
+
+      private UsBankAccount(
+          Map<String, Object> extraParams,
+          EnumParam setupFutureUsage,
+          VerificationMethod verificationMethod) {
+        this.extraParams = extraParams;
+        this.setupFutureUsage = setupFutureUsage;
+        this.verificationMethod = verificationMethod;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private EnumParam setupFutureUsage;
+
+        private VerificationMethod verificationMethod;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public UsBankAccount build() {
+          return new UsBankAccount(
+              this.extraParams, this.setupFutureUsage, this.verificationMethod);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentUpdateParams.PaymentMethodOptions.UsBankAccount#extraParams}
+         * for the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link PaymentIntentUpdateParams.PaymentMethodOptions.UsBankAccount#extraParams}
+         * for the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /**
+         * Indicates that you intend to make future payments with this PaymentIntent's payment
+         * method.
+         *
+         * <p>Providing this parameter will <a
+         * href="https://stripe.com/docs/payments/save-during-payment">attach the payment method</a>
+         * to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any
+         * required actions from the user are complete. If no Customer was provided, the payment
+         * method can still be <a
+         * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer
+         * after the transaction completes.
+         *
+         * <p>When processing card payments, Stripe also uses {@code setup_future_usage} to
+         * dynamically optimize your payment flow and comply with regional legislation and network
+         * rules, such as <a href="https://stripe.com/docs/strong-customer-authentication">SCA</a>.
+         *
+         * <p>If {@code setup_future_usage} is already set and you are performing a request using a
+         * publishable key, you may only update the value from {@code on_session} to {@code
+         * off_session}.
+         */
+        public Builder setSetupFutureUsage(SetupFutureUsage setupFutureUsage) {
+          this.setupFutureUsage = setupFutureUsage;
+          return this;
+        }
+
+        /**
+         * Indicates that you intend to make future payments with this PaymentIntent's payment
+         * method.
+         *
+         * <p>Providing this parameter will <a
+         * href="https://stripe.com/docs/payments/save-during-payment">attach the payment method</a>
+         * to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any
+         * required actions from the user are complete. If no Customer was provided, the payment
+         * method can still be <a
+         * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer
+         * after the transaction completes.
+         *
+         * <p>When processing card payments, Stripe also uses {@code setup_future_usage} to
+         * dynamically optimize your payment flow and comply with regional legislation and network
+         * rules, such as <a href="https://stripe.com/docs/strong-customer-authentication">SCA</a>.
+         *
+         * <p>If {@code setup_future_usage} is already set and you are performing a request using a
+         * publishable key, you may only update the value from {@code on_session} to {@code
+         * off_session}.
+         */
+        public Builder setSetupFutureUsage(EmptyParam setupFutureUsage) {
+          this.setupFutureUsage = setupFutureUsage;
+          return this;
+        }
+
+        /** Verification method for the intent. */
+        public Builder setVerificationMethod(VerificationMethod verificationMethod) {
+          this.verificationMethod = verificationMethod;
+          return this;
+        }
+      }
+
+      public enum SetupFutureUsage implements ApiRequestParams.EnumParam {
+        @SerializedName("none")
+        NONE("none"),
+
+        @SerializedName("off_session")
+        OFF_SESSION("off_session"),
+
+        @SerializedName("on_session")
+        ON_SESSION("on_session");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        SetupFutureUsage(String value) {
+          this.value = value;
+        }
+      }
+
+      public enum VerificationMethod implements ApiRequestParams.EnumParam {
+        @SerializedName("automatic")
+        AUTOMATIC("automatic"),
+
+        @SerializedName("instant")
+        INSTANT("instant"),
+
+        @SerializedName("microdeposits")
+        MICRODEPOSITS("microdeposits");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        VerificationMethod(String value) {
           this.value = value;
         }
       }

--- a/src/main/java/com/stripe/param/PaymentIntentVerifyMicrodepositsParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentVerifyMicrodepositsParams.java
@@ -18,6 +18,10 @@ public class PaymentIntentVerifyMicrodepositsParams extends ApiRequestParams {
   @SerializedName("amounts")
   List<Long> amounts;
 
+  /** A six-character code starting with SM present in the microdeposit sent to the bank account. */
+  @SerializedName("descriptor_code")
+  String descriptorCode;
+
   /** Specifies which fields in the response should be expanded. */
   @SerializedName("expand")
   List<String> expand;
@@ -32,8 +36,12 @@ public class PaymentIntentVerifyMicrodepositsParams extends ApiRequestParams {
   Map<String, Object> extraParams;
 
   private PaymentIntentVerifyMicrodepositsParams(
-      List<Long> amounts, List<String> expand, Map<String, Object> extraParams) {
+      List<Long> amounts,
+      String descriptorCode,
+      List<String> expand,
+      Map<String, Object> extraParams) {
     this.amounts = amounts;
+    this.descriptorCode = descriptorCode;
     this.expand = expand;
     this.extraParams = extraParams;
   }
@@ -45,6 +53,8 @@ public class PaymentIntentVerifyMicrodepositsParams extends ApiRequestParams {
   public static class Builder {
     private List<Long> amounts;
 
+    private String descriptorCode;
+
     private List<String> expand;
 
     private Map<String, Object> extraParams;
@@ -52,7 +62,7 @@ public class PaymentIntentVerifyMicrodepositsParams extends ApiRequestParams {
     /** Finalize and obtain parameter instance from this builder. */
     public PaymentIntentVerifyMicrodepositsParams build() {
       return new PaymentIntentVerifyMicrodepositsParams(
-          this.amounts, this.expand, this.extraParams);
+          this.amounts, this.descriptorCode, this.expand, this.extraParams);
     }
 
     /**
@@ -78,6 +88,14 @@ public class PaymentIntentVerifyMicrodepositsParams extends ApiRequestParams {
         this.amounts = new ArrayList<>();
       }
       this.amounts.addAll(elements);
+      return this;
+    }
+
+    /**
+     * A six-character code starting with SM present in the microdeposit sent to the bank account.
+     */
+    public Builder setDescriptorCode(String descriptorCode) {
+      this.descriptorCode = descriptorCode;
       return this;
     }
 

--- a/src/main/java/com/stripe/param/PaymentMethodCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentMethodCreateParams.java
@@ -180,6 +180,13 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
   String paymentMethod;
 
   /**
+   * If this is a {@code paynow} PaymentMethod, this hash contains details about the PayNow payment
+   * method.
+   */
+  @SerializedName("paynow")
+  Paynow paynow;
+
+  /**
    * If this is a {@code sepa_debit} PaymentMethod, this hash contains details about the SEPA debit
    * bank account.
    */
@@ -199,6 +206,13 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
    */
   @SerializedName("type")
   Type type;
+
+  /**
+   * If this is an {@code us_bank_account} PaymentMethod, this hash contains details about the US
+   * bank account payment method.
+   */
+  @SerializedName("us_bank_account")
+  UsBankAccount usBankAccount;
 
   /**
    * If this is an {@code wechat_pay} PaymentMethod, this hash contains details about the wechat_pay
@@ -232,9 +246,11 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
       Oxxo oxxo,
       P24 p24,
       String paymentMethod,
+      Paynow paynow,
       SepaDebit sepaDebit,
       Sofort sofort,
       Type type,
+      UsBankAccount usBankAccount,
       WechatPay wechatPay) {
     this.acssDebit = acssDebit;
     this.afterpayClearpay = afterpayClearpay;
@@ -260,9 +276,11 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
     this.oxxo = oxxo;
     this.p24 = p24;
     this.paymentMethod = paymentMethod;
+    this.paynow = paynow;
     this.sepaDebit = sepaDebit;
     this.sofort = sofort;
     this.type = type;
+    this.usBankAccount = usBankAccount;
     this.wechatPay = wechatPay;
   }
 
@@ -319,11 +337,15 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
 
     private String paymentMethod;
 
+    private Paynow paynow;
+
     private SepaDebit sepaDebit;
 
     private Sofort sofort;
 
     private Type type;
+
+    private UsBankAccount usBankAccount;
 
     private WechatPay wechatPay;
 
@@ -354,9 +376,11 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
           this.oxxo,
           this.p24,
           this.paymentMethod,
+          this.paynow,
           this.sepaDebit,
           this.sofort,
           this.type,
+          this.usBankAccount,
           this.wechatPay);
     }
 
@@ -639,6 +663,15 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
     }
 
     /**
+     * If this is a {@code paynow} PaymentMethod, this hash contains details about the PayNow
+     * payment method.
+     */
+    public Builder setPaynow(Paynow paynow) {
+      this.paynow = paynow;
+      return this;
+    }
+
+    /**
      * If this is a {@code sepa_debit} PaymentMethod, this hash contains details about the SEPA
      * debit bank account.
      */
@@ -663,6 +696,15 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
      */
     public Builder setType(Type type) {
       this.type = type;
+      return this;
+    }
+
+    /**
+     * If this is an {@code us_bank_account} PaymentMethod, this hash contains details about the US
+     * bank account payment method.
+     */
+    public Builder setUsBankAccount(UsBankAccount usBankAccount) {
+      this.usBankAccount = usBankAccount;
       return this;
     }
 
@@ -2662,6 +2704,61 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
   }
 
   @Getter
+  public static class Paynow {
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    private Paynow(Map<String, Object> extraParams) {
+      this.extraParams = extraParams;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Map<String, Object> extraParams;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public Paynow build() {
+        return new Paynow(this.extraParams);
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * PaymentMethodCreateParams.Paynow#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link PaymentMethodCreateParams.Paynow#extraParams} for the field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+    }
+  }
+
+  @Getter
   public static class SepaDebit {
     /**
      * Map of extra parameters for custom features not available in this client library. The content
@@ -2825,6 +2922,154 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
   }
 
   @Getter
+  public static class UsBankAccount {
+    /** Account holder type: individual or company. */
+    @SerializedName("account_holder_type")
+    AccountHolderType accountHolderType;
+
+    /** Account number of the bank account. */
+    @SerializedName("account_number")
+    String accountNumber;
+
+    /** Account type: checkings or savings. Defaults to checking if omitted. */
+    @SerializedName("account_type")
+    AccountType accountType;
+
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /** Routing number of the bank account. */
+    @SerializedName("routing_number")
+    String routingNumber;
+
+    private UsBankAccount(
+        AccountHolderType accountHolderType,
+        String accountNumber,
+        AccountType accountType,
+        Map<String, Object> extraParams,
+        String routingNumber) {
+      this.accountHolderType = accountHolderType;
+      this.accountNumber = accountNumber;
+      this.accountType = accountType;
+      this.extraParams = extraParams;
+      this.routingNumber = routingNumber;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private AccountHolderType accountHolderType;
+
+      private String accountNumber;
+
+      private AccountType accountType;
+
+      private Map<String, Object> extraParams;
+
+      private String routingNumber;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public UsBankAccount build() {
+        return new UsBankAccount(
+            this.accountHolderType,
+            this.accountNumber,
+            this.accountType,
+            this.extraParams,
+            this.routingNumber);
+      }
+
+      /** Account holder type: individual or company. */
+      public Builder setAccountHolderType(AccountHolderType accountHolderType) {
+        this.accountHolderType = accountHolderType;
+        return this;
+      }
+
+      /** Account number of the bank account. */
+      public Builder setAccountNumber(String accountNumber) {
+        this.accountNumber = accountNumber;
+        return this;
+      }
+
+      /** Account type: checkings or savings. Defaults to checking if omitted. */
+      public Builder setAccountType(AccountType accountType) {
+        this.accountType = accountType;
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * PaymentMethodCreateParams.UsBankAccount#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link PaymentMethodCreateParams.UsBankAccount#extraParams} for the field
+       * documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** Routing number of the bank account. */
+      public Builder setRoutingNumber(String routingNumber) {
+        this.routingNumber = routingNumber;
+        return this;
+      }
+    }
+
+    public enum AccountHolderType implements ApiRequestParams.EnumParam {
+      @SerializedName("company")
+      COMPANY("company"),
+
+      @SerializedName("individual")
+      INDIVIDUAL("individual");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      AccountHolderType(String value) {
+        this.value = value;
+      }
+    }
+
+    public enum AccountType implements ApiRequestParams.EnumParam {
+      @SerializedName("checking")
+      CHECKING("checking"),
+
+      @SerializedName("savings")
+      SAVINGS("savings");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      AccountType(String value) {
+        this.value = value;
+      }
+    }
+  }
+
+  @Getter
   public static class WechatPay {
     /**
      * Map of extra parameters for custom features not available in this client library. The content
@@ -2931,11 +3176,17 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
     @SerializedName("p24")
     P24("p24"),
 
+    @SerializedName("paynow")
+    PAYNOW("paynow"),
+
     @SerializedName("sepa_debit")
     SEPA_DEBIT("sepa_debit"),
 
     @SerializedName("sofort")
     SOFORT("sofort"),
+
+    @SerializedName("us_bank_account")
+    US_BANK_ACCOUNT("us_bank_account"),
 
     @SerializedName("wechat_pay")
     WECHAT_PAY("wechat_pay");

--- a/src/main/java/com/stripe/param/PaymentMethodListParams.java
+++ b/src/main/java/com/stripe/param/PaymentMethodListParams.java
@@ -262,11 +262,17 @@ public class PaymentMethodListParams extends ApiRequestParams {
     @SerializedName("p24")
     P24("p24"),
 
+    @SerializedName("paynow")
+    PAYNOW("paynow"),
+
     @SerializedName("sepa_debit")
     SEPA_DEBIT("sepa_debit"),
 
     @SerializedName("sofort")
     SOFORT("sofort"),
+
+    @SerializedName("us_bank_account")
+    US_BANK_ACCOUNT("us_bank_account"),
 
     @SerializedName("wechat_pay")
     WECHAT_PAY("wechat_pay");

--- a/src/main/java/com/stripe/param/PaymentMethodUpdateParams.java
+++ b/src/main/java/com/stripe/param/PaymentMethodUpdateParams.java
@@ -73,6 +73,13 @@ public class PaymentMethodUpdateParams extends ApiRequestParams {
   @SerializedName("sepa_debit")
   SepaDebit sepaDebit;
 
+  /**
+   * If this is an {@code us_bank_account} PaymentMethod, this hash contains details about the US
+   * bank account payment method.
+   */
+  @SerializedName("us_bank_account")
+  UsBankAccount usBankAccount;
+
   private PaymentMethodUpdateParams(
       AcssDebit acssDebit,
       AuBecsDebit auBecsDebit,
@@ -82,7 +89,8 @@ public class PaymentMethodUpdateParams extends ApiRequestParams {
       List<String> expand,
       Map<String, Object> extraParams,
       Object metadata,
-      SepaDebit sepaDebit) {
+      SepaDebit sepaDebit,
+      UsBankAccount usBankAccount) {
     this.acssDebit = acssDebit;
     this.auBecsDebit = auBecsDebit;
     this.bacsDebit = bacsDebit;
@@ -92,6 +100,7 @@ public class PaymentMethodUpdateParams extends ApiRequestParams {
     this.extraParams = extraParams;
     this.metadata = metadata;
     this.sepaDebit = sepaDebit;
+    this.usBankAccount = usBankAccount;
   }
 
   public static Builder builder() {
@@ -117,6 +126,8 @@ public class PaymentMethodUpdateParams extends ApiRequestParams {
 
     private SepaDebit sepaDebit;
 
+    private UsBankAccount usBankAccount;
+
     /** Finalize and obtain parameter instance from this builder. */
     public PaymentMethodUpdateParams build() {
       return new PaymentMethodUpdateParams(
@@ -128,7 +139,8 @@ public class PaymentMethodUpdateParams extends ApiRequestParams {
           this.expand,
           this.extraParams,
           this.metadata,
-          this.sepaDebit);
+          this.sepaDebit,
+          this.usBankAccount);
     }
 
     /**
@@ -281,6 +293,15 @@ public class PaymentMethodUpdateParams extends ApiRequestParams {
      */
     public Builder setSepaDebit(SepaDebit sepaDebit) {
       this.sepaDebit = sepaDebit;
+      return this;
+    }
+
+    /**
+     * If this is an {@code us_bank_account} PaymentMethod, this hash contains details about the US
+     * bank account payment method.
+     */
+    public Builder setUsBankAccount(UsBankAccount usBankAccount) {
+      this.usBankAccount = usBankAccount;
       return this;
     }
   }
@@ -910,6 +931,90 @@ public class PaymentMethodUpdateParams extends ApiRequestParams {
         }
         this.extraParams.putAll(map);
         return this;
+      }
+    }
+  }
+
+  @Getter
+  public static class UsBankAccount {
+    /** Bank account type. */
+    @SerializedName("account_holder_type")
+    AccountHolderType accountHolderType;
+
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    private UsBankAccount(AccountHolderType accountHolderType, Map<String, Object> extraParams) {
+      this.accountHolderType = accountHolderType;
+      this.extraParams = extraParams;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private AccountHolderType accountHolderType;
+
+      private Map<String, Object> extraParams;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public UsBankAccount build() {
+        return new UsBankAccount(this.accountHolderType, this.extraParams);
+      }
+
+      /** Bank account type. */
+      public Builder setAccountHolderType(AccountHolderType accountHolderType) {
+        this.accountHolderType = accountHolderType;
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * PaymentMethodUpdateParams.UsBankAccount#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link PaymentMethodUpdateParams.UsBankAccount#extraParams} for the field
+       * documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+    }
+
+    public enum AccountHolderType implements ApiRequestParams.EnumParam {
+      @SerializedName("company")
+      COMPANY("company"),
+
+      @SerializedName("individual")
+      INDIVIDUAL("individual");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      AccountHolderType(String value) {
+        this.value = value;
       }
     }
   }

--- a/src/main/java/com/stripe/param/SetupIntentConfirmParams.java
+++ b/src/main/java/com/stripe/param/SetupIntentConfirmParams.java
@@ -568,12 +568,24 @@ public class SetupIntentConfirmParams extends ApiRequestParams {
     @SerializedName("sepa_debit")
     SepaDebit sepaDebit;
 
+    /**
+     * If this is a {@code us_bank_account} SetupIntent, this sub-hash contains details about the US
+     * bank account payment method options.
+     */
+    @SerializedName("us_bank_account")
+    UsBankAccount usBankAccount;
+
     private PaymentMethodOptions(
-        AcssDebit acssDebit, Card card, Map<String, Object> extraParams, SepaDebit sepaDebit) {
+        AcssDebit acssDebit,
+        Card card,
+        Map<String, Object> extraParams,
+        SepaDebit sepaDebit,
+        UsBankAccount usBankAccount) {
       this.acssDebit = acssDebit;
       this.card = card;
       this.extraParams = extraParams;
       this.sepaDebit = sepaDebit;
+      this.usBankAccount = usBankAccount;
     }
 
     public static Builder builder() {
@@ -589,10 +601,12 @@ public class SetupIntentConfirmParams extends ApiRequestParams {
 
       private SepaDebit sepaDebit;
 
+      private UsBankAccount usBankAccount;
+
       /** Finalize and obtain parameter instance from this builder. */
       public PaymentMethodOptions build() {
         return new PaymentMethodOptions(
-            this.acssDebit, this.card, this.extraParams, this.sepaDebit);
+            this.acssDebit, this.card, this.extraParams, this.sepaDebit, this.usBankAccount);
       }
 
       /**
@@ -643,6 +657,15 @@ public class SetupIntentConfirmParams extends ApiRequestParams {
        */
       public Builder setSepaDebit(SepaDebit sepaDebit) {
         this.sepaDebit = sepaDebit;
+        return this;
+      }
+
+      /**
+       * If this is a {@code us_bank_account} SetupIntent, this sub-hash contains details about the
+       * US bank account payment method options.
+       */
+      public Builder setUsBankAccount(UsBankAccount usBankAccount) {
+        this.usBankAccount = usBankAccount;
         return this;
       }
     }
@@ -1631,6 +1654,95 @@ public class SetupIntentConfirmParams extends ApiRequestParams {
             this.extraParams.putAll(map);
             return this;
           }
+        }
+      }
+    }
+
+    @Getter
+    public static class UsBankAccount {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Verification method for the intent. */
+      @SerializedName("verification_method")
+      VerificationMethod verificationMethod;
+
+      private UsBankAccount(
+          Map<String, Object> extraParams, VerificationMethod verificationMethod) {
+        this.extraParams = extraParams;
+        this.verificationMethod = verificationMethod;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private VerificationMethod verificationMethod;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public UsBankAccount build() {
+          return new UsBankAccount(this.extraParams, this.verificationMethod);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link SetupIntentConfirmParams.PaymentMethodOptions.UsBankAccount#extraParams}
+         * for the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link SetupIntentConfirmParams.PaymentMethodOptions.UsBankAccount#extraParams}
+         * for the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Verification method for the intent. */
+        public Builder setVerificationMethod(VerificationMethod verificationMethod) {
+          this.verificationMethod = verificationMethod;
+          return this;
+        }
+      }
+
+      public enum VerificationMethod implements ApiRequestParams.EnumParam {
+        @SerializedName("automatic")
+        AUTOMATIC("automatic"),
+
+        @SerializedName("instant")
+        INSTANT("instant"),
+
+        @SerializedName("microdeposits")
+        MICRODEPOSITS("microdeposits");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        VerificationMethod(String value) {
+          this.value = value;
         }
       }
     }

--- a/src/main/java/com/stripe/param/SetupIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/SetupIntentCreateParams.java
@@ -773,12 +773,24 @@ public class SetupIntentCreateParams extends ApiRequestParams {
     @SerializedName("sepa_debit")
     SepaDebit sepaDebit;
 
+    /**
+     * If this is a {@code us_bank_account} SetupIntent, this sub-hash contains details about the US
+     * bank account payment method options.
+     */
+    @SerializedName("us_bank_account")
+    UsBankAccount usBankAccount;
+
     private PaymentMethodOptions(
-        AcssDebit acssDebit, Card card, Map<String, Object> extraParams, SepaDebit sepaDebit) {
+        AcssDebit acssDebit,
+        Card card,
+        Map<String, Object> extraParams,
+        SepaDebit sepaDebit,
+        UsBankAccount usBankAccount) {
       this.acssDebit = acssDebit;
       this.card = card;
       this.extraParams = extraParams;
       this.sepaDebit = sepaDebit;
+      this.usBankAccount = usBankAccount;
     }
 
     public static Builder builder() {
@@ -794,10 +806,12 @@ public class SetupIntentCreateParams extends ApiRequestParams {
 
       private SepaDebit sepaDebit;
 
+      private UsBankAccount usBankAccount;
+
       /** Finalize and obtain parameter instance from this builder. */
       public PaymentMethodOptions build() {
         return new PaymentMethodOptions(
-            this.acssDebit, this.card, this.extraParams, this.sepaDebit);
+            this.acssDebit, this.card, this.extraParams, this.sepaDebit, this.usBankAccount);
       }
 
       /**
@@ -848,6 +862,15 @@ public class SetupIntentCreateParams extends ApiRequestParams {
        */
       public Builder setSepaDebit(SepaDebit sepaDebit) {
         this.sepaDebit = sepaDebit;
+        return this;
+      }
+
+      /**
+       * If this is a {@code us_bank_account} SetupIntent, this sub-hash contains details about the
+       * US bank account payment method options.
+       */
+      public Builder setUsBankAccount(UsBankAccount usBankAccount) {
+        this.usBankAccount = usBankAccount;
         return this;
       }
     }
@@ -1836,6 +1859,95 @@ public class SetupIntentCreateParams extends ApiRequestParams {
             this.extraParams.putAll(map);
             return this;
           }
+        }
+      }
+    }
+
+    @Getter
+    public static class UsBankAccount {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Verification method for the intent. */
+      @SerializedName("verification_method")
+      VerificationMethod verificationMethod;
+
+      private UsBankAccount(
+          Map<String, Object> extraParams, VerificationMethod verificationMethod) {
+        this.extraParams = extraParams;
+        this.verificationMethod = verificationMethod;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private VerificationMethod verificationMethod;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public UsBankAccount build() {
+          return new UsBankAccount(this.extraParams, this.verificationMethod);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link SetupIntentCreateParams.PaymentMethodOptions.UsBankAccount#extraParams}
+         * for the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link SetupIntentCreateParams.PaymentMethodOptions.UsBankAccount#extraParams}
+         * for the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Verification method for the intent. */
+        public Builder setVerificationMethod(VerificationMethod verificationMethod) {
+          this.verificationMethod = verificationMethod;
+          return this;
+        }
+      }
+
+      public enum VerificationMethod implements ApiRequestParams.EnumParam {
+        @SerializedName("automatic")
+        AUTOMATIC("automatic"),
+
+        @SerializedName("instant")
+        INSTANT("instant"),
+
+        @SerializedName("microdeposits")
+        MICRODEPOSITS("microdeposits");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        VerificationMethod(String value) {
+          this.value = value;
         }
       }
     }

--- a/src/main/java/com/stripe/param/SetupIntentUpdateParams.java
+++ b/src/main/java/com/stripe/param/SetupIntentUpdateParams.java
@@ -336,12 +336,24 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
     @SerializedName("sepa_debit")
     SepaDebit sepaDebit;
 
+    /**
+     * If this is a {@code us_bank_account} SetupIntent, this sub-hash contains details about the US
+     * bank account payment method options.
+     */
+    @SerializedName("us_bank_account")
+    UsBankAccount usBankAccount;
+
     private PaymentMethodOptions(
-        AcssDebit acssDebit, Card card, Map<String, Object> extraParams, SepaDebit sepaDebit) {
+        AcssDebit acssDebit,
+        Card card,
+        Map<String, Object> extraParams,
+        SepaDebit sepaDebit,
+        UsBankAccount usBankAccount) {
       this.acssDebit = acssDebit;
       this.card = card;
       this.extraParams = extraParams;
       this.sepaDebit = sepaDebit;
+      this.usBankAccount = usBankAccount;
     }
 
     public static Builder builder() {
@@ -357,10 +369,12 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
 
       private SepaDebit sepaDebit;
 
+      private UsBankAccount usBankAccount;
+
       /** Finalize and obtain parameter instance from this builder. */
       public PaymentMethodOptions build() {
         return new PaymentMethodOptions(
-            this.acssDebit, this.card, this.extraParams, this.sepaDebit);
+            this.acssDebit, this.card, this.extraParams, this.sepaDebit, this.usBankAccount);
       }
 
       /**
@@ -411,6 +425,15 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
        */
       public Builder setSepaDebit(SepaDebit sepaDebit) {
         this.sepaDebit = sepaDebit;
+        return this;
+      }
+
+      /**
+       * If this is a {@code us_bank_account} SetupIntent, this sub-hash contains details about the
+       * US bank account payment method options.
+       */
+      public Builder setUsBankAccount(UsBankAccount usBankAccount) {
+        this.usBankAccount = usBankAccount;
         return this;
       }
     }
@@ -1434,6 +1457,95 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
             this.extraParams.putAll(map);
             return this;
           }
+        }
+      }
+    }
+
+    @Getter
+    public static class UsBankAccount {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Verification method for the intent. */
+      @SerializedName("verification_method")
+      VerificationMethod verificationMethod;
+
+      private UsBankAccount(
+          Map<String, Object> extraParams, VerificationMethod verificationMethod) {
+        this.extraParams = extraParams;
+        this.verificationMethod = verificationMethod;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private VerificationMethod verificationMethod;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public UsBankAccount build() {
+          return new UsBankAccount(this.extraParams, this.verificationMethod);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link SetupIntentUpdateParams.PaymentMethodOptions.UsBankAccount#extraParams}
+         * for the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link SetupIntentUpdateParams.PaymentMethodOptions.UsBankAccount#extraParams}
+         * for the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Verification method for the intent. */
+        public Builder setVerificationMethod(VerificationMethod verificationMethod) {
+          this.verificationMethod = verificationMethod;
+          return this;
+        }
+      }
+
+      public enum VerificationMethod implements ApiRequestParams.EnumParam {
+        @SerializedName("automatic")
+        AUTOMATIC("automatic"),
+
+        @SerializedName("instant")
+        INSTANT("instant"),
+
+        @SerializedName("microdeposits")
+        MICRODEPOSITS("microdeposits");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        VerificationMethod(String value) {
+          this.value = value;
         }
       }
     }

--- a/src/main/java/com/stripe/param/SetupIntentVerifyMicrodepositsParams.java
+++ b/src/main/java/com/stripe/param/SetupIntentVerifyMicrodepositsParams.java
@@ -18,6 +18,10 @@ public class SetupIntentVerifyMicrodepositsParams extends ApiRequestParams {
   @SerializedName("amounts")
   List<Long> amounts;
 
+  /** A six-character code starting with SM present in the microdeposit sent to the bank account. */
+  @SerializedName("descriptor_code")
+  String descriptorCode;
+
   /** Specifies which fields in the response should be expanded. */
   @SerializedName("expand")
   List<String> expand;
@@ -32,8 +36,12 @@ public class SetupIntentVerifyMicrodepositsParams extends ApiRequestParams {
   Map<String, Object> extraParams;
 
   private SetupIntentVerifyMicrodepositsParams(
-      List<Long> amounts, List<String> expand, Map<String, Object> extraParams) {
+      List<Long> amounts,
+      String descriptorCode,
+      List<String> expand,
+      Map<String, Object> extraParams) {
     this.amounts = amounts;
+    this.descriptorCode = descriptorCode;
     this.expand = expand;
     this.extraParams = extraParams;
   }
@@ -45,13 +53,16 @@ public class SetupIntentVerifyMicrodepositsParams extends ApiRequestParams {
   public static class Builder {
     private List<Long> amounts;
 
+    private String descriptorCode;
+
     private List<String> expand;
 
     private Map<String, Object> extraParams;
 
     /** Finalize and obtain parameter instance from this builder. */
     public SetupIntentVerifyMicrodepositsParams build() {
-      return new SetupIntentVerifyMicrodepositsParams(this.amounts, this.expand, this.extraParams);
+      return new SetupIntentVerifyMicrodepositsParams(
+          this.amounts, this.descriptorCode, this.expand, this.extraParams);
     }
 
     /**
@@ -77,6 +88,14 @@ public class SetupIntentVerifyMicrodepositsParams extends ApiRequestParams {
         this.amounts = new ArrayList<>();
       }
       this.amounts.addAll(elements);
+      return this;
+    }
+
+    /**
+     * A six-character code starting with SM present in the microdeposit sent to the bank account.
+     */
+    public Builder setDescriptorCode(String descriptorCode) {
+      this.descriptorCode = descriptorCode;
       return this;
     }
 

--- a/src/main/java/com/stripe/param/SubscriptionCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionCreateParams.java
@@ -2244,17 +2244,26 @@ public class SubscriptionCreateParams extends ApiRequestParams {
       @SerializedName("konbini")
       Object konbini;
 
+      /**
+       * This sub-hash contains details about the ACH direct debit payment method options to pass to
+       * the invoice’s PaymentIntent.
+       */
+      @SerializedName("us_bank_account")
+      Object usBankAccount;
+
       private PaymentMethodOptions(
           Object acssDebit,
           Object bancontact,
           Object card,
           Map<String, Object> extraParams,
-          Object konbini) {
+          Object konbini,
+          Object usBankAccount) {
         this.acssDebit = acssDebit;
         this.bancontact = bancontact;
         this.card = card;
         this.extraParams = extraParams;
         this.konbini = konbini;
+        this.usBankAccount = usBankAccount;
       }
 
       public static Builder builder() {
@@ -2272,10 +2281,17 @@ public class SubscriptionCreateParams extends ApiRequestParams {
 
         private Object konbini;
 
+        private Object usBankAccount;
+
         /** Finalize and obtain parameter instance from this builder. */
         public PaymentMethodOptions build() {
           return new PaymentMethodOptions(
-              this.acssDebit, this.bancontact, this.card, this.extraParams, this.konbini);
+              this.acssDebit,
+              this.bancontact,
+              this.card,
+              this.extraParams,
+              this.konbini,
+              this.usBankAccount);
         }
 
         /**
@@ -2377,6 +2393,24 @@ public class SubscriptionCreateParams extends ApiRequestParams {
          */
         public Builder setKonbini(EmptyParam konbini) {
           this.konbini = konbini;
+          return this;
+        }
+
+        /**
+         * This sub-hash contains details about the ACH direct debit payment method options to pass
+         * to the invoice’s PaymentIntent.
+         */
+        public Builder setUsBankAccount(UsBankAccount usBankAccount) {
+          this.usBankAccount = usBankAccount;
+          return this;
+        }
+
+        /**
+         * This sub-hash contains details about the ACH direct debit payment method options to pass
+         * to the invoice’s PaymentIntent.
+         */
+        public Builder setUsBankAccount(EmptyParam usBankAccount) {
+          this.usBankAccount = usBankAccount;
           return this;
         }
       }
@@ -2990,6 +3024,98 @@ public class SubscriptionCreateParams extends ApiRequestParams {
           }
         }
       }
+
+      @Getter
+      public static class UsBankAccount {
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /** Verification method for the intent. */
+        @SerializedName("verification_method")
+        VerificationMethod verificationMethod;
+
+        private UsBankAccount(
+            Map<String, Object> extraParams, VerificationMethod verificationMethod) {
+          this.extraParams = extraParams;
+          this.verificationMethod = verificationMethod;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Map<String, Object> extraParams;
+
+          private VerificationMethod verificationMethod;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public UsBankAccount build() {
+            return new UsBankAccount(this.extraParams, this.verificationMethod);
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount#extraParams}
+           * for the field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount#extraParams}
+           * for the field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /** Verification method for the intent. */
+          public Builder setVerificationMethod(VerificationMethod verificationMethod) {
+            this.verificationMethod = verificationMethod;
+            return this;
+          }
+        }
+
+        public enum VerificationMethod implements ApiRequestParams.EnumParam {
+          @SerializedName("automatic")
+          AUTOMATIC("automatic"),
+
+          @SerializedName("instant")
+          INSTANT("instant"),
+
+          @SerializedName("microdeposits")
+          MICRODEPOSITS("microdeposits");
+
+          @Getter(onMethod_ = {@Override})
+          private final String value;
+
+          VerificationMethod(String value) {
+            this.value = value;
+          }
+        }
+      }
     }
 
     public enum PaymentMethodType implements ApiRequestParams.EnumParam {
@@ -3032,6 +3158,9 @@ public class SubscriptionCreateParams extends ApiRequestParams {
       @SerializedName("konbini")
       KONBINI("konbini"),
 
+      @SerializedName("paynow")
+      PAYNOW("paynow"),
+
       @SerializedName("sepa_credit_transfer")
       SEPA_CREDIT_TRANSFER("sepa_credit_transfer"),
 
@@ -3040,6 +3169,9 @@ public class SubscriptionCreateParams extends ApiRequestParams {
 
       @SerializedName("sofort")
       SOFORT("sofort"),
+
+      @SerializedName("us_bank_account")
+      US_BANK_ACCOUNT("us_bank_account"),
 
       @SerializedName("wechat_pay")
       WECHAT_PAY("wechat_pay");

--- a/src/main/java/com/stripe/param/SubscriptionListParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionListParams.java
@@ -88,6 +88,13 @@ public class SubscriptionListParams extends ApiRequestParams {
   @SerializedName("status")
   Status status;
 
+  /**
+   * Filter for subscriptions that are associated with the specified test clock. The response will
+   * not include subscriptions with test clocks if this and the customer parameter is not set.
+   */
+  @SerializedName("test_clock")
+  String testClock;
+
   private SubscriptionListParams(
       CollectionMethod collectionMethod,
       Object created,
@@ -101,7 +108,8 @@ public class SubscriptionListParams extends ApiRequestParams {
       String plan,
       String price,
       String startingAfter,
-      Status status) {
+      Status status,
+      String testClock) {
     this.collectionMethod = collectionMethod;
     this.created = created;
     this.currentPeriodEnd = currentPeriodEnd;
@@ -115,6 +123,7 @@ public class SubscriptionListParams extends ApiRequestParams {
     this.price = price;
     this.startingAfter = startingAfter;
     this.status = status;
+    this.testClock = testClock;
   }
 
   public static Builder builder() {
@@ -148,6 +157,8 @@ public class SubscriptionListParams extends ApiRequestParams {
 
     private Status status;
 
+    private String testClock;
+
     /** Finalize and obtain parameter instance from this builder. */
     public SubscriptionListParams build() {
       return new SubscriptionListParams(
@@ -163,7 +174,8 @@ public class SubscriptionListParams extends ApiRequestParams {
           this.plan,
           this.price,
           this.startingAfter,
-          this.status);
+          this.status,
+          this.testClock);
     }
 
     /**
@@ -317,6 +329,15 @@ public class SubscriptionListParams extends ApiRequestParams {
      */
     public Builder setStatus(Status status) {
       this.status = status;
+      return this;
+    }
+
+    /**
+     * Filter for subscriptions that are associated with the specified test clock. The response will
+     * not include subscriptions with test clocks if this and the customer parameter is not set.
+     */
+    public Builder setTestClock(String testClock) {
+      this.testClock = testClock;
       return this;
     }
   }

--- a/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
@@ -2564,17 +2564,26 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
       @SerializedName("konbini")
       Object konbini;
 
+      /**
+       * This sub-hash contains details about the ACH direct debit payment method options to pass to
+       * the invoice’s PaymentIntent.
+       */
+      @SerializedName("us_bank_account")
+      Object usBankAccount;
+
       private PaymentMethodOptions(
           Object acssDebit,
           Object bancontact,
           Object card,
           Map<String, Object> extraParams,
-          Object konbini) {
+          Object konbini,
+          Object usBankAccount) {
         this.acssDebit = acssDebit;
         this.bancontact = bancontact;
         this.card = card;
         this.extraParams = extraParams;
         this.konbini = konbini;
+        this.usBankAccount = usBankAccount;
       }
 
       public static Builder builder() {
@@ -2592,10 +2601,17 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
 
         private Object konbini;
 
+        private Object usBankAccount;
+
         /** Finalize and obtain parameter instance from this builder. */
         public PaymentMethodOptions build() {
           return new PaymentMethodOptions(
-              this.acssDebit, this.bancontact, this.card, this.extraParams, this.konbini);
+              this.acssDebit,
+              this.bancontact,
+              this.card,
+              this.extraParams,
+              this.konbini,
+              this.usBankAccount);
         }
 
         /**
@@ -2697,6 +2713,24 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
          */
         public Builder setKonbini(EmptyParam konbini) {
           this.konbini = konbini;
+          return this;
+        }
+
+        /**
+         * This sub-hash contains details about the ACH direct debit payment method options to pass
+         * to the invoice’s PaymentIntent.
+         */
+        public Builder setUsBankAccount(UsBankAccount usBankAccount) {
+          this.usBankAccount = usBankAccount;
+          return this;
+        }
+
+        /**
+         * This sub-hash contains details about the ACH direct debit payment method options to pass
+         * to the invoice’s PaymentIntent.
+         */
+        public Builder setUsBankAccount(EmptyParam usBankAccount) {
+          this.usBankAccount = usBankAccount;
           return this;
         }
       }
@@ -3319,6 +3353,98 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
           }
         }
       }
+
+      @Getter
+      public static class UsBankAccount {
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /** Verification method for the intent. */
+        @SerializedName("verification_method")
+        VerificationMethod verificationMethod;
+
+        private UsBankAccount(
+            Map<String, Object> extraParams, VerificationMethod verificationMethod) {
+          this.extraParams = extraParams;
+          this.verificationMethod = verificationMethod;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Map<String, Object> extraParams;
+
+          private VerificationMethod verificationMethod;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public UsBankAccount build() {
+            return new UsBankAccount(this.extraParams, this.verificationMethod);
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount#extraParams}
+           * for the field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount#extraParams}
+           * for the field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /** Verification method for the intent. */
+          public Builder setVerificationMethod(VerificationMethod verificationMethod) {
+            this.verificationMethod = verificationMethod;
+            return this;
+          }
+        }
+
+        public enum VerificationMethod implements ApiRequestParams.EnumParam {
+          @SerializedName("automatic")
+          AUTOMATIC("automatic"),
+
+          @SerializedName("instant")
+          INSTANT("instant"),
+
+          @SerializedName("microdeposits")
+          MICRODEPOSITS("microdeposits");
+
+          @Getter(onMethod_ = {@Override})
+          private final String value;
+
+          VerificationMethod(String value) {
+            this.value = value;
+          }
+        }
+      }
     }
 
     public enum PaymentMethodType implements ApiRequestParams.EnumParam {
@@ -3361,6 +3487,9 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
       @SerializedName("konbini")
       KONBINI("konbini"),
 
+      @SerializedName("paynow")
+      PAYNOW("paynow"),
+
       @SerializedName("sepa_credit_transfer")
       SEPA_CREDIT_TRANSFER("sepa_credit_transfer"),
 
@@ -3369,6 +3498,9 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
 
       @SerializedName("sofort")
       SOFORT("sofort"),
+
+      @SerializedName("us_bank_account")
+      US_BANK_ACCOUNT("us_bank_account"),
 
       @SerializedName("wechat_pay")
       WECHAT_PAY("wechat_pay");

--- a/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
+++ b/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
@@ -3242,6 +3242,10 @@ public class SessionCreateParams extends ApiRequestParams {
     @SerializedName("oxxo")
     Oxxo oxxo;
 
+    /** contains details about the Us Bank Account payment method options. */
+    @SerializedName("us_bank_account")
+    UsBankAccount usBankAccount;
+
     /** contains details about the WeChat Pay payment method options. */
     @SerializedName("wechat_pay")
     WechatPay wechatPay;
@@ -3252,12 +3256,14 @@ public class SessionCreateParams extends ApiRequestParams {
         Map<String, Object> extraParams,
         Konbini konbini,
         Oxxo oxxo,
+        UsBankAccount usBankAccount,
         WechatPay wechatPay) {
       this.acssDebit = acssDebit;
       this.boleto = boleto;
       this.extraParams = extraParams;
       this.konbini = konbini;
       this.oxxo = oxxo;
+      this.usBankAccount = usBankAccount;
       this.wechatPay = wechatPay;
     }
 
@@ -3276,12 +3282,20 @@ public class SessionCreateParams extends ApiRequestParams {
 
       private Oxxo oxxo;
 
+      private UsBankAccount usBankAccount;
+
       private WechatPay wechatPay;
 
       /** Finalize and obtain parameter instance from this builder. */
       public PaymentMethodOptions build() {
         return new PaymentMethodOptions(
-            this.acssDebit, this.boleto, this.extraParams, this.konbini, this.oxxo, this.wechatPay);
+            this.acssDebit,
+            this.boleto,
+            this.extraParams,
+            this.konbini,
+            this.oxxo,
+            this.usBankAccount,
+            this.wechatPay);
       }
 
       /** contains details about the ACSS Debit payment method options. */
@@ -3332,6 +3346,12 @@ public class SessionCreateParams extends ApiRequestParams {
       /** contains details about the OXXO payment method options. */
       public Builder setOxxo(Oxxo oxxo) {
         this.oxxo = oxxo;
+        return this;
+      }
+
+      /** contains details about the Us Bank Account payment method options. */
+      public Builder setUsBankAccount(UsBankAccount usBankAccount) {
+        this.usBankAccount = usBankAccount;
         return this;
       }
 
@@ -3964,6 +3984,92 @@ public class SessionCreateParams extends ApiRequestParams {
           }
           this.extraParams.putAll(map);
           return this;
+        }
+      }
+    }
+
+    @Getter
+    public static class UsBankAccount {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Verification method for the intent. */
+      @SerializedName("verification_method")
+      VerificationMethod verificationMethod;
+
+      private UsBankAccount(
+          Map<String, Object> extraParams, VerificationMethod verificationMethod) {
+        this.extraParams = extraParams;
+        this.verificationMethod = verificationMethod;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private VerificationMethod verificationMethod;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public UsBankAccount build() {
+          return new UsBankAccount(this.extraParams, this.verificationMethod);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link SessionCreateParams.PaymentMethodOptions.UsBankAccount#extraParams} for
+         * the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link SessionCreateParams.PaymentMethodOptions.UsBankAccount#extraParams} for
+         * the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Verification method for the intent. */
+        public Builder setVerificationMethod(VerificationMethod verificationMethod) {
+          this.verificationMethod = verificationMethod;
+          return this;
+        }
+      }
+
+      public enum VerificationMethod implements ApiRequestParams.EnumParam {
+        @SerializedName("automatic")
+        AUTOMATIC("automatic"),
+
+        @SerializedName("instant")
+        INSTANT("instant");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        VerificationMethod(String value) {
+          this.value = value;
         }
       }
     }
@@ -6654,11 +6760,17 @@ public class SessionCreateParams extends ApiRequestParams {
     @SerializedName("p24")
     P24("p24"),
 
+    @SerializedName("paynow")
+    PAYNOW("paynow"),
+
     @SerializedName("sepa_debit")
     SEPA_DEBIT("sepa_debit"),
 
     @SerializedName("sofort")
     SOFORT("sofort"),
+
+    @SerializedName("us_bank_account")
+    US_BANK_ACCOUNT("us_bank_account"),
 
     @SerializedName("wechat_pay")
     WECHAT_PAY("wechat_pay");


### PR DESCRIPTION
Codegen for openapi dc3ef48.
r? @dcr-stripe
cc @stripe/api-libraries

## Changelog
* Add support for PayNow and US Bank Accounts Debits payments
    * **Charge** ([API ref](https://stripe.com/docs/api/charges/object#charge_object-payment_method_details))
        * Add support for `paynow` and `us_bank_account` on `Charge.payment_method_details`
    * **Customer** ([API ref](https://stripe.com/docs/api/payment_methods/customer_list#list_customer_payment_methods-type))
        * Add support for new values `paynow` and `us_bank_account` on enum `CustomerListPaymentMethodsParams.type`
    * **Mandate** ([API ref](https://stripe.com/docs/api/mandates/object#mandate_object-payment_method_details))
        * Add support for `us_bank_account` on `Mandate.payment_method_details`
    * **Payment Intent** ([API ref](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-payment_method_options))
        * Add support for `paynow` and `us_bank_account` on `payment_method_options` on `PaymentIntent`, `PaymentIntentCreateParams`, `PaymentIntentUpdateParams`, and `PaymentIntentConfirmParams` 
        * Add support for `paynow` and `us_bank_account` on `payment_method_data` on `PaymentIntentCreateParams`, `PaymentIntentUpdateParams`, and `PaymentIntentConfirmParams`
        * Add support for `paynow_display_qr_code` on `PaymentIntent.next_action`
        * Add support for new values `paynow` and `us_bank_account` on enums `payment_method_data.type` on `PaymentIntentCreateParams`, and `PaymentIntentUpdateParams`, and `PaymentIntentConfirmParams`
    * **Setup Intent** ([API ref](https://stripe.com/docs/api/setup_intents/object#setup_intent_object-payment_method_options))
        * Add support for `us_bank_account` on `payment_method_options` on `SetupIntent`, `SetupIntentCreateParams`, `SetupIntentUpdateParams`, and `SetupIntentConfirmParams`
    * **Setup Attempt** ([API ref](https://stripe.com/docs/api/setup_attempts/object#setup_attempt_object-payment_method_details))
        * Add support for `us_bank_account` on `SetupAttempt.payment_method_details`
    * **Payment Method** ([API ref](https://stripe.com/docs/api/payment_methods/object#payment_method_object-paynow))
        * Add support for `paynow` and `us_bank_account` on `PaymentMethod` and `PaymentMethodCreateParams`
        * Add support for `us_bank_account` on `PaymentMethodUpdateParams`
        * Add support for new values `paynow` and `us_bank_account` on enums `PaymentMethod.type`, `PaymentMethodCreateParams.type`. and `PaymentMethodListParams.type`
    * **Checkout Session** ([API ref](https://stripe.com/docs/api/checkout/sessions/create#create_checkout_session-payment_method_types))
        * Add support for `us_bank_account` on `payment_method_options` on `Checkout.Session` and `CheckoutSessionCreateParams`
        * Add support for new values `paynow` and `us_bank_account` on enum `CheckoutSessionCreateParams.payment_method_types[]`
    * **Invoice** ([API ref](https://stripe.com/docs/api/invoices/object#invoice_object-payment_settings-payment_method_types))
        * Add support for `us_bank_account` on `payment_settings.payment_method_options` on `Invoice`, `InvoiceCreateParams`, and `InvoiceUpdateParams`
        * Add support for new values `paynow` and `us_bank_account` on enums `payment_settings.payment_method_types[]` on `Invoice`, `InvoiceCreateParams`, and `InvoiceUpdateParams`
    * **Subscription** ([API ref](https://stripe.com/docs/api/subscriptions/object#subscription_object-payment_settings-payment_method_types))
        * Add support for `us_bank_account` on `Subscription.payment_settings.payment_method_options`, `SubscriptionCreateParams.payment_settings.payment_method_options`, and `SubscriptionUpdateParams.payment_settings.payment_method_options`
        * Add support for new values `paynow` and `us_bank_account` on enums `payment_settings.payment_method_types[]` on `Subscription`, `SubscriptionCreateParams`, and `SubscriptionUpdateParams`
    * **Account capabilities** ([API ref](https://stripe.com/docs/api/accounts/object#account_object-capabilities))
        * Add support for `paynow_payments` on `capabilities` on `Account`, `AccountCreateParams`, and `AccountUpdateParams`
* Add support for `failure_balance_transaction` on `Charge`
* Add support for `capture_method` on `afterpay_clearpay`, `card`, and `klarna` on `payment_method_options` on
`PaymentIntent`, `PaymentIntentCreateParams`, `PaymentIntentUpdateParams`, and `PaymentIntentConfirmParams` ([API ref](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-payment_method_options-afterpay_clearpay-capture_method))
* Add additional support for verify microdeposits on Payment Intent and Setup Intent ([API ref](https://stripe.com/docs/api/payment_intents/verify_microdeposits))
    * Add support for `microdeposit_type` on `next_action.verify_with_microdeposits` on `PaymentIntent` and `SetupIntent`
    * Add support for `descriptor_code` on `PaymentIntentVerifyMicrodepositsParams` and `SetupIntentVerifyMicrodepositsParams`
* Add support for `test_clock` on `SubscriptionListParams` ([API ref](https://stripe.com/docs/api/subscriptions/list#list_subscriptions-test_clock))