### PR TITLE
API Updates

### DIFF
--- a/src/main/java/com/stripe/model/Account.java
+++ b/src/main/java/com/stripe/model/Account.java
@@ -677,6 +677,15 @@ public class Account extends ApiResource implements MetadataStore<Account>, Paym
     String bancontactPayments;
 
     /**
+     * The status of the customer_balance payments capability of the account, or whether the account
+     * can directly process customer_balance charges.
+     *
+     * <p>One of {@code active}, {@code inactive}, or {@code pending}.
+     */
+    @SerializedName("bank_transfer_payments")
+    String bankTransferPayments;
+
+    /**
      * The status of the boleto payments capability of the account, or whether the account can
      * directly process boleto charges.
      *

--- a/src/main/java/com/stripe/model/Charge.java
+++ b/src/main/java/com/stripe/model/Charge.java
@@ -1796,6 +1796,13 @@ public class Charge extends ApiResource implements MetadataStore<Charge>, Balanc
       String brand;
 
       /**
+       * When using manual capture, a future timestamp after which the charge will be automatically
+       * refunded if uncaptured.
+       */
+      @SerializedName("capture_before")
+      Long captureBefore;
+
+      /**
        * The cardholder name as read from the card, in <a
        * href="https://en.wikipedia.org/wiki/ISO/IEC_7813">ISO 7813</a> format. May include
        * alphanumeric characters, special characters and first/last name separator ({@code /}). In

--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -1619,6 +1619,13 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
     Card card;
 
     /**
+     * If paying by {@code customer_balance}, this sub-hash contains details about the Bank transfer
+     * payment method options to pass to the invoice’s PaymentIntent.
+     */
+    @SerializedName("customer_balance")
+    CustomerBalance customerBalance;
+
+    /**
      * If paying by {@code konbini}, this sub-hash contains details about the Konbini payment method
      * options to pass to the invoice’s PaymentIntent.
      */
@@ -1692,6 +1699,38 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
        */
       @SerializedName("request_three_d_secure")
       String requestThreeDSecure;
+    }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class CustomerBalance extends StripeObject {
+      @SerializedName("bank_transfer")
+      BankTransfer bankTransfer;
+
+      /**
+       * The funding method type to be used when there are not enough funds in the customer balance.
+       * Permitted values include: {@code bank_transfer}.
+       *
+       * <p>Equal to {@code bank_transfer}.
+       */
+      @SerializedName("funding_type")
+      String fundingType;
+
+      @Getter
+      @Setter
+      @EqualsAndHashCode(callSuper = false)
+      public static class BankTransfer extends StripeObject {
+        /**
+         * The bank transfer type that can be used for funding. Permitted values include: {@code
+         * us_bank_account}, {@code eu_bank_account}, {@code id_bank_account}, {@code
+         * gb_bank_account}, {@code jp_bank_account}, {@code mx_bank_account}, {@code
+         * eu_bank_transfer}, {@code gb_bank_transfer}, {@code id_bank_transfer}, {@code
+         * jp_bank_transfer}, {@code mx_bank_transfer}, or {@code us_bank_transfer}.
+         */
+        @SerializedName("type")
+        String type;
+      }
     }
 
     @Getter

--- a/src/main/java/com/stripe/model/InvoiceLineItemPeriod.java
+++ b/src/main/java/com/stripe/model/InvoiceLineItemPeriod.java
@@ -10,11 +10,11 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class InvoiceLineItemPeriod extends StripeObject {
-  /** End of the line item's billing period. */
+  /** The end of the period, which must be greater than or equal to the start. */
   @SerializedName("end")
   Long end;
 
-  /** Start of the line item's billing period. */
+  /** The start of the period. */
   @SerializedName("start")
   Long start;
 }

--- a/src/main/java/com/stripe/model/PaymentIntent.java
+++ b/src/main/java/com/stripe/model/PaymentIntent.java
@@ -2073,7 +2073,15 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
     @Getter
     @Setter
     @EqualsAndHashCode(callSuper = false)
-    public static class CardPresent extends StripeObject {}
+    public static class CardPresent extends StripeObject {
+      /**
+       * Request ability to capture this payment beyond the standard <a
+       * href="https://stripe.com/docs/terminal/features/extended-authorizations#authorization-validity">authorization
+       * validity window.</a>
+       */
+      @SerializedName("request_extended_authorization")
+      Boolean requestExtendedAuthorization;
+    }
 
     @Getter
     @Setter

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -904,6 +904,13 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
     Card card;
 
     /**
+     * This sub-hash contains details about the Bank transfer payment method options to pass to
+     * invoices created by the subscription.
+     */
+    @SerializedName("customer_balance")
+    Invoice.PaymentMethodOptions.CustomerBalance customerBalance;
+
+    /**
      * This sub-hash contains details about the Konbini payment method options to pass to invoices
      * created by the subscription.
      */

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -908,7 +908,7 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
      * invoices created by the subscription.
      */
     @SerializedName("customer_balance")
-    Invoice.PaymentMethodOptions.CustomerBalance customerBalance;
+    CustomerBalance customerBalance;
 
     /**
      * This sub-hash contains details about the Konbini payment method options to pass to invoices
@@ -1010,6 +1010,38 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
          */
         @SerializedName("description")
         String description;
+      }
+    }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class CustomerBalance extends StripeObject {
+      @SerializedName("bank_transfer")
+      Invoice.PaymentMethodOptions.CustomerBalance.BankTransfer bankTransfer;
+
+      /**
+       * The funding method type to be used when there are not enough funds in the customer balance.
+       * Permitted values include: {@code bank_transfer}.
+       *
+       * <p>Equal to {@code bank_transfer}.
+       */
+      @SerializedName("funding_type")
+      String fundingType;
+
+      @Getter
+      @Setter
+      @EqualsAndHashCode(callSuper = false)
+      public static class BankTransfer extends StripeObject {
+        /**
+         * The bank transfer type that can be used for funding. Permitted values include: {@code
+         * us_bank_account}, {@code eu_bank_account}, {@code id_bank_account}, {@code
+         * gb_bank_account}, {@code jp_bank_account}, {@code mx_bank_account}, {@code
+         * eu_bank_transfer}, {@code gb_bank_transfer}, {@code id_bank_transfer}, {@code
+         * jp_bank_transfer}, {@code mx_bank_transfer}, or {@code us_bank_transfer}.
+         */
+        @SerializedName("type")
+        String type;
       }
     }
 

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -1018,7 +1018,7 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
     @EqualsAndHashCode(callSuper = false)
     public static class CustomerBalance extends StripeObject {
       @SerializedName("bank_transfer")
-      Invoice.PaymentMethodOptions.CustomerBalance.BankTransfer bankTransfer;
+      BankTransfer bankTransfer;
 
       /**
        * The funding method type to be used when there are not enough funds in the customer balance.

--- a/src/main/java/com/stripe/model/checkout/Session.java
+++ b/src/main/java/com/stripe/model/checkout/Session.java
@@ -4,6 +4,7 @@ package com.stripe.model.checkout;
 import com.google.gson.annotations.SerializedName;
 import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
+import com.stripe.model.Address;
 import com.stripe.model.Customer;
 import com.stripe.model.ExpandableField;
 import com.stripe.model.HasId;
@@ -682,6 +683,13 @@ public class Session extends ApiResource implements HasId {
   @EqualsAndHashCode(callSuper = false)
   public static class CustomerDetails extends StripeObject {
     /**
+     * The customer's address at the time of checkout. Note: This property is populated only for
+     * sessions on or after March 30, 2022.
+     */
+    @SerializedName("address")
+    Address address;
+
+    /**
      * The email associated with the Customer, if one exists, on the Checkout Session at the time of
      * checkout or at time of session expiry. Otherwise, if the customer has consented to
      * promotional content, this value is the most recent valid email provided by the customer on
@@ -689,6 +697,13 @@ public class Session extends ApiResource implements HasId {
      */
     @SerializedName("email")
     String email;
+
+    /**
+     * The customer's name at the time of checkout. Note: This property is populated only for
+     * sessions on or after March 30, 2022.
+     */
+    @SerializedName("name")
+    String name;
 
     /** The customer's phone number at the time of checkout. */
     @SerializedName("phone")

--- a/src/main/java/com/stripe/model/terminal/Reader.java
+++ b/src/main/java/com/stripe/model/terminal/Reader.java
@@ -386,12 +386,12 @@ public class Reader extends ApiResource implements HasId, MetadataStore<Reader> 
     return ApiResource.request(ApiResource.RequestMethod.POST, url, params, Reader.class, options);
   }
 
-  /** Sets reader display. */
+  /** Sets reader display to show cart details. */
   public Reader setReaderDisplay(Map<String, Object> params) throws StripeException {
     return setReaderDisplay(params, (RequestOptions) null);
   }
 
-  /** Sets reader display. */
+  /** Sets reader display to show cart details. */
   public Reader setReaderDisplay(Map<String, Object> params, RequestOptions options)
       throws StripeException {
     String url =
@@ -404,12 +404,12 @@ public class Reader extends ApiResource implements HasId, MetadataStore<Reader> 
     return ApiResource.request(ApiResource.RequestMethod.POST, url, params, Reader.class, options);
   }
 
-  /** Sets reader display. */
+  /** Sets reader display to show cart details. */
   public Reader setReaderDisplay(ReaderSetReaderDisplayParams params) throws StripeException {
     return setReaderDisplay(params, (RequestOptions) null);
   }
 
-  /** Sets reader display. */
+  /** Sets reader display to show cart details. */
   public Reader setReaderDisplay(ReaderSetReaderDisplayParams params, RequestOptions options)
       throws StripeException {
     String url =
@@ -602,7 +602,7 @@ public class Reader extends ApiResource implements HasId, MetadataStore<Reader> 
   public class TestHelpers {
     /**
      * Presents a payment method on a simulated reader. Can be used to simulate accepting a payment,
-     * saving a card or refunding a transaction
+     * saving a card or refunding a transaction.
      */
     public Reader presentPaymentMethod() throws StripeException {
       return presentPaymentMethod((Map<String, Object>) null, (RequestOptions) null);
@@ -610,7 +610,7 @@ public class Reader extends ApiResource implements HasId, MetadataStore<Reader> 
 
     /**
      * Presents a payment method on a simulated reader. Can be used to simulate accepting a payment,
-     * saving a card or refunding a transaction
+     * saving a card or refunding a transaction.
      */
     public Reader presentPaymentMethod(RequestOptions options) throws StripeException {
       return presentPaymentMethod((Map<String, Object>) null, options);
@@ -618,7 +618,7 @@ public class Reader extends ApiResource implements HasId, MetadataStore<Reader> 
 
     /**
      * Presents a payment method on a simulated reader. Can be used to simulate accepting a payment,
-     * saving a card or refunding a transaction
+     * saving a card or refunding a transaction.
      */
     public Reader presentPaymentMethod(Map<String, Object> params) throws StripeException {
       return presentPaymentMethod(params, (RequestOptions) null);
@@ -626,7 +626,7 @@ public class Reader extends ApiResource implements HasId, MetadataStore<Reader> 
 
     /**
      * Presents a payment method on a simulated reader. Can be used to simulate accepting a payment,
-     * saving a card or refunding a transaction
+     * saving a card or refunding a transaction.
      */
     public Reader presentPaymentMethod(Map<String, Object> params, RequestOptions options)
         throws StripeException {
@@ -643,7 +643,7 @@ public class Reader extends ApiResource implements HasId, MetadataStore<Reader> 
 
     /**
      * Presents a payment method on a simulated reader. Can be used to simulate accepting a payment,
-     * saving a card or refunding a transaction
+     * saving a card or refunding a transaction.
      */
     public Reader presentPaymentMethod(ReaderPresentPaymentMethodParams params)
         throws StripeException {
@@ -652,7 +652,7 @@ public class Reader extends ApiResource implements HasId, MetadataStore<Reader> 
 
     /**
      * Presents a payment method on a simulated reader. Can be used to simulate accepting a payment,
-     * saving a card or refunding a transaction
+     * saving a card or refunding a transaction.
      */
     public Reader presentPaymentMethod(
         ReaderPresentPaymentMethodParams params, RequestOptions options) throws StripeException {

--- a/src/main/java/com/stripe/param/AccountCreateParams.java
+++ b/src/main/java/com/stripe/param/AccountCreateParams.java
@@ -844,6 +844,10 @@ public class AccountCreateParams extends ApiRequestParams {
     @SerializedName("bancontact_payments")
     BancontactPayments bancontactPayments;
 
+    /** The bank_transfer_payments capability. */
+    @SerializedName("bank_transfer_payments")
+    BankTransferPayments bankTransferPayments;
+
     /** The boleto_payments capability. */
     @SerializedName("boleto_payments")
     BoletoPayments boletoPayments;
@@ -947,6 +951,7 @@ public class AccountCreateParams extends ApiRequestParams {
         AuBecsDebitPayments auBecsDebitPayments,
         BacsDebitPayments bacsDebitPayments,
         BancontactPayments bancontactPayments,
+        BankTransferPayments bankTransferPayments,
         BoletoPayments boletoPayments,
         CardIssuing cardIssuing,
         CardPayments cardPayments,
@@ -975,6 +980,7 @@ public class AccountCreateParams extends ApiRequestParams {
       this.auBecsDebitPayments = auBecsDebitPayments;
       this.bacsDebitPayments = bacsDebitPayments;
       this.bancontactPayments = bancontactPayments;
+      this.bankTransferPayments = bankTransferPayments;
       this.boletoPayments = boletoPayments;
       this.cardIssuing = cardIssuing;
       this.cardPayments = cardPayments;
@@ -1014,6 +1020,8 @@ public class AccountCreateParams extends ApiRequestParams {
       private BacsDebitPayments bacsDebitPayments;
 
       private BancontactPayments bancontactPayments;
+
+      private BankTransferPayments bankTransferPayments;
 
       private BoletoPayments boletoPayments;
 
@@ -1069,6 +1077,7 @@ public class AccountCreateParams extends ApiRequestParams {
             this.auBecsDebitPayments,
             this.bacsDebitPayments,
             this.bancontactPayments,
+            this.bankTransferPayments,
             this.boletoPayments,
             this.cardIssuing,
             this.cardPayments,
@@ -1122,6 +1131,12 @@ public class AccountCreateParams extends ApiRequestParams {
       /** The bancontact_payments capability. */
       public Builder setBancontactPayments(BancontactPayments bancontactPayments) {
         this.bancontactPayments = bancontactPayments;
+        return this;
+      }
+
+      /** The bank_transfer_payments capability. */
+      public Builder setBankTransferPayments(BankTransferPayments bankTransferPayments) {
+        this.bankTransferPayments = bankTransferPayments;
         return this;
       }
 
@@ -1654,6 +1669,84 @@ public class AccountCreateParams extends ApiRequestParams {
          * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
          * map. See {@link AccountCreateParams.Capabilities.BancontactPayments#extraParams} for the
          * field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /**
+         * Passing true requests the capability for the account, if it is not already requested. A
+         * requested capability may not immediately become active. Any requirements to activate the
+         * capability are returned in the {@code requirements} arrays.
+         */
+        public Builder setRequested(Boolean requested) {
+          this.requested = requested;
+          return this;
+        }
+      }
+    }
+
+    @Getter
+    public static class BankTransferPayments {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /**
+       * Passing true requests the capability for the account, if it is not already requested. A
+       * requested capability may not immediately become active. Any requirements to activate the
+       * capability are returned in the {@code requirements} arrays.
+       */
+      @SerializedName("requested")
+      Boolean requested;
+
+      private BankTransferPayments(Map<String, Object> extraParams, Boolean requested) {
+        this.extraParams = extraParams;
+        this.requested = requested;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private Boolean requested;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public BankTransferPayments build() {
+          return new BankTransferPayments(this.extraParams, this.requested);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link AccountCreateParams.Capabilities.BankTransferPayments#extraParams} for
+         * the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link AccountCreateParams.Capabilities.BankTransferPayments#extraParams} for
+         * the field documentation.
          */
         public Builder putAllExtraParam(Map<String, Object> map) {
           if (this.extraParams == null) {

--- a/src/main/java/com/stripe/param/AccountUpdateParams.java
+++ b/src/main/java/com/stripe/param/AccountUpdateParams.java
@@ -931,6 +931,10 @@ public class AccountUpdateParams extends ApiRequestParams {
     @SerializedName("bancontact_payments")
     BancontactPayments bancontactPayments;
 
+    /** The bank_transfer_payments capability. */
+    @SerializedName("bank_transfer_payments")
+    BankTransferPayments bankTransferPayments;
+
     /** The boleto_payments capability. */
     @SerializedName("boleto_payments")
     BoletoPayments boletoPayments;
@@ -1034,6 +1038,7 @@ public class AccountUpdateParams extends ApiRequestParams {
         AuBecsDebitPayments auBecsDebitPayments,
         BacsDebitPayments bacsDebitPayments,
         BancontactPayments bancontactPayments,
+        BankTransferPayments bankTransferPayments,
         BoletoPayments boletoPayments,
         CardIssuing cardIssuing,
         CardPayments cardPayments,
@@ -1062,6 +1067,7 @@ public class AccountUpdateParams extends ApiRequestParams {
       this.auBecsDebitPayments = auBecsDebitPayments;
       this.bacsDebitPayments = bacsDebitPayments;
       this.bancontactPayments = bancontactPayments;
+      this.bankTransferPayments = bankTransferPayments;
       this.boletoPayments = boletoPayments;
       this.cardIssuing = cardIssuing;
       this.cardPayments = cardPayments;
@@ -1101,6 +1107,8 @@ public class AccountUpdateParams extends ApiRequestParams {
       private BacsDebitPayments bacsDebitPayments;
 
       private BancontactPayments bancontactPayments;
+
+      private BankTransferPayments bankTransferPayments;
 
       private BoletoPayments boletoPayments;
 
@@ -1156,6 +1164,7 @@ public class AccountUpdateParams extends ApiRequestParams {
             this.auBecsDebitPayments,
             this.bacsDebitPayments,
             this.bancontactPayments,
+            this.bankTransferPayments,
             this.boletoPayments,
             this.cardIssuing,
             this.cardPayments,
@@ -1209,6 +1218,12 @@ public class AccountUpdateParams extends ApiRequestParams {
       /** The bancontact_payments capability. */
       public Builder setBancontactPayments(BancontactPayments bancontactPayments) {
         this.bancontactPayments = bancontactPayments;
+        return this;
+      }
+
+      /** The bank_transfer_payments capability. */
+      public Builder setBankTransferPayments(BankTransferPayments bankTransferPayments) {
+        this.bankTransferPayments = bankTransferPayments;
         return this;
       }
 
@@ -1741,6 +1756,84 @@ public class AccountUpdateParams extends ApiRequestParams {
          * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
          * map. See {@link AccountUpdateParams.Capabilities.BancontactPayments#extraParams} for the
          * field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /**
+         * Passing true requests the capability for the account, if it is not already requested. A
+         * requested capability may not immediately become active. Any requirements to activate the
+         * capability are returned in the {@code requirements} arrays.
+         */
+        public Builder setRequested(Boolean requested) {
+          this.requested = requested;
+          return this;
+        }
+      }
+    }
+
+    @Getter
+    public static class BankTransferPayments {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /**
+       * Passing true requests the capability for the account, if it is not already requested. A
+       * requested capability may not immediately become active. Any requirements to activate the
+       * capability are returned in the {@code requirements} arrays.
+       */
+      @SerializedName("requested")
+      Boolean requested;
+
+      private BankTransferPayments(Map<String, Object> extraParams, Boolean requested) {
+        this.extraParams = extraParams;
+        this.requested = requested;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private Boolean requested;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public BankTransferPayments build() {
+          return new BankTransferPayments(this.extraParams, this.requested);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link AccountUpdateParams.Capabilities.BankTransferPayments#extraParams} for
+         * the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link AccountUpdateParams.Capabilities.BankTransferPayments#extraParams} for
+         * the field documentation.
          */
         public Builder putAllExtraParam(Map<String, Object> map) {
           if (this.extraParams == null) {

--- a/src/main/java/com/stripe/param/ChargeSearchParams.java
+++ b/src/main/java/com/stripe/param/ChargeSearchParams.java
@@ -32,8 +32,9 @@ public class ChargeSearchParams extends ApiRequestParams {
   Long limit;
 
   /**
-   * A cursor for pagination across multiple pages of results. Do not include this parameter on the
-   * first call. Use the next_page value returned in a response to request subsequent results.
+   * A cursor for pagination across multiple pages of results. Don't include this parameter on the
+   * first call. Use the next_page value returned in a previous response to request subsequent
+   * results.
    */
   @SerializedName("page")
   String page;
@@ -139,8 +140,9 @@ public class ChargeSearchParams extends ApiRequestParams {
     }
 
     /**
-     * A cursor for pagination across multiple pages of results. Do not include this parameter on
-     * the first call. Use the next_page value returned in a response to request subsequent results.
+     * A cursor for pagination across multiple pages of results. Don't include this parameter on the
+     * first call. Use the next_page value returned in a previous response to request subsequent
+     * results.
      */
     public Builder setPage(String page) {
       this.page = page;

--- a/src/main/java/com/stripe/param/CustomerSearchParams.java
+++ b/src/main/java/com/stripe/param/CustomerSearchParams.java
@@ -32,8 +32,9 @@ public class CustomerSearchParams extends ApiRequestParams {
   Long limit;
 
   /**
-   * A cursor for pagination across multiple pages of results. Do not include this parameter on the
-   * first call. Use the next_page value returned in a response to request subsequent results.
+   * A cursor for pagination across multiple pages of results. Don't include this parameter on the
+   * first call. Use the next_page value returned in a previous response to request subsequent
+   * results.
    */
   @SerializedName("page")
   String page;
@@ -139,8 +140,9 @@ public class CustomerSearchParams extends ApiRequestParams {
     }
 
     /**
-     * A cursor for pagination across multiple pages of results. Do not include this parameter on
-     * the first call. Use the next_page value returned in a response to request subsequent results.
+     * A cursor for pagination across multiple pages of results. Don't include this parameter on the
+     * first call. Use the next_page value returned in a previous response to request subsequent
+     * results.
      */
     public Builder setPage(String page) {
       this.page = page;

--- a/src/main/java/com/stripe/param/InvoiceCreateParams.java
+++ b/src/main/java/com/stripe/param/InvoiceCreateParams.java
@@ -1132,6 +1132,13 @@ public class InvoiceCreateParams extends ApiRequestParams {
       Object card;
 
       /**
+       * If paying by {@code customer_balance}, this sub-hash contains details about the Bank
+       * transfer payment method options to pass to the invoice’s PaymentIntent.
+       */
+      @SerializedName("customer_balance")
+      Object customerBalance;
+
+      /**
        * Map of extra parameters for custom features not available in this client library. The
        * content in this map is not serialized under this field's {@code @SerializedName} value.
        * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
@@ -1158,12 +1165,14 @@ public class InvoiceCreateParams extends ApiRequestParams {
           Object acssDebit,
           Object bancontact,
           Object card,
+          Object customerBalance,
           Map<String, Object> extraParams,
           Object konbini,
           Object usBankAccount) {
         this.acssDebit = acssDebit;
         this.bancontact = bancontact;
         this.card = card;
+        this.customerBalance = customerBalance;
         this.extraParams = extraParams;
         this.konbini = konbini;
         this.usBankAccount = usBankAccount;
@@ -1180,6 +1189,8 @@ public class InvoiceCreateParams extends ApiRequestParams {
 
         private Object card;
 
+        private Object customerBalance;
+
         private Map<String, Object> extraParams;
 
         private Object konbini;
@@ -1192,6 +1203,7 @@ public class InvoiceCreateParams extends ApiRequestParams {
               this.acssDebit,
               this.bancontact,
               this.card,
+              this.customerBalance,
               this.extraParams,
               this.konbini,
               this.usBankAccount);
@@ -1248,6 +1260,24 @@ public class InvoiceCreateParams extends ApiRequestParams {
          */
         public Builder setCard(EmptyParam card) {
           this.card = card;
+          return this;
+        }
+
+        /**
+         * If paying by {@code customer_balance}, this sub-hash contains details about the Bank
+         * transfer payment method options to pass to the invoice’s PaymentIntent.
+         */
+        public Builder setCustomerBalance(CustomerBalance customerBalance) {
+          this.customerBalance = customerBalance;
+          return this;
+        }
+
+        /**
+         * If paying by {@code customer_balance}, this sub-hash contains details about the Bank
+         * transfer payment method options to pass to the invoice’s PaymentIntent.
+         */
+        public Builder setCustomerBalance(EmptyParam customerBalance) {
+          this.customerBalance = customerBalance;
           return this;
         }
 
@@ -1718,6 +1748,190 @@ public class InvoiceCreateParams extends ApiRequestParams {
       }
 
       @Getter
+      public static class CustomerBalance {
+        /**
+         * Configuration for the bank transfer funding type, if the {@code funding_type} is set to
+         * {@code bank_transfer}.
+         */
+        @SerializedName("bank_transfer")
+        BankTransfer bankTransfer;
+
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /**
+         * The funding method type to be used when there are not enough funds in the customer
+         * balance. Permitted values include: {@code bank_transfer}.
+         */
+        @SerializedName("funding_type")
+        String fundingType;
+
+        private CustomerBalance(
+            BankTransfer bankTransfer, Map<String, Object> extraParams, String fundingType) {
+          this.bankTransfer = bankTransfer;
+          this.extraParams = extraParams;
+          this.fundingType = fundingType;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private BankTransfer bankTransfer;
+
+          private Map<String, Object> extraParams;
+
+          private String fundingType;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public CustomerBalance build() {
+            return new CustomerBalance(this.bankTransfer, this.extraParams, this.fundingType);
+          }
+
+          /**
+           * Configuration for the bank transfer funding type, if the {@code funding_type} is set to
+           * {@code bank_transfer}.
+           */
+          public Builder setBankTransfer(BankTransfer bankTransfer) {
+            this.bankTransfer = bankTransfer;
+            return this;
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.CustomerBalance#extraParams}
+           * for the field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.CustomerBalance#extraParams}
+           * for the field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /**
+           * The funding method type to be used when there are not enough funds in the customer
+           * balance. Permitted values include: {@code bank_transfer}.
+           */
+          public Builder setFundingType(String fundingType) {
+            this.fundingType = fundingType;
+            return this;
+          }
+        }
+
+        @Getter
+        public static class BankTransfer {
+          /**
+           * Map of extra parameters for custom features not available in this client library. The
+           * content in this map is not serialized under this field's {@code @SerializedName} value.
+           * Instead, each key/value pair is serialized as if the key is a root-level field
+           * (serialized) name in this param object. Effectively, this map is flattened to its
+           * parent instance.
+           */
+          @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+          Map<String, Object> extraParams;
+
+          /**
+           * The bank transfer type that can be used for funding. Permitted values include: {@code
+           * us_bank_account}, {@code eu_bank_account}, {@code id_bank_account}, {@code
+           * gb_bank_account}, {@code jp_bank_account}, {@code mx_bank_account}, {@code
+           * eu_bank_transfer}, {@code gb_bank_transfer}, {@code id_bank_transfer}, {@code
+           * jp_bank_transfer}, {@code mx_bank_transfer}, or {@code us_bank_transfer}.
+           */
+          @SerializedName("type")
+          String type;
+
+          private BankTransfer(Map<String, Object> extraParams, String type) {
+            this.extraParams = extraParams;
+            this.type = type;
+          }
+
+          public static Builder builder() {
+            return new Builder();
+          }
+
+          public static class Builder {
+            private Map<String, Object> extraParams;
+
+            private String type;
+
+            /** Finalize and obtain parameter instance from this builder. */
+            public BankTransfer build() {
+              return new BankTransfer(this.extraParams, this.type);
+            }
+
+            /**
+             * Add a key/value pair to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.CustomerBalance.BankTransfer#extraParams}
+             * for the field documentation.
+             */
+            public Builder putExtraParam(String key, Object value) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.put(key, value);
+              return this;
+            }
+
+            /**
+             * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.CustomerBalance.BankTransfer#extraParams}
+             * for the field documentation.
+             */
+            public Builder putAllExtraParam(Map<String, Object> map) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.putAll(map);
+              return this;
+            }
+
+            /**
+             * The bank transfer type that can be used for funding. Permitted values include: {@code
+             * us_bank_account}, {@code eu_bank_account}, {@code id_bank_account}, {@code
+             * gb_bank_account}, {@code jp_bank_account}, {@code mx_bank_account}, {@code
+             * eu_bank_transfer}, {@code gb_bank_transfer}, {@code id_bank_transfer}, {@code
+             * jp_bank_transfer}, {@code mx_bank_transfer}, or {@code us_bank_transfer}.
+             */
+            public Builder setType(String type) {
+              this.type = type;
+              return this;
+            }
+          }
+        }
+      }
+
+      @Getter
       public static class Konbini {
         /**
          * Map of extra parameters for custom features not available in this client library. The
@@ -1894,6 +2108,9 @@ public class InvoiceCreateParams extends ApiRequestParams {
 
       @SerializedName("card")
       CARD("card"),
+
+      @SerializedName("customer_balance")
+      CUSTOMER_BALANCE("customer_balance"),
 
       @SerializedName("fpx")
       FPX("fpx"),

--- a/src/main/java/com/stripe/param/InvoiceItemCreateParams.java
+++ b/src/main/java/com/stripe/param/InvoiceItemCreateParams.java
@@ -80,7 +80,10 @@ public class InvoiceItemCreateParams extends ApiRequestParams {
   @SerializedName("metadata")
   Object metadata;
 
-  /** The period associated with this invoice item. */
+  /**
+   * The period associated with this invoice item. When set to different values, the period will be
+   * rendered on the invoice.
+   */
   @SerializedName("period")
   Period period;
 
@@ -429,7 +432,10 @@ public class InvoiceItemCreateParams extends ApiRequestParams {
       return this;
     }
 
-    /** The period associated with this invoice item. */
+    /**
+     * The period associated with this invoice item. When set to different values, the period will
+     * be rendered on the invoice.
+     */
     public Builder setPeriod(Period period) {
       this.period = period;
       return this;

--- a/src/main/java/com/stripe/param/InvoiceItemUpdateParams.java
+++ b/src/main/java/com/stripe/param/InvoiceItemUpdateParams.java
@@ -65,7 +65,10 @@ public class InvoiceItemUpdateParams extends ApiRequestParams {
   @SerializedName("metadata")
   Object metadata;
 
-  /** The period associated with this invoice item. */
+  /**
+   * The period associated with this invoice item. When set to different values, the period will be
+   * rendered on the invoice.
+   */
   @SerializedName("period")
   Period period;
 
@@ -377,7 +380,10 @@ public class InvoiceItemUpdateParams extends ApiRequestParams {
       return this;
     }
 
-    /** The period associated with this invoice item. */
+    /**
+     * The period associated with this invoice item. When set to different values, the period will
+     * be rendered on the invoice.
+     */
     public Builder setPeriod(Period period) {
       this.period = period;
       return this;

--- a/src/main/java/com/stripe/param/InvoiceSearchParams.java
+++ b/src/main/java/com/stripe/param/InvoiceSearchParams.java
@@ -32,8 +32,9 @@ public class InvoiceSearchParams extends ApiRequestParams {
   Long limit;
 
   /**
-   * A cursor for pagination across multiple pages of results. Do not include this parameter on the
-   * first call. Use the next_page value returned in a response to request subsequent results.
+   * A cursor for pagination across multiple pages of results. Don't include this parameter on the
+   * first call. Use the next_page value returned in a previous response to request subsequent
+   * results.
    */
   @SerializedName("page")
   String page;
@@ -139,8 +140,9 @@ public class InvoiceSearchParams extends ApiRequestParams {
     }
 
     /**
-     * A cursor for pagination across multiple pages of results. Do not include this parameter on
-     * the first call. Use the next_page value returned in a response to request subsequent results.
+     * A cursor for pagination across multiple pages of results. Don't include this parameter on the
+     * first call. Use the next_page value returned in a previous response to request subsequent
+     * results.
      */
     public Builder setPage(String page) {
       this.page = page;

--- a/src/main/java/com/stripe/param/InvoiceUpcomingParams.java
+++ b/src/main/java/com/stripe/param/InvoiceUpcomingParams.java
@@ -1807,7 +1807,10 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
     @SerializedName("metadata")
     Object metadata;
 
-    /** The period associated with this invoice item. */
+    /**
+     * The period associated with this invoice item. When set to different values, the period will
+     * be rendered on the invoice.
+     */
     @SerializedName("period")
     Period period;
 
@@ -2095,7 +2098,10 @@ public class InvoiceUpcomingParams extends ApiRequestParams {
         return this;
       }
 
-      /** The period associated with this invoice item. */
+      /**
+       * The period associated with this invoice item. When set to different values, the period will
+       * be rendered on the invoice.
+       */
       public Builder setPeriod(Period period) {
         this.period = period;
         return this;

--- a/src/main/java/com/stripe/param/InvoiceUpdateParams.java
+++ b/src/main/java/com/stripe/param/InvoiceUpdateParams.java
@@ -1182,6 +1182,13 @@ public class InvoiceUpdateParams extends ApiRequestParams {
       Object card;
 
       /**
+       * If paying by {@code customer_balance}, this sub-hash contains details about the Bank
+       * transfer payment method options to pass to the invoice’s PaymentIntent.
+       */
+      @SerializedName("customer_balance")
+      Object customerBalance;
+
+      /**
        * Map of extra parameters for custom features not available in this client library. The
        * content in this map is not serialized under this field's {@code @SerializedName} value.
        * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
@@ -1208,12 +1215,14 @@ public class InvoiceUpdateParams extends ApiRequestParams {
           Object acssDebit,
           Object bancontact,
           Object card,
+          Object customerBalance,
           Map<String, Object> extraParams,
           Object konbini,
           Object usBankAccount) {
         this.acssDebit = acssDebit;
         this.bancontact = bancontact;
         this.card = card;
+        this.customerBalance = customerBalance;
         this.extraParams = extraParams;
         this.konbini = konbini;
         this.usBankAccount = usBankAccount;
@@ -1230,6 +1239,8 @@ public class InvoiceUpdateParams extends ApiRequestParams {
 
         private Object card;
 
+        private Object customerBalance;
+
         private Map<String, Object> extraParams;
 
         private Object konbini;
@@ -1242,6 +1253,7 @@ public class InvoiceUpdateParams extends ApiRequestParams {
               this.acssDebit,
               this.bancontact,
               this.card,
+              this.customerBalance,
               this.extraParams,
               this.konbini,
               this.usBankAccount);
@@ -1298,6 +1310,24 @@ public class InvoiceUpdateParams extends ApiRequestParams {
          */
         public Builder setCard(EmptyParam card) {
           this.card = card;
+          return this;
+        }
+
+        /**
+         * If paying by {@code customer_balance}, this sub-hash contains details about the Bank
+         * transfer payment method options to pass to the invoice’s PaymentIntent.
+         */
+        public Builder setCustomerBalance(CustomerBalance customerBalance) {
+          this.customerBalance = customerBalance;
+          return this;
+        }
+
+        /**
+         * If paying by {@code customer_balance}, this sub-hash contains details about the Bank
+         * transfer payment method options to pass to the invoice’s PaymentIntent.
+         */
+        public Builder setCustomerBalance(EmptyParam customerBalance) {
+          this.customerBalance = customerBalance;
           return this;
         }
 
@@ -1768,6 +1798,211 @@ public class InvoiceUpdateParams extends ApiRequestParams {
       }
 
       @Getter
+      public static class CustomerBalance {
+        /**
+         * Configuration for the bank transfer funding type, if the {@code funding_type} is set to
+         * {@code bank_transfer}.
+         */
+        @SerializedName("bank_transfer")
+        BankTransfer bankTransfer;
+
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /**
+         * The funding method type to be used when there are not enough funds in the customer
+         * balance. Permitted values include: {@code bank_transfer}.
+         */
+        @SerializedName("funding_type")
+        Object fundingType;
+
+        private CustomerBalance(
+            BankTransfer bankTransfer, Map<String, Object> extraParams, Object fundingType) {
+          this.bankTransfer = bankTransfer;
+          this.extraParams = extraParams;
+          this.fundingType = fundingType;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private BankTransfer bankTransfer;
+
+          private Map<String, Object> extraParams;
+
+          private Object fundingType;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public CustomerBalance build() {
+            return new CustomerBalance(this.bankTransfer, this.extraParams, this.fundingType);
+          }
+
+          /**
+           * Configuration for the bank transfer funding type, if the {@code funding_type} is set to
+           * {@code bank_transfer}.
+           */
+          public Builder setBankTransfer(BankTransfer bankTransfer) {
+            this.bankTransfer = bankTransfer;
+            return this;
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.CustomerBalance#extraParams}
+           * for the field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.CustomerBalance#extraParams}
+           * for the field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /**
+           * The funding method type to be used when there are not enough funds in the customer
+           * balance. Permitted values include: {@code bank_transfer}.
+           */
+          public Builder setFundingType(String fundingType) {
+            this.fundingType = fundingType;
+            return this;
+          }
+
+          /**
+           * The funding method type to be used when there are not enough funds in the customer
+           * balance. Permitted values include: {@code bank_transfer}.
+           */
+          public Builder setFundingType(EmptyParam fundingType) {
+            this.fundingType = fundingType;
+            return this;
+          }
+        }
+
+        @Getter
+        public static class BankTransfer {
+          /**
+           * Map of extra parameters for custom features not available in this client library. The
+           * content in this map is not serialized under this field's {@code @SerializedName} value.
+           * Instead, each key/value pair is serialized as if the key is a root-level field
+           * (serialized) name in this param object. Effectively, this map is flattened to its
+           * parent instance.
+           */
+          @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+          Map<String, Object> extraParams;
+
+          /**
+           * The bank transfer type that can be used for funding. Permitted values include: {@code
+           * us_bank_account}, {@code eu_bank_account}, {@code id_bank_account}, {@code
+           * gb_bank_account}, {@code jp_bank_account}, {@code mx_bank_account}, {@code
+           * eu_bank_transfer}, {@code gb_bank_transfer}, {@code id_bank_transfer}, {@code
+           * jp_bank_transfer}, {@code mx_bank_transfer}, or {@code us_bank_transfer}.
+           */
+          @SerializedName("type")
+          Object type;
+
+          private BankTransfer(Map<String, Object> extraParams, Object type) {
+            this.extraParams = extraParams;
+            this.type = type;
+          }
+
+          public static Builder builder() {
+            return new Builder();
+          }
+
+          public static class Builder {
+            private Map<String, Object> extraParams;
+
+            private Object type;
+
+            /** Finalize and obtain parameter instance from this builder. */
+            public BankTransfer build() {
+              return new BankTransfer(this.extraParams, this.type);
+            }
+
+            /**
+             * Add a key/value pair to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.CustomerBalance.BankTransfer#extraParams}
+             * for the field documentation.
+             */
+            public Builder putExtraParam(String key, Object value) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.put(key, value);
+              return this;
+            }
+
+            /**
+             * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.CustomerBalance.BankTransfer#extraParams}
+             * for the field documentation.
+             */
+            public Builder putAllExtraParam(Map<String, Object> map) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.putAll(map);
+              return this;
+            }
+
+            /**
+             * The bank transfer type that can be used for funding. Permitted values include: {@code
+             * us_bank_account}, {@code eu_bank_account}, {@code id_bank_account}, {@code
+             * gb_bank_account}, {@code jp_bank_account}, {@code mx_bank_account}, {@code
+             * eu_bank_transfer}, {@code gb_bank_transfer}, {@code id_bank_transfer}, {@code
+             * jp_bank_transfer}, {@code mx_bank_transfer}, or {@code us_bank_transfer}.
+             */
+            public Builder setType(String type) {
+              this.type = type;
+              return this;
+            }
+
+            /**
+             * The bank transfer type that can be used for funding. Permitted values include: {@code
+             * us_bank_account}, {@code eu_bank_account}, {@code id_bank_account}, {@code
+             * gb_bank_account}, {@code jp_bank_account}, {@code mx_bank_account}, {@code
+             * eu_bank_transfer}, {@code gb_bank_transfer}, {@code id_bank_transfer}, {@code
+             * jp_bank_transfer}, {@code mx_bank_transfer}, or {@code us_bank_transfer}.
+             */
+            public Builder setType(EmptyParam type) {
+              this.type = type;
+              return this;
+            }
+          }
+        }
+      }
+
+      @Getter
       public static class Konbini {
         /**
          * Map of extra parameters for custom features not available in this client library. The
@@ -1944,6 +2179,9 @@ public class InvoiceUpdateParams extends ApiRequestParams {
 
       @SerializedName("card")
       CARD("card"),
+
+      @SerializedName("customer_balance")
+      CUSTOMER_BALANCE("customer_balance"),
 
       @SerializedName("fpx")
       FPX("fpx"),

--- a/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
@@ -6892,8 +6892,17 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
       Map<String, Object> extraParams;
 
-      private CardPresent(Map<String, Object> extraParams) {
+      /**
+       * Request ability to capture this payment beyond the standard <a
+       * href="https://stripe.com/docs/terminal/features/extended-authorizations#authorization-validity">authorization
+       * validity window.</a>
+       */
+      @SerializedName("request_extended_authorization")
+      Boolean requestExtendedAuthorization;
+
+      private CardPresent(Map<String, Object> extraParams, Boolean requestExtendedAuthorization) {
         this.extraParams = extraParams;
+        this.requestExtendedAuthorization = requestExtendedAuthorization;
       }
 
       public static Builder builder() {
@@ -6903,9 +6912,11 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       public static class Builder {
         private Map<String, Object> extraParams;
 
+        private Boolean requestExtendedAuthorization;
+
         /** Finalize and obtain parameter instance from this builder. */
         public CardPresent build() {
-          return new CardPresent(this.extraParams);
+          return new CardPresent(this.extraParams, this.requestExtendedAuthorization);
         }
 
         /**
@@ -6933,6 +6944,16 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
             this.extraParams = new HashMap<>();
           }
           this.extraParams.putAll(map);
+          return this;
+        }
+
+        /**
+         * Request ability to capture this payment beyond the standard <a
+         * href="https://stripe.com/docs/terminal/features/extended-authorizations#authorization-validity">authorization
+         * validity window.</a>
+         */
+        public Builder setRequestExtendedAuthorization(Boolean requestExtendedAuthorization) {
+          this.requestExtendedAuthorization = requestExtendedAuthorization;
           return this;
         }
       }

--- a/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
@@ -7354,8 +7354,17 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
       Map<String, Object> extraParams;
 
-      private CardPresent(Map<String, Object> extraParams) {
+      /**
+       * Request ability to capture this payment beyond the standard <a
+       * href="https://stripe.com/docs/terminal/features/extended-authorizations#authorization-validity">authorization
+       * validity window.</a>
+       */
+      @SerializedName("request_extended_authorization")
+      Boolean requestExtendedAuthorization;
+
+      private CardPresent(Map<String, Object> extraParams, Boolean requestExtendedAuthorization) {
         this.extraParams = extraParams;
+        this.requestExtendedAuthorization = requestExtendedAuthorization;
       }
 
       public static Builder builder() {
@@ -7365,9 +7374,11 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       public static class Builder {
         private Map<String, Object> extraParams;
 
+        private Boolean requestExtendedAuthorization;
+
         /** Finalize and obtain parameter instance from this builder. */
         public CardPresent build() {
-          return new CardPresent(this.extraParams);
+          return new CardPresent(this.extraParams, this.requestExtendedAuthorization);
         }
 
         /**
@@ -7395,6 +7406,16 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
             this.extraParams = new HashMap<>();
           }
           this.extraParams.putAll(map);
+          return this;
+        }
+
+        /**
+         * Request ability to capture this payment beyond the standard <a
+         * href="https://stripe.com/docs/terminal/features/extended-authorizations#authorization-validity">authorization
+         * validity window.</a>
+         */
+        public Builder setRequestExtendedAuthorization(Boolean requestExtendedAuthorization) {
+          this.requestExtendedAuthorization = requestExtendedAuthorization;
           return this;
         }
       }

--- a/src/main/java/com/stripe/param/PaymentIntentSearchParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentSearchParams.java
@@ -32,8 +32,9 @@ public class PaymentIntentSearchParams extends ApiRequestParams {
   Long limit;
 
   /**
-   * A cursor for pagination across multiple pages of results. Do not include this parameter on the
-   * first call. Use the next_page value returned in a response to request subsequent results.
+   * A cursor for pagination across multiple pages of results. Don't include this parameter on the
+   * first call. Use the next_page value returned in a previous response to request subsequent
+   * results.
    */
   @SerializedName("page")
   String page;
@@ -140,8 +141,9 @@ public class PaymentIntentSearchParams extends ApiRequestParams {
     }
 
     /**
-     * A cursor for pagination across multiple pages of results. Do not include this parameter on
-     * the first call. Use the next_page value returned in a response to request subsequent results.
+     * A cursor for pagination across multiple pages of results. Don't include this parameter on the
+     * first call. Use the next_page value returned in a previous response to request subsequent
+     * results.
      */
     public Builder setPage(String page) {
       this.page = page;

--- a/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
@@ -6959,8 +6959,17 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
       Map<String, Object> extraParams;
 
-      private CardPresent(Map<String, Object> extraParams) {
+      /**
+       * Request ability to capture this payment beyond the standard <a
+       * href="https://stripe.com/docs/terminal/features/extended-authorizations#authorization-validity">authorization
+       * validity window.</a>
+       */
+      @SerializedName("request_extended_authorization")
+      Boolean requestExtendedAuthorization;
+
+      private CardPresent(Map<String, Object> extraParams, Boolean requestExtendedAuthorization) {
         this.extraParams = extraParams;
+        this.requestExtendedAuthorization = requestExtendedAuthorization;
       }
 
       public static Builder builder() {
@@ -6970,9 +6979,11 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       public static class Builder {
         private Map<String, Object> extraParams;
 
+        private Boolean requestExtendedAuthorization;
+
         /** Finalize and obtain parameter instance from this builder. */
         public CardPresent build() {
-          return new CardPresent(this.extraParams);
+          return new CardPresent(this.extraParams, this.requestExtendedAuthorization);
         }
 
         /**
@@ -7000,6 +7011,16 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
             this.extraParams = new HashMap<>();
           }
           this.extraParams.putAll(map);
+          return this;
+        }
+
+        /**
+         * Request ability to capture this payment beyond the standard <a
+         * href="https://stripe.com/docs/terminal/features/extended-authorizations#authorization-validity">authorization
+         * validity window.</a>
+         */
+        public Builder setRequestExtendedAuthorization(Boolean requestExtendedAuthorization) {
+          this.requestExtendedAuthorization = requestExtendedAuthorization;
           return this;
         }
       }

--- a/src/main/java/com/stripe/param/PriceSearchParams.java
+++ b/src/main/java/com/stripe/param/PriceSearchParams.java
@@ -32,8 +32,9 @@ public class PriceSearchParams extends ApiRequestParams {
   Long limit;
 
   /**
-   * A cursor for pagination across multiple pages of results. Do not include this parameter on the
-   * first call. Use the next_page value returned in a response to request subsequent results.
+   * A cursor for pagination across multiple pages of results. Don't include this parameter on the
+   * first call. Use the next_page value returned in a previous response to request subsequent
+   * results.
    */
   @SerializedName("page")
   String page;
@@ -139,8 +140,9 @@ public class PriceSearchParams extends ApiRequestParams {
     }
 
     /**
-     * A cursor for pagination across multiple pages of results. Do not include this parameter on
-     * the first call. Use the next_page value returned in a response to request subsequent results.
+     * A cursor for pagination across multiple pages of results. Don't include this parameter on the
+     * first call. Use the next_page value returned in a previous response to request subsequent
+     * results.
      */
     public Builder setPage(String page) {
       this.page = page;

--- a/src/main/java/com/stripe/param/ProductSearchParams.java
+++ b/src/main/java/com/stripe/param/ProductSearchParams.java
@@ -32,8 +32,9 @@ public class ProductSearchParams extends ApiRequestParams {
   Long limit;
 
   /**
-   * A cursor for pagination across multiple pages of results. Do not include this parameter on the
-   * first call. Use the next_page value returned in a response to request subsequent results.
+   * A cursor for pagination across multiple pages of results. Don't include this parameter on the
+   * first call. Use the next_page value returned in a previous response to request subsequent
+   * results.
    */
   @SerializedName("page")
   String page;
@@ -139,8 +140,9 @@ public class ProductSearchParams extends ApiRequestParams {
     }
 
     /**
-     * A cursor for pagination across multiple pages of results. Do not include this parameter on
-     * the first call. Use the next_page value returned in a response to request subsequent results.
+     * A cursor for pagination across multiple pages of results. Don't include this parameter on the
+     * first call. Use the next_page value returned in a previous response to request subsequent
+     * results.
      */
     public Builder setPage(String page) {
       this.page = page;

--- a/src/main/java/com/stripe/param/SubscriptionCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionCreateParams.java
@@ -2229,6 +2229,13 @@ public class SubscriptionCreateParams extends ApiRequestParams {
       Object card;
 
       /**
+       * This sub-hash contains details about the Bank transfer payment method options to pass to
+       * the invoice’s PaymentIntent.
+       */
+      @SerializedName("customer_balance")
+      Object customerBalance;
+
+      /**
        * Map of extra parameters for custom features not available in this client library. The
        * content in this map is not serialized under this field's {@code @SerializedName} value.
        * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
@@ -2255,12 +2262,14 @@ public class SubscriptionCreateParams extends ApiRequestParams {
           Object acssDebit,
           Object bancontact,
           Object card,
+          Object customerBalance,
           Map<String, Object> extraParams,
           Object konbini,
           Object usBankAccount) {
         this.acssDebit = acssDebit;
         this.bancontact = bancontact;
         this.card = card;
+        this.customerBalance = customerBalance;
         this.extraParams = extraParams;
         this.konbini = konbini;
         this.usBankAccount = usBankAccount;
@@ -2277,6 +2286,8 @@ public class SubscriptionCreateParams extends ApiRequestParams {
 
         private Object card;
 
+        private Object customerBalance;
+
         private Map<String, Object> extraParams;
 
         private Object konbini;
@@ -2289,6 +2300,7 @@ public class SubscriptionCreateParams extends ApiRequestParams {
               this.acssDebit,
               this.bancontact,
               this.card,
+              this.customerBalance,
               this.extraParams,
               this.konbini,
               this.usBankAccount);
@@ -2345,6 +2357,24 @@ public class SubscriptionCreateParams extends ApiRequestParams {
          */
         public Builder setCard(EmptyParam card) {
           this.card = card;
+          return this;
+        }
+
+        /**
+         * This sub-hash contains details about the Bank transfer payment method options to pass to
+         * the invoice’s PaymentIntent.
+         */
+        public Builder setCustomerBalance(CustomerBalance customerBalance) {
+          this.customerBalance = customerBalance;
+          return this;
+        }
+
+        /**
+         * This sub-hash contains details about the Bank transfer payment method options to pass to
+         * the invoice’s PaymentIntent.
+         */
+        public Builder setCustomerBalance(EmptyParam customerBalance) {
+          this.customerBalance = customerBalance;
           return this;
         }
 
@@ -2966,6 +2996,190 @@ public class SubscriptionCreateParams extends ApiRequestParams {
       }
 
       @Getter
+      public static class CustomerBalance {
+        /**
+         * Configuration for the bank transfer funding type, if the {@code funding_type} is set to
+         * {@code bank_transfer}.
+         */
+        @SerializedName("bank_transfer")
+        BankTransfer bankTransfer;
+
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /**
+         * The funding method type to be used when there are not enough funds in the customer
+         * balance. Permitted values include: {@code bank_transfer}.
+         */
+        @SerializedName("funding_type")
+        String fundingType;
+
+        private CustomerBalance(
+            BankTransfer bankTransfer, Map<String, Object> extraParams, String fundingType) {
+          this.bankTransfer = bankTransfer;
+          this.extraParams = extraParams;
+          this.fundingType = fundingType;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private BankTransfer bankTransfer;
+
+          private Map<String, Object> extraParams;
+
+          private String fundingType;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public CustomerBalance build() {
+            return new CustomerBalance(this.bankTransfer, this.extraParams, this.fundingType);
+          }
+
+          /**
+           * Configuration for the bank transfer funding type, if the {@code funding_type} is set to
+           * {@code bank_transfer}.
+           */
+          public Builder setBankTransfer(BankTransfer bankTransfer) {
+            this.bankTransfer = bankTransfer;
+            return this;
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.CustomerBalance#extraParams}
+           * for the field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.CustomerBalance#extraParams}
+           * for the field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /**
+           * The funding method type to be used when there are not enough funds in the customer
+           * balance. Permitted values include: {@code bank_transfer}.
+           */
+          public Builder setFundingType(String fundingType) {
+            this.fundingType = fundingType;
+            return this;
+          }
+        }
+
+        @Getter
+        public static class BankTransfer {
+          /**
+           * Map of extra parameters for custom features not available in this client library. The
+           * content in this map is not serialized under this field's {@code @SerializedName} value.
+           * Instead, each key/value pair is serialized as if the key is a root-level field
+           * (serialized) name in this param object. Effectively, this map is flattened to its
+           * parent instance.
+           */
+          @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+          Map<String, Object> extraParams;
+
+          /**
+           * The bank transfer type that can be used for funding. Permitted values include: {@code
+           * us_bank_account}, {@code eu_bank_account}, {@code id_bank_account}, {@code
+           * gb_bank_account}, {@code jp_bank_account}, {@code mx_bank_account}, {@code
+           * eu_bank_transfer}, {@code gb_bank_transfer}, {@code id_bank_transfer}, {@code
+           * jp_bank_transfer}, {@code mx_bank_transfer}, or {@code us_bank_transfer}.
+           */
+          @SerializedName("type")
+          String type;
+
+          private BankTransfer(Map<String, Object> extraParams, String type) {
+            this.extraParams = extraParams;
+            this.type = type;
+          }
+
+          public static Builder builder() {
+            return new Builder();
+          }
+
+          public static class Builder {
+            private Map<String, Object> extraParams;
+
+            private String type;
+
+            /** Finalize and obtain parameter instance from this builder. */
+            public BankTransfer build() {
+              return new BankTransfer(this.extraParams, this.type);
+            }
+
+            /**
+             * Add a key/value pair to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.CustomerBalance.BankTransfer#extraParams}
+             * for the field documentation.
+             */
+            public Builder putExtraParam(String key, Object value) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.put(key, value);
+              return this;
+            }
+
+            /**
+             * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.CustomerBalance.BankTransfer#extraParams}
+             * for the field documentation.
+             */
+            public Builder putAllExtraParam(Map<String, Object> map) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.putAll(map);
+              return this;
+            }
+
+            /**
+             * The bank transfer type that can be used for funding. Permitted values include: {@code
+             * us_bank_account}, {@code eu_bank_account}, {@code id_bank_account}, {@code
+             * gb_bank_account}, {@code jp_bank_account}, {@code mx_bank_account}, {@code
+             * eu_bank_transfer}, {@code gb_bank_transfer}, {@code id_bank_transfer}, {@code
+             * jp_bank_transfer}, {@code mx_bank_transfer}, or {@code us_bank_transfer}.
+             */
+            public Builder setType(String type) {
+              this.type = type;
+              return this;
+            }
+          }
+        }
+      }
+
+      @Getter
       public static class Konbini {
         /**
          * Map of extra parameters for custom features not available in this client library. The
@@ -3142,6 +3356,9 @@ public class SubscriptionCreateParams extends ApiRequestParams {
 
       @SerializedName("card")
       CARD("card"),
+
+      @SerializedName("customer_balance")
+      CUSTOMER_BALANCE("customer_balance"),
 
       @SerializedName("fpx")
       FPX("fpx"),

--- a/src/main/java/com/stripe/param/SubscriptionSearchParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionSearchParams.java
@@ -32,8 +32,9 @@ public class SubscriptionSearchParams extends ApiRequestParams {
   Long limit;
 
   /**
-   * A cursor for pagination across multiple pages of results. Do not include this parameter on the
-   * first call. Use the next_page value returned in a response to request subsequent results.
+   * A cursor for pagination across multiple pages of results. Don't include this parameter on the
+   * first call. Use the next_page value returned in a previous response to request subsequent
+   * results.
    */
   @SerializedName("page")
   String page;
@@ -139,8 +140,9 @@ public class SubscriptionSearchParams extends ApiRequestParams {
     }
 
     /**
-     * A cursor for pagination across multiple pages of results. Do not include this parameter on
-     * the first call. Use the next_page value returned in a response to request subsequent results.
+     * A cursor for pagination across multiple pages of results. Don't include this parameter on the
+     * first call. Use the next_page value returned in a previous response to request subsequent
+     * results.
      */
     public Builder setPage(String page) {
       this.page = page;

--- a/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
@@ -2549,6 +2549,13 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
       Object card;
 
       /**
+       * This sub-hash contains details about the Bank transfer payment method options to pass to
+       * the invoice’s PaymentIntent.
+       */
+      @SerializedName("customer_balance")
+      Object customerBalance;
+
+      /**
        * Map of extra parameters for custom features not available in this client library. The
        * content in this map is not serialized under this field's {@code @SerializedName} value.
        * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
@@ -2575,12 +2582,14 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
           Object acssDebit,
           Object bancontact,
           Object card,
+          Object customerBalance,
           Map<String, Object> extraParams,
           Object konbini,
           Object usBankAccount) {
         this.acssDebit = acssDebit;
         this.bancontact = bancontact;
         this.card = card;
+        this.customerBalance = customerBalance;
         this.extraParams = extraParams;
         this.konbini = konbini;
         this.usBankAccount = usBankAccount;
@@ -2597,6 +2606,8 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
 
         private Object card;
 
+        private Object customerBalance;
+
         private Map<String, Object> extraParams;
 
         private Object konbini;
@@ -2609,6 +2620,7 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
               this.acssDebit,
               this.bancontact,
               this.card,
+              this.customerBalance,
               this.extraParams,
               this.konbini,
               this.usBankAccount);
@@ -2665,6 +2677,24 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
          */
         public Builder setCard(EmptyParam card) {
           this.card = card;
+          return this;
+        }
+
+        /**
+         * This sub-hash contains details about the Bank transfer payment method options to pass to
+         * the invoice’s PaymentIntent.
+         */
+        public Builder setCustomerBalance(CustomerBalance customerBalance) {
+          this.customerBalance = customerBalance;
+          return this;
+        }
+
+        /**
+         * This sub-hash contains details about the Bank transfer payment method options to pass to
+         * the invoice’s PaymentIntent.
+         */
+        public Builder setCustomerBalance(EmptyParam customerBalance) {
+          this.customerBalance = customerBalance;
           return this;
         }
 
@@ -3295,6 +3325,211 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
       }
 
       @Getter
+      public static class CustomerBalance {
+        /**
+         * Configuration for the bank transfer funding type, if the {@code funding_type} is set to
+         * {@code bank_transfer}.
+         */
+        @SerializedName("bank_transfer")
+        BankTransfer bankTransfer;
+
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /**
+         * The funding method type to be used when there are not enough funds in the customer
+         * balance. Permitted values include: {@code bank_transfer}.
+         */
+        @SerializedName("funding_type")
+        Object fundingType;
+
+        private CustomerBalance(
+            BankTransfer bankTransfer, Map<String, Object> extraParams, Object fundingType) {
+          this.bankTransfer = bankTransfer;
+          this.extraParams = extraParams;
+          this.fundingType = fundingType;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private BankTransfer bankTransfer;
+
+          private Map<String, Object> extraParams;
+
+          private Object fundingType;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public CustomerBalance build() {
+            return new CustomerBalance(this.bankTransfer, this.extraParams, this.fundingType);
+          }
+
+          /**
+           * Configuration for the bank transfer funding type, if the {@code funding_type} is set to
+           * {@code bank_transfer}.
+           */
+          public Builder setBankTransfer(BankTransfer bankTransfer) {
+            this.bankTransfer = bankTransfer;
+            return this;
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.CustomerBalance#extraParams}
+           * for the field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.CustomerBalance#extraParams}
+           * for the field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /**
+           * The funding method type to be used when there are not enough funds in the customer
+           * balance. Permitted values include: {@code bank_transfer}.
+           */
+          public Builder setFundingType(String fundingType) {
+            this.fundingType = fundingType;
+            return this;
+          }
+
+          /**
+           * The funding method type to be used when there are not enough funds in the customer
+           * balance. Permitted values include: {@code bank_transfer}.
+           */
+          public Builder setFundingType(EmptyParam fundingType) {
+            this.fundingType = fundingType;
+            return this;
+          }
+        }
+
+        @Getter
+        public static class BankTransfer {
+          /**
+           * Map of extra parameters for custom features not available in this client library. The
+           * content in this map is not serialized under this field's {@code @SerializedName} value.
+           * Instead, each key/value pair is serialized as if the key is a root-level field
+           * (serialized) name in this param object. Effectively, this map is flattened to its
+           * parent instance.
+           */
+          @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+          Map<String, Object> extraParams;
+
+          /**
+           * The bank transfer type that can be used for funding. Permitted values include: {@code
+           * us_bank_account}, {@code eu_bank_account}, {@code id_bank_account}, {@code
+           * gb_bank_account}, {@code jp_bank_account}, {@code mx_bank_account}, {@code
+           * eu_bank_transfer}, {@code gb_bank_transfer}, {@code id_bank_transfer}, {@code
+           * jp_bank_transfer}, {@code mx_bank_transfer}, or {@code us_bank_transfer}.
+           */
+          @SerializedName("type")
+          Object type;
+
+          private BankTransfer(Map<String, Object> extraParams, Object type) {
+            this.extraParams = extraParams;
+            this.type = type;
+          }
+
+          public static Builder builder() {
+            return new Builder();
+          }
+
+          public static class Builder {
+            private Map<String, Object> extraParams;
+
+            private Object type;
+
+            /** Finalize and obtain parameter instance from this builder. */
+            public BankTransfer build() {
+              return new BankTransfer(this.extraParams, this.type);
+            }
+
+            /**
+             * Add a key/value pair to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.CustomerBalance.BankTransfer#extraParams}
+             * for the field documentation.
+             */
+            public Builder putExtraParam(String key, Object value) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.put(key, value);
+              return this;
+            }
+
+            /**
+             * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.CustomerBalance.BankTransfer#extraParams}
+             * for the field documentation.
+             */
+            public Builder putAllExtraParam(Map<String, Object> map) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.putAll(map);
+              return this;
+            }
+
+            /**
+             * The bank transfer type that can be used for funding. Permitted values include: {@code
+             * us_bank_account}, {@code eu_bank_account}, {@code id_bank_account}, {@code
+             * gb_bank_account}, {@code jp_bank_account}, {@code mx_bank_account}, {@code
+             * eu_bank_transfer}, {@code gb_bank_transfer}, {@code id_bank_transfer}, {@code
+             * jp_bank_transfer}, {@code mx_bank_transfer}, or {@code us_bank_transfer}.
+             */
+            public Builder setType(String type) {
+              this.type = type;
+              return this;
+            }
+
+            /**
+             * The bank transfer type that can be used for funding. Permitted values include: {@code
+             * us_bank_account}, {@code eu_bank_account}, {@code id_bank_account}, {@code
+             * gb_bank_account}, {@code jp_bank_account}, {@code mx_bank_account}, {@code
+             * eu_bank_transfer}, {@code gb_bank_transfer}, {@code id_bank_transfer}, {@code
+             * jp_bank_transfer}, {@code mx_bank_transfer}, or {@code us_bank_transfer}.
+             */
+            public Builder setType(EmptyParam type) {
+              this.type = type;
+              return this;
+            }
+          }
+        }
+      }
+
+      @Getter
       public static class Konbini {
         /**
          * Map of extra parameters for custom features not available in this client library. The
@@ -3471,6 +3706,9 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
 
       @SerializedName("card")
       CARD("card"),
+
+      @SerializedName("customer_balance")
+      CUSTOMER_BALANCE("customer_balance"),
 
       @SerializedName("fpx")
       FPX("fpx"),

--- a/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
+++ b/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
@@ -879,6 +879,9 @@ public class WebhookEndpointCreateParams extends ApiRequestParams {
     @SerializedName("payment_intent.created")
     PAYMENT_INTENT__CREATED("payment_intent.created"),
 
+    @SerializedName("payment_intent.partially_funded")
+    PAYMENT_INTENT__PARTIALLY_FUNDED("payment_intent.partially_funded"),
+
     @SerializedName("payment_intent.payment_failed")
     PAYMENT_INTENT__PAYMENT_FAILED("payment_intent.payment_failed"),
 
@@ -1082,6 +1085,12 @@ public class WebhookEndpointCreateParams extends ApiRequestParams {
 
     @SerializedName("tax_rate.updated")
     TAX_RATE__UPDATED("tax_rate.updated"),
+
+    @SerializedName("terminal.reader.action_failed")
+    TERMINAL__READER__ACTION_FAILED("terminal.reader.action_failed"),
+
+    @SerializedName("terminal.reader.action_succeeded")
+    TERMINAL__READER__ACTION_SUCCEEDED("terminal.reader.action_succeeded"),
 
     @SerializedName("test_helpers.test_clock.advancing")
     TEST_HELPERS__TEST_CLOCK__ADVANCING("test_helpers.test_clock.advancing"),

--- a/src/main/java/com/stripe/param/WebhookEndpointUpdateParams.java
+++ b/src/main/java/com/stripe/param/WebhookEndpointUpdateParams.java
@@ -567,6 +567,9 @@ public class WebhookEndpointUpdateParams extends ApiRequestParams {
     @SerializedName("payment_intent.created")
     PAYMENT_INTENT__CREATED("payment_intent.created"),
 
+    @SerializedName("payment_intent.partially_funded")
+    PAYMENT_INTENT__PARTIALLY_FUNDED("payment_intent.partially_funded"),
+
     @SerializedName("payment_intent.payment_failed")
     PAYMENT_INTENT__PAYMENT_FAILED("payment_intent.payment_failed"),
 
@@ -770,6 +773,12 @@ public class WebhookEndpointUpdateParams extends ApiRequestParams {
 
     @SerializedName("tax_rate.updated")
     TAX_RATE__UPDATED("tax_rate.updated"),
+
+    @SerializedName("terminal.reader.action_failed")
+    TERMINAL__READER__ACTION_FAILED("terminal.reader.action_failed"),
+
+    @SerializedName("terminal.reader.action_succeeded")
+    TERMINAL__READER__ACTION_SUCCEEDED("terminal.reader.action_succeeded"),
 
     @SerializedName("test_helpers.test_clock.advancing")
     TEST_HELPERS__TEST_CLOCK__ADVANCING("test_helpers.test_clock.advancing"),


### PR DESCRIPTION
Codegen for openapi d412983.
r? @dcr-stripe
cc @stripe/api-libraries

## Changelog
* Add support for `bank_transfer_payments` on `Account.capabilities`, `AccountCreateParams.capabilities`, and `AccountUpdateParams.capabilities`
* Add support for `capture_before` on `Charge.payment_method_details.card_present`
* Add support for `address` and `name` on `Checkout.Session.customer_details`
* Add support for `customer_balance` on `Invoice.payment_settings.payment_method_options`, `InvoiceCreateParams.payment_settings.payment_method_options`, `InvoiceUpdateParams.payment_settings.payment_method_options`, `Subscription.payment_settings.payment_method_options`, `SubscriptionCreateParams.payment_settings.payment_method_options`, and `SubscriptionUpdateParams.payment_settings.payment_method_options`
* Add support for new value `customer_balance` on enums `InvoiceCreateParams.payment_settings.payment_method_types[]`, `InvoiceUpdateParams.payment_settings.payment_method_types[]`, `SubscriptionCreateParams.payment_settings.payment_method_types[]`, and `SubscriptionUpdateParams.payment_settings.payment_method_types[]`
* Add support for `request_extended_authorization` on `PaymentIntent.payment_method_options.card_present`, `PaymentIntentConfirmParams.payment_method_options.card_present`, `PaymentIntentCreateParams.payment_method_options.card_present`, and `PaymentIntentUpdateParams.payment_method_options.card_present`
* Add support for new values `payment_intent.partially_funded`, `terminal.reader.action_failed`, and `terminal.reader.action_succeeded` on enums `WebhookEndpointCreateParams.enabled_events[]` and `WebhookEndpointUpdateParams.enabled_events[]`


