### PR TITLE
Add null checks before streaming expandable IDs in setters.

### DIFF
--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -673,7 +673,11 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
       this.accountTaxIds = null;
       return;
     }
-    if (this.accountTaxIds.stream().map(x -> x.getId()).collect(Collectors.toList()).equals(ids)) {
+    if (this.accountTaxIds != null
+        && this.accountTaxIds.stream()
+            .map(x -> x.getId())
+            .collect(Collectors.toList())
+            .equals(ids)) {
       // noop if the ids are equal to what are already present
       return;
     }
@@ -713,7 +717,8 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
       this.discounts = null;
       return;
     }
-    if (this.discounts.stream().map(x -> x.getId()).collect(Collectors.toList()).equals(ids)) {
+    if (this.discounts != null
+        && this.discounts.stream().map(x -> x.getId()).collect(Collectors.toList()).equals(ids)) {
       // noop if the ids are equal to what are already present
       return;
     }

--- a/src/main/java/com/stripe/model/InvoiceItem.java
+++ b/src/main/java/com/stripe/model/InvoiceItem.java
@@ -245,7 +245,8 @@ public class InvoiceItem extends ApiResource implements HasId, MetadataStore<Inv
       this.discounts = null;
       return;
     }
-    if (this.discounts.stream().map(x -> x.getId()).collect(Collectors.toList()).equals(ids)) {
+    if (this.discounts != null
+        && this.discounts.stream().map(x -> x.getId()).collect(Collectors.toList()).equals(ids)) {
       // noop if the ids are equal to what are already present
       return;
     }

--- a/src/main/java/com/stripe/model/InvoiceLineItem.java
+++ b/src/main/java/com/stripe/model/InvoiceLineItem.java
@@ -143,7 +143,8 @@ public class InvoiceLineItem extends StripeObject implements HasId {
       this.discounts = null;
       return;
     }
-    if (this.discounts.stream().map(x -> x.getId()).collect(Collectors.toList()).equals(ids)) {
+    if (this.discounts != null
+        && this.discounts.stream().map(x -> x.getId()).collect(Collectors.toList()).equals(ids)) {
       // noop if the ids are equal to what are already present
       return;
     }

--- a/src/main/java/com/stripe/model/Quote.java
+++ b/src/main/java/com/stripe/model/Quote.java
@@ -351,10 +351,11 @@ public class Quote extends ApiResource implements HasId, MetadataStore<Quote> {
       this.defaultTaxRates = null;
       return;
     }
-    if (this.defaultTaxRates.stream()
-        .map(x -> x.getId())
-        .collect(Collectors.toList())
-        .equals(ids)) {
+    if (this.defaultTaxRates != null
+        && this.defaultTaxRates.stream()
+            .map(x -> x.getId())
+            .collect(Collectors.toList())
+            .equals(ids)) {
       // noop if the ids are equal to what are already present
       return;
     }
@@ -394,7 +395,8 @@ public class Quote extends ApiResource implements HasId, MetadataStore<Quote> {
       this.discounts = null;
       return;
     }
-    if (this.discounts.stream().map(x -> x.getId()).collect(Collectors.toList()).equals(ids)) {
+    if (this.discounts != null
+        && this.discounts.stream().map(x -> x.getId()).collect(Collectors.toList()).equals(ids)) {
       // noop if the ids are equal to what are already present
       return;
     }


### PR DESCRIPTION
r? @richardm-stripe 

## Summary

Add null checks before streaming the list of IDs to determine whether the set call is a no-op. Previously this line would result in a `NullPointerException`.

## Motivation

Fixes https://github.com/stripe/stripe-java/issues/1316