### PR TITLE
API Updates

### DIFF
--- a/src/main/java/com/stripe/model/Discount.java
+++ b/src/main/java/com/stripe/model/Discount.java
@@ -21,9 +21,12 @@ public class Discount extends StripeObject implements HasId {
   /**
    * A coupon contains information about a percent-off or amount-off discount you might want to
    * apply to a customer. Coupons may be applied to <a
-   * href="https://stripe.com/docs/api#invoices">invoices</a> or <a
-   * href="https://stripe.com/docs/api#create_order_legacy-coupon">orders</a>. Coupons do not work
-   * with conventional one-off <a href="https://stripe.com/docs/api#create_charge">charges</a>.
+   * href="https://stripe.com/docs/api#subscriptions">subscriptions</a>, <a
+   * href="https://stripe.com/docs/api#invoices">invoices</a>, <a
+   * href="https://stripe.com/docs/api/checkout/sessions">checkout sessions</a>, <a
+   * href="https://stripe.com/docs/api#quotes">quotes</a>, and more. Coupons do not work with
+   * conventional one-off <a href="https://stripe.com/docs/api#create_charge">charges</a> or <a
+   * href="https://stripe.com/docs/api/payment_intents">payment intents</a>.
    */
   @SerializedName("coupon")
   Coupon coupon;

--- a/src/main/java/com/stripe/model/LineItem.java
+++ b/src/main/java/com/stripe/model/LineItem.java
@@ -112,8 +112,10 @@ public class LineItem extends StripeObject implements HasId {
     Long amount;
 
     /**
-     * A discount represents the actual application of a coupon to a particular customer. It
-     * contains information about when the discount began and when it will end.
+     * A discount represents the actual application of a <a
+     * href="https://stripe.com/docs/api#coupons">coupon</a> or <a
+     * href="https://stripe.com/docs/api#promotion_codes">promotion code</a>. It contains
+     * information about when the discount began, when it will end, and what it is applied to.
      *
      * <p>Related guide: <a href="https://stripe.com/docs/billing/subscriptions/discounts">Applying
      * Discounts to Subscriptions</a>.

--- a/src/main/java/com/stripe/model/PaymentLink.java
+++ b/src/main/java/com/stripe/model/PaymentLink.java
@@ -61,6 +61,18 @@ public class PaymentLink extends ApiResource implements HasId, MetadataStore<Pay
   @SerializedName("billing_address_collection")
   String billingAddressCollection;
 
+  /** When set, provides configuration to gather active consent from customers. */
+  @SerializedName("consent_collection")
+  ConsentCollection consentCollection;
+
+  /**
+   * Configuration for Customer creation during checkout.
+   *
+   * <p>One of {@code always}, or {@code if_required}.
+   */
+  @SerializedName("customer_creation")
+  String customerCreation;
+
   /** Unique identifier for the object. */
   @Getter(onMethod_ = {@Override})
   @SerializedName("id")
@@ -104,6 +116,10 @@ public class PaymentLink extends ApiResource implements HasId, MetadataStore<Pay
   @Setter(lombok.AccessLevel.NONE)
   ExpandableField<Account> onBehalfOf;
 
+  /** Indicates the parameters to be passed to PaymentIntent creation during checkout. */
+  @SerializedName("payment_intent_data")
+  PaymentIntentData paymentIntentData;
+
   /**
    * The list of payment method types that customers can use. When {@code null}, Stripe will
    * dynamically show relevant payment methods you've enabled in your <a
@@ -119,12 +135,28 @@ public class PaymentLink extends ApiResource implements HasId, MetadataStore<Pay
   @SerializedName("shipping_address_collection")
   ShippingAddressCollection shippingAddressCollection;
 
+  /** The shipping rate options applied to the session. */
+  @SerializedName("shipping_options")
+  List<PaymentLink.ShippingOption> shippingOptions;
+
+  /**
+   * Indicates the type of transaction being performed which customizes relevant text on the page,
+   * such as the submit button.
+   *
+   * <p>One of {@code auto}, {@code book}, {@code donate}, or {@code pay}.
+   */
+  @SerializedName("submit_type")
+  String submitType;
+
   /**
    * When creating a subscription, the specified configuration data will be used. There must be at
    * least one line item with a recurring price to use {@code subscription_data}.
    */
   @SerializedName("subscription_data")
   SubscriptionData subscriptionData;
+
+  @SerializedName("tax_id_collection")
+  TaxIdCollection taxIdCollection;
 
   /**
    * The account (if any) the payments will be attributed to for tax reporting, and where funds from
@@ -387,6 +419,42 @@ public class PaymentLink extends ApiResource implements HasId, MetadataStore<Pay
   @Getter
   @Setter
   @EqualsAndHashCode(callSuper = false)
+  public static class ConsentCollection extends StripeObject {
+    /**
+     * If set to {@code auto}, enables the collection of customer consent for promotional
+     * communications.
+     *
+     * <p>Equal to {@code auto}.
+     */
+    @SerializedName("promotions")
+    String promotions;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class PaymentIntentData extends StripeObject {
+    /**
+     * Indicates when the funds will be captured from the customer's account.
+     *
+     * <p>One of {@code automatic}, or {@code manual}.
+     */
+    @SerializedName("capture_method")
+    String captureMethod;
+
+    /**
+     * Indicates that you intend to make future payments with the payment method collected during
+     * checkout.
+     *
+     * <p>One of {@code off_session}, or {@code on_session}.
+     */
+    @SerializedName("setup_future_usage")
+    String setupFutureUsage;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
   public static class PhoneNumberCollection extends StripeObject {
     /** If {@code true}, a phone number will be collected during checkout. */
     @SerializedName("enabled")
@@ -409,6 +477,40 @@ public class PaymentLink extends ApiResource implements HasId, MetadataStore<Pay
   @Getter
   @Setter
   @EqualsAndHashCode(callSuper = false)
+  public static class ShippingOption extends StripeObject {
+    /** A non-negative integer in cents representing how much to charge. */
+    @SerializedName("shipping_amount")
+    Long shippingAmount;
+
+    /** The ID of the Shipping Rate to use for this shipping option. */
+    @SerializedName("shipping_rate")
+    @Getter(lombok.AccessLevel.NONE)
+    @Setter(lombok.AccessLevel.NONE)
+    ExpandableField<ShippingRate> shippingRate;
+
+    /** Get ID of expandable {@code shippingRate} object. */
+    public String getShippingRate() {
+      return (this.shippingRate != null) ? this.shippingRate.getId() : null;
+    }
+
+    public void setShippingRate(String id) {
+      this.shippingRate = ApiResource.setExpandableFieldId(id, this.shippingRate);
+    }
+
+    /** Get expanded {@code shippingRate}. */
+    public ShippingRate getShippingRateObject() {
+      return (this.shippingRate != null) ? this.shippingRate.getExpanded() : null;
+    }
+
+    public void setShippingRateObject(ShippingRate expandableObject) {
+      this.shippingRate =
+          new ExpandableField<ShippingRate>(expandableObject.getId(), expandableObject);
+    }
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
   public static class SubscriptionData extends StripeObject {
     /**
      * Integer representing the number of trial period days before the customer is charged for the
@@ -416,6 +518,15 @@ public class PaymentLink extends ApiResource implements HasId, MetadataStore<Pay
      */
     @SerializedName("trial_period_days")
     Long trialPeriodDays;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class TaxIdCollection extends StripeObject {
+    /** Indicates whether tax ID collection is enabled for the session. */
+    @SerializedName("enabled")
+    Boolean enabled;
   }
 
   @Getter

--- a/src/main/java/com/stripe/model/PromotionCode.java
+++ b/src/main/java/com/stripe/model/PromotionCode.java
@@ -36,9 +36,12 @@ public class PromotionCode extends ApiResource implements HasId, MetadataStore<P
   /**
    * A coupon contains information about a percent-off or amount-off discount you might want to
    * apply to a customer. Coupons may be applied to <a
-   * href="https://stripe.com/docs/api#invoices">invoices</a> or <a
-   * href="https://stripe.com/docs/api#create_order_legacy-coupon">orders</a>. Coupons do not work
-   * with conventional one-off <a href="https://stripe.com/docs/api#create_charge">charges</a>.
+   * href="https://stripe.com/docs/api#subscriptions">subscriptions</a>, <a
+   * href="https://stripe.com/docs/api#invoices">invoices</a>, <a
+   * href="https://stripe.com/docs/api/checkout/sessions">checkout sessions</a>, <a
+   * href="https://stripe.com/docs/api#quotes">quotes</a>, and more. Coupons do not work with
+   * conventional one-off <a href="https://stripe.com/docs/api#create_charge">charges</a> or <a
+   * href="https://stripe.com/docs/api/payment_intents">payment intents</a>.
    */
   @SerializedName("coupon")
   Coupon coupon;

--- a/src/main/java/com/stripe/model/Refund.java
+++ b/src/main/java/com/stripe/model/Refund.java
@@ -131,8 +131,8 @@ public class Refund extends ApiResource implements MetadataStore<Refund>, Balanc
 
   /**
    * Status of the refund. For credit card refunds, this can be {@code pending}, {@code succeeded},
-   * or {@code failed}. For other types of refunds, it can be {@code pending}, {@code succeeded},
-   * {@code failed}, or {@code canceled}. Refer to our <a
+   * or {@code failed}. For other types of refunds, it can be {@code pending}, {@code
+   * requires_action}, {@code succeeded}, {@code failed}, or {@code canceled}. Refer to our <a
    * href="https://stripe.com/docs/refunds#failed-refunds">refunds</a> documentation for more
    * details.
    */

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -152,6 +152,13 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
   List<TaxRate> defaultTaxRates;
 
   /**
+   * The subscription's description, meant to be displayable to the customer. Use this field to
+   * optionally store an explanation of the subscription for rendering in Stripe surfaces.
+   */
+  @SerializedName("description")
+  String description;
+
+  /**
    * Describes the current discount applied to this subscription, if there is one. When billing, a
    * discount applied to a subscription overrides a discount applied on a customer-wide basis.
    */

--- a/src/main/java/com/stripe/model/SubscriptionSchedule.java
+++ b/src/main/java/com/stripe/model/SubscriptionSchedule.java
@@ -771,6 +771,15 @@ public class SubscriptionSchedule extends ApiResource
     List<SubscriptionSchedule.PhaseItem> items;
 
     /**
+     * Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can attach
+     * to a phase. Metadata on a schedule's phase will update the underlying subscription's {@code
+     * metadata} when the phase is entered. Updating the underlying subscription's {@code metadata}
+     * directly will not affect the current phase's {@code metadata}.
+     */
+    @SerializedName("metadata")
+    Map<String, String> metadata;
+
+    /**
      * If the subscription schedule will prorate when transitioning to this phase. Possible values
      * are {@code create_prorations} and {@code none}.
      *

--- a/src/main/java/com/stripe/param/PaymentLinkCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentLinkCreateParams.java
@@ -45,6 +45,18 @@ public class PaymentLinkCreateParams extends ApiRequestParams {
   @SerializedName("billing_address_collection")
   BillingAddressCollection billingAddressCollection;
 
+  /** Configure fields to gather active consent from customers. */
+  @SerializedName("consent_collection")
+  ConsentCollection consentCollection;
+
+  /**
+   * Configures whether <a href="https://stripe.com/docs/api/checkout/sessions">checkout
+   * sessions</a> created by this payment link create a <a
+   * href="https://stripe.com/docs/api/customers">Customer</a>.
+   */
+  @SerializedName("customer_creation")
+  CustomerCreation customerCreation;
+
   /** Specifies which fields in the response should be expanded. */
   @SerializedName("expand")
   List<String> expand;
@@ -82,6 +94,13 @@ public class PaymentLinkCreateParams extends ApiRequestParams {
   String onBehalfOf;
 
   /**
+   * A subset of parameters to be passed to PaymentIntent creation for Checkout Sessions in {@code
+   * payment} mode.
+   */
+  @SerializedName("payment_intent_data")
+  PaymentIntentData paymentIntentData;
+
+  /**
    * The list of payment method types that customers can use. Only {@code card} is supported. If no
    * value is passed, Stripe will dynamically show relevant payment methods from your <a
    * href="https://dashboard.stripe.com/settings/payment_methods">payment method settings</a> (20+
@@ -104,11 +123,30 @@ public class PaymentLinkCreateParams extends ApiRequestParams {
   ShippingAddressCollection shippingAddressCollection;
 
   /**
+   * The shipping rate options to apply to <a
+   * href="https://stripe.com/docs/api/checkout/sessions">checkout sessions</a> created by this
+   * payment link.
+   */
+  @SerializedName("shipping_options")
+  List<ShippingOption> shippingOptions;
+
+  /**
+   * Describes the type of transaction being performed in order to customize relevant text on the
+   * page, such as the submit button.
+   */
+  @SerializedName("submit_type")
+  SubmitType submitType;
+
+  /**
    * When creating a subscription, the specified configuration data will be used. There must be at
    * least one line item with a recurring price to use {@code subscription_data}.
    */
   @SerializedName("subscription_data")
   SubscriptionData subscriptionData;
+
+  /** Controls tax ID collection during checkout. */
+  @SerializedName("tax_id_collection")
+  TaxIdCollection taxIdCollection;
 
   /**
    * The account (if any) the payments will be attributed to for tax reporting, and where funds from
@@ -124,15 +162,21 @@ public class PaymentLinkCreateParams extends ApiRequestParams {
       BigDecimal applicationFeePercent,
       AutomaticTax automaticTax,
       BillingAddressCollection billingAddressCollection,
+      ConsentCollection consentCollection,
+      CustomerCreation customerCreation,
       List<String> expand,
       Map<String, Object> extraParams,
       List<LineItem> lineItems,
       Map<String, String> metadata,
       String onBehalfOf,
+      PaymentIntentData paymentIntentData,
       List<PaymentMethodType> paymentMethodTypes,
       PhoneNumberCollection phoneNumberCollection,
       ShippingAddressCollection shippingAddressCollection,
+      List<ShippingOption> shippingOptions,
+      SubmitType submitType,
       SubscriptionData subscriptionData,
+      TaxIdCollection taxIdCollection,
       TransferData transferData) {
     this.afterCompletion = afterCompletion;
     this.allowPromotionCodes = allowPromotionCodes;
@@ -140,15 +184,21 @@ public class PaymentLinkCreateParams extends ApiRequestParams {
     this.applicationFeePercent = applicationFeePercent;
     this.automaticTax = automaticTax;
     this.billingAddressCollection = billingAddressCollection;
+    this.consentCollection = consentCollection;
+    this.customerCreation = customerCreation;
     this.expand = expand;
     this.extraParams = extraParams;
     this.lineItems = lineItems;
     this.metadata = metadata;
     this.onBehalfOf = onBehalfOf;
+    this.paymentIntentData = paymentIntentData;
     this.paymentMethodTypes = paymentMethodTypes;
     this.phoneNumberCollection = phoneNumberCollection;
     this.shippingAddressCollection = shippingAddressCollection;
+    this.shippingOptions = shippingOptions;
+    this.submitType = submitType;
     this.subscriptionData = subscriptionData;
+    this.taxIdCollection = taxIdCollection;
     this.transferData = transferData;
   }
 
@@ -169,6 +219,10 @@ public class PaymentLinkCreateParams extends ApiRequestParams {
 
     private BillingAddressCollection billingAddressCollection;
 
+    private ConsentCollection consentCollection;
+
+    private CustomerCreation customerCreation;
+
     private List<String> expand;
 
     private Map<String, Object> extraParams;
@@ -179,13 +233,21 @@ public class PaymentLinkCreateParams extends ApiRequestParams {
 
     private String onBehalfOf;
 
+    private PaymentIntentData paymentIntentData;
+
     private List<PaymentMethodType> paymentMethodTypes;
 
     private PhoneNumberCollection phoneNumberCollection;
 
     private ShippingAddressCollection shippingAddressCollection;
 
+    private List<ShippingOption> shippingOptions;
+
+    private SubmitType submitType;
+
     private SubscriptionData subscriptionData;
+
+    private TaxIdCollection taxIdCollection;
 
     private TransferData transferData;
 
@@ -198,15 +260,21 @@ public class PaymentLinkCreateParams extends ApiRequestParams {
           this.applicationFeePercent,
           this.automaticTax,
           this.billingAddressCollection,
+          this.consentCollection,
+          this.customerCreation,
           this.expand,
           this.extraParams,
           this.lineItems,
           this.metadata,
           this.onBehalfOf,
+          this.paymentIntentData,
           this.paymentMethodTypes,
           this.phoneNumberCollection,
           this.shippingAddressCollection,
+          this.shippingOptions,
+          this.submitType,
           this.subscriptionData,
+          this.taxIdCollection,
           this.transferData);
     }
 
@@ -252,6 +320,22 @@ public class PaymentLinkCreateParams extends ApiRequestParams {
     /** Configuration for collecting the customer's billing address. */
     public Builder setBillingAddressCollection(BillingAddressCollection billingAddressCollection) {
       this.billingAddressCollection = billingAddressCollection;
+      return this;
+    }
+
+    /** Configure fields to gather active consent from customers. */
+    public Builder setConsentCollection(ConsentCollection consentCollection) {
+      this.consentCollection = consentCollection;
+      return this;
+    }
+
+    /**
+     * Configures whether <a href="https://stripe.com/docs/api/checkout/sessions">checkout
+     * sessions</a> created by this payment link create a <a
+     * href="https://stripe.com/docs/api/customers">Customer</a>.
+     */
+    public Builder setCustomerCreation(CustomerCreation customerCreation) {
+      this.customerCreation = customerCreation;
       return this;
     }
 
@@ -366,6 +450,15 @@ public class PaymentLinkCreateParams extends ApiRequestParams {
     }
 
     /**
+     * A subset of parameters to be passed to PaymentIntent creation for Checkout Sessions in {@code
+     * payment} mode.
+     */
+    public Builder setPaymentIntentData(PaymentIntentData paymentIntentData) {
+      this.paymentIntentData = paymentIntentData;
+      return this;
+    }
+
+    /**
      * Add an element to `paymentMethodTypes` list. A list is initialized for the first `add/addAll`
      * call, and subsequent calls adds additional elements to the original list. See {@link
      * PaymentLinkCreateParams#paymentMethodTypes} for the field documentation.
@@ -409,11 +502,52 @@ public class PaymentLinkCreateParams extends ApiRequestParams {
     }
 
     /**
+     * Add an element to `shippingOptions` list. A list is initialized for the first `add/addAll`
+     * call, and subsequent calls adds additional elements to the original list. See {@link
+     * PaymentLinkCreateParams#shippingOptions} for the field documentation.
+     */
+    public Builder addShippingOption(ShippingOption element) {
+      if (this.shippingOptions == null) {
+        this.shippingOptions = new ArrayList<>();
+      }
+      this.shippingOptions.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `shippingOptions` list. A list is initialized for the first `add/addAll`
+     * call, and subsequent calls adds additional elements to the original list. See {@link
+     * PaymentLinkCreateParams#shippingOptions} for the field documentation.
+     */
+    public Builder addAllShippingOption(List<ShippingOption> elements) {
+      if (this.shippingOptions == null) {
+        this.shippingOptions = new ArrayList<>();
+      }
+      this.shippingOptions.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Describes the type of transaction being performed in order to customize relevant text on the
+     * page, such as the submit button.
+     */
+    public Builder setSubmitType(SubmitType submitType) {
+      this.submitType = submitType;
+      return this;
+    }
+
+    /**
      * When creating a subscription, the specified configuration data will be used. There must be at
      * least one line item with a recurring price to use {@code subscription_data}.
      */
     public Builder setSubscriptionData(SubscriptionData subscriptionData) {
       this.subscriptionData = subscriptionData;
+      return this;
+    }
+
+    /** Controls tax ID collection during checkout. */
+    public Builder setTaxIdCollection(TaxIdCollection taxIdCollection) {
+      this.taxIdCollection = taxIdCollection;
       return this;
     }
 
@@ -767,6 +901,97 @@ public class PaymentLinkCreateParams extends ApiRequestParams {
   }
 
   @Getter
+  public static class ConsentCollection {
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /**
+     * If set to {@code auto}, enables the collection of customer consent for promotional
+     * communications. The Checkout Session will determine whether to display an option to opt into
+     * promotional communication from the merchant depending on the customer's locale. Only
+     * available to US merchants.
+     */
+    @SerializedName("promotions")
+    Promotions promotions;
+
+    private ConsentCollection(Map<String, Object> extraParams, Promotions promotions) {
+      this.extraParams = extraParams;
+      this.promotions = promotions;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Map<String, Object> extraParams;
+
+      private Promotions promotions;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public ConsentCollection build() {
+        return new ConsentCollection(this.extraParams, this.promotions);
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * PaymentLinkCreateParams.ConsentCollection#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link PaymentLinkCreateParams.ConsentCollection#extraParams} for the field
+       * documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /**
+       * If set to {@code auto}, enables the collection of customer consent for promotional
+       * communications. The Checkout Session will determine whether to display an option to opt
+       * into promotional communication from the merchant depending on the customer's locale. Only
+       * available to US merchants.
+       */
+      public Builder setPromotions(Promotions promotions) {
+        this.promotions = promotions;
+        return this;
+      }
+    }
+
+    public enum Promotions implements ApiRequestParams.EnumParam {
+      @SerializedName("auto")
+      AUTO("auto");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      Promotions(String value) {
+        this.value = value;
+      }
+    }
+  }
+
+  @Getter
   public static class LineItem {
     /**
      * When set, provides configuration for this item’s quantity to be adjusted by the customer
@@ -983,6 +1208,162 @@ public class PaymentLinkCreateParams extends ApiRequestParams {
           this.minimum = minimum;
           return this;
         }
+      }
+    }
+  }
+
+  @Getter
+  public static class PaymentIntentData {
+    /** Controls when the funds will be captured from the customer's account. */
+    @SerializedName("capture_method")
+    CaptureMethod captureMethod;
+
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /**
+     * Indicates that you intend to <a
+     * href="https://stripe.com/docs/payments/payment-intents#future-usage">make future payments</a>
+     * with the payment method collected by this Checkout Session.
+     *
+     * <p>When setting this to {@code on_session}, Checkout will show a notice to the customer that
+     * their payment details will be saved.
+     *
+     * <p>When setting this to {@code off_session}, Checkout will show a notice to the customer that
+     * their payment details will be saved and used for future payments.
+     *
+     * <p>If a Customer has been provided or Checkout creates a new Customer,Checkout will attach
+     * the payment method to the Customer.
+     *
+     * <p>If Checkout does not create a Customer, the payment method is not attached to a Customer.
+     * To reuse the payment method, you can retrieve it from the Checkout Session's PaymentIntent.
+     *
+     * <p>When processing card payments, Checkout also uses {@code setup_future_usage} to
+     * dynamically optimize your payment flow and comply with regional legislation and network
+     * rules, such as SCA.
+     */
+    @SerializedName("setup_future_usage")
+    SetupFutureUsage setupFutureUsage;
+
+    private PaymentIntentData(
+        CaptureMethod captureMethod,
+        Map<String, Object> extraParams,
+        SetupFutureUsage setupFutureUsage) {
+      this.captureMethod = captureMethod;
+      this.extraParams = extraParams;
+      this.setupFutureUsage = setupFutureUsage;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private CaptureMethod captureMethod;
+
+      private Map<String, Object> extraParams;
+
+      private SetupFutureUsage setupFutureUsage;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public PaymentIntentData build() {
+        return new PaymentIntentData(this.captureMethod, this.extraParams, this.setupFutureUsage);
+      }
+
+      /** Controls when the funds will be captured from the customer's account. */
+      public Builder setCaptureMethod(CaptureMethod captureMethod) {
+        this.captureMethod = captureMethod;
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * PaymentLinkCreateParams.PaymentIntentData#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link PaymentLinkCreateParams.PaymentIntentData#extraParams} for the field
+       * documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /**
+       * Indicates that you intend to <a
+       * href="https://stripe.com/docs/payments/payment-intents#future-usage">make future
+       * payments</a> with the payment method collected by this Checkout Session.
+       *
+       * <p>When setting this to {@code on_session}, Checkout will show a notice to the customer
+       * that their payment details will be saved.
+       *
+       * <p>When setting this to {@code off_session}, Checkout will show a notice to the customer
+       * that their payment details will be saved and used for future payments.
+       *
+       * <p>If a Customer has been provided or Checkout creates a new Customer,Checkout will attach
+       * the payment method to the Customer.
+       *
+       * <p>If Checkout does not create a Customer, the payment method is not attached to a
+       * Customer. To reuse the payment method, you can retrieve it from the Checkout Session's
+       * PaymentIntent.
+       *
+       * <p>When processing card payments, Checkout also uses {@code setup_future_usage} to
+       * dynamically optimize your payment flow and comply with regional legislation and network
+       * rules, such as SCA.
+       */
+      public Builder setSetupFutureUsage(SetupFutureUsage setupFutureUsage) {
+        this.setupFutureUsage = setupFutureUsage;
+        return this;
+      }
+    }
+
+    public enum CaptureMethod implements ApiRequestParams.EnumParam {
+      @SerializedName("automatic")
+      AUTOMATIC("automatic"),
+
+      @SerializedName("manual")
+      MANUAL("manual");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      CaptureMethod(String value) {
+        this.value = value;
+      }
+    }
+
+    public enum SetupFutureUsage implements ApiRequestParams.EnumParam {
+      @SerializedName("off_session")
+      OFF_SESSION("off_session"),
+
+      @SerializedName("on_session")
+      ON_SESSION("on_session");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      SetupFutureUsage(String value) {
+        this.value = value;
       }
     }
   }
@@ -1873,6 +2254,74 @@ public class PaymentLinkCreateParams extends ApiRequestParams {
   }
 
   @Getter
+  public static class ShippingOption {
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /** The ID of the Shipping Rate to use for this shipping option. */
+    @SerializedName("shipping_rate")
+    String shippingRate;
+
+    private ShippingOption(Map<String, Object> extraParams, String shippingRate) {
+      this.extraParams = extraParams;
+      this.shippingRate = shippingRate;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Map<String, Object> extraParams;
+
+      private String shippingRate;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public ShippingOption build() {
+        return new ShippingOption(this.extraParams, this.shippingRate);
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * PaymentLinkCreateParams.ShippingOption#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link PaymentLinkCreateParams.ShippingOption#extraParams} for the field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** The ID of the Shipping Rate to use for this shipping option. */
+      public Builder setShippingRate(String shippingRate) {
+        this.shippingRate = shippingRate;
+        return this;
+      }
+    }
+  }
+
+  @Getter
   public static class SubscriptionData {
     /**
      * Map of extra parameters for custom features not available in this client library. The content
@@ -1942,6 +2391,75 @@ public class PaymentLinkCreateParams extends ApiRequestParams {
        */
       public Builder setTrialPeriodDays(Long trialPeriodDays) {
         this.trialPeriodDays = trialPeriodDays;
+        return this;
+      }
+    }
+  }
+
+  @Getter
+  public static class TaxIdCollection {
+    /** Set to {@code true} to enable tax ID collection. */
+    @SerializedName("enabled")
+    Boolean enabled;
+
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    private TaxIdCollection(Boolean enabled, Map<String, Object> extraParams) {
+      this.enabled = enabled;
+      this.extraParams = extraParams;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Boolean enabled;
+
+      private Map<String, Object> extraParams;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public TaxIdCollection build() {
+        return new TaxIdCollection(this.enabled, this.extraParams);
+      }
+
+      /** Set to {@code true} to enable tax ID collection. */
+      public Builder setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * PaymentLinkCreateParams.TaxIdCollection#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link PaymentLinkCreateParams.TaxIdCollection#extraParams} for the field
+       * documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
         return this;
       }
     }
@@ -2052,6 +2570,21 @@ public class PaymentLinkCreateParams extends ApiRequestParams {
     }
   }
 
+  public enum CustomerCreation implements ApiRequestParams.EnumParam {
+    @SerializedName("always")
+    ALWAYS("always"),
+
+    @SerializedName("if_required")
+    IF_REQUIRED("if_required");
+
+    @Getter(onMethod_ = {@Override})
+    private final String value;
+
+    CustomerCreation(String value) {
+      this.value = value;
+    }
+  }
+
   public enum PaymentMethodType implements ApiRequestParams.EnumParam {
     @SerializedName("card")
     CARD("card");
@@ -2060,6 +2593,27 @@ public class PaymentLinkCreateParams extends ApiRequestParams {
     private final String value;
 
     PaymentMethodType(String value) {
+      this.value = value;
+    }
+  }
+
+  public enum SubmitType implements ApiRequestParams.EnumParam {
+    @SerializedName("auto")
+    AUTO("auto"),
+
+    @SerializedName("book")
+    BOOK("book"),
+
+    @SerializedName("donate")
+    DONATE("donate"),
+
+    @SerializedName("pay")
+    PAY("pay");
+
+    @Getter(onMethod_ = {@Override})
+    private final String value;
+
+    SubmitType(String value) {
       this.value = value;
     }
   }

--- a/src/main/java/com/stripe/param/PaymentLinkUpdateParams.java
+++ b/src/main/java/com/stripe/param/PaymentLinkUpdateParams.java
@@ -35,6 +35,14 @@ public class PaymentLinkUpdateParams extends ApiRequestParams {
   @SerializedName("billing_address_collection")
   BillingAddressCollection billingAddressCollection;
 
+  /**
+   * Configures whether <a href="https://stripe.com/docs/api/checkout/sessions">checkout
+   * sessions</a> created by this payment link create a <a
+   * href="https://stripe.com/docs/api/customers">Customer</a>.
+   */
+  @SerializedName("customer_creation")
+  CustomerCreation customerCreation;
+
   /** Specifies which fields in the response should be expanded. */
   @SerializedName("expand")
   List<String> expand;
@@ -85,6 +93,7 @@ public class PaymentLinkUpdateParams extends ApiRequestParams {
       Boolean allowPromotionCodes,
       AutomaticTax automaticTax,
       BillingAddressCollection billingAddressCollection,
+      CustomerCreation customerCreation,
       List<String> expand,
       Map<String, Object> extraParams,
       List<LineItem> lineItems,
@@ -96,6 +105,7 @@ public class PaymentLinkUpdateParams extends ApiRequestParams {
     this.allowPromotionCodes = allowPromotionCodes;
     this.automaticTax = automaticTax;
     this.billingAddressCollection = billingAddressCollection;
+    this.customerCreation = customerCreation;
     this.expand = expand;
     this.extraParams = extraParams;
     this.lineItems = lineItems;
@@ -119,6 +129,8 @@ public class PaymentLinkUpdateParams extends ApiRequestParams {
 
     private BillingAddressCollection billingAddressCollection;
 
+    private CustomerCreation customerCreation;
+
     private List<String> expand;
 
     private Map<String, Object> extraParams;
@@ -139,6 +151,7 @@ public class PaymentLinkUpdateParams extends ApiRequestParams {
           this.allowPromotionCodes,
           this.automaticTax,
           this.billingAddressCollection,
+          this.customerCreation,
           this.expand,
           this.extraParams,
           this.lineItems,
@@ -177,6 +190,16 @@ public class PaymentLinkUpdateParams extends ApiRequestParams {
     /** Configuration for collecting the customer's billing address. */
     public Builder setBillingAddressCollection(BillingAddressCollection billingAddressCollection) {
       this.billingAddressCollection = billingAddressCollection;
+      return this;
+    }
+
+    /**
+     * Configures whether <a href="https://stripe.com/docs/api/checkout/sessions">checkout
+     * sessions</a> created by this payment link create a <a
+     * href="https://stripe.com/docs/api/customers">Customer</a>.
+     */
+    public Builder setCustomerCreation(CustomerCreation customerCreation) {
+      this.customerCreation = customerCreation;
       return this;
     }
 
@@ -1750,6 +1773,21 @@ public class PaymentLinkUpdateParams extends ApiRequestParams {
     private final String value;
 
     BillingAddressCollection(String value) {
+      this.value = value;
+    }
+  }
+
+  public enum CustomerCreation implements ApiRequestParams.EnumParam {
+    @SerializedName("always")
+    ALWAYS("always"),
+
+    @SerializedName("if_required")
+    IF_REQUIRED("if_required");
+
+    @Getter(onMethod_ = {@Override})
+    private final String value;
+
+    CustomerCreation(String value) {
       this.value = value;
     }
   }

--- a/src/main/java/com/stripe/param/SubscriptionCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionCreateParams.java
@@ -132,6 +132,13 @@ public class SubscriptionCreateParams extends ApiRequestParams {
   @SerializedName("default_tax_rates")
   Object defaultTaxRates;
 
+  /**
+   * The subscription's description, meant to be displayable to the customer. Use this field to
+   * optionally store an explanation of the subscription for rendering in Stripe surfaces.
+   */
+  @SerializedName("description")
+  String description;
+
   /** Specifies which fields in the response should be expanded. */
   @SerializedName("expand")
   List<String> expand;
@@ -279,6 +286,7 @@ public class SubscriptionCreateParams extends ApiRequestParams {
       String defaultPaymentMethod,
       String defaultSource,
       Object defaultTaxRates,
+      String description,
       List<String> expand,
       Map<String, Object> extraParams,
       List<Item> items,
@@ -308,6 +316,7 @@ public class SubscriptionCreateParams extends ApiRequestParams {
     this.defaultPaymentMethod = defaultPaymentMethod;
     this.defaultSource = defaultSource;
     this.defaultTaxRates = defaultTaxRates;
+    this.description = description;
     this.expand = expand;
     this.extraParams = extraParams;
     this.items = items;
@@ -359,6 +368,8 @@ public class SubscriptionCreateParams extends ApiRequestParams {
 
     private Object defaultTaxRates;
 
+    private String description;
+
     private List<String> expand;
 
     private Map<String, Object> extraParams;
@@ -405,6 +416,7 @@ public class SubscriptionCreateParams extends ApiRequestParams {
           this.defaultPaymentMethod,
           this.defaultSource,
           this.defaultTaxRates,
+          this.description,
           this.expand,
           this.extraParams,
           this.items,
@@ -631,6 +643,15 @@ public class SubscriptionCreateParams extends ApiRequestParams {
      */
     public Builder setDefaultTaxRates(List<String> defaultTaxRates) {
       this.defaultTaxRates = defaultTaxRates;
+      return this;
+    }
+
+    /**
+     * The subscription's description, meant to be displayable to the customer. Use this field to
+     * optionally store an explanation of the subscription for rendering in Stripe surfaces.
+     */
+    public Builder setDescription(String description) {
+      this.description = description;
       return this;
     }
 

--- a/src/main/java/com/stripe/param/SubscriptionScheduleCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionScheduleCreateParams.java
@@ -1060,6 +1060,18 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
     Long iterations;
 
     /**
+     * Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can attach
+     * to a phase. Metadata on a schedule's phase will update the underlying subscription's {@code
+     * metadata} when the phase is entered, adding new keys and replacing existing keys in the
+     * subscription's {@code metadata}. Individual keys in the subscription's {@code metadata} can
+     * be unset by posting an empty value to them in the phase's {@code metadata}. To unset all keys
+     * in the subscription's {@code metadata}, update the subscription directly or unset every key
+     * individually from the phase's {@code metadata}.
+     */
+    @SerializedName("metadata")
+    Map<String, String> metadata;
+
+    /**
      * If a subscription schedule will create prorations when transitioning to this phase. Possible
      * values are {@code create_prorations} or {@code none}, and the default value is {@code
      * create_prorations}. See <a
@@ -1104,6 +1116,7 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
         InvoiceSettings invoiceSettings,
         List<Item> items,
         Long iterations,
+        Map<String, String> metadata,
         ProrationBehavior prorationBehavior,
         TransferData transferData,
         Boolean trial,
@@ -1122,6 +1135,7 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
       this.invoiceSettings = invoiceSettings;
       this.items = items;
       this.iterations = iterations;
+      this.metadata = metadata;
       this.prorationBehavior = prorationBehavior;
       this.transferData = transferData;
       this.trial = trial;
@@ -1161,6 +1175,8 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
 
       private Long iterations;
 
+      private Map<String, String> metadata;
+
       private ProrationBehavior prorationBehavior;
 
       private TransferData transferData;
@@ -1186,6 +1202,7 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
             this.invoiceSettings,
             this.items,
             this.iterations,
+            this.metadata,
             this.prorationBehavior,
             this.transferData,
             this.trial,
@@ -1423,6 +1440,32 @@ public class SubscriptionScheduleCreateParams extends ApiRequestParams {
        */
       public Builder setIterations(Long iterations) {
         this.iterations = iterations;
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `metadata` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * SubscriptionScheduleCreateParams.Phase#metadata} for the field documentation.
+       */
+      public Builder putMetadata(String key, String value) {
+        if (this.metadata == null) {
+          this.metadata = new HashMap<>();
+        }
+        this.metadata.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `metadata` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link SubscriptionScheduleCreateParams.Phase#metadata} for the field documentation.
+       */
+      public Builder putAllMetadata(Map<String, String> map) {
+        if (this.metadata == null) {
+          this.metadata = new HashMap<>();
+        }
+        this.metadata.putAll(map);
         return this;
       }
 

--- a/src/main/java/com/stripe/param/SubscriptionScheduleUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionScheduleUpdateParams.java
@@ -1025,6 +1025,18 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
     Long iterations;
 
     /**
+     * Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can attach
+     * to a phase. Metadata on a schedule's phase will update the underlying subscription's {@code
+     * metadata} when the phase is entered, adding new keys and replacing existing keys in the
+     * subscription's {@code metadata}. Individual keys in the subscription's {@code metadata} can
+     * be unset by posting an empty value to them in the phase's {@code metadata}. To unset all keys
+     * in the subscription's {@code metadata}, update the subscription directly or unset every key
+     * individually from the phase's {@code metadata}.
+     */
+    @SerializedName("metadata")
+    Map<String, String> metadata;
+
+    /**
      * If a subscription schedule will create prorations when transitioning to this phase. Possible
      * values are {@code create_prorations} or {@code none}, and the default value is {@code
      * create_prorations}. See <a
@@ -1076,6 +1088,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
         InvoiceSettings invoiceSettings,
         List<Item> items,
         Long iterations,
+        Map<String, String> metadata,
         ProrationBehavior prorationBehavior,
         Object startDate,
         TransferData transferData,
@@ -1095,6 +1108,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
       this.invoiceSettings = invoiceSettings;
       this.items = items;
       this.iterations = iterations;
+      this.metadata = metadata;
       this.prorationBehavior = prorationBehavior;
       this.startDate = startDate;
       this.transferData = transferData;
@@ -1135,6 +1149,8 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
 
       private Long iterations;
 
+      private Map<String, String> metadata;
+
       private ProrationBehavior prorationBehavior;
 
       private Object startDate;
@@ -1162,6 +1178,7 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
             this.invoiceSettings,
             this.items,
             this.iterations,
+            this.metadata,
             this.prorationBehavior,
             this.startDate,
             this.transferData,
@@ -1425,6 +1442,32 @@ public class SubscriptionScheduleUpdateParams extends ApiRequestParams {
        */
       public Builder setIterations(Long iterations) {
         this.iterations = iterations;
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `metadata` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * SubscriptionScheduleUpdateParams.Phase#metadata} for the field documentation.
+       */
+      public Builder putMetadata(String key, String value) {
+        if (this.metadata == null) {
+          this.metadata = new HashMap<>();
+        }
+        this.metadata.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `metadata` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link SubscriptionScheduleUpdateParams.Phase#metadata} for the field documentation.
+       */
+      public Builder putAllMetadata(Map<String, String> map) {
+        if (this.metadata == null) {
+          this.metadata = new HashMap<>();
+        }
+        this.metadata.putAll(map);
         return this;
       }
 

--- a/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
@@ -119,6 +119,13 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
   @SerializedName("default_tax_rates")
   Object defaultTaxRates;
 
+  /**
+   * The subscription's description, meant to be displayable to the customer. Use this field to
+   * optionally store an explanation of the subscription for rendering in Stripe surfaces.
+   */
+  @SerializedName("description")
+  Object description;
+
   /** Specifies which fields in the response should be expanded. */
   @SerializedName("expand")
   List<String> expand;
@@ -273,6 +280,7 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
       Object defaultPaymentMethod,
       Object defaultSource,
       Object defaultTaxRates,
+      Object description,
       List<String> expand,
       Map<String, Object> extraParams,
       List<Item> items,
@@ -301,6 +309,7 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
     this.defaultPaymentMethod = defaultPaymentMethod;
     this.defaultSource = defaultSource;
     this.defaultTaxRates = defaultTaxRates;
+    this.description = description;
     this.expand = expand;
     this.extraParams = extraParams;
     this.items = items;
@@ -349,6 +358,8 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
 
     private Object defaultTaxRates;
 
+    private Object description;
+
     private List<String> expand;
 
     private Map<String, Object> extraParams;
@@ -395,6 +406,7 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
           this.defaultPaymentMethod,
           this.defaultSource,
           this.defaultTaxRates,
+          this.description,
           this.expand,
           this.extraParams,
           this.items,
@@ -653,6 +665,24 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
      */
     public Builder setDefaultTaxRates(List<String> defaultTaxRates) {
       this.defaultTaxRates = defaultTaxRates;
+      return this;
+    }
+
+    /**
+     * The subscription's description, meant to be displayable to the customer. Use this field to
+     * optionally store an explanation of the subscription for rendering in Stripe surfaces.
+     */
+    public Builder setDescription(String description) {
+      this.description = description;
+      return this;
+    }
+
+    /**
+     * The subscription's description, meant to be displayable to the customer. Use this field to
+     * optionally store an explanation of the subscription for rendering in Stripe surfaces.
+     */
+    public Builder setDescription(EmptyParam description) {
+      this.description = description;
       return this;
     }
 

--- a/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
+++ b/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
@@ -612,6 +612,9 @@ public class WebhookEndpointCreateParams extends ApiRequestParams {
     @SerializedName("billing_portal.configuration.updated")
     BILLING_PORTAL__CONFIGURATION__UPDATED("billing_portal.configuration.updated"),
 
+    @SerializedName("billing_portal.session.created")
+    BILLING_PORTAL__SESSION__CREATED("billing_portal.session.created"),
+
     @SerializedName("capability.updated")
     CAPABILITY__UPDATED("capability.updated"),
 

--- a/src/main/java/com/stripe/param/WebhookEndpointUpdateParams.java
+++ b/src/main/java/com/stripe/param/WebhookEndpointUpdateParams.java
@@ -300,6 +300,9 @@ public class WebhookEndpointUpdateParams extends ApiRequestParams {
     @SerializedName("billing_portal.configuration.updated")
     BILLING_PORTAL__CONFIGURATION__UPDATED("billing_portal.configuration.updated"),
 
+    @SerializedName("billing_portal.session.created")
+    BILLING_PORTAL__SESSION__CREATED("billing_portal.session.created"),
+
     @SerializedName("capability.updated")
     CAPABILITY__UPDATED("capability.updated"),
 

--- a/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
+++ b/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
@@ -6165,6 +6165,13 @@ public class SessionCreateParams extends ApiRequestParams {
     List<String> defaultTaxRates;
 
     /**
+     * The subscription's description, meant to be displayable to the customer. Use this field to
+     * optionally store an explanation of the subscription for rendering in Stripe hosted surfaces.
+     */
+    @SerializedName("description")
+    String description;
+
+    /**
      * Map of extra parameters for custom features not available in this client library. The content
      * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
      * key/value pair is serialized as if the key is a root-level field (serialized) name in this
@@ -6222,6 +6229,7 @@ public class SessionCreateParams extends ApiRequestParams {
         BigDecimal applicationFeePercent,
         String coupon,
         List<String> defaultTaxRates,
+        String description,
         Map<String, Object> extraParams,
         List<Item> items,
         Map<String, String> metadata,
@@ -6232,6 +6240,7 @@ public class SessionCreateParams extends ApiRequestParams {
       this.applicationFeePercent = applicationFeePercent;
       this.coupon = coupon;
       this.defaultTaxRates = defaultTaxRates;
+      this.description = description;
       this.extraParams = extraParams;
       this.items = items;
       this.metadata = metadata;
@@ -6251,6 +6260,8 @@ public class SessionCreateParams extends ApiRequestParams {
       private String coupon;
 
       private List<String> defaultTaxRates;
+
+      private String description;
 
       private Map<String, Object> extraParams;
 
@@ -6272,6 +6283,7 @@ public class SessionCreateParams extends ApiRequestParams {
             this.applicationFeePercent,
             this.coupon,
             this.defaultTaxRates,
+            this.description,
             this.extraParams,
             this.items,
             this.metadata,
@@ -6326,6 +6338,16 @@ public class SessionCreateParams extends ApiRequestParams {
           this.defaultTaxRates = new ArrayList<>();
         }
         this.defaultTaxRates.addAll(elements);
+        return this;
+      }
+
+      /**
+       * The subscription's description, meant to be displayable to the customer. Use this field to
+       * optionally store an explanation of the subscription for rendering in Stripe hosted
+       * surfaces.
+       */
+      public Builder setDescription(String description) {
+        this.description = description;
         return this;
       }
 

--- a/src/test/java/com/stripe/functional/GeneratedExamples.java
+++ b/src/test/java/com/stripe/functional/GeneratedExamples.java
@@ -3085,14 +3085,14 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testAccountRefresh() throws StripeException {
+    com.stripe.model.financialconnections.Account resource =
+        com.stripe.model.financialconnections.Account.retrieve("fca_xyz");
     com.stripe.param.financialconnections.AccountRefreshParams params =
         com.stripe.param.financialconnections.AccountRefreshParams.builder()
             .addFeature(com.stripe.param.financialconnections.AccountRefreshParams.Feature.BALANCE)
             .build();
 
-    com.stripe.net.RequestOptions opts = com.stripe.net.RequestOptions.builder().build();
-    com.stripe.model.financialconnections.Account account =
-        com.stripe.model.financialconnections.Account.refresh("fca_xyz", params, opts);
+    com.stripe.model.financialconnections.Account account = resource.refresh(params);
     assertNotNull(account);
     verifyRequest(
         ApiResource.RequestMethod.POST,
@@ -3102,12 +3102,12 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testAccountDisconnect() throws StripeException {
+    com.stripe.model.financialconnections.Account resource =
+        com.stripe.model.financialconnections.Account.retrieve("fca_xyz");
     com.stripe.param.financialconnections.AccountDisconnectParams params =
         com.stripe.param.financialconnections.AccountDisconnectParams.builder().build();
 
-    com.stripe.net.RequestOptions opts = com.stripe.net.RequestOptions.builder().build();
-    com.stripe.model.financialconnections.Account account =
-        com.stripe.model.financialconnections.Account.disconnect("fca_xyz", params, opts);
+    com.stripe.model.financialconnections.Account account = resource.disconnect(params);
     assertNotNull(account);
     verifyRequest(
         ApiResource.RequestMethod.POST,

--- a/src/test/java/com/stripe/functional/GeneratedExamples.java
+++ b/src/test/java/com/stripe/functional/GeneratedExamples.java
@@ -3085,14 +3085,14 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testAccountRefresh() throws StripeException {
-    com.stripe.model.financialconnections.Account resource =
-        com.stripe.model.financialconnections.Account.retrieve("fca_xyz");
     com.stripe.param.financialconnections.AccountRefreshParams params =
         com.stripe.param.financialconnections.AccountRefreshParams.builder()
             .addFeature(com.stripe.param.financialconnections.AccountRefreshParams.Feature.BALANCE)
             .build();
 
-    com.stripe.model.financialconnections.Account account = resource.refresh(params);
+    com.stripe.net.RequestOptions opts = com.stripe.net.RequestOptions.builder().build();
+    com.stripe.model.financialconnections.Account account =
+        com.stripe.model.financialconnections.Account.refresh("fca_xyz", params, opts);
     assertNotNull(account);
     verifyRequest(
         ApiResource.RequestMethod.POST,
@@ -3102,12 +3102,12 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testAccountDisconnect() throws StripeException {
-    com.stripe.model.financialconnections.Account resource =
-        com.stripe.model.financialconnections.Account.retrieve("fca_xyz");
     com.stripe.param.financialconnections.AccountDisconnectParams params =
         com.stripe.param.financialconnections.AccountDisconnectParams.builder().build();
 
-    com.stripe.model.financialconnections.Account account = resource.disconnect(params);
+    com.stripe.net.RequestOptions opts = com.stripe.net.RequestOptions.builder().build();
+    com.stripe.model.financialconnections.Account account =
+        com.stripe.model.financialconnections.Account.disconnect("fca_xyz", params, opts);
     assertNotNull(account);
     verifyRequest(
         ApiResource.RequestMethod.POST,


### PR DESCRIPTION
Codegen for openapi 7789931.
r? @richardm-stripe
cc @stripe/api-libraries

## Changelog
* Add support for `description` on `CheckoutSessionCreateParams.subscription_data`, `SubscriptionCreateParams`, `SubscriptionUpdateParams`, and `Subscription`
* Add support for `consent_collection`, `payment_intent_data`, `shipping_options`, `submit_type`, and `tax_id_collection` on `PaymentLinkCreateParams` and `PaymentLink`
* Add support for `customer_creation` on `PaymentLinkCreateParams`, `PaymentLinkUpdateParams`, and `PaymentLink`
* Add support for `metadata` on `SubscriptionSchedule.phases[]`, `SubscriptionScheduleCreateParams.phases[]`, and `SubscriptionScheduleUpdateParams.phases[]`
* Add support for new value `billing_portal.session.created` on enums `WebhookEndpointCreateParams.enabled_events[]` and `WebhookEndpointUpdateParams.enabled_events[]`

