### PR TITLE
API Updates

### DIFF
--- a/src/main/java/com/stripe/model/EventDataClassLookup.java
+++ b/src/main/java/com/stripe/model/EventDataClassLookup.java
@@ -100,6 +100,12 @@ final class EventDataClassLookup {
     classLookup.put(
         "financial_connections.account", com.stripe.model.financialconnections.Account.class);
     classLookup.put(
+        "financial_connections.account_owner",
+        com.stripe.model.financialconnections.AccountOwner.class);
+    classLookup.put(
+        "financial_connections.account_ownership",
+        com.stripe.model.financialconnections.AccountOwnership.class);
+    classLookup.put(
         "financial_connections.session", com.stripe.model.financialconnections.Session.class);
 
     classLookup.put(

--- a/src/main/java/com/stripe/model/EventDataClassLookup.java
+++ b/src/main/java/com/stripe/model/EventDataClassLookup.java
@@ -98,6 +98,11 @@ final class EventDataClassLookup {
     classLookup.put("checkout.session", com.stripe.model.checkout.Session.class);
 
     classLookup.put(
+        "financial_connections.account", com.stripe.model.financialconnections.Account.class);
+    classLookup.put(
+        "financial_connections.session", com.stripe.model.financialconnections.Session.class);
+
+    classLookup.put(
         "identity.verification_report", com.stripe.model.identity.VerificationReport.class);
     classLookup.put(
         "identity.verification_session", com.stripe.model.identity.VerificationSession.class);

--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -1771,6 +1771,9 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
     @Setter
     @EqualsAndHashCode(callSuper = false)
     public static class UsBankAccount extends StripeObject {
+      @SerializedName("financial_connections")
+      FinancialConnections financialConnections;
+
       /**
        * Bank account verification method.
        *
@@ -1778,6 +1781,18 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
        */
       @SerializedName("verification_method")
       String verificationMethod;
+
+      @Getter
+      @Setter
+      @EqualsAndHashCode(callSuper = false)
+      public static class FinancialConnections extends StripeObject {
+        /**
+         * The list of permissions to request. The {@code payment_method} permission must be
+         * included.
+         */
+        @SerializedName("permissions")
+        List<String> permissions;
+      }
     }
   }
 

--- a/src/main/java/com/stripe/model/PaymentIntent.java
+++ b/src/main/java/com/stripe/model/PaymentIntent.java
@@ -2857,6 +2857,9 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
     @Setter
     @EqualsAndHashCode(callSuper = false)
     public static class UsBankAccount extends StripeObject {
+      @SerializedName("financial_connections")
+      FinancialConnections financialConnections;
+
       /**
        * Indicates that you intend to make future payments with this PaymentIntent's payment method.
        *
@@ -2884,6 +2887,25 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
        */
       @SerializedName("verification_method")
       String verificationMethod;
+
+      @Getter
+      @Setter
+      @EqualsAndHashCode(callSuper = false)
+      public static class FinancialConnections extends StripeObject {
+        /**
+         * The list of permissions to request. The {@code payment_method} permission must be
+         * included.
+         */
+        @SerializedName("permissions")
+        List<String> permissions;
+
+        /**
+         * For webview integrations only. Upon completing OAuth login in the native browser, the
+         * user will be redirected to this URL to return to your app.
+         */
+        @SerializedName("return_url")
+        String returnUrl;
+      }
     }
 
     @Getter

--- a/src/main/java/com/stripe/model/PaymentMethod.java
+++ b/src/main/java/com/stripe/model/PaymentMethod.java
@@ -1152,6 +1152,10 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
     @SerializedName("bank_name")
     String bankName;
 
+    /** The ID of the Financial Connections Account used to create the payment method. */
+    @SerializedName("financial_connections_account")
+    String financialConnectionsAccount;
+
     /**
      * Uniquely identifies this particular bank account. You can use this attribute to check whether
      * two bank accounts are the same.

--- a/src/main/java/com/stripe/model/SetupIntent.java
+++ b/src/main/java/com/stripe/model/SetupIntent.java
@@ -972,6 +972,9 @@ public class SetupIntent extends ApiResource implements HasId, MetadataStore<Set
     @Setter
     @EqualsAndHashCode(callSuper = false)
     public static class UsBankAccount extends StripeObject {
+      @SerializedName("financial_connections")
+      FinancialConnections financialConnections;
+
       /**
        * Bank account verification method.
        *
@@ -979,6 +982,25 @@ public class SetupIntent extends ApiResource implements HasId, MetadataStore<Set
        */
       @SerializedName("verification_method")
       String verificationMethod;
+
+      @Getter
+      @Setter
+      @EqualsAndHashCode(callSuper = false)
+      public static class FinancialConnections extends StripeObject {
+        /**
+         * The list of permissions to request. The {@code payment_method} permission must be
+         * included.
+         */
+        @SerializedName("permissions")
+        List<String> permissions;
+
+        /**
+         * For webview integrations only. Upon completing OAuth login in the native browser, the
+         * user will be redirected to this URL to return to your app.
+         */
+        @SerializedName("return_url")
+        String returnUrl;
+      }
     }
   }
 }

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -1078,6 +1078,9 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
     @Setter
     @EqualsAndHashCode(callSuper = false)
     public static class UsBankAccount extends StripeObject {
+      @SerializedName("financial_connections")
+      FinancialConnections financialConnections;
+
       /**
        * Bank account verification method.
        *
@@ -1085,6 +1088,18 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
        */
       @SerializedName("verification_method")
       String verificationMethod;
+
+      @Getter
+      @Setter
+      @EqualsAndHashCode(callSuper = false)
+      public static class FinancialConnections extends StripeObject {
+        /**
+         * The list of permissions to request. The {@code payment_method} permission must be
+         * included.
+         */
+        @SerializedName("permissions")
+        List<String> permissions;
+      }
     }
   }
 

--- a/src/main/java/com/stripe/model/checkout/Session.java
+++ b/src/main/java/com/stripe/model/checkout/Session.java
@@ -924,6 +924,9 @@ public class Session extends ApiResource implements HasId {
     @Setter
     @EqualsAndHashCode(callSuper = false)
     public static class UsBankAccount extends StripeObject {
+      @SerializedName("financial_connections")
+      FinancialConnections financialConnections;
+
       /**
        * Bank account verification method.
        *
@@ -931,6 +934,25 @@ public class Session extends ApiResource implements HasId {
        */
       @SerializedName("verification_method")
       String verificationMethod;
+
+      @Getter
+      @Setter
+      @EqualsAndHashCode(callSuper = false)
+      public static class FinancialConnections extends StripeObject {
+        /**
+         * The list of permissions to request. The {@code payment_method} permission must be
+         * included.
+         */
+        @SerializedName("permissions")
+        List<String> permissions;
+
+        /**
+         * For webview integrations only. Upon completing OAuth login in the native browser, the
+         * user will be redirected to this URL to return to your app.
+         */
+        @SerializedName("return_url")
+        String returnUrl;
+      }
     }
   }
 

--- a/src/main/java/com/stripe/model/financialconnections/Account.java
+++ b/src/main/java/com/stripe/model/financialconnections/Account.java
@@ -1,0 +1,481 @@
+// File generated from our OpenAPI spec
+package com.stripe.model.financialconnections;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.Stripe;
+import com.stripe.exception.StripeException;
+import com.stripe.model.Account;
+import com.stripe.model.Customer;
+import com.stripe.model.ExpandableField;
+import com.stripe.model.HasId;
+import com.stripe.model.StripeObject;
+import com.stripe.net.ApiResource;
+import com.stripe.net.RequestOptions;
+import com.stripe.param.financialconnections.AccountDisconnectParams;
+import com.stripe.param.financialconnections.AccountRefreshParams;
+import com.stripe.param.financialconnections.AccountRetrieveParams;
+import java.util.List;
+import java.util.Map;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
+public class Account extends ApiResource implements HasId {
+  /** The account holder that this account belongs to. */
+  @SerializedName("account_holder")
+  AccountHolder accountHolder;
+
+  /** The most recent information about the account's balance. */
+  @SerializedName("balance")
+  Balance balance;
+
+  /** The state of the most recent attempt to refresh the account balance. */
+  @SerializedName("balance_refresh")
+  BalanceRefresh balanceRefresh;
+
+  /**
+   * The type of the account. Account category is further divided in {@code subcategory}.
+   *
+   * <p>One of {@code cash}, {@code credit}, {@code investment}, or {@code other}.
+   */
+  @SerializedName("category")
+  String category;
+
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  @SerializedName("created")
+  Long created;
+
+  /**
+   * A human-readable name that has been assigned to this account, either by the account holder or
+   * by the institution.
+   */
+  @SerializedName("display_name")
+  String displayName;
+
+  /** Unique identifier for the object. */
+  @Getter(onMethod_ = {@Override})
+  @SerializedName("id")
+  String id;
+
+  /** The name of the institution that holds this account. */
+  @SerializedName("institution_name")
+  String institutionName;
+
+  /** The last 4 digits of the account number. If present, this will be 4 numeric characters. */
+  @SerializedName("last4")
+  String last4;
+
+  /**
+   * Has the value {@code true} if the object exists in live mode or the value {@code false} if the
+   * object exists in test mode.
+   */
+  @SerializedName("livemode")
+  Boolean livemode;
+
+  /**
+   * String representing the object's type. Objects of the same type share the same value.
+   *
+   * <p>Equal to {@code financial_connections.account}.
+   */
+  @SerializedName("object")
+  String object;
+
+  /** The most recent information about the account's owners. */
+  @SerializedName("ownership")
+  @Getter(lombok.AccessLevel.NONE)
+  @Setter(lombok.AccessLevel.NONE)
+  ExpandableField<Account.Ownership> ownership;
+
+  /** The state of the most recent attempt to refresh the account owners. */
+  @SerializedName("ownership_refresh")
+  OwnershipRefresh ownershipRefresh;
+
+  /** The list of permissions granted by this account. */
+  @SerializedName("permissions")
+  List<String> permissions;
+
+  /**
+   * The status of the link to the account.
+   *
+   * <p>One of {@code active}, {@code disconnected}, or {@code inactive}.
+   */
+  @SerializedName("status")
+  String status;
+
+  /**
+   * If {@code category} is {@code cash}, one of:
+   *
+   * <p>- {@code checking} - {@code savings} - {@code other}
+   *
+   * <p>If {@code category} is {@code credit}, one of:
+   *
+   * <p>- {@code mortgage} - {@code line_of_credit} - {@code credit_card} - {@code other}
+   *
+   * <p>If {@code category} is {@code investment} or {@code other}, this will be {@code other}.
+   */
+  @SerializedName("subcategory")
+  String subcategory;
+
+  /**
+   * The <a
+   * href="https://stripe.com/docs/api/payment_methods/object#payment_method_object-type">PaymentMethod
+   * type</a>(s) that can be created from this account.
+   */
+  @SerializedName("supported_payment_method_types")
+  List<String> supportedPaymentMethodTypes;
+
+  /** Get ID of expandable {@code ownership} object. */
+  public String getOwnership() {
+    return (this.ownership != null) ? this.ownership.getId() : null;
+  }
+
+  public void setOwnership(String id) {
+    this.ownership = ApiResource.setExpandableFieldId(id, this.ownership);
+  }
+
+  /** Get expanded {@code ownership}. */
+  public Account.Ownership getOwnershipObject() {
+    return (this.ownership != null) ? this.ownership.getExpanded() : null;
+  }
+
+  public void setOwnershipObject(Account.Ownership expandableObject) {
+    this.ownership =
+        new ExpandableField<Account.Ownership>(expandableObject.getId(), expandableObject);
+  }
+
+  /** Retrieves the details of an Financial Connections <code>Account</code>. */
+  public static com.stripe.model.financialconnections.Account retrieve(String account)
+      throws StripeException {
+    return retrieve(account, (Map<String, Object>) null, (RequestOptions) null);
+  }
+
+  /** Retrieves the details of an Financial Connections <code>Account</code>. */
+  public static com.stripe.model.financialconnections.Account retrieve(
+      String account, RequestOptions options) throws StripeException {
+    return retrieve(account, (Map<String, Object>) null, options);
+  }
+
+  /** Retrieves the details of an Financial Connections <code>Account</code>. */
+  public static com.stripe.model.financialconnections.Account retrieve(
+      String account, Map<String, Object> params, RequestOptions options) throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/financial_connections/accounts/%s", ApiResource.urlEncodeId(account)));
+    return ApiResource.request(
+        ApiResource.RequestMethod.GET,
+        url,
+        params,
+        com.stripe.model.financialconnections.Account.class,
+        options);
+  }
+
+  /** Retrieves the details of an Financial Connections <code>Account</code>. */
+  public static com.stripe.model.financialconnections.Account retrieve(
+      String account, AccountRetrieveParams params, RequestOptions options) throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/financial_connections/accounts/%s", ApiResource.urlEncodeId(account)));
+    return ApiResource.request(
+        ApiResource.RequestMethod.GET,
+        url,
+        params,
+        com.stripe.model.financialconnections.Account.class,
+        options);
+  }
+
+  /** Refreshes the data associated with a Financial Connections <code>Account</code>. */
+  public static com.stripe.model.financialconnections.Account refresh(
+      String account, Map<String, Object> params, RequestOptions options) throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/financial_connections/accounts/%s/refresh", ApiResource.urlEncodeId(account)));
+    return ApiResource.request(
+        ApiResource.RequestMethod.POST,
+        url,
+        params,
+        com.stripe.model.financialconnections.Account.class,
+        options);
+  }
+
+  /** Refreshes the data associated with a Financial Connections <code>Account</code>. */
+  public static com.stripe.model.financialconnections.Account refresh(
+      String account, AccountRefreshParams params, RequestOptions options) throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/financial_connections/accounts/%s/refresh", ApiResource.urlEncodeId(account)));
+    return ApiResource.request(
+        ApiResource.RequestMethod.POST,
+        url,
+        params,
+        com.stripe.model.financialconnections.Account.class,
+        options);
+  }
+
+  /**
+   * Disables your access to a Financial Connections <code>Account</code>. You will no longer be
+   * able to access data associated with the account (e.g. balances, transactions).
+   */
+  public static com.stripe.model.financialconnections.Account disconnect(
+      String account, Map<String, Object> params, RequestOptions options) throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/financial_connections/accounts/%s/disconnect",
+                ApiResource.urlEncodeId(account)));
+    return ApiResource.request(
+        ApiResource.RequestMethod.POST,
+        url,
+        params,
+        com.stripe.model.financialconnections.Account.class,
+        options);
+  }
+
+  /**
+   * Disables your access to a Financial Connections <code>Account</code>. You will no longer be
+   * able to access data associated with the account (e.g. balances, transactions).
+   */
+  public static com.stripe.model.financialconnections.Account disconnect(
+      String account, AccountDisconnectParams params, RequestOptions options)
+      throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/financial_connections/accounts/%s/disconnect",
+                ApiResource.urlEncodeId(account)));
+    return ApiResource.request(
+        ApiResource.RequestMethod.POST,
+        url,
+        params,
+        com.stripe.model.financialconnections.Account.class,
+        options);
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class AccountHolder extends StripeObject {
+    /**
+     * The ID of the Stripe account this account belongs to. Should only be present if {@code
+     * account_holder.type} is {@code account}.
+     */
+    @SerializedName("account")
+    @Getter(lombok.AccessLevel.NONE)
+    @Setter(lombok.AccessLevel.NONE)
+    ExpandableField<com.stripe.model.Account> account;
+
+    /**
+     * ID of the Stripe customer this account belongs to. Present if and only if {@code
+     * account_holder.type} is {@code customer}.
+     */
+    @SerializedName("customer")
+    @Getter(lombok.AccessLevel.NONE)
+    @Setter(lombok.AccessLevel.NONE)
+    ExpandableField<Customer> customer;
+
+    /**
+     * Type of account holder that this account belongs to.
+     *
+     * <p>One of {@code account}, or {@code customer}.
+     */
+    @SerializedName("type")
+    String type;
+
+    /** Get ID of expandable {@code account} object. */
+    public String getAccount() {
+      return (this.account != null) ? this.account.getId() : null;
+    }
+
+    public void setAccount(String id) {
+      this.account = ApiResource.setExpandableFieldId(id, this.account);
+    }
+
+    /** Get expanded {@code account}. */
+    public com.stripe.model.Account getAccountObject() {
+      return (this.account != null) ? this.account.getExpanded() : null;
+    }
+
+    public void setAccountObject(com.stripe.model.Account expandableObject) {
+      this.account =
+          new ExpandableField<com.stripe.model.Account>(expandableObject.getId(), expandableObject);
+    }
+
+    /** Get ID of expandable {@code customer} object. */
+    public String getCustomer() {
+      return (this.customer != null) ? this.customer.getId() : null;
+    }
+
+    public void setCustomer(String id) {
+      this.customer = ApiResource.setExpandableFieldId(id, this.customer);
+    }
+
+    /** Get expanded {@code customer}. */
+    public Customer getCustomerObject() {
+      return (this.customer != null) ? this.customer.getExpanded() : null;
+    }
+
+    public void setCustomerObject(Customer expandableObject) {
+      this.customer = new ExpandableField<Customer>(expandableObject.getId(), expandableObject);
+    }
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class Balance extends StripeObject {
+    /**
+     * The time that the external institution calculated this balance. Measured in seconds since the
+     * Unix epoch.
+     */
+    @SerializedName("as_of")
+    Long asOf;
+
+    @SerializedName("cash")
+    CashBalance cash;
+
+    @SerializedName("credit")
+    CreditBalance credit;
+
+    /**
+     * The balances owed to (or by) the account holder.
+     *
+     * <p>Each key is a three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO
+     * currency code</a>, in lowercase.
+     *
+     * <p>Each value is a integer amount. A positive amount indicates money owed to the account
+     * holder. A negative amount indicates money owed by the account holder.
+     */
+    @SerializedName("current")
+    Map<String, Long> current;
+
+    /**
+     * The {@code type} of the balance. An additional hash is included on the balance with a name
+     * matching this value.
+     *
+     * <p>One of {@code cash}, or {@code credit}.
+     */
+    @SerializedName("type")
+    String type;
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class CashBalance extends StripeObject {
+      /**
+       * The funds available to the account holder. Typically this is the current balance less any
+       * holds.
+       *
+       * <p>Each key is a three-letter <a
+       * href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency code</a>, in
+       * lowercase.
+       *
+       * <p>Each value is a integer amount. A positive amount indicates money owed to the account
+       * holder. A negative amount indicates money owed by the account holder.
+       */
+      @SerializedName("available")
+      Map<String, Long> available;
+    }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class CreditBalance extends StripeObject {
+      /**
+       * The credit that has been used by the account holder.
+       *
+       * <p>Each key is a three-letter <a
+       * href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency code</a>, in
+       * lowercase.
+       *
+       * <p>Each value is a integer amount. A positive amount indicates money owed to the account
+       * holder. A negative amount indicates money owed by the account holder.
+       */
+      @SerializedName("used")
+      Map<String, Long> used;
+    }
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class BalanceRefresh extends StripeObject {
+    /**
+     * The time at which the last refresh attempt was initiated. Measured in seconds since the Unix
+     * epoch.
+     */
+    @SerializedName("last_attempted_at")
+    Long lastAttemptedAt;
+
+    /**
+     * The status of the last refresh attempt.
+     *
+     * <p>One of {@code failed}, {@code pending}, or {@code succeeded}.
+     */
+    @SerializedName("status")
+    String status;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class Ownership extends StripeObject implements HasId {
+    /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+    @SerializedName("created")
+    Long created;
+
+    /** Unique identifier for the object. */
+    @Getter(onMethod_ = {@Override})
+    @SerializedName("id")
+    String id;
+
+    /**
+     * String representing the object's type. Objects of the same type share the same value.
+     *
+     * <p>Equal to {@code financial_connections.account_ownership}.
+     */
+    @SerializedName("object")
+    String object;
+
+    /** A paginated list of owners for this account. */
+    @SerializedName("owners")
+    AccountOwnerCollection owners;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class OwnershipRefresh extends StripeObject {
+    /**
+     * The time at which the last refresh attempt was initiated. Measured in seconds since the Unix
+     * epoch.
+     */
+    @SerializedName("last_attempted_at")
+    Long lastAttemptedAt;
+
+    /**
+     * The status of the last refresh attempt.
+     *
+     * <p>One of {@code failed}, {@code pending}, or {@code succeeded}.
+     */
+    @SerializedName("status")
+    String status;
+  }
+}

--- a/src/main/java/com/stripe/model/financialconnections/Account.java
+++ b/src/main/java/com/stripe/model/financialconnections/Account.java
@@ -4,7 +4,6 @@ package com.stripe.model.financialconnections;
 import com.google.gson.annotations.SerializedName;
 import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
-import com.stripe.model.Account;
 import com.stripe.model.Customer;
 import com.stripe.model.ExpandableField;
 import com.stripe.model.HasId;
@@ -87,7 +86,7 @@ public class Account extends ApiResource implements HasId {
   @SerializedName("ownership")
   @Getter(lombok.AccessLevel.NONE)
   @Setter(lombok.AccessLevel.NONE)
-  ExpandableField<Account.Ownership> ownership;
+  ExpandableField<AccountOwnership> ownership;
 
   /** The state of the most recent attempt to refresh the account owners. */
   @SerializedName("ownership_refresh")
@@ -137,13 +136,13 @@ public class Account extends ApiResource implements HasId {
   }
 
   /** Get expanded {@code ownership}. */
-  public Account.Ownership getOwnershipObject() {
+  public AccountOwnership getOwnershipObject() {
     return (this.ownership != null) ? this.ownership.getExpanded() : null;
   }
 
-  public void setOwnershipObject(Account.Ownership expandableObject) {
+  public void setOwnershipObject(AccountOwnership expandableObject) {
     this.ownership =
-        new ExpandableField<Account.Ownership>(expandableObject.getId(), expandableObject);
+        new ExpandableField<AccountOwnership>(expandableObject.getId(), expandableObject);
   }
 
   /** Retrieves the details of an Financial Connections <code>Account</code>. */
@@ -431,32 +430,6 @@ public class Account extends ApiResource implements HasId {
      */
     @SerializedName("status")
     String status;
-  }
-
-  @Getter
-  @Setter
-  @EqualsAndHashCode(callSuper = false)
-  public static class Ownership extends StripeObject implements HasId {
-    /** Time at which the object was created. Measured in seconds since the Unix epoch. */
-    @SerializedName("created")
-    Long created;
-
-    /** Unique identifier for the object. */
-    @Getter(onMethod_ = {@Override})
-    @SerializedName("id")
-    String id;
-
-    /**
-     * String representing the object's type. Objects of the same type share the same value.
-     *
-     * <p>Equal to {@code financial_connections.account_ownership}.
-     */
-    @SerializedName("object")
-    String object;
-
-    /** A paginated list of owners for this account. */
-    @SerializedName("owners")
-    AccountOwnerCollection owners;
   }
 
   @Getter

--- a/src/main/java/com/stripe/model/financialconnections/AccountCollection.java
+++ b/src/main/java/com/stripe/model/financialconnections/AccountCollection.java
@@ -1,0 +1,6 @@
+// File generated from our OpenAPI spec
+package com.stripe.model.financialconnections;
+
+import com.stripe.model.StripeCollection;
+
+public class AccountCollection extends StripeCollection<Account> {}

--- a/src/main/java/com/stripe/model/financialconnections/AccountOwner.java
+++ b/src/main/java/com/stripe/model/financialconnections/AccountOwner.java
@@ -16,6 +16,7 @@ public class AccountOwner extends StripeObject implements HasId {
   @SerializedName("email")
   String email;
 
+  /** Unique identifier for the object. */
   @Getter(onMethod_ = {@Override})
   @SerializedName("id")
   String id;
@@ -24,6 +25,11 @@ public class AccountOwner extends StripeObject implements HasId {
   @SerializedName("name")
   String name;
 
+  /**
+   * String representing the object's type. Objects of the same type share the same value.
+   *
+   * <p>Equal to {@code financial_connections.account_owner}.
+   */
   @SerializedName("object")
   String object;
 

--- a/src/main/java/com/stripe/model/financialconnections/AccountOwner.java
+++ b/src/main/java/com/stripe/model/financialconnections/AccountOwner.java
@@ -2,6 +2,7 @@
 package com.stripe.model.financialconnections;
 
 import com.google.gson.annotations.SerializedName;
+import com.stripe.model.HasId;
 import com.stripe.model.StripeObject;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -10,10 +11,14 @@ import lombok.Setter;
 @Getter
 @Setter
 @EqualsAndHashCode(callSuper = false)
-public class AccountOwner extends StripeObject {
+public class AccountOwner extends StripeObject implements HasId {
   /** The email address of the owner. */
   @SerializedName("email")
   String email;
+
+  @Getter(onMethod_ = {@Override})
+  @SerializedName("id")
+  String id;
 
   /** The full name of the owner. */
   @SerializedName("name")

--- a/src/main/java/com/stripe/model/financialconnections/AccountOwner.java
+++ b/src/main/java/com/stripe/model/financialconnections/AccountOwner.java
@@ -1,0 +1,37 @@
+// File generated from our OpenAPI spec
+package com.stripe.model.financialconnections;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.model.StripeObject;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
+public class AccountOwner extends StripeObject {
+  /** The email address of the owner. */
+  @SerializedName("email")
+  String email;
+
+  /** The full name of the owner. */
+  @SerializedName("name")
+  String name;
+
+  /** The ownership object that this owner belongs to. */
+  @SerializedName("ownership")
+  String ownership;
+
+  /** The raw phone number of the owner. */
+  @SerializedName("phone")
+  String phone;
+
+  /** The raw physical address of the owner. */
+  @SerializedName("raw_address")
+  String rawAddress;
+
+  /** The timestamp of the refresh that updated this owner. */
+  @SerializedName("refreshed_at")
+  Long refreshedAt;
+}

--- a/src/main/java/com/stripe/model/financialconnections/AccountOwner.java
+++ b/src/main/java/com/stripe/model/financialconnections/AccountOwner.java
@@ -19,6 +19,9 @@ public class AccountOwner extends StripeObject {
   @SerializedName("name")
   String name;
 
+  @SerializedName("object")
+  String object;
+
   /** The ownership object that this owner belongs to. */
   @SerializedName("ownership")
   String ownership;

--- a/src/main/java/com/stripe/model/financialconnections/AccountOwnerCollection.java
+++ b/src/main/java/com/stripe/model/financialconnections/AccountOwnerCollection.java
@@ -1,0 +1,6 @@
+// File generated from our OpenAPI spec
+package com.stripe.model.financialconnections;
+
+import com.stripe.model.StripeCollection;
+
+public class AccountOwnerCollection extends StripeCollection<AccountOwner> {}

--- a/src/main/java/com/stripe/model/financialconnections/AccountOwnership.java
+++ b/src/main/java/com/stripe/model/financialconnections/AccountOwnership.java
@@ -1,0 +1,35 @@
+// File generated from our OpenAPI spec
+package com.stripe.model.financialconnections;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.model.HasId;
+import com.stripe.model.StripeObject;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
+public class AccountOwnership extends StripeObject implements HasId {
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  @SerializedName("created")
+  Long created;
+
+  /** Unique identifier for the object. */
+  @Getter(onMethod_ = {@Override})
+  @SerializedName("id")
+  String id;
+
+  /**
+   * String representing the object's type. Objects of the same type share the same value.
+   *
+   * <p>Equal to {@code financial_connections.account_ownership}.
+   */
+  @SerializedName("object")
+  String object;
+
+  /** A paginated list of owners for this account. */
+  @SerializedName("owners")
+  AccountOwnerCollection owners;
+}

--- a/src/main/java/com/stripe/model/financialconnections/Session.java
+++ b/src/main/java/com/stripe/model/financialconnections/Session.java
@@ -1,0 +1,217 @@
+// File generated from our OpenAPI spec
+package com.stripe.model.financialconnections;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.Stripe;
+import com.stripe.exception.StripeException;
+import com.stripe.model.Account;
+import com.stripe.model.Customer;
+import com.stripe.model.ExpandableField;
+import com.stripe.model.HasId;
+import com.stripe.model.StripeObject;
+import com.stripe.net.ApiResource;
+import com.stripe.net.RequestOptions;
+import com.stripe.param.financialconnections.SessionCreateParams;
+import com.stripe.param.financialconnections.SessionRetrieveParams;
+import java.util.List;
+import java.util.Map;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
+public class Session extends ApiResource implements HasId {
+  /** The account holder for whom accounts are collected in this session. */
+  @SerializedName("account_holder")
+  AccountHolder accountHolder;
+
+  /** The accounts that were collected as part of this Session. */
+  @SerializedName("accounts")
+  AccountCollection accounts;
+
+  /** A value that will be passed to the client to launch the authentication flow. */
+  @SerializedName("client_secret")
+  String clientSecret;
+
+  @SerializedName("filters")
+  Filters filters;
+
+  /** Unique identifier for the object. */
+  @Getter(onMethod_ = {@Override})
+  @SerializedName("id")
+  String id;
+
+  /**
+   * Has the value {@code true} if the object exists in live mode or the value {@code false} if the
+   * object exists in test mode.
+   */
+  @SerializedName("livemode")
+  Boolean livemode;
+
+  /**
+   * String representing the object's type. Objects of the same type share the same value.
+   *
+   * <p>Equal to {@code financial_connections.session}.
+   */
+  @SerializedName("object")
+  String object;
+
+  /** Permissions requested for accounts collected during this session. */
+  @SerializedName("permissions")
+  List<String> permissions;
+
+  /**
+   * For webview integrations only. Upon completing OAuth login in the native browser, the user will
+   * be redirected to this URL to return to your app.
+   */
+  @SerializedName("return_url")
+  String returnUrl;
+
+  /**
+   * To launch the Financial Connections authorization flow, create a <code>Session</code>. The
+   * session’s <code>client_secret</code> can be used to launch the flow using Stripe.js.
+   */
+  public static Session create(Map<String, Object> params) throws StripeException {
+    return create(params, (RequestOptions) null);
+  }
+
+  /**
+   * To launch the Financial Connections authorization flow, create a <code>Session</code>. The
+   * session’s <code>client_secret</code> can be used to launch the flow using Stripe.js.
+   */
+  public static Session create(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/financial_connections/sessions");
+    return ApiResource.request(ApiResource.RequestMethod.POST, url, params, Session.class, options);
+  }
+
+  /**
+   * To launch the Financial Connections authorization flow, create a <code>Session</code>. The
+   * session’s <code>client_secret</code> can be used to launch the flow using Stripe.js.
+   */
+  public static Session create(SessionCreateParams params) throws StripeException {
+    return create(params, (RequestOptions) null);
+  }
+
+  /**
+   * To launch the Financial Connections authorization flow, create a <code>Session</code>. The
+   * session’s <code>client_secret</code> can be used to launch the flow using Stripe.js.
+   */
+  public static Session create(SessionCreateParams params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/financial_connections/sessions");
+    return ApiResource.request(ApiResource.RequestMethod.POST, url, params, Session.class, options);
+  }
+
+  /** Retrieves the details of a Financial Connections <code>Session</code>. */
+  public static Session retrieve(String session) throws StripeException {
+    return retrieve(session, (Map<String, Object>) null, (RequestOptions) null);
+  }
+
+  /** Retrieves the details of a Financial Connections <code>Session</code>. */
+  public static Session retrieve(String session, RequestOptions options) throws StripeException {
+    return retrieve(session, (Map<String, Object>) null, options);
+  }
+
+  /** Retrieves the details of a Financial Connections <code>Session</code>. */
+  public static Session retrieve(String session, Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/financial_connections/sessions/%s", ApiResource.urlEncodeId(session)));
+    return ApiResource.request(ApiResource.RequestMethod.GET, url, params, Session.class, options);
+  }
+
+  /** Retrieves the details of a Financial Connections <code>Session</code>. */
+  public static Session retrieve(
+      String session, SessionRetrieveParams params, RequestOptions options) throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/financial_connections/sessions/%s", ApiResource.urlEncodeId(session)));
+    return ApiResource.request(ApiResource.RequestMethod.GET, url, params, Session.class, options);
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class AccountHolder extends StripeObject {
+    /**
+     * The ID of the Stripe account this account belongs to. Should only be present if {@code
+     * account_holder.type} is {@code account}.
+     */
+    @SerializedName("account")
+    @Getter(lombok.AccessLevel.NONE)
+    @Setter(lombok.AccessLevel.NONE)
+    ExpandableField<Account> account;
+
+    /**
+     * ID of the Stripe customer this account belongs to. Present if and only if {@code
+     * account_holder.type} is {@code customer}.
+     */
+    @SerializedName("customer")
+    @Getter(lombok.AccessLevel.NONE)
+    @Setter(lombok.AccessLevel.NONE)
+    ExpandableField<Customer> customer;
+
+    /**
+     * Type of account holder that this account belongs to.
+     *
+     * <p>One of {@code account}, or {@code customer}.
+     */
+    @SerializedName("type")
+    String type;
+
+    /** Get ID of expandable {@code account} object. */
+    public String getAccount() {
+      return (this.account != null) ? this.account.getId() : null;
+    }
+
+    public void setAccount(String id) {
+      this.account = ApiResource.setExpandableFieldId(id, this.account);
+    }
+
+    /** Get expanded {@code account}. */
+    public Account getAccountObject() {
+      return (this.account != null) ? this.account.getExpanded() : null;
+    }
+
+    public void setAccountObject(Account expandableObject) {
+      this.account = new ExpandableField<Account>(expandableObject.getId(), expandableObject);
+    }
+
+    /** Get ID of expandable {@code customer} object. */
+    public String getCustomer() {
+      return (this.customer != null) ? this.customer.getId() : null;
+    }
+
+    public void setCustomer(String id) {
+      this.customer = ApiResource.setExpandableFieldId(id, this.customer);
+    }
+
+    /** Get expanded {@code customer}. */
+    public Customer getCustomerObject() {
+      return (this.customer != null) ? this.customer.getExpanded() : null;
+    }
+
+    public void setCustomerObject(Customer expandableObject) {
+      this.customer = new ExpandableField<Customer>(expandableObject.getId(), expandableObject);
+    }
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class Filters extends StripeObject {
+    /** List of countries from which to filter accounts. */
+    @SerializedName("countries")
+    List<String> countries;
+  }
+}

--- a/src/main/java/com/stripe/param/InvoiceCreateParams.java
+++ b/src/main/java/com/stripe/param/InvoiceCreateParams.java
@@ -2003,13 +2003,20 @@ public class InvoiceCreateParams extends ApiRequestParams {
         @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
         Map<String, Object> extraParams;
 
+        /** Additional fields for Financial Connections Session creation. */
+        @SerializedName("financial_connections")
+        FinancialConnections financialConnections;
+
         /** Verification method for the intent. */
         @SerializedName("verification_method")
         VerificationMethod verificationMethod;
 
         private UsBankAccount(
-            Map<String, Object> extraParams, VerificationMethod verificationMethod) {
+            Map<String, Object> extraParams,
+            FinancialConnections financialConnections,
+            VerificationMethod verificationMethod) {
           this.extraParams = extraParams;
+          this.financialConnections = financialConnections;
           this.verificationMethod = verificationMethod;
         }
 
@@ -2020,11 +2027,14 @@ public class InvoiceCreateParams extends ApiRequestParams {
         public static class Builder {
           private Map<String, Object> extraParams;
 
+          private FinancialConnections financialConnections;
+
           private VerificationMethod verificationMethod;
 
           /** Finalize and obtain parameter instance from this builder. */
           public UsBankAccount build() {
-            return new UsBankAccount(this.extraParams, this.verificationMethod);
+            return new UsBankAccount(
+                this.extraParams, this.financialConnections, this.verificationMethod);
           }
 
           /**
@@ -2057,10 +2067,139 @@ public class InvoiceCreateParams extends ApiRequestParams {
             return this;
           }
 
+          /** Additional fields for Financial Connections Session creation. */
+          public Builder setFinancialConnections(FinancialConnections financialConnections) {
+            this.financialConnections = financialConnections;
+            return this;
+          }
+
           /** Verification method for the intent. */
           public Builder setVerificationMethod(VerificationMethod verificationMethod) {
             this.verificationMethod = verificationMethod;
             return this;
+          }
+        }
+
+        @Getter
+        public static class FinancialConnections {
+          /**
+           * Map of extra parameters for custom features not available in this client library. The
+           * content in this map is not serialized under this field's {@code @SerializedName} value.
+           * Instead, each key/value pair is serialized as if the key is a root-level field
+           * (serialized) name in this param object. Effectively, this map is flattened to its
+           * parent instance.
+           */
+          @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+          Map<String, Object> extraParams;
+
+          /**
+           * The list of permissions to request. If this parameter is passed, the {@code
+           * payment_method} permission must be included. Valid permissions include: {@code
+           * balances}, {@code payment_method}, and {@code transactions}.
+           */
+          @SerializedName("permissions")
+          List<Permission> permissions;
+
+          private FinancialConnections(
+              Map<String, Object> extraParams, List<Permission> permissions) {
+            this.extraParams = extraParams;
+            this.permissions = permissions;
+          }
+
+          public static Builder builder() {
+            return new Builder();
+          }
+
+          public static class Builder {
+            private Map<String, Object> extraParams;
+
+            private List<Permission> permissions;
+
+            /** Finalize and obtain parameter instance from this builder. */
+            public FinancialConnections build() {
+              return new FinancialConnections(this.extraParams, this.permissions);
+            }
+
+            /**
+             * Add a key/value pair to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections#extraParams}
+             * for the field documentation.
+             */
+            public Builder putExtraParam(String key, Object value) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.put(key, value);
+              return this;
+            }
+
+            /**
+             * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections#extraParams}
+             * for the field documentation.
+             */
+            public Builder putAllExtraParam(Map<String, Object> map) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.putAll(map);
+              return this;
+            }
+
+            /**
+             * Add an element to `permissions` list. A list is initialized for the first
+             * `add/addAll` call, and subsequent calls adds additional elements to the original
+             * list. See {@link
+             * InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections#permissions}
+             * for the field documentation.
+             */
+            public Builder addPermission(Permission element) {
+              if (this.permissions == null) {
+                this.permissions = new ArrayList<>();
+              }
+              this.permissions.add(element);
+              return this;
+            }
+
+            /**
+             * Add all elements to `permissions` list. A list is initialized for the first
+             * `add/addAll` call, and subsequent calls adds additional elements to the original
+             * list. See {@link
+             * InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections#permissions}
+             * for the field documentation.
+             */
+            public Builder addAllPermission(List<Permission> elements) {
+              if (this.permissions == null) {
+                this.permissions = new ArrayList<>();
+              }
+              this.permissions.addAll(elements);
+              return this;
+            }
+          }
+
+          public enum Permission implements ApiRequestParams.EnumParam {
+            @SerializedName("balances")
+            BALANCES("balances"),
+
+            @SerializedName("ownership")
+            OWNERSHIP("ownership"),
+
+            @SerializedName("payment_method")
+            PAYMENT_METHOD("payment_method"),
+
+            @SerializedName("transactions")
+            TRANSACTIONS("transactions");
+
+            @Getter(onMethod_ = {@Override})
+            private final String value;
+
+            Permission(String value) {
+              this.value = value;
+            }
           }
         }
 

--- a/src/main/java/com/stripe/param/InvoiceUpdateParams.java
+++ b/src/main/java/com/stripe/param/InvoiceUpdateParams.java
@@ -2074,13 +2074,20 @@ public class InvoiceUpdateParams extends ApiRequestParams {
         @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
         Map<String, Object> extraParams;
 
+        /** Additional fields for Financial Connections Session creation. */
+        @SerializedName("financial_connections")
+        FinancialConnections financialConnections;
+
         /** Verification method for the intent. */
         @SerializedName("verification_method")
         VerificationMethod verificationMethod;
 
         private UsBankAccount(
-            Map<String, Object> extraParams, VerificationMethod verificationMethod) {
+            Map<String, Object> extraParams,
+            FinancialConnections financialConnections,
+            VerificationMethod verificationMethod) {
           this.extraParams = extraParams;
+          this.financialConnections = financialConnections;
           this.verificationMethod = verificationMethod;
         }
 
@@ -2091,11 +2098,14 @@ public class InvoiceUpdateParams extends ApiRequestParams {
         public static class Builder {
           private Map<String, Object> extraParams;
 
+          private FinancialConnections financialConnections;
+
           private VerificationMethod verificationMethod;
 
           /** Finalize and obtain parameter instance from this builder. */
           public UsBankAccount build() {
-            return new UsBankAccount(this.extraParams, this.verificationMethod);
+            return new UsBankAccount(
+                this.extraParams, this.financialConnections, this.verificationMethod);
           }
 
           /**
@@ -2128,10 +2138,139 @@ public class InvoiceUpdateParams extends ApiRequestParams {
             return this;
           }
 
+          /** Additional fields for Financial Connections Session creation. */
+          public Builder setFinancialConnections(FinancialConnections financialConnections) {
+            this.financialConnections = financialConnections;
+            return this;
+          }
+
           /** Verification method for the intent. */
           public Builder setVerificationMethod(VerificationMethod verificationMethod) {
             this.verificationMethod = verificationMethod;
             return this;
+          }
+        }
+
+        @Getter
+        public static class FinancialConnections {
+          /**
+           * Map of extra parameters for custom features not available in this client library. The
+           * content in this map is not serialized under this field's {@code @SerializedName} value.
+           * Instead, each key/value pair is serialized as if the key is a root-level field
+           * (serialized) name in this param object. Effectively, this map is flattened to its
+           * parent instance.
+           */
+          @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+          Map<String, Object> extraParams;
+
+          /**
+           * The list of permissions to request. If this parameter is passed, the {@code
+           * payment_method} permission must be included. Valid permissions include: {@code
+           * balances}, {@code payment_method}, and {@code transactions}.
+           */
+          @SerializedName("permissions")
+          List<Permission> permissions;
+
+          private FinancialConnections(
+              Map<String, Object> extraParams, List<Permission> permissions) {
+            this.extraParams = extraParams;
+            this.permissions = permissions;
+          }
+
+          public static Builder builder() {
+            return new Builder();
+          }
+
+          public static class Builder {
+            private Map<String, Object> extraParams;
+
+            private List<Permission> permissions;
+
+            /** Finalize and obtain parameter instance from this builder. */
+            public FinancialConnections build() {
+              return new FinancialConnections(this.extraParams, this.permissions);
+            }
+
+            /**
+             * Add a key/value pair to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections#extraParams}
+             * for the field documentation.
+             */
+            public Builder putExtraParam(String key, Object value) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.put(key, value);
+              return this;
+            }
+
+            /**
+             * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections#extraParams}
+             * for the field documentation.
+             */
+            public Builder putAllExtraParam(Map<String, Object> map) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.putAll(map);
+              return this;
+            }
+
+            /**
+             * Add an element to `permissions` list. A list is initialized for the first
+             * `add/addAll` call, and subsequent calls adds additional elements to the original
+             * list. See {@link
+             * InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections#permissions}
+             * for the field documentation.
+             */
+            public Builder addPermission(Permission element) {
+              if (this.permissions == null) {
+                this.permissions = new ArrayList<>();
+              }
+              this.permissions.add(element);
+              return this;
+            }
+
+            /**
+             * Add all elements to `permissions` list. A list is initialized for the first
+             * `add/addAll` call, and subsequent calls adds additional elements to the original
+             * list. See {@link
+             * InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections#permissions}
+             * for the field documentation.
+             */
+            public Builder addAllPermission(List<Permission> elements) {
+              if (this.permissions == null) {
+                this.permissions = new ArrayList<>();
+              }
+              this.permissions.addAll(elements);
+              return this;
+            }
+          }
+
+          public enum Permission implements ApiRequestParams.EnumParam {
+            @SerializedName("balances")
+            BALANCES("balances"),
+
+            @SerializedName("ownership")
+            OWNERSHIP("ownership"),
+
+            @SerializedName("payment_method")
+            PAYMENT_METHOD("payment_method"),
+
+            @SerializedName("transactions")
+            TRANSACTIONS("transactions");
+
+            @Getter(onMethod_ = {@Override})
+            private final String value;
+
+            Permission(String value) {
+              this.value = value;
+            }
           }
         }
 

--- a/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
@@ -3574,6 +3574,10 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
       Map<String, Object> extraParams;
 
+      /** The ID of a Financial Connections Account to use as a payment method. */
+      @SerializedName("financial_connections_account")
+      String financialConnectionsAccount;
+
       /** Routing number of the bank account. */
       @SerializedName("routing_number")
       String routingNumber;
@@ -3583,11 +3587,13 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
           String accountNumber,
           AccountType accountType,
           Map<String, Object> extraParams,
+          String financialConnectionsAccount,
           String routingNumber) {
         this.accountHolderType = accountHolderType;
         this.accountNumber = accountNumber;
         this.accountType = accountType;
         this.extraParams = extraParams;
+        this.financialConnectionsAccount = financialConnectionsAccount;
         this.routingNumber = routingNumber;
       }
 
@@ -3604,6 +3610,8 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
 
         private Map<String, Object> extraParams;
 
+        private String financialConnectionsAccount;
+
         private String routingNumber;
 
         /** Finalize and obtain parameter instance from this builder. */
@@ -3613,6 +3621,7 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
               this.accountNumber,
               this.accountType,
               this.extraParams,
+              this.financialConnectionsAccount,
               this.routingNumber);
         }
 
@@ -3659,6 +3668,12 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
             this.extraParams = new HashMap<>();
           }
           this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** The ID of a Financial Connections Account to use as a payment method. */
+        public Builder setFinancialConnectionsAccount(String financialConnectionsAccount) {
+          this.financialConnectionsAccount = financialConnectionsAccount;
           return this;
         }
 
@@ -9471,6 +9486,10 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
       Map<String, Object> extraParams;
 
+      /** Additional fields for Financial Connections Session creation. */
+      @SerializedName("financial_connections")
+      FinancialConnections financialConnections;
+
       /**
        * Indicates that you intend to make future payments with this PaymentIntent's payment method.
        *
@@ -9499,9 +9518,11 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
 
       private UsBankAccount(
           Map<String, Object> extraParams,
+          FinancialConnections financialConnections,
           EnumParam setupFutureUsage,
           VerificationMethod verificationMethod) {
         this.extraParams = extraParams;
+        this.financialConnections = financialConnections;
         this.setupFutureUsage = setupFutureUsage;
         this.verificationMethod = verificationMethod;
       }
@@ -9513,6 +9534,8 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       public static class Builder {
         private Map<String, Object> extraParams;
 
+        private FinancialConnections financialConnections;
+
         private EnumParam setupFutureUsage;
 
         private VerificationMethod verificationMethod;
@@ -9520,7 +9543,10 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
         /** Finalize and obtain parameter instance from this builder. */
         public UsBankAccount build() {
           return new UsBankAccount(
-              this.extraParams, this.setupFutureUsage, this.verificationMethod);
+              this.extraParams,
+              this.financialConnections,
+              this.setupFutureUsage,
+              this.verificationMethod);
         }
 
         /**
@@ -9550,6 +9576,12 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
             this.extraParams = new HashMap<>();
           }
           this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Additional fields for Financial Connections Session creation. */
+        public Builder setFinancialConnections(FinancialConnections financialConnections) {
+          this.financialConnections = financialConnections;
           return this;
         }
 
@@ -9607,6 +9639,147 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
         public Builder setVerificationMethod(VerificationMethod verificationMethod) {
           this.verificationMethod = verificationMethod;
           return this;
+        }
+      }
+
+      @Getter
+      public static class FinancialConnections {
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /**
+         * The list of permissions to request. If this parameter is passed, the {@code
+         * payment_method} permission must be included. Valid permissions include: {@code balances},
+         * {@code payment_method}, and {@code transactions}.
+         */
+        @SerializedName("permissions")
+        List<Permission> permissions;
+
+        /**
+         * For webview integrations only. Upon completing OAuth login in the native browser, the
+         * user will be redirected to this URL to return to your app.
+         */
+        @SerializedName("return_url")
+        String returnUrl;
+
+        private FinancialConnections(
+            Map<String, Object> extraParams, List<Permission> permissions, String returnUrl) {
+          this.extraParams = extraParams;
+          this.permissions = permissions;
+          this.returnUrl = returnUrl;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Map<String, Object> extraParams;
+
+          private List<Permission> permissions;
+
+          private String returnUrl;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public FinancialConnections build() {
+            return new FinancialConnections(this.extraParams, this.permissions, this.returnUrl);
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * PaymentIntentConfirmParams.PaymentMethodOptions.UsBankAccount.FinancialConnections#extraParams}
+           * for the field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * PaymentIntentConfirmParams.PaymentMethodOptions.UsBankAccount.FinancialConnections#extraParams}
+           * for the field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /**
+           * Add an element to `permissions` list. A list is initialized for the first `add/addAll`
+           * call, and subsequent calls adds additional elements to the original list. See {@link
+           * PaymentIntentConfirmParams.PaymentMethodOptions.UsBankAccount.FinancialConnections#permissions}
+           * for the field documentation.
+           */
+          public Builder addPermission(Permission element) {
+            if (this.permissions == null) {
+              this.permissions = new ArrayList<>();
+            }
+            this.permissions.add(element);
+            return this;
+          }
+
+          /**
+           * Add all elements to `permissions` list. A list is initialized for the first
+           * `add/addAll` call, and subsequent calls adds additional elements to the original list.
+           * See {@link
+           * PaymentIntentConfirmParams.PaymentMethodOptions.UsBankAccount.FinancialConnections#permissions}
+           * for the field documentation.
+           */
+          public Builder addAllPermission(List<Permission> elements) {
+            if (this.permissions == null) {
+              this.permissions = new ArrayList<>();
+            }
+            this.permissions.addAll(elements);
+            return this;
+          }
+
+          /**
+           * For webview integrations only. Upon completing OAuth login in the native browser, the
+           * user will be redirected to this URL to return to your app.
+           */
+          public Builder setReturnUrl(String returnUrl) {
+            this.returnUrl = returnUrl;
+            return this;
+          }
+        }
+
+        public enum Permission implements ApiRequestParams.EnumParam {
+          @SerializedName("balances")
+          BALANCES("balances"),
+
+          @SerializedName("ownership")
+          OWNERSHIP("ownership"),
+
+          @SerializedName("payment_method")
+          PAYMENT_METHOD("payment_method"),
+
+          @SerializedName("transactions")
+          TRANSACTIONS("transactions");
+
+          @Getter(onMethod_ = {@Override})
+          private final String value;
+
+          Permission(String value) {
+            this.value = value;
+          }
         }
       }
 

--- a/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
@@ -4036,6 +4036,10 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
       Map<String, Object> extraParams;
 
+      /** The ID of a Financial Connections Account to use as a payment method. */
+      @SerializedName("financial_connections_account")
+      String financialConnectionsAccount;
+
       /** Routing number of the bank account. */
       @SerializedName("routing_number")
       String routingNumber;
@@ -4045,11 +4049,13 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
           String accountNumber,
           AccountType accountType,
           Map<String, Object> extraParams,
+          String financialConnectionsAccount,
           String routingNumber) {
         this.accountHolderType = accountHolderType;
         this.accountNumber = accountNumber;
         this.accountType = accountType;
         this.extraParams = extraParams;
+        this.financialConnectionsAccount = financialConnectionsAccount;
         this.routingNumber = routingNumber;
       }
 
@@ -4066,6 +4072,8 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
 
         private Map<String, Object> extraParams;
 
+        private String financialConnectionsAccount;
+
         private String routingNumber;
 
         /** Finalize and obtain parameter instance from this builder. */
@@ -4075,6 +4083,7 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
               this.accountNumber,
               this.accountType,
               this.extraParams,
+              this.financialConnectionsAccount,
               this.routingNumber);
         }
 
@@ -4121,6 +4130,12 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
             this.extraParams = new HashMap<>();
           }
           this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** The ID of a Financial Connections Account to use as a payment method. */
+        public Builder setFinancialConnectionsAccount(String financialConnectionsAccount) {
+          this.financialConnectionsAccount = financialConnectionsAccount;
           return this;
         }
 
@@ -9933,6 +9948,10 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
       Map<String, Object> extraParams;
 
+      /** Additional fields for Financial Connections Session creation. */
+      @SerializedName("financial_connections")
+      FinancialConnections financialConnections;
+
       /**
        * Indicates that you intend to make future payments with this PaymentIntent's payment method.
        *
@@ -9961,9 +9980,11 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
 
       private UsBankAccount(
           Map<String, Object> extraParams,
+          FinancialConnections financialConnections,
           EnumParam setupFutureUsage,
           VerificationMethod verificationMethod) {
         this.extraParams = extraParams;
+        this.financialConnections = financialConnections;
         this.setupFutureUsage = setupFutureUsage;
         this.verificationMethod = verificationMethod;
       }
@@ -9975,6 +9996,8 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       public static class Builder {
         private Map<String, Object> extraParams;
 
+        private FinancialConnections financialConnections;
+
         private EnumParam setupFutureUsage;
 
         private VerificationMethod verificationMethod;
@@ -9982,7 +10005,10 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
         /** Finalize and obtain parameter instance from this builder. */
         public UsBankAccount build() {
           return new UsBankAccount(
-              this.extraParams, this.setupFutureUsage, this.verificationMethod);
+              this.extraParams,
+              this.financialConnections,
+              this.setupFutureUsage,
+              this.verificationMethod);
         }
 
         /**
@@ -10010,6 +10036,12 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
             this.extraParams = new HashMap<>();
           }
           this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Additional fields for Financial Connections Session creation. */
+        public Builder setFinancialConnections(FinancialConnections financialConnections) {
+          this.financialConnections = financialConnections;
           return this;
         }
 
@@ -10067,6 +10099,147 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
         public Builder setVerificationMethod(VerificationMethod verificationMethod) {
           this.verificationMethod = verificationMethod;
           return this;
+        }
+      }
+
+      @Getter
+      public static class FinancialConnections {
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /**
+         * The list of permissions to request. If this parameter is passed, the {@code
+         * payment_method} permission must be included. Valid permissions include: {@code balances},
+         * {@code payment_method}, and {@code transactions}.
+         */
+        @SerializedName("permissions")
+        List<Permission> permissions;
+
+        /**
+         * For webview integrations only. Upon completing OAuth login in the native browser, the
+         * user will be redirected to this URL to return to your app.
+         */
+        @SerializedName("return_url")
+        String returnUrl;
+
+        private FinancialConnections(
+            Map<String, Object> extraParams, List<Permission> permissions, String returnUrl) {
+          this.extraParams = extraParams;
+          this.permissions = permissions;
+          this.returnUrl = returnUrl;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Map<String, Object> extraParams;
+
+          private List<Permission> permissions;
+
+          private String returnUrl;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public FinancialConnections build() {
+            return new FinancialConnections(this.extraParams, this.permissions, this.returnUrl);
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * PaymentIntentCreateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections#extraParams}
+           * for the field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * PaymentIntentCreateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections#extraParams}
+           * for the field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /**
+           * Add an element to `permissions` list. A list is initialized for the first `add/addAll`
+           * call, and subsequent calls adds additional elements to the original list. See {@link
+           * PaymentIntentCreateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections#permissions}
+           * for the field documentation.
+           */
+          public Builder addPermission(Permission element) {
+            if (this.permissions == null) {
+              this.permissions = new ArrayList<>();
+            }
+            this.permissions.add(element);
+            return this;
+          }
+
+          /**
+           * Add all elements to `permissions` list. A list is initialized for the first
+           * `add/addAll` call, and subsequent calls adds additional elements to the original list.
+           * See {@link
+           * PaymentIntentCreateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections#permissions}
+           * for the field documentation.
+           */
+          public Builder addAllPermission(List<Permission> elements) {
+            if (this.permissions == null) {
+              this.permissions = new ArrayList<>();
+            }
+            this.permissions.addAll(elements);
+            return this;
+          }
+
+          /**
+           * For webview integrations only. Upon completing OAuth login in the native browser, the
+           * user will be redirected to this URL to return to your app.
+           */
+          public Builder setReturnUrl(String returnUrl) {
+            this.returnUrl = returnUrl;
+            return this;
+          }
+        }
+
+        public enum Permission implements ApiRequestParams.EnumParam {
+          @SerializedName("balances")
+          BALANCES("balances"),
+
+          @SerializedName("ownership")
+          OWNERSHIP("ownership"),
+
+          @SerializedName("payment_method")
+          PAYMENT_METHOD("payment_method"),
+
+          @SerializedName("transactions")
+          TRANSACTIONS("transactions");
+
+          @Getter(onMethod_ = {@Override})
+          private final String value;
+
+          Permission(String value) {
+            this.value = value;
+          }
         }
       }
 

--- a/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
@@ -3584,6 +3584,10 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
       Map<String, Object> extraParams;
 
+      /** The ID of a Financial Connections Account to use as a payment method. */
+      @SerializedName("financial_connections_account")
+      Object financialConnectionsAccount;
+
       /** Routing number of the bank account. */
       @SerializedName("routing_number")
       Object routingNumber;
@@ -3593,11 +3597,13 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
           Object accountNumber,
           AccountType accountType,
           Map<String, Object> extraParams,
+          Object financialConnectionsAccount,
           Object routingNumber) {
         this.accountHolderType = accountHolderType;
         this.accountNumber = accountNumber;
         this.accountType = accountType;
         this.extraParams = extraParams;
+        this.financialConnectionsAccount = financialConnectionsAccount;
         this.routingNumber = routingNumber;
       }
 
@@ -3614,6 +3620,8 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
 
         private Map<String, Object> extraParams;
 
+        private Object financialConnectionsAccount;
+
         private Object routingNumber;
 
         /** Finalize and obtain parameter instance from this builder. */
@@ -3623,6 +3631,7 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
               this.accountNumber,
               this.accountType,
               this.extraParams,
+              this.financialConnectionsAccount,
               this.routingNumber);
         }
 
@@ -3675,6 +3684,18 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
             this.extraParams = new HashMap<>();
           }
           this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** The ID of a Financial Connections Account to use as a payment method. */
+        public Builder setFinancialConnectionsAccount(String financialConnectionsAccount) {
+          this.financialConnectionsAccount = financialConnectionsAccount;
+          return this;
+        }
+
+        /** The ID of a Financial Connections Account to use as a payment method. */
+        public Builder setFinancialConnectionsAccount(EmptyParam financialConnectionsAccount) {
+          this.financialConnectionsAccount = financialConnectionsAccount;
           return this;
         }
 
@@ -9557,6 +9578,10 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
       Map<String, Object> extraParams;
 
+      /** Additional fields for Financial Connections Session creation. */
+      @SerializedName("financial_connections")
+      FinancialConnections financialConnections;
+
       /**
        * Indicates that you intend to make future payments with this PaymentIntent's payment method.
        *
@@ -9585,9 +9610,11 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
 
       private UsBankAccount(
           Map<String, Object> extraParams,
+          FinancialConnections financialConnections,
           EnumParam setupFutureUsage,
           VerificationMethod verificationMethod) {
         this.extraParams = extraParams;
+        this.financialConnections = financialConnections;
         this.setupFutureUsage = setupFutureUsage;
         this.verificationMethod = verificationMethod;
       }
@@ -9599,6 +9626,8 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       public static class Builder {
         private Map<String, Object> extraParams;
 
+        private FinancialConnections financialConnections;
+
         private EnumParam setupFutureUsage;
 
         private VerificationMethod verificationMethod;
@@ -9606,7 +9635,10 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
         /** Finalize and obtain parameter instance from this builder. */
         public UsBankAccount build() {
           return new UsBankAccount(
-              this.extraParams, this.setupFutureUsage, this.verificationMethod);
+              this.extraParams,
+              this.financialConnections,
+              this.setupFutureUsage,
+              this.verificationMethod);
         }
 
         /**
@@ -9634,6 +9666,12 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
             this.extraParams = new HashMap<>();
           }
           this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Additional fields for Financial Connections Session creation. */
+        public Builder setFinancialConnections(FinancialConnections financialConnections) {
+          this.financialConnections = financialConnections;
           return this;
         }
 
@@ -9691,6 +9729,156 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
         public Builder setVerificationMethod(VerificationMethod verificationMethod) {
           this.verificationMethod = verificationMethod;
           return this;
+        }
+      }
+
+      @Getter
+      public static class FinancialConnections {
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /**
+         * The list of permissions to request. If this parameter is passed, the {@code
+         * payment_method} permission must be included. Valid permissions include: {@code balances},
+         * {@code payment_method}, and {@code transactions}.
+         */
+        @SerializedName("permissions")
+        List<Permission> permissions;
+
+        /**
+         * For webview integrations only. Upon completing OAuth login in the native browser, the
+         * user will be redirected to this URL to return to your app.
+         */
+        @SerializedName("return_url")
+        Object returnUrl;
+
+        private FinancialConnections(
+            Map<String, Object> extraParams, List<Permission> permissions, Object returnUrl) {
+          this.extraParams = extraParams;
+          this.permissions = permissions;
+          this.returnUrl = returnUrl;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Map<String, Object> extraParams;
+
+          private List<Permission> permissions;
+
+          private Object returnUrl;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public FinancialConnections build() {
+            return new FinancialConnections(this.extraParams, this.permissions, this.returnUrl);
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * PaymentIntentUpdateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections#extraParams}
+           * for the field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * PaymentIntentUpdateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections#extraParams}
+           * for the field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /**
+           * Add an element to `permissions` list. A list is initialized for the first `add/addAll`
+           * call, and subsequent calls adds additional elements to the original list. See {@link
+           * PaymentIntentUpdateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections#permissions}
+           * for the field documentation.
+           */
+          public Builder addPermission(Permission element) {
+            if (this.permissions == null) {
+              this.permissions = new ArrayList<>();
+            }
+            this.permissions.add(element);
+            return this;
+          }
+
+          /**
+           * Add all elements to `permissions` list. A list is initialized for the first
+           * `add/addAll` call, and subsequent calls adds additional elements to the original list.
+           * See {@link
+           * PaymentIntentUpdateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections#permissions}
+           * for the field documentation.
+           */
+          public Builder addAllPermission(List<Permission> elements) {
+            if (this.permissions == null) {
+              this.permissions = new ArrayList<>();
+            }
+            this.permissions.addAll(elements);
+            return this;
+          }
+
+          /**
+           * For webview integrations only. Upon completing OAuth login in the native browser, the
+           * user will be redirected to this URL to return to your app.
+           */
+          public Builder setReturnUrl(String returnUrl) {
+            this.returnUrl = returnUrl;
+            return this;
+          }
+
+          /**
+           * For webview integrations only. Upon completing OAuth login in the native browser, the
+           * user will be redirected to this URL to return to your app.
+           */
+          public Builder setReturnUrl(EmptyParam returnUrl) {
+            this.returnUrl = returnUrl;
+            return this;
+          }
+        }
+
+        public enum Permission implements ApiRequestParams.EnumParam {
+          @SerializedName("balances")
+          BALANCES("balances"),
+
+          @SerializedName("ownership")
+          OWNERSHIP("ownership"),
+
+          @SerializedName("payment_method")
+          PAYMENT_METHOD("payment_method"),
+
+          @SerializedName("transactions")
+          TRANSACTIONS("transactions");
+
+          @Getter(onMethod_ = {@Override})
+          private final String value;
+
+          Permission(String value) {
+            this.value = value;
+          }
         }
       }
 

--- a/src/main/java/com/stripe/param/PaymentMethodCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentMethodCreateParams.java
@@ -3021,6 +3021,10 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
     @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
     Map<String, Object> extraParams;
 
+    /** The ID of a Financial Connections Account to use as a payment method. */
+    @SerializedName("financial_connections_account")
+    String financialConnectionsAccount;
+
     /** Routing number of the bank account. */
     @SerializedName("routing_number")
     String routingNumber;
@@ -3030,11 +3034,13 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
         String accountNumber,
         AccountType accountType,
         Map<String, Object> extraParams,
+        String financialConnectionsAccount,
         String routingNumber) {
       this.accountHolderType = accountHolderType;
       this.accountNumber = accountNumber;
       this.accountType = accountType;
       this.extraParams = extraParams;
+      this.financialConnectionsAccount = financialConnectionsAccount;
       this.routingNumber = routingNumber;
     }
 
@@ -3051,6 +3057,8 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
 
       private Map<String, Object> extraParams;
 
+      private String financialConnectionsAccount;
+
       private String routingNumber;
 
       /** Finalize and obtain parameter instance from this builder. */
@@ -3060,6 +3068,7 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
             this.accountNumber,
             this.accountType,
             this.extraParams,
+            this.financialConnectionsAccount,
             this.routingNumber);
       }
 
@@ -3105,6 +3114,12 @@ public class PaymentMethodCreateParams extends ApiRequestParams {
           this.extraParams = new HashMap<>();
         }
         this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** The ID of a Financial Connections Account to use as a payment method. */
+      public Builder setFinancialConnectionsAccount(String financialConnectionsAccount) {
+        this.financialConnectionsAccount = financialConnectionsAccount;
         return this;
       }
 

--- a/src/main/java/com/stripe/param/SetupIntentConfirmParams.java
+++ b/src/main/java/com/stripe/param/SetupIntentConfirmParams.java
@@ -3343,6 +3343,10 @@ public class SetupIntentConfirmParams extends ApiRequestParams {
       @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
       Map<String, Object> extraParams;
 
+      /** The ID of a Financial Connections Account to use as a payment method. */
+      @SerializedName("financial_connections_account")
+      String financialConnectionsAccount;
+
       /** Routing number of the bank account. */
       @SerializedName("routing_number")
       String routingNumber;
@@ -3352,11 +3356,13 @@ public class SetupIntentConfirmParams extends ApiRequestParams {
           String accountNumber,
           AccountType accountType,
           Map<String, Object> extraParams,
+          String financialConnectionsAccount,
           String routingNumber) {
         this.accountHolderType = accountHolderType;
         this.accountNumber = accountNumber;
         this.accountType = accountType;
         this.extraParams = extraParams;
+        this.financialConnectionsAccount = financialConnectionsAccount;
         this.routingNumber = routingNumber;
       }
 
@@ -3373,6 +3379,8 @@ public class SetupIntentConfirmParams extends ApiRequestParams {
 
         private Map<String, Object> extraParams;
 
+        private String financialConnectionsAccount;
+
         private String routingNumber;
 
         /** Finalize and obtain parameter instance from this builder. */
@@ -3382,6 +3390,7 @@ public class SetupIntentConfirmParams extends ApiRequestParams {
               this.accountNumber,
               this.accountType,
               this.extraParams,
+              this.financialConnectionsAccount,
               this.routingNumber);
         }
 
@@ -3428,6 +3437,12 @@ public class SetupIntentConfirmParams extends ApiRequestParams {
             this.extraParams = new HashMap<>();
           }
           this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** The ID of a Financial Connections Account to use as a payment method. */
+        public Builder setFinancialConnectionsAccount(String financialConnectionsAccount) {
+          this.financialConnectionsAccount = financialConnectionsAccount;
           return this;
         }
 
@@ -4732,13 +4747,20 @@ public class SetupIntentConfirmParams extends ApiRequestParams {
       @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
       Map<String, Object> extraParams;
 
+      /** Additional fields for Financial Connections Session creation. */
+      @SerializedName("financial_connections")
+      FinancialConnections financialConnections;
+
       /** Verification method for the intent. */
       @SerializedName("verification_method")
       VerificationMethod verificationMethod;
 
       private UsBankAccount(
-          Map<String, Object> extraParams, VerificationMethod verificationMethod) {
+          Map<String, Object> extraParams,
+          FinancialConnections financialConnections,
+          VerificationMethod verificationMethod) {
         this.extraParams = extraParams;
+        this.financialConnections = financialConnections;
         this.verificationMethod = verificationMethod;
       }
 
@@ -4749,11 +4771,14 @@ public class SetupIntentConfirmParams extends ApiRequestParams {
       public static class Builder {
         private Map<String, Object> extraParams;
 
+        private FinancialConnections financialConnections;
+
         private VerificationMethod verificationMethod;
 
         /** Finalize and obtain parameter instance from this builder. */
         public UsBankAccount build() {
-          return new UsBankAccount(this.extraParams, this.verificationMethod);
+          return new UsBankAccount(
+              this.extraParams, this.financialConnections, this.verificationMethod);
         }
 
         /**
@@ -4784,10 +4809,157 @@ public class SetupIntentConfirmParams extends ApiRequestParams {
           return this;
         }
 
+        /** Additional fields for Financial Connections Session creation. */
+        public Builder setFinancialConnections(FinancialConnections financialConnections) {
+          this.financialConnections = financialConnections;
+          return this;
+        }
+
         /** Verification method for the intent. */
         public Builder setVerificationMethod(VerificationMethod verificationMethod) {
           this.verificationMethod = verificationMethod;
           return this;
+        }
+      }
+
+      @Getter
+      public static class FinancialConnections {
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /**
+         * The list of permissions to request. If this parameter is passed, the {@code
+         * payment_method} permission must be included. Valid permissions include: {@code balances},
+         * {@code payment_method}, and {@code transactions}.
+         */
+        @SerializedName("permissions")
+        List<Permission> permissions;
+
+        /**
+         * For webview integrations only. Upon completing OAuth login in the native browser, the
+         * user will be redirected to this URL to return to your app.
+         */
+        @SerializedName("return_url")
+        String returnUrl;
+
+        private FinancialConnections(
+            Map<String, Object> extraParams, List<Permission> permissions, String returnUrl) {
+          this.extraParams = extraParams;
+          this.permissions = permissions;
+          this.returnUrl = returnUrl;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Map<String, Object> extraParams;
+
+          private List<Permission> permissions;
+
+          private String returnUrl;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public FinancialConnections build() {
+            return new FinancialConnections(this.extraParams, this.permissions, this.returnUrl);
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * SetupIntentConfirmParams.PaymentMethodOptions.UsBankAccount.FinancialConnections#extraParams}
+           * for the field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * SetupIntentConfirmParams.PaymentMethodOptions.UsBankAccount.FinancialConnections#extraParams}
+           * for the field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /**
+           * Add an element to `permissions` list. A list is initialized for the first `add/addAll`
+           * call, and subsequent calls adds additional elements to the original list. See {@link
+           * SetupIntentConfirmParams.PaymentMethodOptions.UsBankAccount.FinancialConnections#permissions}
+           * for the field documentation.
+           */
+          public Builder addPermission(Permission element) {
+            if (this.permissions == null) {
+              this.permissions = new ArrayList<>();
+            }
+            this.permissions.add(element);
+            return this;
+          }
+
+          /**
+           * Add all elements to `permissions` list. A list is initialized for the first
+           * `add/addAll` call, and subsequent calls adds additional elements to the original list.
+           * See {@link
+           * SetupIntentConfirmParams.PaymentMethodOptions.UsBankAccount.FinancialConnections#permissions}
+           * for the field documentation.
+           */
+          public Builder addAllPermission(List<Permission> elements) {
+            if (this.permissions == null) {
+              this.permissions = new ArrayList<>();
+            }
+            this.permissions.addAll(elements);
+            return this;
+          }
+
+          /**
+           * For webview integrations only. Upon completing OAuth login in the native browser, the
+           * user will be redirected to this URL to return to your app.
+           */
+          public Builder setReturnUrl(String returnUrl) {
+            this.returnUrl = returnUrl;
+            return this;
+          }
+        }
+
+        public enum Permission implements ApiRequestParams.EnumParam {
+          @SerializedName("balances")
+          BALANCES("balances"),
+
+          @SerializedName("ownership")
+          OWNERSHIP("ownership"),
+
+          @SerializedName("payment_method")
+          PAYMENT_METHOD("payment_method"),
+
+          @SerializedName("transactions")
+          TRANSACTIONS("transactions");
+
+          @Getter(onMethod_ = {@Override})
+          private final String value;
+
+          Permission(String value) {
+            this.value = value;
+          }
         }
       }
 

--- a/src/main/java/com/stripe/param/SetupIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/SetupIntentCreateParams.java
@@ -3547,6 +3547,10 @@ public class SetupIntentCreateParams extends ApiRequestParams {
       @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
       Map<String, Object> extraParams;
 
+      /** The ID of a Financial Connections Account to use as a payment method. */
+      @SerializedName("financial_connections_account")
+      String financialConnectionsAccount;
+
       /** Routing number of the bank account. */
       @SerializedName("routing_number")
       String routingNumber;
@@ -3556,11 +3560,13 @@ public class SetupIntentCreateParams extends ApiRequestParams {
           String accountNumber,
           AccountType accountType,
           Map<String, Object> extraParams,
+          String financialConnectionsAccount,
           String routingNumber) {
         this.accountHolderType = accountHolderType;
         this.accountNumber = accountNumber;
         this.accountType = accountType;
         this.extraParams = extraParams;
+        this.financialConnectionsAccount = financialConnectionsAccount;
         this.routingNumber = routingNumber;
       }
 
@@ -3577,6 +3583,8 @@ public class SetupIntentCreateParams extends ApiRequestParams {
 
         private Map<String, Object> extraParams;
 
+        private String financialConnectionsAccount;
+
         private String routingNumber;
 
         /** Finalize and obtain parameter instance from this builder. */
@@ -3586,6 +3594,7 @@ public class SetupIntentCreateParams extends ApiRequestParams {
               this.accountNumber,
               this.accountType,
               this.extraParams,
+              this.financialConnectionsAccount,
               this.routingNumber);
         }
 
@@ -3632,6 +3641,12 @@ public class SetupIntentCreateParams extends ApiRequestParams {
             this.extraParams = new HashMap<>();
           }
           this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** The ID of a Financial Connections Account to use as a payment method. */
+        public Builder setFinancialConnectionsAccount(String financialConnectionsAccount) {
+          this.financialConnectionsAccount = financialConnectionsAccount;
           return this;
         }
 
@@ -4936,13 +4951,20 @@ public class SetupIntentCreateParams extends ApiRequestParams {
       @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
       Map<String, Object> extraParams;
 
+      /** Additional fields for Financial Connections Session creation. */
+      @SerializedName("financial_connections")
+      FinancialConnections financialConnections;
+
       /** Verification method for the intent. */
       @SerializedName("verification_method")
       VerificationMethod verificationMethod;
 
       private UsBankAccount(
-          Map<String, Object> extraParams, VerificationMethod verificationMethod) {
+          Map<String, Object> extraParams,
+          FinancialConnections financialConnections,
+          VerificationMethod verificationMethod) {
         this.extraParams = extraParams;
+        this.financialConnections = financialConnections;
         this.verificationMethod = verificationMethod;
       }
 
@@ -4953,11 +4975,14 @@ public class SetupIntentCreateParams extends ApiRequestParams {
       public static class Builder {
         private Map<String, Object> extraParams;
 
+        private FinancialConnections financialConnections;
+
         private VerificationMethod verificationMethod;
 
         /** Finalize and obtain parameter instance from this builder. */
         public UsBankAccount build() {
-          return new UsBankAccount(this.extraParams, this.verificationMethod);
+          return new UsBankAccount(
+              this.extraParams, this.financialConnections, this.verificationMethod);
         }
 
         /**
@@ -4988,10 +5013,157 @@ public class SetupIntentCreateParams extends ApiRequestParams {
           return this;
         }
 
+        /** Additional fields for Financial Connections Session creation. */
+        public Builder setFinancialConnections(FinancialConnections financialConnections) {
+          this.financialConnections = financialConnections;
+          return this;
+        }
+
         /** Verification method for the intent. */
         public Builder setVerificationMethod(VerificationMethod verificationMethod) {
           this.verificationMethod = verificationMethod;
           return this;
+        }
+      }
+
+      @Getter
+      public static class FinancialConnections {
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /**
+         * The list of permissions to request. If this parameter is passed, the {@code
+         * payment_method} permission must be included. Valid permissions include: {@code balances},
+         * {@code payment_method}, and {@code transactions}.
+         */
+        @SerializedName("permissions")
+        List<Permission> permissions;
+
+        /**
+         * For webview integrations only. Upon completing OAuth login in the native browser, the
+         * user will be redirected to this URL to return to your app.
+         */
+        @SerializedName("return_url")
+        String returnUrl;
+
+        private FinancialConnections(
+            Map<String, Object> extraParams, List<Permission> permissions, String returnUrl) {
+          this.extraParams = extraParams;
+          this.permissions = permissions;
+          this.returnUrl = returnUrl;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Map<String, Object> extraParams;
+
+          private List<Permission> permissions;
+
+          private String returnUrl;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public FinancialConnections build() {
+            return new FinancialConnections(this.extraParams, this.permissions, this.returnUrl);
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * SetupIntentCreateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections#extraParams}
+           * for the field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * SetupIntentCreateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections#extraParams}
+           * for the field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /**
+           * Add an element to `permissions` list. A list is initialized for the first `add/addAll`
+           * call, and subsequent calls adds additional elements to the original list. See {@link
+           * SetupIntentCreateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections#permissions}
+           * for the field documentation.
+           */
+          public Builder addPermission(Permission element) {
+            if (this.permissions == null) {
+              this.permissions = new ArrayList<>();
+            }
+            this.permissions.add(element);
+            return this;
+          }
+
+          /**
+           * Add all elements to `permissions` list. A list is initialized for the first
+           * `add/addAll` call, and subsequent calls adds additional elements to the original list.
+           * See {@link
+           * SetupIntentCreateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections#permissions}
+           * for the field documentation.
+           */
+          public Builder addAllPermission(List<Permission> elements) {
+            if (this.permissions == null) {
+              this.permissions = new ArrayList<>();
+            }
+            this.permissions.addAll(elements);
+            return this;
+          }
+
+          /**
+           * For webview integrations only. Upon completing OAuth login in the native browser, the
+           * user will be redirected to this URL to return to your app.
+           */
+          public Builder setReturnUrl(String returnUrl) {
+            this.returnUrl = returnUrl;
+            return this;
+          }
+        }
+
+        public enum Permission implements ApiRequestParams.EnumParam {
+          @SerializedName("balances")
+          BALANCES("balances"),
+
+          @SerializedName("ownership")
+          OWNERSHIP("ownership"),
+
+          @SerializedName("payment_method")
+          PAYMENT_METHOD("payment_method"),
+
+          @SerializedName("transactions")
+          TRANSACTIONS("transactions");
+
+          @Getter(onMethod_ = {@Override})
+          private final String value;
+
+          Permission(String value) {
+            this.value = value;
+          }
         }
       }
 

--- a/src/main/java/com/stripe/param/SetupIntentUpdateParams.java
+++ b/src/main/java/com/stripe/param/SetupIntentUpdateParams.java
@@ -3218,6 +3218,10 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
       @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
       Map<String, Object> extraParams;
 
+      /** The ID of a Financial Connections Account to use as a payment method. */
+      @SerializedName("financial_connections_account")
+      Object financialConnectionsAccount;
+
       /** Routing number of the bank account. */
       @SerializedName("routing_number")
       Object routingNumber;
@@ -3227,11 +3231,13 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
           Object accountNumber,
           AccountType accountType,
           Map<String, Object> extraParams,
+          Object financialConnectionsAccount,
           Object routingNumber) {
         this.accountHolderType = accountHolderType;
         this.accountNumber = accountNumber;
         this.accountType = accountType;
         this.extraParams = extraParams;
+        this.financialConnectionsAccount = financialConnectionsAccount;
         this.routingNumber = routingNumber;
       }
 
@@ -3248,6 +3254,8 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
 
         private Map<String, Object> extraParams;
 
+        private Object financialConnectionsAccount;
+
         private Object routingNumber;
 
         /** Finalize and obtain parameter instance from this builder. */
@@ -3257,6 +3265,7 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
               this.accountNumber,
               this.accountType,
               this.extraParams,
+              this.financialConnectionsAccount,
               this.routingNumber);
         }
 
@@ -3309,6 +3318,18 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
             this.extraParams = new HashMap<>();
           }
           this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** The ID of a Financial Connections Account to use as a payment method. */
+        public Builder setFinancialConnectionsAccount(String financialConnectionsAccount) {
+          this.financialConnectionsAccount = financialConnectionsAccount;
+          return this;
+        }
+
+        /** The ID of a Financial Connections Account to use as a payment method. */
+        public Builder setFinancialConnectionsAccount(EmptyParam financialConnectionsAccount) {
+          this.financialConnectionsAccount = financialConnectionsAccount;
           return this;
         }
 
@@ -4654,13 +4675,20 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
       @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
       Map<String, Object> extraParams;
 
+      /** Additional fields for Financial Connections Session creation. */
+      @SerializedName("financial_connections")
+      FinancialConnections financialConnections;
+
       /** Verification method for the intent. */
       @SerializedName("verification_method")
       VerificationMethod verificationMethod;
 
       private UsBankAccount(
-          Map<String, Object> extraParams, VerificationMethod verificationMethod) {
+          Map<String, Object> extraParams,
+          FinancialConnections financialConnections,
+          VerificationMethod verificationMethod) {
         this.extraParams = extraParams;
+        this.financialConnections = financialConnections;
         this.verificationMethod = verificationMethod;
       }
 
@@ -4671,11 +4699,14 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
       public static class Builder {
         private Map<String, Object> extraParams;
 
+        private FinancialConnections financialConnections;
+
         private VerificationMethod verificationMethod;
 
         /** Finalize and obtain parameter instance from this builder. */
         public UsBankAccount build() {
-          return new UsBankAccount(this.extraParams, this.verificationMethod);
+          return new UsBankAccount(
+              this.extraParams, this.financialConnections, this.verificationMethod);
         }
 
         /**
@@ -4706,10 +4737,166 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
           return this;
         }
 
+        /** Additional fields for Financial Connections Session creation. */
+        public Builder setFinancialConnections(FinancialConnections financialConnections) {
+          this.financialConnections = financialConnections;
+          return this;
+        }
+
         /** Verification method for the intent. */
         public Builder setVerificationMethod(VerificationMethod verificationMethod) {
           this.verificationMethod = verificationMethod;
           return this;
+        }
+      }
+
+      @Getter
+      public static class FinancialConnections {
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /**
+         * The list of permissions to request. If this parameter is passed, the {@code
+         * payment_method} permission must be included. Valid permissions include: {@code balances},
+         * {@code payment_method}, and {@code transactions}.
+         */
+        @SerializedName("permissions")
+        List<Permission> permissions;
+
+        /**
+         * For webview integrations only. Upon completing OAuth login in the native browser, the
+         * user will be redirected to this URL to return to your app.
+         */
+        @SerializedName("return_url")
+        Object returnUrl;
+
+        private FinancialConnections(
+            Map<String, Object> extraParams, List<Permission> permissions, Object returnUrl) {
+          this.extraParams = extraParams;
+          this.permissions = permissions;
+          this.returnUrl = returnUrl;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Map<String, Object> extraParams;
+
+          private List<Permission> permissions;
+
+          private Object returnUrl;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public FinancialConnections build() {
+            return new FinancialConnections(this.extraParams, this.permissions, this.returnUrl);
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * SetupIntentUpdateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections#extraParams}
+           * for the field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * SetupIntentUpdateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections#extraParams}
+           * for the field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /**
+           * Add an element to `permissions` list. A list is initialized for the first `add/addAll`
+           * call, and subsequent calls adds additional elements to the original list. See {@link
+           * SetupIntentUpdateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections#permissions}
+           * for the field documentation.
+           */
+          public Builder addPermission(Permission element) {
+            if (this.permissions == null) {
+              this.permissions = new ArrayList<>();
+            }
+            this.permissions.add(element);
+            return this;
+          }
+
+          /**
+           * Add all elements to `permissions` list. A list is initialized for the first
+           * `add/addAll` call, and subsequent calls adds additional elements to the original list.
+           * See {@link
+           * SetupIntentUpdateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections#permissions}
+           * for the field documentation.
+           */
+          public Builder addAllPermission(List<Permission> elements) {
+            if (this.permissions == null) {
+              this.permissions = new ArrayList<>();
+            }
+            this.permissions.addAll(elements);
+            return this;
+          }
+
+          /**
+           * For webview integrations only. Upon completing OAuth login in the native browser, the
+           * user will be redirected to this URL to return to your app.
+           */
+          public Builder setReturnUrl(String returnUrl) {
+            this.returnUrl = returnUrl;
+            return this;
+          }
+
+          /**
+           * For webview integrations only. Upon completing OAuth login in the native browser, the
+           * user will be redirected to this URL to return to your app.
+           */
+          public Builder setReturnUrl(EmptyParam returnUrl) {
+            this.returnUrl = returnUrl;
+            return this;
+          }
+        }
+
+        public enum Permission implements ApiRequestParams.EnumParam {
+          @SerializedName("balances")
+          BALANCES("balances"),
+
+          @SerializedName("ownership")
+          OWNERSHIP("ownership"),
+
+          @SerializedName("payment_method")
+          PAYMENT_METHOD("payment_method"),
+
+          @SerializedName("transactions")
+          TRANSACTIONS("transactions");
+
+          @Getter(onMethod_ = {@Override})
+          private final String value;
+
+          Permission(String value) {
+            this.value = value;
+          }
         }
       }
 

--- a/src/main/java/com/stripe/param/SubscriptionCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionCreateParams.java
@@ -3251,13 +3251,20 @@ public class SubscriptionCreateParams extends ApiRequestParams {
         @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
         Map<String, Object> extraParams;
 
+        /** Additional fields for Financial Connections Session creation. */
+        @SerializedName("financial_connections")
+        FinancialConnections financialConnections;
+
         /** Verification method for the intent. */
         @SerializedName("verification_method")
         VerificationMethod verificationMethod;
 
         private UsBankAccount(
-            Map<String, Object> extraParams, VerificationMethod verificationMethod) {
+            Map<String, Object> extraParams,
+            FinancialConnections financialConnections,
+            VerificationMethod verificationMethod) {
           this.extraParams = extraParams;
+          this.financialConnections = financialConnections;
           this.verificationMethod = verificationMethod;
         }
 
@@ -3268,11 +3275,14 @@ public class SubscriptionCreateParams extends ApiRequestParams {
         public static class Builder {
           private Map<String, Object> extraParams;
 
+          private FinancialConnections financialConnections;
+
           private VerificationMethod verificationMethod;
 
           /** Finalize and obtain parameter instance from this builder. */
           public UsBankAccount build() {
-            return new UsBankAccount(this.extraParams, this.verificationMethod);
+            return new UsBankAccount(
+                this.extraParams, this.financialConnections, this.verificationMethod);
           }
 
           /**
@@ -3305,10 +3315,139 @@ public class SubscriptionCreateParams extends ApiRequestParams {
             return this;
           }
 
+          /** Additional fields for Financial Connections Session creation. */
+          public Builder setFinancialConnections(FinancialConnections financialConnections) {
+            this.financialConnections = financialConnections;
+            return this;
+          }
+
           /** Verification method for the intent. */
           public Builder setVerificationMethod(VerificationMethod verificationMethod) {
             this.verificationMethod = verificationMethod;
             return this;
+          }
+        }
+
+        @Getter
+        public static class FinancialConnections {
+          /**
+           * Map of extra parameters for custom features not available in this client library. The
+           * content in this map is not serialized under this field's {@code @SerializedName} value.
+           * Instead, each key/value pair is serialized as if the key is a root-level field
+           * (serialized) name in this param object. Effectively, this map is flattened to its
+           * parent instance.
+           */
+          @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+          Map<String, Object> extraParams;
+
+          /**
+           * The list of permissions to request. If this parameter is passed, the {@code
+           * payment_method} permission must be included. Valid permissions include: {@code
+           * balances}, {@code payment_method}, and {@code transactions}.
+           */
+          @SerializedName("permissions")
+          List<Permission> permissions;
+
+          private FinancialConnections(
+              Map<String, Object> extraParams, List<Permission> permissions) {
+            this.extraParams = extraParams;
+            this.permissions = permissions;
+          }
+
+          public static Builder builder() {
+            return new Builder();
+          }
+
+          public static class Builder {
+            private Map<String, Object> extraParams;
+
+            private List<Permission> permissions;
+
+            /** Finalize and obtain parameter instance from this builder. */
+            public FinancialConnections build() {
+              return new FinancialConnections(this.extraParams, this.permissions);
+            }
+
+            /**
+             * Add a key/value pair to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections#extraParams}
+             * for the field documentation.
+             */
+            public Builder putExtraParam(String key, Object value) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.put(key, value);
+              return this;
+            }
+
+            /**
+             * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections#extraParams}
+             * for the field documentation.
+             */
+            public Builder putAllExtraParam(Map<String, Object> map) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.putAll(map);
+              return this;
+            }
+
+            /**
+             * Add an element to `permissions` list. A list is initialized for the first
+             * `add/addAll` call, and subsequent calls adds additional elements to the original
+             * list. See {@link
+             * SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections#permissions}
+             * for the field documentation.
+             */
+            public Builder addPermission(Permission element) {
+              if (this.permissions == null) {
+                this.permissions = new ArrayList<>();
+              }
+              this.permissions.add(element);
+              return this;
+            }
+
+            /**
+             * Add all elements to `permissions` list. A list is initialized for the first
+             * `add/addAll` call, and subsequent calls adds additional elements to the original
+             * list. See {@link
+             * SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections#permissions}
+             * for the field documentation.
+             */
+            public Builder addAllPermission(List<Permission> elements) {
+              if (this.permissions == null) {
+                this.permissions = new ArrayList<>();
+              }
+              this.permissions.addAll(elements);
+              return this;
+            }
+          }
+
+          public enum Permission implements ApiRequestParams.EnumParam {
+            @SerializedName("balances")
+            BALANCES("balances"),
+
+            @SerializedName("ownership")
+            OWNERSHIP("ownership"),
+
+            @SerializedName("payment_method")
+            PAYMENT_METHOD("payment_method"),
+
+            @SerializedName("transactions")
+            TRANSACTIONS("transactions");
+
+            @Getter(onMethod_ = {@Override})
+            private final String value;
+
+            Permission(String value) {
+              this.value = value;
+            }
           }
         }
 

--- a/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
@@ -3601,13 +3601,20 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
         @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
         Map<String, Object> extraParams;
 
+        /** Additional fields for Financial Connections Session creation. */
+        @SerializedName("financial_connections")
+        FinancialConnections financialConnections;
+
         /** Verification method for the intent. */
         @SerializedName("verification_method")
         VerificationMethod verificationMethod;
 
         private UsBankAccount(
-            Map<String, Object> extraParams, VerificationMethod verificationMethod) {
+            Map<String, Object> extraParams,
+            FinancialConnections financialConnections,
+            VerificationMethod verificationMethod) {
           this.extraParams = extraParams;
+          this.financialConnections = financialConnections;
           this.verificationMethod = verificationMethod;
         }
 
@@ -3618,11 +3625,14 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
         public static class Builder {
           private Map<String, Object> extraParams;
 
+          private FinancialConnections financialConnections;
+
           private VerificationMethod verificationMethod;
 
           /** Finalize and obtain parameter instance from this builder. */
           public UsBankAccount build() {
-            return new UsBankAccount(this.extraParams, this.verificationMethod);
+            return new UsBankAccount(
+                this.extraParams, this.financialConnections, this.verificationMethod);
           }
 
           /**
@@ -3655,10 +3665,139 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
             return this;
           }
 
+          /** Additional fields for Financial Connections Session creation. */
+          public Builder setFinancialConnections(FinancialConnections financialConnections) {
+            this.financialConnections = financialConnections;
+            return this;
+          }
+
           /** Verification method for the intent. */
           public Builder setVerificationMethod(VerificationMethod verificationMethod) {
             this.verificationMethod = verificationMethod;
             return this;
+          }
+        }
+
+        @Getter
+        public static class FinancialConnections {
+          /**
+           * Map of extra parameters for custom features not available in this client library. The
+           * content in this map is not serialized under this field's {@code @SerializedName} value.
+           * Instead, each key/value pair is serialized as if the key is a root-level field
+           * (serialized) name in this param object. Effectively, this map is flattened to its
+           * parent instance.
+           */
+          @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+          Map<String, Object> extraParams;
+
+          /**
+           * The list of permissions to request. If this parameter is passed, the {@code
+           * payment_method} permission must be included. Valid permissions include: {@code
+           * balances}, {@code payment_method}, and {@code transactions}.
+           */
+          @SerializedName("permissions")
+          List<Permission> permissions;
+
+          private FinancialConnections(
+              Map<String, Object> extraParams, List<Permission> permissions) {
+            this.extraParams = extraParams;
+            this.permissions = permissions;
+          }
+
+          public static Builder builder() {
+            return new Builder();
+          }
+
+          public static class Builder {
+            private Map<String, Object> extraParams;
+
+            private List<Permission> permissions;
+
+            /** Finalize and obtain parameter instance from this builder. */
+            public FinancialConnections build() {
+              return new FinancialConnections(this.extraParams, this.permissions);
+            }
+
+            /**
+             * Add a key/value pair to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections#extraParams}
+             * for the field documentation.
+             */
+            public Builder putExtraParam(String key, Object value) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.put(key, value);
+              return this;
+            }
+
+            /**
+             * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections#extraParams}
+             * for the field documentation.
+             */
+            public Builder putAllExtraParam(Map<String, Object> map) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.putAll(map);
+              return this;
+            }
+
+            /**
+             * Add an element to `permissions` list. A list is initialized for the first
+             * `add/addAll` call, and subsequent calls adds additional elements to the original
+             * list. See {@link
+             * SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections#permissions}
+             * for the field documentation.
+             */
+            public Builder addPermission(Permission element) {
+              if (this.permissions == null) {
+                this.permissions = new ArrayList<>();
+              }
+              this.permissions.add(element);
+              return this;
+            }
+
+            /**
+             * Add all elements to `permissions` list. A list is initialized for the first
+             * `add/addAll` call, and subsequent calls adds additional elements to the original
+             * list. See {@link
+             * SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections#permissions}
+             * for the field documentation.
+             */
+            public Builder addAllPermission(List<Permission> elements) {
+              if (this.permissions == null) {
+                this.permissions = new ArrayList<>();
+              }
+              this.permissions.addAll(elements);
+              return this;
+            }
+          }
+
+          public enum Permission implements ApiRequestParams.EnumParam {
+            @SerializedName("balances")
+            BALANCES("balances"),
+
+            @SerializedName("ownership")
+            OWNERSHIP("ownership"),
+
+            @SerializedName("payment_method")
+            PAYMENT_METHOD("payment_method"),
+
+            @SerializedName("transactions")
+            TRANSACTIONS("transactions");
+
+            @Getter(onMethod_ = {@Override})
+            private final String value;
+
+            Permission(String value) {
+              this.value = value;
+            }
           }
         }
 

--- a/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
+++ b/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
@@ -4066,13 +4066,20 @@ public class SessionCreateParams extends ApiRequestParams {
       @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
       Map<String, Object> extraParams;
 
+      /** Additional fields for Financial Connections Session creation. */
+      @SerializedName("financial_connections")
+      FinancialConnections financialConnections;
+
       /** Verification method for the intent. */
       @SerializedName("verification_method")
       VerificationMethod verificationMethod;
 
       private UsBankAccount(
-          Map<String, Object> extraParams, VerificationMethod verificationMethod) {
+          Map<String, Object> extraParams,
+          FinancialConnections financialConnections,
+          VerificationMethod verificationMethod) {
         this.extraParams = extraParams;
+        this.financialConnections = financialConnections;
         this.verificationMethod = verificationMethod;
       }
 
@@ -4083,11 +4090,14 @@ public class SessionCreateParams extends ApiRequestParams {
       public static class Builder {
         private Map<String, Object> extraParams;
 
+        private FinancialConnections financialConnections;
+
         private VerificationMethod verificationMethod;
 
         /** Finalize and obtain parameter instance from this builder. */
         public UsBankAccount build() {
-          return new UsBankAccount(this.extraParams, this.verificationMethod);
+          return new UsBankAccount(
+              this.extraParams, this.financialConnections, this.verificationMethod);
         }
 
         /**
@@ -4118,10 +4128,138 @@ public class SessionCreateParams extends ApiRequestParams {
           return this;
         }
 
+        /** Additional fields for Financial Connections Session creation. */
+        public Builder setFinancialConnections(FinancialConnections financialConnections) {
+          this.financialConnections = financialConnections;
+          return this;
+        }
+
         /** Verification method for the intent. */
         public Builder setVerificationMethod(VerificationMethod verificationMethod) {
           this.verificationMethod = verificationMethod;
           return this;
+        }
+      }
+
+      @Getter
+      public static class FinancialConnections {
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /**
+         * The list of permissions to request. If this parameter is passed, the {@code
+         * payment_method} permission must be included. Valid permissions include: {@code balances},
+         * {@code payment_method}, and {@code transactions}.
+         */
+        @SerializedName("permissions")
+        List<Permission> permissions;
+
+        private FinancialConnections(
+            Map<String, Object> extraParams, List<Permission> permissions) {
+          this.extraParams = extraParams;
+          this.permissions = permissions;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Map<String, Object> extraParams;
+
+          private List<Permission> permissions;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public FinancialConnections build() {
+            return new FinancialConnections(this.extraParams, this.permissions);
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * SessionCreateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections#extraParams}
+           * for the field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * SessionCreateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections#extraParams}
+           * for the field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /**
+           * Add an element to `permissions` list. A list is initialized for the first `add/addAll`
+           * call, and subsequent calls adds additional elements to the original list. See {@link
+           * SessionCreateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections#permissions}
+           * for the field documentation.
+           */
+          public Builder addPermission(Permission element) {
+            if (this.permissions == null) {
+              this.permissions = new ArrayList<>();
+            }
+            this.permissions.add(element);
+            return this;
+          }
+
+          /**
+           * Add all elements to `permissions` list. A list is initialized for the first
+           * `add/addAll` call, and subsequent calls adds additional elements to the original list.
+           * See {@link
+           * SessionCreateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections#permissions}
+           * for the field documentation.
+           */
+          public Builder addAllPermission(List<Permission> elements) {
+            if (this.permissions == null) {
+              this.permissions = new ArrayList<>();
+            }
+            this.permissions.addAll(elements);
+            return this;
+          }
+        }
+
+        public enum Permission implements ApiRequestParams.EnumParam {
+          @SerializedName("balances")
+          BALANCES("balances"),
+
+          @SerializedName("ownership")
+          OWNERSHIP("ownership"),
+
+          @SerializedName("payment_method")
+          PAYMENT_METHOD("payment_method"),
+
+          @SerializedName("transactions")
+          TRANSACTIONS("transactions");
+
+          @Getter(onMethod_ = {@Override})
+          private final String value;
+
+          Permission(String value) {
+            this.value = value;
+          }
         }
       }
 

--- a/src/main/java/com/stripe/param/financialconnections/AccountDisconnectParams.java
+++ b/src/main/java/com/stripe/param/financialconnections/AccountDisconnectParams.java
@@ -1,0 +1,98 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.financialconnections;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class AccountDisconnectParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  private AccountDisconnectParams(List<String> expand, Map<String, Object> extraParams) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public AccountDisconnectParams build() {
+      return new AccountDisconnectParams(this.expand, this.extraParams);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * AccountDisconnectParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * AccountDisconnectParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * AccountDisconnectParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link AccountDisconnectParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/financialconnections/AccountRefreshParams.java
+++ b/src/main/java/com/stripe/param/financialconnections/AccountRefreshParams.java
@@ -1,0 +1,150 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.financialconnections;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class AccountRefreshParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  /**
+   * The list of account features that you would like to refresh. Either: {@code balance} or {@code
+   * ownership}.
+   */
+  @SerializedName("features")
+  List<Feature> features;
+
+  private AccountRefreshParams(
+      List<String> expand, Map<String, Object> extraParams, List<Feature> features) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+    this.features = features;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    private List<Feature> features;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public AccountRefreshParams build() {
+      return new AccountRefreshParams(this.expand, this.extraParams, this.features);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * AccountRefreshParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * AccountRefreshParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * AccountRefreshParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link AccountRefreshParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /**
+     * Add an element to `features` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * AccountRefreshParams#features} for the field documentation.
+     */
+    public Builder addFeature(Feature element) {
+      if (this.features == null) {
+        this.features = new ArrayList<>();
+      }
+      this.features.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `features` list. A list is initialized for the first `add/addAll` call,
+     * and subsequent calls adds additional elements to the original list. See {@link
+     * AccountRefreshParams#features} for the field documentation.
+     */
+    public Builder addAllFeature(List<Feature> elements) {
+      if (this.features == null) {
+        this.features = new ArrayList<>();
+      }
+      this.features.addAll(elements);
+      return this;
+    }
+  }
+
+  public enum Feature implements ApiRequestParams.EnumParam {
+    @SerializedName("balance")
+    BALANCE("balance"),
+
+    @SerializedName("ownership")
+    OWNERSHIP("ownership");
+
+    @Getter(onMethod_ = {@Override})
+    private final String value;
+
+    Feature(String value) {
+      this.value = value;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/financialconnections/AccountRetrieveParams.java
+++ b/src/main/java/com/stripe/param/financialconnections/AccountRetrieveParams.java
@@ -1,0 +1,98 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.financialconnections;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class AccountRetrieveParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  private AccountRetrieveParams(List<String> expand, Map<String, Object> extraParams) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public AccountRetrieveParams build() {
+      return new AccountRetrieveParams(this.expand, this.extraParams);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * AccountRetrieveParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * AccountRetrieveParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * AccountRetrieveParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link AccountRetrieveParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/financialconnections/SessionCreateParams.java
+++ b/src/main/java/com/stripe/param/financialconnections/SessionCreateParams.java
@@ -1,0 +1,424 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.financialconnections;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class SessionCreateParams extends ApiRequestParams {
+  /** The account holder to link accounts for. */
+  @SerializedName("account_holder")
+  AccountHolder accountHolder;
+
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  /** Filters to restrict the kinds of accounts to collect. */
+  @SerializedName("filters")
+  Filters filters;
+
+  /**
+   * List of data features that you would like to request access to.
+   *
+   * <p>Possible values are {@code balances}, {@code transactions}, {@code ownership}, and {@code
+   * payment_method}.
+   */
+  @SerializedName("permissions")
+  List<Permission> permissions;
+
+  /**
+   * For webview integrations only. Upon completing OAuth login in the native browser, the user will
+   * be redirected to this URL to return to your app.
+   */
+  @SerializedName("return_url")
+  String returnUrl;
+
+  private SessionCreateParams(
+      AccountHolder accountHolder,
+      List<String> expand,
+      Map<String, Object> extraParams,
+      Filters filters,
+      List<Permission> permissions,
+      String returnUrl) {
+    this.accountHolder = accountHolder;
+    this.expand = expand;
+    this.extraParams = extraParams;
+    this.filters = filters;
+    this.permissions = permissions;
+    this.returnUrl = returnUrl;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private AccountHolder accountHolder;
+
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    private Filters filters;
+
+    private List<Permission> permissions;
+
+    private String returnUrl;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public SessionCreateParams build() {
+      return new SessionCreateParams(
+          this.accountHolder,
+          this.expand,
+          this.extraParams,
+          this.filters,
+          this.permissions,
+          this.returnUrl);
+    }
+
+    /** The account holder to link accounts for. */
+    public Builder setAccountHolder(AccountHolder accountHolder) {
+      this.accountHolder = accountHolder;
+      return this;
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * SessionCreateParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * SessionCreateParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * SessionCreateParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link SessionCreateParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /** Filters to restrict the kinds of accounts to collect. */
+    public Builder setFilters(Filters filters) {
+      this.filters = filters;
+      return this;
+    }
+
+    /**
+     * Add an element to `permissions` list. A list is initialized for the first `add/addAll` call,
+     * and subsequent calls adds additional elements to the original list. See {@link
+     * SessionCreateParams#permissions} for the field documentation.
+     */
+    public Builder addPermission(Permission element) {
+      if (this.permissions == null) {
+        this.permissions = new ArrayList<>();
+      }
+      this.permissions.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `permissions` list. A list is initialized for the first `add/addAll`
+     * call, and subsequent calls adds additional elements to the original list. See {@link
+     * SessionCreateParams#permissions} for the field documentation.
+     */
+    public Builder addAllPermission(List<Permission> elements) {
+      if (this.permissions == null) {
+        this.permissions = new ArrayList<>();
+      }
+      this.permissions.addAll(elements);
+      return this;
+    }
+
+    /**
+     * For webview integrations only. Upon completing OAuth login in the native browser, the user
+     * will be redirected to this URL to return to your app.
+     */
+    public Builder setReturnUrl(String returnUrl) {
+      this.returnUrl = returnUrl;
+      return this;
+    }
+  }
+
+  @Getter
+  public static class AccountHolder {
+    /**
+     * The ID of the Stripe account whose accounts will be retrieved. Should only be present if
+     * {@code type} is {@code account}.
+     */
+    @SerializedName("account")
+    String account;
+
+    /**
+     * The ID of the Stripe customer whose accounts will be retrieved. Should only be present if
+     * {@code type} is {@code customer}.
+     */
+    @SerializedName("customer")
+    String customer;
+
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /** Type of account holder to collect accounts for. */
+    @SerializedName("type")
+    Type type;
+
+    private AccountHolder(
+        String account, String customer, Map<String, Object> extraParams, Type type) {
+      this.account = account;
+      this.customer = customer;
+      this.extraParams = extraParams;
+      this.type = type;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private String account;
+
+      private String customer;
+
+      private Map<String, Object> extraParams;
+
+      private Type type;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public AccountHolder build() {
+        return new AccountHolder(this.account, this.customer, this.extraParams, this.type);
+      }
+
+      /**
+       * The ID of the Stripe account whose accounts will be retrieved. Should only be present if
+       * {@code type} is {@code account}.
+       */
+      public Builder setAccount(String account) {
+        this.account = account;
+        return this;
+      }
+
+      /**
+       * The ID of the Stripe customer whose accounts will be retrieved. Should only be present if
+       * {@code type} is {@code customer}.
+       */
+      public Builder setCustomer(String customer) {
+        this.customer = customer;
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * SessionCreateParams.AccountHolder#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link SessionCreateParams.AccountHolder#extraParams} for the field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** Type of account holder to collect accounts for. */
+      public Builder setType(Type type) {
+        this.type = type;
+        return this;
+      }
+    }
+
+    public enum Type implements ApiRequestParams.EnumParam {
+      @SerializedName("account")
+      ACCOUNT("account"),
+
+      @SerializedName("customer")
+      CUSTOMER("customer");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      Type(String value) {
+        this.value = value;
+      }
+    }
+  }
+
+  @Getter
+  public static class Filters {
+    /** List of countries from which to collect accounts. */
+    @SerializedName("countries")
+    List<String> countries;
+
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    private Filters(List<String> countries, Map<String, Object> extraParams) {
+      this.countries = countries;
+      this.extraParams = extraParams;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private List<String> countries;
+
+      private Map<String, Object> extraParams;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public Filters build() {
+        return new Filters(this.countries, this.extraParams);
+      }
+
+      /**
+       * Add an element to `countries` list. A list is initialized for the first `add/addAll` call,
+       * and subsequent calls adds additional elements to the original list. See {@link
+       * SessionCreateParams.Filters#countries} for the field documentation.
+       */
+      public Builder addCountry(String element) {
+        if (this.countries == null) {
+          this.countries = new ArrayList<>();
+        }
+        this.countries.add(element);
+        return this;
+      }
+
+      /**
+       * Add all elements to `countries` list. A list is initialized for the first `add/addAll`
+       * call, and subsequent calls adds additional elements to the original list. See {@link
+       * SessionCreateParams.Filters#countries} for the field documentation.
+       */
+      public Builder addAllCountry(List<String> elements) {
+        if (this.countries == null) {
+          this.countries = new ArrayList<>();
+        }
+        this.countries.addAll(elements);
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * SessionCreateParams.Filters#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link SessionCreateParams.Filters#extraParams} for the field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+    }
+  }
+
+  public enum Permission implements ApiRequestParams.EnumParam {
+    @SerializedName("balances")
+    BALANCES("balances"),
+
+    @SerializedName("ownership")
+    OWNERSHIP("ownership"),
+
+    @SerializedName("payment_method")
+    PAYMENT_METHOD("payment_method"),
+
+    @SerializedName("transactions")
+    TRANSACTIONS("transactions");
+
+    @Getter(onMethod_ = {@Override})
+    private final String value;
+
+    Permission(String value) {
+      this.value = value;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/financialconnections/SessionRetrieveParams.java
+++ b/src/main/java/com/stripe/param/financialconnections/SessionRetrieveParams.java
@@ -1,0 +1,98 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.financialconnections;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class SessionRetrieveParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  private SessionRetrieveParams(List<String> expand, Map<String, Object> extraParams) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public SessionRetrieveParams build() {
+      return new SessionRetrieveParams(this.expand, this.extraParams);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * SessionRetrieveParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * SessionRetrieveParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * SessionRetrieveParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link SessionRetrieveParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+  }
+}


### PR DESCRIPTION
Codegen for openapi 42cbb18.
r? @kamil-stripe
cc @stripe/api-libraries

## Changelog
* Add support for new resources `FinancialConnections.AccountOwner`, `FinancialConnections.AccountOwnership`, `FinancialConnections.Account`, and `FinancialConnections.Session`
* Add support for `financial_connections` on `Checkout.Session.payment_method_options.us_bank_account`, `CheckoutSessionCreateParams.payment_method_options.us_bank_account`, `Invoice.payment_settings.payment_method_options.us_bank_account`, `InvoiceCreateParams.payment_settings.payment_method_options.us_bank_account`, `InvoiceUpdateParams.payment_settings.payment_method_options.us_bank_account`, `PaymentIntent.payment_method_options.us_bank_account`, `PaymentIntentConfirmParams.payment_method_options.us_bank_account`, `PaymentIntentCreateParams.payment_method_options.us_bank_account`, `PaymentIntentUpdateParams.payment_method_options.us_bank_account`, `SetupIntent.payment_method_options.us_bank_account`, `SetupIntentConfirmParams.payment_method_options.us_bank_account`, `SetupIntentCreateParams.payment_method_options.us_bank_account`, `SetupIntentUpdateParams.payment_method_options.us_bank_account`, `Subscription.payment_settings.payment_method_options.us_bank_account`, `SubscriptionCreateParams.payment_settings.payment_method_options.us_bank_account`, and `SubscriptionUpdateParams.payment_settings.payment_method_options.us_bank_account`
* Add support for `financial_connections_account` on `PaymentIntentConfirmParams.payment_method_data.us_bank_account`, `PaymentIntentCreateParams.payment_method_data.us_bank_account`, `PaymentIntentUpdateParams.payment_method_data.us_bank_account`, `PaymentMethod.us_bank_account`, `PaymentMethodCreateParams.us_bank_account`, `SetupIntentConfirmParams.payment_method_data.us_bank_account`, `SetupIntentCreateParams.payment_method_data.us_bank_account`, and `SetupIntentUpdateParams.payment_method_data.us_bank_account`

