### PR TITLE
Add support for updating the version of the repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: update-version codegen-format
+update-version:
+	@echo "$(VERSION)" > VERSION
+	@perl -pi -e 's|implementation "com\.stripe:stripe-java:[.\d\-\w]+"|implementation "com.stripe:stripe-java:$(VERSION)|' README.md
+	@perl -pi -e 's|<version>[.\d\-\w]+<\/version>|<version>$(VERSION)</version>|' README.md
+	@perl -pi -e 's|VERSION_NAME=[.\d\-\w]+|VERSION_NAME=$(VERSION)|' gradle.properties
+	@perl -pi -e 's|public static final String VERSION = "[.\d\-\w]+";|public static final String VERSION = "$(VERSION)";|' src/main/java/com/stripe/Stripe.java
+
+codegen-format:
+	./gradlew spotlessApply


### PR DESCRIPTION
Encodes the logic for version updating as a Makefile. Simplifies what the generation tools needs to know about the repo.
The plan is to have the same interface across all the repos.

Sample usage:

```
make update-version VERSION=1.2.5
```

Also adds a target that codegen will use to format all our repos:

```
make codegen-format
```