### PR TITLE
Attempt to fix java tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -161,5 +161,6 @@ gitPublish {
 }
 jacoco
 {
+    // test code instrumentation for Java 18
     toolVersion = "0.8.8"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -159,3 +159,7 @@ gitPublish {
         }
     }
 }
+jacoco
+{
+    toolVersion = "0.8.8"
+}

--- a/src/test/java/com/stripe/functional/ErrorTest.java
+++ b/src/test/java/com/stripe/functional/ErrorTest.java
@@ -44,14 +44,13 @@ public class ErrorTest extends BaseStripeTest {
   @Test
   public void testOAuthError() throws StripeException, IOException, InterruptedException {
     String oldBase = Stripe.getConnectBase();
-    try
-    {
+    try {
       InvalidClientException exception = null;
       @Cleanup MockWebServer server = new MockWebServer();
       server.enqueue(
-        new MockResponse()
-          .setResponseCode(401)
-          .setBody(getResourceAsString("/oauth_fixtures/error_invalid_client.json")));
+          new MockResponse()
+              .setResponseCode(401)
+              .setBody(getResourceAsString("/oauth_fixtures/error_invalid_client.json")));
 
       Stripe.overrideConnectBase(server.url("").toString());
 
@@ -66,8 +65,7 @@ public class ErrorTest extends BaseStripeTest {
       assertNotNull(exception.getOauthError());
       assertEquals("invalid_client", exception.getOauthError().getError());
       assertNotNull(exception.getOauthError().getLastResponse());
-    }
-    finally {
+    } finally {
       Stripe.overrideConnectBase(oldBase);
     }
   }

--- a/src/test/java/com/stripe/functional/ErrorTest.java
+++ b/src/test/java/com/stripe/functional/ErrorTest.java
@@ -50,7 +50,7 @@ public class ErrorTest extends BaseStripeTest {
             .setResponseCode(401)
             .setBody(getResourceAsString("/oauth_fixtures/error_invalid_client.json")));
 
-    Stripe.overrideApiBase(server.url("").toString());
+    Stripe.overrideConnectBase(server.url("").toString());
 
     try {
       OAuth.token(null, null);


### PR DESCRIPTION
`OAuth` uses `getConnectBase` for the base path. We were overriding `apiBase` instead. Not sure how it ever worked.