### PR TITLE
Update readme with new jar download URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Add this dependency to your project's POM:
 
 You'll need to manually install the following JARs:
 
-- The Stripe JAR from <https://github.com/stripe/stripe-java/releases/latest>
+- [The Stripe JAR](https://search.maven.org/remote_content?g=com.stripe&a=stripe-java&v=LATEST)
 - [Google Gson][gson] from <https://repo1.maven.org/maven2/com/google/code/gson/gson/2.8.9/gson-2.8.9.jar>.
 
 ### [ProGuard][proguard]


### PR DESCRIPTION
We don't publish JAR to github releases anymore. Fix the readme.