### PR TITLE
API Updates

### DIFF
--- a/src/main/java/com/stripe/model/CashBalance.java
+++ b/src/main/java/com/stripe/model/CashBalance.java
@@ -6,6 +6,7 @@ import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
+import com.stripe.param.CashBalanceRetrieveCashBalanceParams;
 import com.stripe.param.CashBalanceRetrieveParams;
 import com.stripe.param.CashBalanceUpdateParams;
 import java.util.Map;
@@ -45,6 +46,42 @@ public class CashBalance extends ApiResource {
 
   @SerializedName("settings")
   BalanceSettings settings;
+
+  /** Retrieves a customer’s cash balance. */
+  public static CashBalance retrieveCashBalance(String customer) throws StripeException {
+    return retrieveCashBalance(customer, (Map<String, Object>) null, (RequestOptions) null);
+  }
+
+  /** Retrieves a customer’s cash balance. */
+  public static CashBalance retrieveCashBalance(String customer, RequestOptions options)
+      throws StripeException {
+    return retrieveCashBalance(customer, (Map<String, Object>) null, options);
+  }
+
+  /** Retrieves a customer’s cash balance. */
+  public static CashBalance retrieveCashBalance(
+      String customer, Map<String, Object> params, RequestOptions options) throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/customers/%s/cash_balance", ApiResource.urlEncodeId(customer)));
+    return ApiResource.request(
+        ApiResource.RequestMethod.GET, url, params, CashBalance.class, options);
+  }
+
+  /** Retrieves a customer’s cash balance. */
+  public static CashBalance retrieveCashBalance(
+      String customer, CashBalanceRetrieveCashBalanceParams params, RequestOptions options)
+      throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/customers/%s/cash_balance", ApiResource.urlEncodeId(customer)));
+    return ApiResource.request(
+        ApiResource.RequestMethod.GET, url, params, CashBalance.class, options);
+  }
 
   /** Retrieves a customer’s cash balance. */
   public CashBalance retrieve(String customer) throws StripeException {

--- a/src/main/java/com/stripe/model/Customer.java
+++ b/src/main/java/com/stripe/model/Customer.java
@@ -13,6 +13,7 @@ import com.stripe.param.CustomerCreateParams;
 import com.stripe.param.CustomerListParams;
 import com.stripe.param.CustomerListPaymentMethodsParams;
 import com.stripe.param.CustomerRetrieveParams;
+import com.stripe.param.CustomerRetrievePaymentMethodParams;
 import com.stripe.param.CustomerSearchParams;
 import com.stripe.param.CustomerUpdateParams;
 import java.util.List;
@@ -532,6 +533,35 @@ public class Customer extends ApiResource implements HasId, MetadataStore<Custom
             String.format(
                 "/v1/customers/%s/payment_methods", ApiResource.urlEncodeId(this.getId())));
     return ApiResource.requestCollection(url, params, PaymentMethodCollection.class, options);
+  }
+
+  /** Retrieves a PaymentMethod object. */
+  public PaymentMethod retrievePaymentMethod(
+      String customer, Map<String, Object> params, RequestOptions options) throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/customers/%s/payment_methods/%s",
+                ApiResource.urlEncodeId(customer), ApiResource.urlEncodeId(this.getId())));
+    return ApiResource.request(
+        ApiResource.RequestMethod.GET, url, params, PaymentMethod.class, options);
+  }
+
+  /** Retrieves a PaymentMethod object. */
+  public PaymentMethod retrievePaymentMethod(
+      String customer, CustomerRetrievePaymentMethodParams params, RequestOptions options)
+      throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/customers/%s/payment_methods/%s",
+                ApiResource.urlEncodeId(customer), ApiResource.urlEncodeId(this.getId())));
+    return ApiResource.request(
+        ApiResource.RequestMethod.GET, url, params, PaymentMethod.class, options);
   }
 
   /**

--- a/src/main/java/com/stripe/model/EventDataClassLookup.java
+++ b/src/main/java/com/stripe/model/EventDataClassLookup.java
@@ -134,6 +134,20 @@ final class EventDataClassLookup {
     classLookup.put("terminal.reader", com.stripe.model.terminal.Reader.class);
 
     classLookup.put("test_helpers.test_clock", com.stripe.model.testhelpers.TestClock.class);
+
+    classLookup.put("treasury.credit_reversal", com.stripe.model.treasury.CreditReversal.class);
+    classLookup.put("treasury.debit_reversal", com.stripe.model.treasury.DebitReversal.class);
+    classLookup.put("treasury.financial_account", com.stripe.model.treasury.FinancialAccount.class);
+    classLookup.put(
+        "treasury.financial_account_features",
+        com.stripe.model.treasury.FinancialAccountFeatures.class);
+    classLookup.put("treasury.inbound_transfer", com.stripe.model.treasury.InboundTransfer.class);
+    classLookup.put("treasury.outbound_payment", com.stripe.model.treasury.OutboundPayment.class);
+    classLookup.put("treasury.outbound_transfer", com.stripe.model.treasury.OutboundTransfer.class);
+    classLookup.put("treasury.received_credit", com.stripe.model.treasury.ReceivedCredit.class);
+    classLookup.put("treasury.received_debit", com.stripe.model.treasury.ReceivedDebit.class);
+    classLookup.put("treasury.transaction", com.stripe.model.treasury.Transaction.class);
+    classLookup.put("treasury.transaction_entry", com.stripe.model.treasury.TransactionEntry.class);
   }
 
   public static Class<? extends StripeObject> findClass(String objectType) {

--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -478,7 +478,7 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
 
   /** The aggregate amounts calculated per discount across all line items. */
   @SerializedName("total_discount_amounts")
-  List<Invoice.DiscountAmount> totalDiscountAmounts;
+  List<DiscountAmount> totalDiscountAmounts;
 
   /** The aggregate amounts calculated per tax rate for all line items. */
   @SerializedName("total_tax_amounts")

--- a/src/main/java/com/stripe/model/PaymentMethod.java
+++ b/src/main/java/com/stripe/model/PaymentMethod.java
@@ -1169,7 +1169,7 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
 
     /** Contains information about US bank account networks that can be used. */
     @SerializedName("networks")
-    USBankAccountNetworks networks;
+    Networks networks;
 
     /** Routing number of the bank account. */
     @SerializedName("routing_number")
@@ -1178,7 +1178,7 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
     @Getter
     @Setter
     @EqualsAndHashCode(callSuper = false)
-    public static class USBankAccountNetworks extends StripeObject {
+    public static class Networks extends StripeObject {
       /** The preferred network. */
       @SerializedName("preferred")
       String preferred;

--- a/src/main/java/com/stripe/model/PaymentMethod.java
+++ b/src/main/java/com/stripe/model/PaymentMethod.java
@@ -1167,9 +1167,26 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
     @SerializedName("last4")
     String last4;
 
+    /** Contains information about US bank account networks that can be used. */
+    @SerializedName("networks")
+    USBankAccountNetworks networks;
+
     /** Routing number of the bank account. */
     @SerializedName("routing_number")
     String routingNumber;
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class USBankAccountNetworks extends StripeObject {
+      /** The preferred network. */
+      @SerializedName("preferred")
+      String preferred;
+
+      /** All supported networks. */
+      @SerializedName("supported")
+      List<String> supported;
+    }
   }
 
   @Getter

--- a/src/main/java/com/stripe/model/SetupIntent.java
+++ b/src/main/java/com/stripe/model/SetupIntent.java
@@ -30,6 +30,16 @@ public class SetupIntent extends ApiResource implements HasId, MetadataStore<Set
   ExpandableField<Application> application;
 
   /**
+   * If present, the SetupIntent's payment method will be attached to the in-context Stripe Account.
+   *
+   * <p>It can only be used for this Stripe Account’s own money movement flows like InboundTransfer
+   * and OutboundTransfers. It cannot be set to true when setting up a PaymentMethod for a Customer,
+   * and defaults to false when attaching a PaymentMethod to a Customer.
+   */
+  @SerializedName("attach_to_self")
+  Boolean attachToSelf;
+
+  /**
    * Reason for cancellation of this SetupIntent, one of {@code abandoned}, {@code
    * requested_by_customer}, or {@code duplicate}.
    */
@@ -64,6 +74,17 @@ public class SetupIntent extends ApiResource implements HasId, MetadataStore<Set
   /** An arbitrary string attached to the object. Often useful for displaying to users. */
   @SerializedName("description")
   String description;
+
+  /**
+   * Indicates the directions of money movement for which this payment method is intended to be
+   * used.
+   *
+   * <p>Include {@code inbound} if you intend to use the payment method as the origin to pull funds
+   * from. Include {@code outbound} if you intend to use the payment method as the destination to
+   * send funds to. You can include both if you intend to use the payment method for both purposes.
+   */
+  @SerializedName("flow_directions")
+  List<String> flowDirections;
 
   /** Unique identifier for the object. */
   @Getter(onMethod_ = {@Override})

--- a/src/main/java/com/stripe/model/Subscription.java
+++ b/src/main/java/com/stripe/model/Subscription.java
@@ -1127,6 +1127,15 @@ public class Subscription extends ApiResource implements HasId, MetadataStore<Su
      */
     @SerializedName("payment_method_types")
     List<String> paymentMethodTypes;
+
+    /**
+     * Either {@code off}, or {@code on_subscription}. With {@code on_subscription} Stripe updates
+     * {@code subscription.default_payment_method} when a subscription payment succeeds.
+     *
+     * <p>One of {@code off}, or {@code on_subscription}.
+     */
+    @SerializedName("save_default_payment_method")
+    String saveDefaultPaymentMethod;
   }
 
   @Getter

--- a/src/main/java/com/stripe/model/checkout/Session.java
+++ b/src/main/java/com/stripe/model/checkout/Session.java
@@ -757,17 +757,47 @@ public class Session extends ApiResource implements HasId {
     @SerializedName("acss_debit")
     AcssDebit acssDebit;
 
+    @SerializedName("afterpay_clearpay")
+    AfterpayClearpay afterpayClearpay;
+
     @SerializedName("alipay")
     Alipay alipay;
 
+    @SerializedName("au_becs_debit")
+    AuBecsDebit auBecsDebit;
+
+    @SerializedName("bacs_debit")
+    BacsDebit bacsDebit;
+
     @SerializedName("boleto")
     Boleto boleto;
+
+    @SerializedName("eps")
+    Eps eps;
+
+    @SerializedName("fpx")
+    Fpx fpx;
+
+    @SerializedName("giropay")
+    Giropay giropay;
+
+    @SerializedName("grabpay")
+    GrabPay grabpay;
+
+    @SerializedName("klarna")
+    Klarna klarna;
 
     @SerializedName("konbini")
     Konbini konbini;
 
     @SerializedName("oxxo")
     Oxxo oxxo;
+
+    @SerializedName("paynow")
+    Paynow paynow;
+
+    @SerializedName("sepa_debit")
+    SepaDebit sepaDebit;
 
     @SerializedName("us_bank_account")
     UsBankAccount usBankAccount;
@@ -838,7 +868,22 @@ public class Session extends ApiResource implements HasId {
     @Getter
     @Setter
     @EqualsAndHashCode(callSuper = false)
+    public static class AfterpayClearpay extends StripeObject {}
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
     public static class Alipay extends StripeObject {}
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class AuBecsDebit extends StripeObject {}
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class BacsDebit extends StripeObject {}
 
     @Getter
     @Setter
@@ -872,6 +917,31 @@ public class Session extends ApiResource implements HasId {
       @SerializedName("setup_future_usage")
       String setupFutureUsage;
     }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class Eps extends StripeObject {}
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class Fpx extends StripeObject {}
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class Giropay extends StripeObject {}
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class GrabPay extends StripeObject {}
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class Klarna extends StripeObject {}
 
     @Getter
     @Setter
@@ -919,6 +989,16 @@ public class Session extends ApiResource implements HasId {
       @SerializedName("setup_future_usage")
       String setupFutureUsage;
     }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class Paynow extends StripeObject {}
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class SepaDebit extends StripeObject {}
 
     @Getter
     @Setter

--- a/src/main/java/com/stripe/model/checkout/Session.java
+++ b/src/main/java/com/stripe/model/checkout/Session.java
@@ -897,23 +897,7 @@ public class Session extends ApiResource implements HasId {
       @SerializedName("expires_after_days")
       Long expiresAfterDays;
 
-      /**
-       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-       *
-       * <p>Providing this parameter will <a
-       * href="https://stripe.com/docs/payments/save-during-payment">attach the payment method</a>
-       * to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any
-       * required actions from the user are complete. If no Customer was provided, the payment
-       * method can still be <a
-       * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer after
-       * the transaction completes.
-       *
-       * <p>When processing card payments, Stripe also uses {@code setup_future_usage} to
-       * dynamically optimize your payment flow and comply with regional legislation and network
-       * rules, such as <a href="https://stripe.com/docs/strong-customer-authentication">SCA</a>.
-       *
-       * <p>One of {@code none}, {@code off_session}, or {@code on_session}.
-       */
+      /** Deprecated. Do not use. */
       @SerializedName("setup_future_usage")
       String setupFutureUsage;
     }
@@ -969,23 +953,7 @@ public class Session extends ApiResource implements HasId {
       @SerializedName("expires_after_days")
       Long expiresAfterDays;
 
-      /**
-       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-       *
-       * <p>Providing this parameter will <a
-       * href="https://stripe.com/docs/payments/save-during-payment">attach the payment method</a>
-       * to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any
-       * required actions from the user are complete. If no Customer was provided, the payment
-       * method can still be <a
-       * href="https://stripe.com/docs/api/payment_methods/attach">attached</a> to a Customer after
-       * the transaction completes.
-       *
-       * <p>When processing card payments, Stripe also uses {@code setup_future_usage} to
-       * dynamically optimize your payment flow and comply with regional legislation and network
-       * rules, such as <a href="https://stripe.com/docs/strong-customer-authentication">SCA</a>.
-       *
-       * <p>Equal to {@code none}.
-       */
+      /** Deprecated. Do not use. */
       @SerializedName("setup_future_usage")
       String setupFutureUsage;
     }

--- a/src/main/java/com/stripe/model/financialconnections/Account.java
+++ b/src/main/java/com/stripe/model/financialconnections/Account.java
@@ -11,6 +11,8 @@ import com.stripe.model.StripeObject;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 import com.stripe.param.financialconnections.AccountDisconnectParams;
+import com.stripe.param.financialconnections.AccountListOwnersParams;
+import com.stripe.param.financialconnections.AccountListParams;
 import com.stripe.param.financialconnections.AccountRefreshParams;
 import com.stripe.param.financialconnections.AccountRetrieveParams;
 import java.util.List;
@@ -145,6 +147,30 @@ public class Account extends ApiResource implements HasId {
         new ExpandableField<AccountOwnership>(expandableObject.getId(), expandableObject);
   }
 
+  /** Returns a list of Financial Connections <code>Account</code> objects. */
+  public static AccountCollection list(Map<String, Object> params) throws StripeException {
+    return list(params, (RequestOptions) null);
+  }
+
+  /** Returns a list of Financial Connections <code>Account</code> objects. */
+  public static AccountCollection list(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/financial_connections/accounts");
+    return ApiResource.requestCollection(url, params, AccountCollection.class, options);
+  }
+
+  /** Returns a list of Financial Connections <code>Account</code> objects. */
+  public static AccountCollection list(AccountListParams params) throws StripeException {
+    return list(params, (RequestOptions) null);
+  }
+
+  /** Returns a list of Financial Connections <code>Account</code> objects. */
+  public static AccountCollection list(AccountListParams params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/financial_connections/accounts");
+    return ApiResource.requestCollection(url, params, AccountCollection.class, options);
+  }
+
   /** Retrieves the details of an Financial Connections <code>Account</code>. */
   public static com.stripe.model.financialconnections.Account retrieve(String account)
       throws StripeException {
@@ -191,6 +217,90 @@ public class Account extends ApiResource implements HasId {
         options);
   }
 
+  /** Lists all owners for a given <code>Account</code>. */
+  public AccountOwnerCollection listOwners(Map<String, Object> params) throws StripeException {
+    return listOwners(params, (RequestOptions) null);
+  }
+
+  /** Lists all owners for a given <code>Account</code>. */
+  public AccountOwnerCollection listOwners(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/financial_connections/accounts/%s/owners",
+                ApiResource.urlEncodeId(this.getId())));
+    return ApiResource.requestCollection(url, params, AccountOwnerCollection.class, options);
+  }
+
+  /** Lists all owners for a given <code>Account</code>. */
+  public AccountOwnerCollection listOwners(AccountListOwnersParams params) throws StripeException {
+    return listOwners(params, (RequestOptions) null);
+  }
+
+  /** Lists all owners for a given <code>Account</code>. */
+  public AccountOwnerCollection listOwners(AccountListOwnersParams params, RequestOptions options)
+      throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/financial_connections/accounts/%s/owners",
+                ApiResource.urlEncodeId(this.getId())));
+    return ApiResource.requestCollection(url, params, AccountOwnerCollection.class, options);
+  }
+
+  /** Refreshes the data associated with a Financial Connections <code>Account</code>. */
+  public com.stripe.model.financialconnections.Account refresh(Map<String, Object> params)
+      throws StripeException {
+    return refresh(params, (RequestOptions) null);
+  }
+
+  /** Refreshes the data associated with a Financial Connections <code>Account</code>. */
+  public com.stripe.model.financialconnections.Account refresh(
+      Map<String, Object> params, RequestOptions options) throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/financial_connections/accounts/%s/refresh",
+                ApiResource.urlEncodeId(this.getId())));
+    return ApiResource.request(
+        ApiResource.RequestMethod.POST,
+        url,
+        params,
+        com.stripe.model.financialconnections.Account.class,
+        options);
+  }
+
+  /** Refreshes the data associated with a Financial Connections <code>Account</code>. */
+  public com.stripe.model.financialconnections.Account refresh(AccountRefreshParams params)
+      throws StripeException {
+    return refresh(params, (RequestOptions) null);
+  }
+
+  /** Refreshes the data associated with a Financial Connections <code>Account</code>. */
+  public com.stripe.model.financialconnections.Account refresh(
+      AccountRefreshParams params, RequestOptions options) throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/financial_connections/accounts/%s/refresh",
+                ApiResource.urlEncodeId(this.getId())));
+    return ApiResource.request(
+        ApiResource.RequestMethod.POST,
+        url,
+        params,
+        com.stripe.model.financialconnections.Account.class,
+        options);
+  }
+
   /** Refreshes the data associated with a Financial Connections <code>Account</code>. */
   public static com.stripe.model.financialconnections.Account refresh(
       String account, Map<String, Object> params, RequestOptions options) throws StripeException {
@@ -217,6 +327,83 @@ public class Account extends ApiResource implements HasId {
             Stripe.getApiBase(),
             String.format(
                 "/v1/financial_connections/accounts/%s/refresh", ApiResource.urlEncodeId(account)));
+    return ApiResource.request(
+        ApiResource.RequestMethod.POST,
+        url,
+        params,
+        com.stripe.model.financialconnections.Account.class,
+        options);
+  }
+
+  /**
+   * Disables your access to a Financial Connections <code>Account</code>. You will no longer be
+   * able to access data associated with the account (e.g. balances, transactions).
+   */
+  public com.stripe.model.financialconnections.Account disconnect() throws StripeException {
+    return disconnect((Map<String, Object>) null, (RequestOptions) null);
+  }
+
+  /**
+   * Disables your access to a Financial Connections <code>Account</code>. You will no longer be
+   * able to access data associated with the account (e.g. balances, transactions).
+   */
+  public com.stripe.model.financialconnections.Account disconnect(RequestOptions options)
+      throws StripeException {
+    return disconnect((Map<String, Object>) null, options);
+  }
+
+  /**
+   * Disables your access to a Financial Connections <code>Account</code>. You will no longer be
+   * able to access data associated with the account (e.g. balances, transactions).
+   */
+  public com.stripe.model.financialconnections.Account disconnect(Map<String, Object> params)
+      throws StripeException {
+    return disconnect(params, (RequestOptions) null);
+  }
+
+  /**
+   * Disables your access to a Financial Connections <code>Account</code>. You will no longer be
+   * able to access data associated with the account (e.g. balances, transactions).
+   */
+  public com.stripe.model.financialconnections.Account disconnect(
+      Map<String, Object> params, RequestOptions options) throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/financial_connections/accounts/%s/disconnect",
+                ApiResource.urlEncodeId(this.getId())));
+    return ApiResource.request(
+        ApiResource.RequestMethod.POST,
+        url,
+        params,
+        com.stripe.model.financialconnections.Account.class,
+        options);
+  }
+
+  /**
+   * Disables your access to a Financial Connections <code>Account</code>. You will no longer be
+   * able to access data associated with the account (e.g. balances, transactions).
+   */
+  public com.stripe.model.financialconnections.Account disconnect(AccountDisconnectParams params)
+      throws StripeException {
+    return disconnect(params, (RequestOptions) null);
+  }
+
+  /**
+   * Disables your access to a Financial Connections <code>Account</code>. You will no longer be
+   * able to access data associated with the account (e.g. balances, transactions).
+   */
+  public com.stripe.model.financialconnections.Account disconnect(
+      AccountDisconnectParams params, RequestOptions options) throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/financial_connections/accounts/%s/disconnect",
+                ApiResource.urlEncodeId(this.getId())));
     return ApiResource.request(
         ApiResource.RequestMethod.POST,
         url,

--- a/src/main/java/com/stripe/model/issuing/Authorization.java
+++ b/src/main/java/com/stripe/model/issuing/Authorization.java
@@ -162,6 +162,14 @@ public class Authorization extends ApiResource
   @SerializedName("transactions")
   List<Transaction> transactions;
 
+  /**
+   * <a href="https://stripe.com/docs/api/treasury">Treasury</a> details related to this
+   * authorization if it was created on a <a
+   * href="https://stripe.com/docs/api/treasury/financial_accounts">FinancialAccount</a>.
+   */
+  @SerializedName("treasury")
+  Treasury treasury;
+
   @SerializedName("verification_data")
   VerificationData verificationData;
 
@@ -629,6 +637,34 @@ public class Authorization extends ApiResource
      */
     @SerializedName("reason")
     String reason;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class Treasury extends StripeObject {
+    /**
+     * The array of <a
+     * href="https://stripe.com/docs/api/treasury/received_credits">ReceivedCredits</a> associated
+     * with this authorization
+     */
+    @SerializedName("received_credits")
+    List<String> receivedCredits;
+
+    /**
+     * The array of <a
+     * href="https://stripe.com/docs/api/treasury/received_debits">ReceivedDebits</a> associated
+     * with this authorization
+     */
+    @SerializedName("received_debits")
+    List<String> receivedDebits;
+
+    /**
+     * The Treasury <a href="https://stripe.com/docs/api/treasury/transactions">Transaction</a>
+     * associated with this authorization
+     */
+    @SerializedName("transaction")
+    String transaction;
   }
 
   @Getter

--- a/src/main/java/com/stripe/model/issuing/Card.java
+++ b/src/main/java/com/stripe/model/issuing/Card.java
@@ -77,6 +77,10 @@ public class Card extends ApiResource implements HasId, MetadataStore<Card> {
   @SerializedName("exp_year")
   Long expYear;
 
+  /** The financial account this card is attached to. */
+  @SerializedName("financial_account")
+  String financialAccount;
+
   /** Unique identifier for the object. */
   @Getter(onMethod_ = {@Override})
   @SerializedName("id")

--- a/src/main/java/com/stripe/model/issuing/Dispute.java
+++ b/src/main/java/com/stripe/model/issuing/Dispute.java
@@ -94,6 +94,13 @@ public class Dispute extends ApiResource
   @Setter(lombok.AccessLevel.NONE)
   ExpandableField<Transaction> transaction;
 
+  /**
+   * <a href="https://stripe.com/docs/api/treasury">Treasury</a> details related to this dispute if
+   * it was created on a [FinancialAccount](/docs/api/treasury/financial_accounts
+   */
+  @SerializedName("treasury")
+  Treasury treasury;
+
   /** Get ID of expandable {@code transaction} object. */
   public String getTransaction() {
     return (this.transaction != null) ? this.transaction.getId() : null;
@@ -848,5 +855,24 @@ public class Dispute extends ApiResource
             new ExpandableField<File>(expandableObject.getId(), expandableObject);
       }
     }
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class Treasury extends StripeObject {
+    /**
+     * The Treasury <a href="https://stripe.com/docs/api/treasury/debit_reversals">DebitReversal</a>
+     * representing this Issuing dispute
+     */
+    @SerializedName("debit_reversal")
+    String debitReversal;
+
+    /**
+     * The Treasury <a href="https://stripe.com/docs/api/treasury/received_debits">ReceivedDebit</a>
+     * that is being disputed.
+     */
+    @SerializedName("received_debit")
+    String receivedDebit;
   }
 }

--- a/src/main/java/com/stripe/model/issuing/Transaction.java
+++ b/src/main/java/com/stripe/model/issuing/Transaction.java
@@ -134,6 +134,13 @@ public class Transaction extends ApiResource
   PurchaseDetails purchaseDetails;
 
   /**
+   * <a href="https://stripe.com/docs/api/treasury">Treasury</a> details related to this transaction
+   * if it was created on a [FinancialAccount](/docs/api/treasury/financial_accounts
+   */
+  @SerializedName("treasury")
+  Treasury treasury;
+
+  /**
    * The nature of the transaction.
    *
    * <p>One of {@code capture}, or {@code refund}.
@@ -511,5 +518,26 @@ public class Transaction extends ApiResource
       @SerializedName("unit_cost")
       Long unitCost;
     }
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class Treasury extends StripeObject {
+    /**
+     * The Treasury <a
+     * href="https://stripe.com/docs/api/treasury/received_debits">ReceivedCredit</a> representing
+     * this Issuing transaction if it is a refund
+     */
+    @SerializedName("received_credit")
+    String receivedCredit;
+
+    /**
+     * The Treasury <a
+     * href="https://stripe.com/docs/api/treasury/received_credits">ReceivedDebit</a> representing
+     * this Issuing transaction if it is a capture
+     */
+    @SerializedName("received_debit")
+    String receivedDebit;
   }
 }

--- a/src/main/java/com/stripe/model/terminal/Configuration.java
+++ b/src/main/java/com/stripe/model/terminal/Configuration.java
@@ -254,6 +254,9 @@ public class Configuration extends ApiResource implements HasId {
     @SerializedName("chf")
     Chf chf;
 
+    @SerializedName("czk")
+    Czk czk;
+
     @SerializedName("dkk")
     Dkk dkk;
 
@@ -328,6 +331,26 @@ public class Configuration extends ApiResource implements HasId {
     @Setter
     @EqualsAndHashCode(callSuper = false)
     public static class Chf extends StripeObject {
+      /** Fixed amounts displayed when collecting a tip. */
+      @SerializedName("fixed_amounts")
+      List<Long> fixedAmounts;
+
+      /** Percentages displayed when collecting a tip. */
+      @SerializedName("percentages")
+      List<Long> percentages;
+
+      /**
+       * Below this amount, fixed amounts will be displayed; above it, percentages will be
+       * displayed.
+       */
+      @SerializedName("smart_tip_threshold")
+      Long smartTipThreshold;
+    }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class Czk extends StripeObject {
       /** Fixed amounts displayed when collecting a tip. */
       @SerializedName("fixed_amounts")
       List<Long> fixedAmounts;

--- a/src/main/java/com/stripe/model/treasury/BillingDetails.java
+++ b/src/main/java/com/stripe/model/treasury/BillingDetails.java
@@ -1,0 +1,25 @@
+// File generated from our OpenAPI spec
+package com.stripe.model.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.model.Address;
+import com.stripe.model.StripeObject;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
+public class BillingDetails extends StripeObject {
+  @SerializedName("address")
+  Address address;
+
+  /** Email address. */
+  @SerializedName("email")
+  String email;
+
+  /** Full name. */
+  @SerializedName("name")
+  String name;
+}

--- a/src/main/java/com/stripe/model/treasury/CreditReversal.java
+++ b/src/main/java/com/stripe/model/treasury/CreditReversal.java
@@ -1,0 +1,221 @@
+// File generated from our OpenAPI spec
+package com.stripe.model.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.Stripe;
+import com.stripe.exception.StripeException;
+import com.stripe.model.ExpandableField;
+import com.stripe.model.HasId;
+import com.stripe.net.ApiResource;
+import com.stripe.net.RequestOptions;
+import com.stripe.param.treasury.CreditReversalCreateParams;
+import com.stripe.param.treasury.CreditReversalListParams;
+import com.stripe.param.treasury.CreditReversalRetrieveParams;
+import java.util.Map;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
+public class CreditReversal extends ApiResource implements HasId {
+  /** Amount (in cents) transferred. */
+  @SerializedName("amount")
+  Long amount;
+
+  /**
+   * Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency code</a>,
+   * in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported currency</a>.
+   */
+  @SerializedName("currency")
+  String currency;
+
+  /** The FinancialAccount to reverse funds from. */
+  @SerializedName("financial_account")
+  String financialAccount;
+
+  /**
+   * A hosted transaction receipt URL that is provided when money movement is considered regulated
+   * under Stripe's money transmission licenses.
+   */
+  @SerializedName("hosted_regulatory_receipt_url")
+  String hostedRegulatoryReceiptUrl;
+
+  /** Unique identifier for the object. */
+  @Getter(onMethod_ = {@Override})
+  @SerializedName("id")
+  String id;
+
+  /**
+   * Has the value {@code true} if the object exists in live mode or the value {@code false} if the
+   * object exists in test mode.
+   */
+  @SerializedName("livemode")
+  Boolean livemode;
+
+  /**
+   * Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can attach
+   * to an object. This can be useful for storing additional information about the object in a
+   * structured format.
+   */
+  @SerializedName("metadata")
+  Map<String, String> metadata;
+
+  /**
+   * The rails used to reverse the funds.
+   *
+   * <p>One of {@code ach}, or {@code stripe}.
+   */
+  @SerializedName("network")
+  String network;
+
+  /**
+   * String representing the object's type. Objects of the same type share the same value.
+   *
+   * <p>Equal to {@code treasury.credit_reversal}.
+   */
+  @SerializedName("object")
+  String object;
+
+  /** The ReceivedCredit being reversed. */
+  @SerializedName("received_credit")
+  String receivedCredit;
+
+  /**
+   * Status of the CreditReversal
+   *
+   * <p>One of {@code canceled}, {@code posted}, or {@code processing}.
+   */
+  @SerializedName("status")
+  String status;
+
+  @SerializedName("status_transitions")
+  ReceivedCredit.StatusTransitions statusTransitions;
+
+  /** The Transaction associated with this object. */
+  @SerializedName("transaction")
+  @Getter(lombok.AccessLevel.NONE)
+  @Setter(lombok.AccessLevel.NONE)
+  ExpandableField<Transaction> transaction;
+
+  /** Get ID of expandable {@code transaction} object. */
+  public String getTransaction() {
+    return (this.transaction != null) ? this.transaction.getId() : null;
+  }
+
+  public void setTransaction(String id) {
+    this.transaction = ApiResource.setExpandableFieldId(id, this.transaction);
+  }
+
+  /** Get expanded {@code transaction}. */
+  public Transaction getTransactionObject() {
+    return (this.transaction != null) ? this.transaction.getExpanded() : null;
+  }
+
+  public void setTransactionObject(Transaction expandableObject) {
+    this.transaction = new ExpandableField<Transaction>(expandableObject.getId(), expandableObject);
+  }
+
+  /** Returns a list of CreditReversals. */
+  public static CreditReversalCollection list(Map<String, Object> params) throws StripeException {
+    return list(params, (RequestOptions) null);
+  }
+
+  /** Returns a list of CreditReversals. */
+  public static CreditReversalCollection list(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/treasury/credit_reversals");
+    return ApiResource.requestCollection(url, params, CreditReversalCollection.class, options);
+  }
+
+  /** Returns a list of CreditReversals. */
+  public static CreditReversalCollection list(CreditReversalListParams params)
+      throws StripeException {
+    return list(params, (RequestOptions) null);
+  }
+
+  /** Returns a list of CreditReversals. */
+  public static CreditReversalCollection list(
+      CreditReversalListParams params, RequestOptions options) throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/treasury/credit_reversals");
+    return ApiResource.requestCollection(url, params, CreditReversalCollection.class, options);
+  }
+
+  /**
+   * Retrieves the details of an existing CreditReversal by passing the unique CreditReversal ID
+   * from either the CreditReversal creation request or CreditReversal list.
+   */
+  public static CreditReversal retrieve(String creditReversal) throws StripeException {
+    return retrieve(creditReversal, (Map<String, Object>) null, (RequestOptions) null);
+  }
+
+  /**
+   * Retrieves the details of an existing CreditReversal by passing the unique CreditReversal ID
+   * from either the CreditReversal creation request or CreditReversal list.
+   */
+  public static CreditReversal retrieve(String creditReversal, RequestOptions options)
+      throws StripeException {
+    return retrieve(creditReversal, (Map<String, Object>) null, options);
+  }
+
+  /**
+   * Retrieves the details of an existing CreditReversal by passing the unique CreditReversal ID
+   * from either the CreditReversal creation request or CreditReversal list.
+   */
+  public static CreditReversal retrieve(
+      String creditReversal, Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/treasury/credit_reversals/%s", ApiResource.urlEncodeId(creditReversal)));
+    return ApiResource.request(
+        ApiResource.RequestMethod.GET, url, params, CreditReversal.class, options);
+  }
+
+  /**
+   * Retrieves the details of an existing CreditReversal by passing the unique CreditReversal ID
+   * from either the CreditReversal creation request or CreditReversal list.
+   */
+  public static CreditReversal retrieve(
+      String creditReversal, CreditReversalRetrieveParams params, RequestOptions options)
+      throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/treasury/credit_reversals/%s", ApiResource.urlEncodeId(creditReversal)));
+    return ApiResource.request(
+        ApiResource.RequestMethod.GET, url, params, CreditReversal.class, options);
+  }
+
+  /** Reverses a ReceivedCredit and creates a CreditReversal object. */
+  public static CreditReversal create(Map<String, Object> params) throws StripeException {
+    return create(params, (RequestOptions) null);
+  }
+
+  /** Reverses a ReceivedCredit and creates a CreditReversal object. */
+  public static CreditReversal create(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/treasury/credit_reversals");
+    return ApiResource.request(
+        ApiResource.RequestMethod.POST, url, params, CreditReversal.class, options);
+  }
+
+  /** Reverses a ReceivedCredit and creates a CreditReversal object. */
+  public static CreditReversal create(CreditReversalCreateParams params) throws StripeException {
+    return create(params, (RequestOptions) null);
+  }
+
+  /** Reverses a ReceivedCredit and creates a CreditReversal object. */
+  public static CreditReversal create(CreditReversalCreateParams params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/treasury/credit_reversals");
+    return ApiResource.request(
+        ApiResource.RequestMethod.POST, url, params, CreditReversal.class, options);
+  }
+}

--- a/src/main/java/com/stripe/model/treasury/CreditReversal.java
+++ b/src/main/java/com/stripe/model/treasury/CreditReversal.java
@@ -6,6 +6,7 @@ import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
 import com.stripe.model.ExpandableField;
 import com.stripe.model.HasId;
+import com.stripe.model.StripeObject;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 import com.stripe.param.treasury.CreditReversalCreateParams;
@@ -91,7 +92,7 @@ public class CreditReversal extends ApiResource implements HasId {
   String status;
 
   @SerializedName("status_transitions")
-  ReceivedCredit.StatusTransitions statusTransitions;
+  StatusTransitions statusTransitions;
 
   /** The Transaction associated with this object. */
   @SerializedName("transaction")
@@ -217,5 +218,14 @@ public class CreditReversal extends ApiResource implements HasId {
     String url = String.format("%s%s", Stripe.getApiBase(), "/v1/treasury/credit_reversals");
     return ApiResource.request(
         ApiResource.RequestMethod.POST, url, params, CreditReversal.class, options);
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class StatusTransitions extends StripeObject {
+    /** Timestamp describing when the CreditReversal changed status to {@code posted}. */
+    @SerializedName("posted_at")
+    Long postedAt;
   }
 }

--- a/src/main/java/com/stripe/model/treasury/CreditReversalCollection.java
+++ b/src/main/java/com/stripe/model/treasury/CreditReversalCollection.java
@@ -1,0 +1,6 @@
+// File generated from our OpenAPI spec
+package com.stripe.model.treasury;
+
+import com.stripe.model.StripeCollection;
+
+public class CreditReversalCollection extends StripeCollection<CreditReversal> {}

--- a/src/main/java/com/stripe/model/treasury/DebitReversal.java
+++ b/src/main/java/com/stripe/model/treasury/DebitReversal.java
@@ -96,7 +96,7 @@ public class DebitReversal extends ApiResource implements HasId {
   String status;
 
   @SerializedName("status_transitions")
-  ReceivedDebit.StatusTransitions statusTransitions;
+  StatusTransitions statusTransitions;
 
   /** The Transaction associated with this object. */
   @SerializedName("transaction")
@@ -219,5 +219,14 @@ public class DebitReversal extends ApiResource implements HasId {
     /** Set if there is an Issuing dispute associated with the DebitReversal. */
     @SerializedName("issuing_dispute")
     String issuingDispute;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class StatusTransitions extends StripeObject {
+    /** Timestamp describing when the DebitReversal changed status to {@code completed}. */
+    @SerializedName("completed_at")
+    Long completedAt;
   }
 }

--- a/src/main/java/com/stripe/model/treasury/DebitReversal.java
+++ b/src/main/java/com/stripe/model/treasury/DebitReversal.java
@@ -1,0 +1,223 @@
+// File generated from our OpenAPI spec
+package com.stripe.model.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.Stripe;
+import com.stripe.exception.StripeException;
+import com.stripe.model.ExpandableField;
+import com.stripe.model.HasId;
+import com.stripe.model.StripeObject;
+import com.stripe.net.ApiResource;
+import com.stripe.net.RequestOptions;
+import com.stripe.param.treasury.DebitReversalCreateParams;
+import com.stripe.param.treasury.DebitReversalListParams;
+import com.stripe.param.treasury.DebitReversalRetrieveParams;
+import java.util.Map;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
+public class DebitReversal extends ApiResource implements HasId {
+  /** Amount (in cents) transferred. */
+  @SerializedName("amount")
+  Long amount;
+
+  /**
+   * Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency code</a>,
+   * in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported currency</a>.
+   */
+  @SerializedName("currency")
+  String currency;
+
+  /** The FinancialAccount to reverse funds from. */
+  @SerializedName("financial_account")
+  String financialAccount;
+
+  /**
+   * A hosted transaction receipt URL that is provided when money movement is considered regulated
+   * under Stripe's money transmission licenses.
+   */
+  @SerializedName("hosted_regulatory_receipt_url")
+  String hostedRegulatoryReceiptUrl;
+
+  /** Unique identifier for the object. */
+  @Getter(onMethod_ = {@Override})
+  @SerializedName("id")
+  String id;
+
+  /** Other flows linked to a DebitReversal. */
+  @SerializedName("linked_flows")
+  LinkedFlows linkedFlows;
+
+  /**
+   * Has the value {@code true} if the object exists in live mode or the value {@code false} if the
+   * object exists in test mode.
+   */
+  @SerializedName("livemode")
+  Boolean livemode;
+
+  /**
+   * Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can attach
+   * to an object. This can be useful for storing additional information about the object in a
+   * structured format.
+   */
+  @SerializedName("metadata")
+  Map<String, String> metadata;
+
+  /**
+   * The rails used to reverse the funds.
+   *
+   * <p>One of {@code ach}, or {@code card}.
+   */
+  @SerializedName("network")
+  String network;
+
+  /**
+   * String representing the object's type. Objects of the same type share the same value.
+   *
+   * <p>Equal to {@code treasury.debit_reversal}.
+   */
+  @SerializedName("object")
+  String object;
+
+  /** The ReceivedDebit being reversed. */
+  @SerializedName("received_debit")
+  String receivedDebit;
+
+  /**
+   * Status of the DebitReversal
+   *
+   * <p>One of {@code failed}, {@code processing}, or {@code succeeded}.
+   */
+  @SerializedName("status")
+  String status;
+
+  @SerializedName("status_transitions")
+  ReceivedDebit.StatusTransitions statusTransitions;
+
+  /** The Transaction associated with this object. */
+  @SerializedName("transaction")
+  @Getter(lombok.AccessLevel.NONE)
+  @Setter(lombok.AccessLevel.NONE)
+  ExpandableField<Transaction> transaction;
+
+  /** Get ID of expandable {@code transaction} object. */
+  public String getTransaction() {
+    return (this.transaction != null) ? this.transaction.getId() : null;
+  }
+
+  public void setTransaction(String id) {
+    this.transaction = ApiResource.setExpandableFieldId(id, this.transaction);
+  }
+
+  /** Get expanded {@code transaction}. */
+  public Transaction getTransactionObject() {
+    return (this.transaction != null) ? this.transaction.getExpanded() : null;
+  }
+
+  public void setTransactionObject(Transaction expandableObject) {
+    this.transaction = new ExpandableField<Transaction>(expandableObject.getId(), expandableObject);
+  }
+
+  /** Reverses a ReceivedDebit and creates a DebitReversal object. */
+  public static DebitReversal create(Map<String, Object> params) throws StripeException {
+    return create(params, (RequestOptions) null);
+  }
+
+  /** Reverses a ReceivedDebit and creates a DebitReversal object. */
+  public static DebitReversal create(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/treasury/debit_reversals");
+    return ApiResource.request(
+        ApiResource.RequestMethod.POST, url, params, DebitReversal.class, options);
+  }
+
+  /** Reverses a ReceivedDebit and creates a DebitReversal object. */
+  public static DebitReversal create(DebitReversalCreateParams params) throws StripeException {
+    return create(params, (RequestOptions) null);
+  }
+
+  /** Reverses a ReceivedDebit and creates a DebitReversal object. */
+  public static DebitReversal create(DebitReversalCreateParams params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/treasury/debit_reversals");
+    return ApiResource.request(
+        ApiResource.RequestMethod.POST, url, params, DebitReversal.class, options);
+  }
+
+  /** Retrieves a DebitReversal object. */
+  public static DebitReversal retrieve(String debitReversal) throws StripeException {
+    return retrieve(debitReversal, (Map<String, Object>) null, (RequestOptions) null);
+  }
+
+  /** Retrieves a DebitReversal object. */
+  public static DebitReversal retrieve(String debitReversal, RequestOptions options)
+      throws StripeException {
+    return retrieve(debitReversal, (Map<String, Object>) null, options);
+  }
+
+  /** Retrieves a DebitReversal object. */
+  public static DebitReversal retrieve(
+      String debitReversal, Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/treasury/debit_reversals/%s", ApiResource.urlEncodeId(debitReversal)));
+    return ApiResource.request(
+        ApiResource.RequestMethod.GET, url, params, DebitReversal.class, options);
+  }
+
+  /** Retrieves a DebitReversal object. */
+  public static DebitReversal retrieve(
+      String debitReversal, DebitReversalRetrieveParams params, RequestOptions options)
+      throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/treasury/debit_reversals/%s", ApiResource.urlEncodeId(debitReversal)));
+    return ApiResource.request(
+        ApiResource.RequestMethod.GET, url, params, DebitReversal.class, options);
+  }
+
+  /** Returns a list of DebitReversals. */
+  public static DebitReversalCollection list(Map<String, Object> params) throws StripeException {
+    return list(params, (RequestOptions) null);
+  }
+
+  /** Returns a list of DebitReversals. */
+  public static DebitReversalCollection list(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/treasury/debit_reversals");
+    return ApiResource.requestCollection(url, params, DebitReversalCollection.class, options);
+  }
+
+  /** Returns a list of DebitReversals. */
+  public static DebitReversalCollection list(DebitReversalListParams params)
+      throws StripeException {
+    return list(params, (RequestOptions) null);
+  }
+
+  /** Returns a list of DebitReversals. */
+  public static DebitReversalCollection list(DebitReversalListParams params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/treasury/debit_reversals");
+    return ApiResource.requestCollection(url, params, DebitReversalCollection.class, options);
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class LinkedFlows extends StripeObject {
+    /** Set if there is an Issuing dispute associated with the DebitReversal. */
+    @SerializedName("issuing_dispute")
+    String issuingDispute;
+  }
+}

--- a/src/main/java/com/stripe/model/treasury/DebitReversalCollection.java
+++ b/src/main/java/com/stripe/model/treasury/DebitReversalCollection.java
@@ -1,0 +1,6 @@
+// File generated from our OpenAPI spec
+package com.stripe.model.treasury;
+
+import com.stripe.model.StripeCollection;
+
+public class DebitReversalCollection extends StripeCollection<DebitReversal> {}

--- a/src/main/java/com/stripe/model/treasury/FinancialAccount.java
+++ b/src/main/java/com/stripe/model/treasury/FinancialAccount.java
@@ -1,0 +1,493 @@
+// File generated from our OpenAPI spec
+package com.stripe.model.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.Stripe;
+import com.stripe.exception.StripeException;
+import com.stripe.model.HasId;
+import com.stripe.model.MetadataStore;
+import com.stripe.model.StripeObject;
+import com.stripe.net.ApiResource;
+import com.stripe.net.RequestOptions;
+import com.stripe.param.treasury.FinancialAccountCreateParams;
+import com.stripe.param.treasury.FinancialAccountListParams;
+import com.stripe.param.treasury.FinancialAccountRetrieveFeaturesParams;
+import com.stripe.param.treasury.FinancialAccountRetrieveParams;
+import com.stripe.param.treasury.FinancialAccountUpdateFeaturesParams;
+import com.stripe.param.treasury.FinancialAccountUpdateParams;
+import java.util.List;
+import java.util.Map;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
+public class FinancialAccount extends ApiResource
+    implements HasId, MetadataStore<FinancialAccount> {
+  /** The array of paths to active Features in the Features hash. */
+  @SerializedName("active_features")
+  List<String> activeFeatures;
+
+  /** Balance information for the FinancialAccount. */
+  @SerializedName("balance")
+  Balance balance;
+
+  /**
+   * Two-letter country code (<a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO 3166-1
+   * alpha-2</a>).
+   */
+  @SerializedName("country")
+  String country;
+
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  @SerializedName("created")
+  Long created;
+
+  /**
+   * Encodes whether a FinancialAccount has access to a particular Feature, with a {@code status}
+   * enum and associated {@code status_details}. Stripe or the platform can control Features via the
+   * requested field.
+   */
+  @SerializedName("features")
+  FinancialAccountFeatures features;
+
+  /** The set of credentials that resolve to a FinancialAccount. */
+  @SerializedName("financial_addresses")
+  List<FinancialAccount.FinancialAddresses> financialAddresses;
+
+  /** Unique identifier for the object. */
+  @Getter(onMethod_ = {@Override})
+  @SerializedName("id")
+  String id;
+
+  /**
+   * Has the value {@code true} if the object exists in live mode or the value {@code false} if the
+   * object exists in test mode.
+   */
+  @SerializedName("livemode")
+  Boolean livemode;
+
+  /**
+   * Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can attach
+   * to an object. This can be useful for storing additional information about the object in a
+   * structured format.
+   */
+  @Getter(onMethod_ = {@Override})
+  @SerializedName("metadata")
+  Map<String, String> metadata;
+
+  /**
+   * String representing the object's type. Objects of the same type share the same value.
+   *
+   * <p>Equal to {@code treasury.financial_account}.
+   */
+  @SerializedName("object")
+  String object;
+
+  /** The array of paths to pending Features in the Features hash. */
+  @SerializedName("pending_features")
+  List<String> pendingFeatures;
+
+  /** The set of functionalities that the platform can restrict on the FinancialAccount. */
+  @SerializedName("platform_restrictions")
+  FinancialAccountFeatures.PlatformRestriction platformRestrictions;
+
+  /** The array of paths to restricted Features in the Features hash. */
+  @SerializedName("restricted_features")
+  List<String> restrictedFeatures;
+
+  /**
+   * The enum specifying what state the account is in.
+   *
+   * <p>One of {@code closed}, or {@code open}.
+   */
+  @SerializedName("status")
+  String status;
+
+  @SerializedName("status_details")
+  StatusDetails statusDetails;
+
+  /**
+   * The currencies the FinancialAccount can hold a balance in. Three-letter <a
+   * href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency code</a>, in lowercase.
+   */
+  @SerializedName("supported_currencies")
+  List<String> supportedCurrencies;
+
+  /**
+   * Creates a new FinancialAccount. For now, each connected account can only have one
+   * FinancialAccount.
+   */
+  public static FinancialAccount create(Map<String, Object> params) throws StripeException {
+    return create(params, (RequestOptions) null);
+  }
+
+  /**
+   * Creates a new FinancialAccount. For now, each connected account can only have one
+   * FinancialAccount.
+   */
+  public static FinancialAccount create(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/treasury/financial_accounts");
+    return ApiResource.request(
+        ApiResource.RequestMethod.POST, url, params, FinancialAccount.class, options);
+  }
+
+  /**
+   * Creates a new FinancialAccount. For now, each connected account can only have one
+   * FinancialAccount.
+   */
+  public static FinancialAccount create(FinancialAccountCreateParams params)
+      throws StripeException {
+    return create(params, (RequestOptions) null);
+  }
+
+  /**
+   * Creates a new FinancialAccount. For now, each connected account can only have one
+   * FinancialAccount.
+   */
+  public static FinancialAccount create(FinancialAccountCreateParams params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/treasury/financial_accounts");
+    return ApiResource.request(
+        ApiResource.RequestMethod.POST, url, params, FinancialAccount.class, options);
+  }
+
+  /** Updates the details of a FinancialAccount. */
+  @Override
+  public FinancialAccount update(Map<String, Object> params) throws StripeException {
+    return update(params, (RequestOptions) null);
+  }
+
+  /** Updates the details of a FinancialAccount. */
+  @Override
+  public FinancialAccount update(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/treasury/financial_accounts/%s", ApiResource.urlEncodeId(this.getId())));
+    return ApiResource.request(
+        ApiResource.RequestMethod.POST, url, params, FinancialAccount.class, options);
+  }
+
+  /** Updates the details of a FinancialAccount. */
+  public FinancialAccount update(FinancialAccountUpdateParams params) throws StripeException {
+    return update(params, (RequestOptions) null);
+  }
+
+  /** Updates the details of a FinancialAccount. */
+  public FinancialAccount update(FinancialAccountUpdateParams params, RequestOptions options)
+      throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/treasury/financial_accounts/%s", ApiResource.urlEncodeId(this.getId())));
+    return ApiResource.request(
+        ApiResource.RequestMethod.POST, url, params, FinancialAccount.class, options);
+  }
+
+  /** Updates the Features associated with a FinancialAccount. */
+  public FinancialAccountFeatures updateFeatures() throws StripeException {
+    return updateFeatures((Map<String, Object>) null, (RequestOptions) null);
+  }
+
+  /** Updates the Features associated with a FinancialAccount. */
+  public FinancialAccountFeatures updateFeatures(RequestOptions options) throws StripeException {
+    return updateFeatures((Map<String, Object>) null, options);
+  }
+
+  /** Updates the Features associated with a FinancialAccount. */
+  public FinancialAccountFeatures updateFeatures(Map<String, Object> params)
+      throws StripeException {
+    return updateFeatures(params, (RequestOptions) null);
+  }
+
+  /** Updates the Features associated with a FinancialAccount. */
+  public FinancialAccountFeatures updateFeatures(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/treasury/financial_accounts/%s/features",
+                ApiResource.urlEncodeId(this.getId())));
+    return ApiResource.request(
+        ApiResource.RequestMethod.POST, url, params, FinancialAccountFeatures.class, options);
+  }
+
+  /** Updates the Features associated with a FinancialAccount. */
+  public FinancialAccountFeatures updateFeatures(FinancialAccountUpdateFeaturesParams params)
+      throws StripeException {
+    return updateFeatures(params, (RequestOptions) null);
+  }
+
+  /** Updates the Features associated with a FinancialAccount. */
+  public FinancialAccountFeatures updateFeatures(
+      FinancialAccountUpdateFeaturesParams params, RequestOptions options) throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/treasury/financial_accounts/%s/features",
+                ApiResource.urlEncodeId(this.getId())));
+    return ApiResource.request(
+        ApiResource.RequestMethod.POST, url, params, FinancialAccountFeatures.class, options);
+  }
+
+  /** Returns a list of FinancialAccounts. */
+  public static FinancialAccountCollection list(Map<String, Object> params) throws StripeException {
+    return list(params, (RequestOptions) null);
+  }
+
+  /** Returns a list of FinancialAccounts. */
+  public static FinancialAccountCollection list(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/treasury/financial_accounts");
+    return ApiResource.requestCollection(url, params, FinancialAccountCollection.class, options);
+  }
+
+  /** Returns a list of FinancialAccounts. */
+  public static FinancialAccountCollection list(FinancialAccountListParams params)
+      throws StripeException {
+    return list(params, (RequestOptions) null);
+  }
+
+  /** Returns a list of FinancialAccounts. */
+  public static FinancialAccountCollection list(
+      FinancialAccountListParams params, RequestOptions options) throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/treasury/financial_accounts");
+    return ApiResource.requestCollection(url, params, FinancialAccountCollection.class, options);
+  }
+
+  /** Retrieves the details of a FinancialAccount. */
+  public static FinancialAccount retrieve(String financialAccount) throws StripeException {
+    return retrieve(financialAccount, (Map<String, Object>) null, (RequestOptions) null);
+  }
+
+  /** Retrieves the details of a FinancialAccount. */
+  public static FinancialAccount retrieve(String financialAccount, RequestOptions options)
+      throws StripeException {
+    return retrieve(financialAccount, (Map<String, Object>) null, options);
+  }
+
+  /** Retrieves the details of a FinancialAccount. */
+  public static FinancialAccount retrieve(
+      String financialAccount, Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/treasury/financial_accounts/%s", ApiResource.urlEncodeId(financialAccount)));
+    return ApiResource.request(
+        ApiResource.RequestMethod.GET, url, params, FinancialAccount.class, options);
+  }
+
+  /** Retrieves the details of a FinancialAccount. */
+  public static FinancialAccount retrieve(
+      String financialAccount, FinancialAccountRetrieveParams params, RequestOptions options)
+      throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/treasury/financial_accounts/%s", ApiResource.urlEncodeId(financialAccount)));
+    return ApiResource.request(
+        ApiResource.RequestMethod.GET, url, params, FinancialAccount.class, options);
+  }
+
+  /** Retrieves Features information associated with the FinancialAccount. */
+  public FinancialAccountFeatures retrieveFeatures() throws StripeException {
+    return retrieveFeatures((Map<String, Object>) null, (RequestOptions) null);
+  }
+
+  /** Retrieves Features information associated with the FinancialAccount. */
+  public FinancialAccountFeatures retrieveFeatures(Map<String, Object> params)
+      throws StripeException {
+    return retrieveFeatures(params, (RequestOptions) null);
+  }
+
+  /** Retrieves Features information associated with the FinancialAccount. */
+  public FinancialAccountFeatures retrieveFeatures(
+      Map<String, Object> params, RequestOptions options) throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/treasury/financial_accounts/%s/features",
+                ApiResource.urlEncodeId(this.getId())));
+    return ApiResource.request(
+        ApiResource.RequestMethod.GET, url, params, FinancialAccountFeatures.class, options);
+  }
+
+  /** Retrieves Features information associated with the FinancialAccount. */
+  public FinancialAccountFeatures retrieveFeatures(FinancialAccountRetrieveFeaturesParams params)
+      throws StripeException {
+    return retrieveFeatures(params, (RequestOptions) null);
+  }
+
+  /** Retrieves Features information associated with the FinancialAccount. */
+  public FinancialAccountFeatures retrieveFeatures(
+      FinancialAccountRetrieveFeaturesParams params, RequestOptions options)
+      throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/treasury/financial_accounts/%s/features",
+                ApiResource.urlEncodeId(this.getId())));
+    return ApiResource.request(
+        ApiResource.RequestMethod.GET, url, params, FinancialAccountFeatures.class, options);
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class Balance extends StripeObject {
+    /** Funds the user can spend right now. */
+    @SerializedName("cash")
+    Map<String, Long> cash;
+
+    /** Funds not spendable yet, but will become available at a later time. */
+    @SerializedName("inbound_pending")
+    Map<String, Long> inboundPending;
+
+    /**
+     * Funds in the account, but not spendable because they are being held for pending outbound
+     * flows.
+     */
+    @SerializedName("outbound_pending")
+    Map<String, Long> outboundPending;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class FinancialAddresses extends StripeObject {
+    /** ABA Records contain U.S. bank account details per the ABA format. */
+    @SerializedName("aba")
+    ABARecord aba;
+
+    /** The list of networks that the address supports. */
+    @SerializedName("supported_networks")
+    List<String> supportedNetworks;
+
+    /**
+     * The type of financial address
+     *
+     * <p>Equal to {@code aba}.
+     */
+    @SerializedName("type")
+    String type;
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class ABARecord extends StripeObject {
+      /** The name of the person or business that owns the bank account. */
+      @SerializedName("account_holder_name")
+      String accountHolderName;
+
+      /** The account number. */
+      @SerializedName("account_number")
+      String accountNumber;
+
+      /** The last four characters of the account number. */
+      @SerializedName("account_number_last4")
+      String accountNumberLast4;
+
+      /** Name of the bank. */
+      @SerializedName("bank_name")
+      String bankName;
+
+      /** Routing number for the account. */
+      @SerializedName("routing_number")
+      String routingNumber;
+    }
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class StatusDetails extends StripeObject {
+    /** Details related to the closure of this FinancialAccount. */
+    @SerializedName("closed")
+    ClosedStatusDetails closed;
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class ClosedStatusDetails extends StripeObject {
+      /** The array that contains reasons for a FinancialAccount closure. */
+      @SerializedName("reasons")
+      List<String> reasons;
+    }
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class ToggleSettings extends StripeObject {
+    /** Whether the FinancialAccount should have the Feature. */
+    @SerializedName("requested")
+    Boolean requested;
+
+    /**
+     * Whether the Feature is operational.
+     *
+     * <p>One of {@code active}, {@code pending}, or {@code restricted}.
+     */
+    @SerializedName("status")
+    String status;
+
+    /** Additional details; includes at least one entry when the status is not {@code active}. */
+    @SerializedName("status_details")
+    List<FinancialAccount.ToggleSettings.StatusDetails> statusDetails;
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class StatusDetails extends StripeObject {
+      /**
+       * Represents the reason why the status is {@code pending} or {@code restricted}.
+       *
+       * <p>One of {@code activating}, {@code capability_not_requested}, {@code
+       * financial_account_closed}, {@code rejected_other}, {@code rejected_unsupported_business},
+       * {@code requirements_past_due}, {@code requirements_pending_verification}, {@code
+       * restricted_by_platform}, or {@code restricted_other}.
+       */
+      @SerializedName("code")
+      String code;
+
+      /**
+       * Represents what the user should do, if anything, to activate the Feature.
+       *
+       * <p>One of {@code contact_stripe}, {@code provide_information}, or {@code
+       * remove_restriction}.
+       */
+      @SerializedName("resolution")
+      String resolution;
+
+      /**
+       * The {@code platform_restrictions} that are restricting this Feature.
+       *
+       * <p>One of {@code inbound_flows}, or {@code outbound_flows}.
+       */
+      @SerializedName("restriction")
+      String restriction;
+    }
+  }
+}

--- a/src/main/java/com/stripe/model/treasury/FinancialAccount.java
+++ b/src/main/java/com/stripe/model/treasury/FinancialAccount.java
@@ -55,7 +55,7 @@ public class FinancialAccount extends ApiResource
 
   /** The set of credentials that resolve to a FinancialAccount. */
   @SerializedName("financial_addresses")
-  List<FinancialAccount.FinancialAddresses> financialAddresses;
+  List<FinancialAccount.FinancialAddress> financialAddresses;
 
   /** Unique identifier for the object. */
   @Getter(onMethod_ = {@Override})
@@ -92,7 +92,7 @@ public class FinancialAccount extends ApiResource
 
   /** The set of functionalities that the platform can restrict on the FinancialAccount. */
   @SerializedName("platform_restrictions")
-  FinancialAccountFeatures.PlatformRestriction platformRestrictions;
+  PlatformRestrictions platformRestrictions;
 
   /** The array of paths to restricted Features in the Features hash. */
   @SerializedName("restricted_features")
@@ -376,10 +376,10 @@ public class FinancialAccount extends ApiResource
   @Getter
   @Setter
   @EqualsAndHashCode(callSuper = false)
-  public static class FinancialAddresses extends StripeObject {
+  public static class FinancialAddress extends StripeObject {
     /** ABA Records contain U.S. bank account details per the ABA format. */
     @SerializedName("aba")
-    ABARecord aba;
+    Aba aba;
 
     /** The list of networks that the address supports. */
     @SerializedName("supported_networks")
@@ -396,7 +396,7 @@ public class FinancialAccount extends ApiResource
     @Getter
     @Setter
     @EqualsAndHashCode(callSuper = false)
-    public static class ABARecord extends StripeObject {
+    public static class Aba extends StripeObject {
       /** The name of the person or business that owns the bank account. */
       @SerializedName("account_holder_name")
       String accountHolderName;
@@ -422,15 +422,36 @@ public class FinancialAccount extends ApiResource
   @Getter
   @Setter
   @EqualsAndHashCode(callSuper = false)
+  public static class PlatformRestrictions extends StripeObject {
+    /**
+     * Restricts all inbound money movement.
+     *
+     * <p>One of {@code restricted}, or {@code unrestricted}.
+     */
+    @SerializedName("inbound_flows")
+    String inboundFlows;
+
+    /**
+     * Restricts all outbound money movement.
+     *
+     * <p>One of {@code restricted}, or {@code unrestricted}.
+     */
+    @SerializedName("outbound_flows")
+    String outboundFlows;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
   public static class StatusDetails extends StripeObject {
     /** Details related to the closure of this FinancialAccount. */
     @SerializedName("closed")
-    ClosedStatusDetails closed;
+    Closed closed;
 
     @Getter
     @Setter
     @EqualsAndHashCode(callSuper = false)
-    public static class ClosedStatusDetails extends StripeObject {
+    public static class Closed extends StripeObject {
       /** The array that contains reasons for a FinancialAccount closure. */
       @SerializedName("reasons")
       List<String> reasons;

--- a/src/main/java/com/stripe/model/treasury/FinancialAccountCollection.java
+++ b/src/main/java/com/stripe/model/treasury/FinancialAccountCollection.java
@@ -1,0 +1,6 @@
+// File generated from our OpenAPI spec
+package com.stripe.model.treasury;
+
+import com.stripe.model.StripeCollection;
+
+public class FinancialAccountCollection extends StripeCollection<FinancialAccount> {}

--- a/src/main/java/com/stripe/model/treasury/FinancialAccountFeatures.java
+++ b/src/main/java/com/stripe/model/treasury/FinancialAccountFeatures.java
@@ -1,0 +1,114 @@
+// File generated from our OpenAPI spec
+package com.stripe.model.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.model.StripeObject;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
+public class FinancialAccountFeatures extends StripeObject {
+  /** Toggle settings for enabling/disabling a feature. */
+  @SerializedName("card_issuing")
+  FinancialAccount.ToggleSettings cardIssuing;
+
+  /** Toggle settings for enabling/disabling a feature. */
+  @SerializedName("deposit_insurance")
+  FinancialAccount.ToggleSettings depositInsurance;
+
+  /** Settings related to Financial Addresses features on a Financial Account. */
+  @SerializedName("financial_addresses")
+  FinancialAddress financialAddresses;
+
+  /** InboundTransfers contains inbound transfers features for a FinancialAccount. */
+  @SerializedName("inbound_transfers")
+  InboundTransfer inboundTransfers;
+
+  /** Toggle settings for enabling/disabling a feature. */
+  @SerializedName("intra_stripe_flows")
+  FinancialAccount.ToggleSettings intraStripeFlows;
+
+  /**
+   * String representing the object's type. Objects of the same type share the same value.
+   *
+   * <p>Equal to {@code treasury.financial_account_features}.
+   */
+  @SerializedName("object")
+  String object;
+
+  /** Settings related to Outbound Payments features on a Financial Account. */
+  @SerializedName("outbound_payments")
+  OutboundPayment outboundPayments;
+
+  /** OutboundTransfers contains outbound transfers features for a FinancialAccount. */
+  @SerializedName("outbound_transfers")
+  OutboundTransfer outboundTransfers;
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class FinancialAddress extends StripeObject {
+    /** Toggle settings for enabling/disabling a feature. */
+    @SerializedName("aba")
+    FinancialAccount.ToggleSettings aba;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class InboundTransfer extends StripeObject {
+    /** Toggle settings for enabling/disabling a feature. */
+    @SerializedName("ach")
+    FinancialAccount.ToggleSettings ach;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class OutboundPayment extends StripeObject {
+    /** Toggle settings for enabling/disabling a feature. */
+    @SerializedName("ach")
+    FinancialAccount.ToggleSettings ach;
+
+    /** Toggle settings for enabling/disabling a feature. */
+    @SerializedName("us_domestic_wire")
+    FinancialAccount.ToggleSettings usDomesticWire;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class OutboundTransfer extends StripeObject {
+    /** Toggle settings for enabling/disabling a feature. */
+    @SerializedName("ach")
+    FinancialAccount.ToggleSettings ach;
+
+    /** Toggle settings for enabling/disabling a feature. */
+    @SerializedName("us_domestic_wire")
+    FinancialAccount.ToggleSettings usDomesticWire;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class PlatformRestriction extends StripeObject {
+    /**
+     * Restricts all inbound money movement.
+     *
+     * <p>One of {@code restricted}, or {@code unrestricted}.
+     */
+    @SerializedName("inbound_flows")
+    String inboundFlows;
+
+    /**
+     * Restricts all outbound money movement.
+     *
+     * <p>One of {@code restricted}, or {@code unrestricted}.
+     */
+    @SerializedName("outbound_flows")
+    String outboundFlows;
+  }
+}

--- a/src/main/java/com/stripe/model/treasury/FinancialAccountFeatures.java
+++ b/src/main/java/com/stripe/model/treasury/FinancialAccountFeatures.java
@@ -3,6 +3,7 @@ package com.stripe.model.treasury;
 
 import com.google.gson.annotations.SerializedName;
 import com.stripe.model.StripeObject;
+import java.util.List;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -13,23 +14,23 @@ import lombok.Setter;
 public class FinancialAccountFeatures extends StripeObject {
   /** Toggle settings for enabling/disabling a feature. */
   @SerializedName("card_issuing")
-  FinancialAccount.ToggleSettings cardIssuing;
+  CardIssuing cardIssuing;
 
   /** Toggle settings for enabling/disabling a feature. */
   @SerializedName("deposit_insurance")
-  FinancialAccount.ToggleSettings depositInsurance;
+  DepositInsurance depositInsurance;
 
   /** Settings related to Financial Addresses features on a Financial Account. */
   @SerializedName("financial_addresses")
-  FinancialAddress financialAddresses;
+  FinancialAddresses financialAddresses;
 
   /** InboundTransfers contains inbound transfers features for a FinancialAccount. */
   @SerializedName("inbound_transfers")
-  InboundTransfer inboundTransfers;
+  InboundTransfers inboundTransfers;
 
   /** Toggle settings for enabling/disabling a feature. */
   @SerializedName("intra_stripe_flows")
-  FinancialAccount.ToggleSettings intraStripeFlows;
+  IntraStripeFlows intraStripeFlows;
 
   /**
    * String representing the object's type. Objects of the same type share the same value.
@@ -41,54 +42,540 @@ public class FinancialAccountFeatures extends StripeObject {
 
   /** Settings related to Outbound Payments features on a Financial Account. */
   @SerializedName("outbound_payments")
-  OutboundPayment outboundPayments;
+  OutboundPayments outboundPayments;
 
   /** OutboundTransfers contains outbound transfers features for a FinancialAccount. */
   @SerializedName("outbound_transfers")
-  OutboundTransfer outboundTransfers;
+  OutboundTransfers outboundTransfers;
 
   @Getter
   @Setter
   @EqualsAndHashCode(callSuper = false)
-  public static class FinancialAddress extends StripeObject {
+  public static class CardIssuing extends StripeObject {
+    /** Whether the FinancialAccount should have the Feature. */
+    @SerializedName("requested")
+    Boolean requested;
+
+    /**
+     * Whether the Feature is operational.
+     *
+     * <p>One of {@code active}, {@code pending}, or {@code restricted}.
+     */
+    @SerializedName("status")
+    String status;
+
+    /** Additional details; includes at least one entry when the status is not {@code active}. */
+    @SerializedName("status_details")
+    List<FinancialAccountFeatures.CardIssuing.StatusDetails> statusDetails;
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class StatusDetails extends StripeObject {
+      /**
+       * Represents the reason why the status is {@code pending} or {@code restricted}.
+       *
+       * <p>One of {@code activating}, {@code capability_not_requested}, {@code
+       * financial_account_closed}, {@code rejected_other}, {@code rejected_unsupported_business},
+       * {@code requirements_past_due}, {@code requirements_pending_verification}, {@code
+       * restricted_by_platform}, or {@code restricted_other}.
+       */
+      @SerializedName("code")
+      String code;
+
+      /**
+       * Represents what the user should do, if anything, to activate the Feature.
+       *
+       * <p>One of {@code contact_stripe}, {@code provide_information}, or {@code
+       * remove_restriction}.
+       */
+      @SerializedName("resolution")
+      String resolution;
+
+      /**
+       * The {@code platform_restrictions} that are restricting this Feature.
+       *
+       * <p>One of {@code inbound_flows}, or {@code outbound_flows}.
+       */
+      @SerializedName("restriction")
+      String restriction;
+    }
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class DepositInsurance extends StripeObject {
+    /** Whether the FinancialAccount should have the Feature. */
+    @SerializedName("requested")
+    Boolean requested;
+
+    /**
+     * Whether the Feature is operational.
+     *
+     * <p>One of {@code active}, {@code pending}, or {@code restricted}.
+     */
+    @SerializedName("status")
+    String status;
+
+    /** Additional details; includes at least one entry when the status is not {@code active}. */
+    @SerializedName("status_details")
+    List<FinancialAccountFeatures.DepositInsurance.StatusDetails> statusDetails;
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class StatusDetails extends StripeObject {
+      /**
+       * Represents the reason why the status is {@code pending} or {@code restricted}.
+       *
+       * <p>One of {@code activating}, {@code capability_not_requested}, {@code
+       * financial_account_closed}, {@code rejected_other}, {@code rejected_unsupported_business},
+       * {@code requirements_past_due}, {@code requirements_pending_verification}, {@code
+       * restricted_by_platform}, or {@code restricted_other}.
+       */
+      @SerializedName("code")
+      String code;
+
+      /**
+       * Represents what the user should do, if anything, to activate the Feature.
+       *
+       * <p>One of {@code contact_stripe}, {@code provide_information}, or {@code
+       * remove_restriction}.
+       */
+      @SerializedName("resolution")
+      String resolution;
+
+      /**
+       * The {@code platform_restrictions} that are restricting this Feature.
+       *
+       * <p>One of {@code inbound_flows}, or {@code outbound_flows}.
+       */
+      @SerializedName("restriction")
+      String restriction;
+    }
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class FinancialAddresses extends StripeObject {
     /** Toggle settings for enabling/disabling a feature. */
     @SerializedName("aba")
-    FinancialAccount.ToggleSettings aba;
+    Aba aba;
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class Aba extends StripeObject {
+      /** Whether the FinancialAccount should have the Feature. */
+      @SerializedName("requested")
+      Boolean requested;
+
+      /**
+       * Whether the Feature is operational.
+       *
+       * <p>One of {@code active}, {@code pending}, or {@code restricted}.
+       */
+      @SerializedName("status")
+      String status;
+
+      /** Additional details; includes at least one entry when the status is not {@code active}. */
+      @SerializedName("status_details")
+      List<FinancialAccountFeatures.FinancialAddresses.Aba.StatusDetails> statusDetails;
+
+      @Getter
+      @Setter
+      @EqualsAndHashCode(callSuper = false)
+      public static class StatusDetails extends StripeObject {
+        /**
+         * Represents the reason why the status is {@code pending} or {@code restricted}.
+         *
+         * <p>One of {@code activating}, {@code capability_not_requested}, {@code
+         * financial_account_closed}, {@code rejected_other}, {@code rejected_unsupported_business},
+         * {@code requirements_past_due}, {@code requirements_pending_verification}, {@code
+         * restricted_by_platform}, or {@code restricted_other}.
+         */
+        @SerializedName("code")
+        String code;
+
+        /**
+         * Represents what the user should do, if anything, to activate the Feature.
+         *
+         * <p>One of {@code contact_stripe}, {@code provide_information}, or {@code
+         * remove_restriction}.
+         */
+        @SerializedName("resolution")
+        String resolution;
+
+        /**
+         * The {@code platform_restrictions} that are restricting this Feature.
+         *
+         * <p>One of {@code inbound_flows}, or {@code outbound_flows}.
+         */
+        @SerializedName("restriction")
+        String restriction;
+      }
+    }
   }
 
   @Getter
   @Setter
   @EqualsAndHashCode(callSuper = false)
-  public static class InboundTransfer extends StripeObject {
+  public static class InboundTransfers extends StripeObject {
     /** Toggle settings for enabling/disabling a feature. */
     @SerializedName("ach")
-    FinancialAccount.ToggleSettings ach;
+    Ach ach;
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class Ach extends StripeObject {
+      /** Whether the FinancialAccount should have the Feature. */
+      @SerializedName("requested")
+      Boolean requested;
+
+      /**
+       * Whether the Feature is operational.
+       *
+       * <p>One of {@code active}, {@code pending}, or {@code restricted}.
+       */
+      @SerializedName("status")
+      String status;
+
+      /** Additional details; includes at least one entry when the status is not {@code active}. */
+      @SerializedName("status_details")
+      List<FinancialAccountFeatures.InboundTransfers.Ach.StatusDetails> statusDetails;
+
+      @Getter
+      @Setter
+      @EqualsAndHashCode(callSuper = false)
+      public static class StatusDetails extends StripeObject {
+        /**
+         * Represents the reason why the status is {@code pending} or {@code restricted}.
+         *
+         * <p>One of {@code activating}, {@code capability_not_requested}, {@code
+         * financial_account_closed}, {@code rejected_other}, {@code rejected_unsupported_business},
+         * {@code requirements_past_due}, {@code requirements_pending_verification}, {@code
+         * restricted_by_platform}, or {@code restricted_other}.
+         */
+        @SerializedName("code")
+        String code;
+
+        /**
+         * Represents what the user should do, if anything, to activate the Feature.
+         *
+         * <p>One of {@code contact_stripe}, {@code provide_information}, or {@code
+         * remove_restriction}.
+         */
+        @SerializedName("resolution")
+        String resolution;
+
+        /**
+         * The {@code platform_restrictions} that are restricting this Feature.
+         *
+         * <p>One of {@code inbound_flows}, or {@code outbound_flows}.
+         */
+        @SerializedName("restriction")
+        String restriction;
+      }
+    }
   }
 
   @Getter
   @Setter
   @EqualsAndHashCode(callSuper = false)
-  public static class OutboundPayment extends StripeObject {
+  public static class IntraStripeFlows extends StripeObject {
+    /** Whether the FinancialAccount should have the Feature. */
+    @SerializedName("requested")
+    Boolean requested;
+
+    /**
+     * Whether the Feature is operational.
+     *
+     * <p>One of {@code active}, {@code pending}, or {@code restricted}.
+     */
+    @SerializedName("status")
+    String status;
+
+    /** Additional details; includes at least one entry when the status is not {@code active}. */
+    @SerializedName("status_details")
+    List<FinancialAccountFeatures.IntraStripeFlows.StatusDetails> statusDetails;
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class StatusDetails extends StripeObject {
+      /**
+       * Represents the reason why the status is {@code pending} or {@code restricted}.
+       *
+       * <p>One of {@code activating}, {@code capability_not_requested}, {@code
+       * financial_account_closed}, {@code rejected_other}, {@code rejected_unsupported_business},
+       * {@code requirements_past_due}, {@code requirements_pending_verification}, {@code
+       * restricted_by_platform}, or {@code restricted_other}.
+       */
+      @SerializedName("code")
+      String code;
+
+      /**
+       * Represents what the user should do, if anything, to activate the Feature.
+       *
+       * <p>One of {@code contact_stripe}, {@code provide_information}, or {@code
+       * remove_restriction}.
+       */
+      @SerializedName("resolution")
+      String resolution;
+
+      /**
+       * The {@code platform_restrictions} that are restricting this Feature.
+       *
+       * <p>One of {@code inbound_flows}, or {@code outbound_flows}.
+       */
+      @SerializedName("restriction")
+      String restriction;
+    }
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class OutboundPayments extends StripeObject {
     /** Toggle settings for enabling/disabling a feature. */
     @SerializedName("ach")
-    FinancialAccount.ToggleSettings ach;
+    Ach ach;
 
     /** Toggle settings for enabling/disabling a feature. */
     @SerializedName("us_domestic_wire")
-    FinancialAccount.ToggleSettings usDomesticWire;
+    UsDomesticWire usDomesticWire;
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class Ach extends StripeObject {
+      /** Whether the FinancialAccount should have the Feature. */
+      @SerializedName("requested")
+      Boolean requested;
+
+      /**
+       * Whether the Feature is operational.
+       *
+       * <p>One of {@code active}, {@code pending}, or {@code restricted}.
+       */
+      @SerializedName("status")
+      String status;
+
+      /** Additional details; includes at least one entry when the status is not {@code active}. */
+      @SerializedName("status_details")
+      List<FinancialAccountFeatures.OutboundPayments.Ach.StatusDetails> statusDetails;
+
+      @Getter
+      @Setter
+      @EqualsAndHashCode(callSuper = false)
+      public static class StatusDetails extends StripeObject {
+        /**
+         * Represents the reason why the status is {@code pending} or {@code restricted}.
+         *
+         * <p>One of {@code activating}, {@code capability_not_requested}, {@code
+         * financial_account_closed}, {@code rejected_other}, {@code rejected_unsupported_business},
+         * {@code requirements_past_due}, {@code requirements_pending_verification}, {@code
+         * restricted_by_platform}, or {@code restricted_other}.
+         */
+        @SerializedName("code")
+        String code;
+
+        /**
+         * Represents what the user should do, if anything, to activate the Feature.
+         *
+         * <p>One of {@code contact_stripe}, {@code provide_information}, or {@code
+         * remove_restriction}.
+         */
+        @SerializedName("resolution")
+        String resolution;
+
+        /**
+         * The {@code platform_restrictions} that are restricting this Feature.
+         *
+         * <p>One of {@code inbound_flows}, or {@code outbound_flows}.
+         */
+        @SerializedName("restriction")
+        String restriction;
+      }
+    }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class UsDomesticWire extends StripeObject {
+      /** Whether the FinancialAccount should have the Feature. */
+      @SerializedName("requested")
+      Boolean requested;
+
+      /**
+       * Whether the Feature is operational.
+       *
+       * <p>One of {@code active}, {@code pending}, or {@code restricted}.
+       */
+      @SerializedName("status")
+      String status;
+
+      /** Additional details; includes at least one entry when the status is not {@code active}. */
+      @SerializedName("status_details")
+      List<FinancialAccountFeatures.OutboundPayments.UsDomesticWire.StatusDetails> statusDetails;
+
+      @Getter
+      @Setter
+      @EqualsAndHashCode(callSuper = false)
+      public static class StatusDetails extends StripeObject {
+        /**
+         * Represents the reason why the status is {@code pending} or {@code restricted}.
+         *
+         * <p>One of {@code activating}, {@code capability_not_requested}, {@code
+         * financial_account_closed}, {@code rejected_other}, {@code rejected_unsupported_business},
+         * {@code requirements_past_due}, {@code requirements_pending_verification}, {@code
+         * restricted_by_platform}, or {@code restricted_other}.
+         */
+        @SerializedName("code")
+        String code;
+
+        /**
+         * Represents what the user should do, if anything, to activate the Feature.
+         *
+         * <p>One of {@code contact_stripe}, {@code provide_information}, or {@code
+         * remove_restriction}.
+         */
+        @SerializedName("resolution")
+        String resolution;
+
+        /**
+         * The {@code platform_restrictions} that are restricting this Feature.
+         *
+         * <p>One of {@code inbound_flows}, or {@code outbound_flows}.
+         */
+        @SerializedName("restriction")
+        String restriction;
+      }
+    }
   }
 
   @Getter
   @Setter
   @EqualsAndHashCode(callSuper = false)
-  public static class OutboundTransfer extends StripeObject {
+  public static class OutboundTransfers extends StripeObject {
     /** Toggle settings for enabling/disabling a feature. */
     @SerializedName("ach")
-    FinancialAccount.ToggleSettings ach;
+    Ach ach;
 
     /** Toggle settings for enabling/disabling a feature. */
     @SerializedName("us_domestic_wire")
-    FinancialAccount.ToggleSettings usDomesticWire;
+    UsDomesticWire usDomesticWire;
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class Ach extends StripeObject {
+      /** Whether the FinancialAccount should have the Feature. */
+      @SerializedName("requested")
+      Boolean requested;
+
+      /**
+       * Whether the Feature is operational.
+       *
+       * <p>One of {@code active}, {@code pending}, or {@code restricted}.
+       */
+      @SerializedName("status")
+      String status;
+
+      /** Additional details; includes at least one entry when the status is not {@code active}. */
+      @SerializedName("status_details")
+      List<FinancialAccountFeatures.OutboundTransfers.Ach.StatusDetails> statusDetails;
+
+      @Getter
+      @Setter
+      @EqualsAndHashCode(callSuper = false)
+      public static class StatusDetails extends StripeObject {
+        /**
+         * Represents the reason why the status is {@code pending} or {@code restricted}.
+         *
+         * <p>One of {@code activating}, {@code capability_not_requested}, {@code
+         * financial_account_closed}, {@code rejected_other}, {@code rejected_unsupported_business},
+         * {@code requirements_past_due}, {@code requirements_pending_verification}, {@code
+         * restricted_by_platform}, or {@code restricted_other}.
+         */
+        @SerializedName("code")
+        String code;
+
+        /**
+         * Represents what the user should do, if anything, to activate the Feature.
+         *
+         * <p>One of {@code contact_stripe}, {@code provide_information}, or {@code
+         * remove_restriction}.
+         */
+        @SerializedName("resolution")
+        String resolution;
+
+        /**
+         * The {@code platform_restrictions} that are restricting this Feature.
+         *
+         * <p>One of {@code inbound_flows}, or {@code outbound_flows}.
+         */
+        @SerializedName("restriction")
+        String restriction;
+      }
+    }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class UsDomesticWire extends StripeObject {
+      /** Whether the FinancialAccount should have the Feature. */
+      @SerializedName("requested")
+      Boolean requested;
+
+      /**
+       * Whether the Feature is operational.
+       *
+       * <p>One of {@code active}, {@code pending}, or {@code restricted}.
+       */
+      @SerializedName("status")
+      String status;
+
+      /** Additional details; includes at least one entry when the status is not {@code active}. */
+      @SerializedName("status_details")
+      List<FinancialAccountFeatures.OutboundTransfers.UsDomesticWire.StatusDetails> statusDetails;
+
+      @Getter
+      @Setter
+      @EqualsAndHashCode(callSuper = false)
+      public static class StatusDetails extends StripeObject {
+        /**
+         * Represents the reason why the status is {@code pending} or {@code restricted}.
+         *
+         * <p>One of {@code activating}, {@code capability_not_requested}, {@code
+         * financial_account_closed}, {@code rejected_other}, {@code rejected_unsupported_business},
+         * {@code requirements_past_due}, {@code requirements_pending_verification}, {@code
+         * restricted_by_platform}, or {@code restricted_other}.
+         */
+        @SerializedName("code")
+        String code;
+
+        /**
+         * Represents what the user should do, if anything, to activate the Feature.
+         *
+         * <p>One of {@code contact_stripe}, {@code provide_information}, or {@code
+         * remove_restriction}.
+         */
+        @SerializedName("resolution")
+        String resolution;
+
+        /**
+         * The {@code platform_restrictions} that are restricting this Feature.
+         *
+         * <p>One of {@code inbound_flows}, or {@code outbound_flows}.
+         */
+        @SerializedName("restriction")
+        String restriction;
+      }
+    }
   }
 
   @Getter

--- a/src/main/java/com/stripe/model/treasury/FlowDetails.java
+++ b/src/main/java/com/stripe/model/treasury/FlowDetails.java
@@ -1,0 +1,103 @@
+// File generated from our OpenAPI spec
+package com.stripe.model.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.model.StripeObject;
+import com.stripe.model.issuing.Authorization;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
+public class FlowDetails extends StripeObject {
+  /**
+   * You can reverse some <a href="https://stripe.com/docs/api#received_credits">ReceivedCredits</a>
+   * depending on their network and source flow. Reversing a ReceivedCredit leads to the creation of
+   * a new object known as a CreditReversal.
+   */
+  @SerializedName("credit_reversal")
+  CreditReversal creditReversal;
+
+  /**
+   * You can reverse some <a href="https://stripe.com/docs/api#received_debits">ReceivedDebits</a>
+   * depending on their network and source flow. Reversing a ReceivedDebit leads to the creation of
+   * a new object known as a DebitReversal.
+   */
+  @SerializedName("debit_reversal")
+  DebitReversal debitReversal;
+
+  /**
+   * Use InboundTransfers to add funds to your <a
+   * href="https://stripe.com/docs/api#financial_accounts">FinancialAccount</a> via a PaymentMethod
+   * that is owned by you. The funds will be transferred via an ACH debit.
+   */
+  @SerializedName("inbound_transfer")
+  InboundTransfer inboundTransfer;
+
+  /**
+   * When an <a href="https://stripe.com/docs/issuing">issued card</a> is used to make a purchase,
+   * an Issuing {@code Authorization} object is created. <a
+   * href="https://stripe.com/docs/issuing/purchases/authorizations">Authorizations</a> must be
+   * approved for the purchase to be completed successfully.
+   *
+   * <p>Related guide: <a href="https://stripe.com/docs/issuing/purchases/authorizations">Issued
+   * Card Authorizations</a>.
+   */
+  @SerializedName("issuing_authorization")
+  Authorization issuingAuthorization;
+
+  /**
+   * Use OutboundPayments to send funds to another party's external bank account or <a
+   * href="https://stripe.com/docs/api#financial_accounts">FinancialAccount</a>. To send money to an
+   * account belonging to the same user, use an <a
+   * href="https://stripe.com/docs/api#outbound_transfers">OutboundTransfer</a>.
+   *
+   * <p>Simulate OutboundPayment state changes with the {@code
+   * /v1/test_helpers/treasury/outbound_payments} endpoints. These methods can only be called on
+   * test mode objects.
+   */
+  @SerializedName("outbound_payment")
+  OutboundPayment outboundPayment;
+
+  /**
+   * Use OutboundTransfers to transfer funds from a <a
+   * href="https://stripe.com/docs/api#financial_accounts">FinancialAccount</a> to a PaymentMethod
+   * belonging to the same entity. To send funds to a different party, use <a
+   * href="https://stripe.com/docs/api#outbound_payments">OutboundPayments</a> instead. You can send
+   * funds over ACH rails or through a domestic wire transfer to a user's own external bank account.
+   *
+   * <p>Simulate OutboundTransfer state changes with the {@code
+   * /v1/test_helpers/treasury/outbound_transfers} endpoints. These methods can only be called on
+   * test mode objects.
+   */
+  @SerializedName("outbound_transfer")
+  OutboundTransfer outboundTransfer;
+
+  /**
+   * ReceivedCredits represent funds sent to a <a
+   * href="https://stripe.com/docs/api#financial_accounts">FinancialAccount</a> (for example, via
+   * ACH or wire). These money movements are not initiated from the FinancialAccount.
+   */
+  @SerializedName("received_credit")
+  ReceivedCredit receivedCredit;
+
+  /**
+   * ReceivedDebits represent funds pulled from a <a
+   * href="https://stripe.com/docs/api#financial_accounts">FinancialAccount</a>. These are not
+   * initiated from the FinancialAccount.
+   */
+  @SerializedName("received_debit")
+  ReceivedDebit receivedDebit;
+
+  /**
+   * Type of the flow that created the Transaction. Set to the same value as {@code flow_type}.
+   *
+   * <p>One of {@code credit_reversal}, {@code debit_reversal}, {@code inbound_transfer}, {@code
+   * issuing_authorization}, {@code other}, {@code outbound_payment}, {@code outbound_transfer},
+   * {@code received_credit}, or {@code received_debit}.
+   */
+  @SerializedName("type")
+  String type;
+}

--- a/src/main/java/com/stripe/model/treasury/InboundTransfer.java
+++ b/src/main/java/com/stripe/model/treasury/InboundTransfer.java
@@ -1,0 +1,608 @@
+// File generated from our OpenAPI spec
+package com.stripe.model.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.Stripe;
+import com.stripe.exception.StripeException;
+import com.stripe.model.ExpandableField;
+import com.stripe.model.HasId;
+import com.stripe.model.StripeObject;
+import com.stripe.net.ApiResource;
+import com.stripe.net.RequestOptions;
+import com.stripe.param.treasury.InboundTransferCancelParams;
+import com.stripe.param.treasury.InboundTransferCreateParams;
+import com.stripe.param.treasury.InboundTransferFailParams;
+import com.stripe.param.treasury.InboundTransferListParams;
+import com.stripe.param.treasury.InboundTransferRetrieveParams;
+import com.stripe.param.treasury.InboundTransferReturnInboundTransferParams;
+import com.stripe.param.treasury.InboundTransferSucceedParams;
+import java.util.Map;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
+public class InboundTransfer extends ApiResource implements HasId {
+  /** Amount (in cents) transferred. */
+  @SerializedName("amount")
+  Long amount;
+
+  /** Returns {@code true} if the InboundTransfer is able to be canceled. */
+  @SerializedName("cancelable")
+  Boolean cancelable;
+
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  @SerializedName("created")
+  Long created;
+
+  /**
+   * Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency code</a>,
+   * in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported currency</a>.
+   */
+  @SerializedName("currency")
+  String currency;
+
+  /** An arbitrary string attached to the object. Often useful for displaying to users. */
+  @SerializedName("description")
+  String description;
+
+  /** Details about this InboundTransfer's failure. Only set when status is {@code failed}. */
+  @SerializedName("failure_details")
+  FailureDetails failureDetails;
+
+  /** The FinancialAccount that received the funds. */
+  @SerializedName("financial_account")
+  String financialAccount;
+
+  /**
+   * A hosted transaction receipt URL that is provided when money movement is considered regulated
+   * under Stripe's money transmission licenses.
+   */
+  @SerializedName("hosted_regulatory_receipt_url")
+  String hostedRegulatoryReceiptUrl;
+
+  /** Unique identifier for the object. */
+  @Getter(onMethod_ = {@Override})
+  @SerializedName("id")
+  String id;
+
+  @SerializedName("linked_flows")
+  LinkedFlows linkedFlows;
+
+  /**
+   * Has the value {@code true} if the object exists in live mode or the value {@code false} if the
+   * object exists in test mode.
+   */
+  @SerializedName("livemode")
+  Boolean livemode;
+
+  /**
+   * Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can attach
+   * to an object. This can be useful for storing additional information about the object in a
+   * structured format.
+   */
+  @SerializedName("metadata")
+  Map<String, String> metadata;
+
+  /**
+   * String representing the object's type. Objects of the same type share the same value.
+   *
+   * <p>Equal to {@code treasury.inbound_transfer}.
+   */
+  @SerializedName("object")
+  String object;
+
+  /** The origin payment method to be debited for an InboundTransfer. */
+  @SerializedName("origin_payment_method")
+  String originPaymentMethod;
+
+  /** Details about the PaymentMethod for an InboundTransfer. */
+  @SerializedName("origin_payment_method_details")
+  PaymentMethodDetails originPaymentMethodDetails;
+
+  /**
+   * Returns {@code true} if the funds for an InboundTransfer were returned after the
+   * InboundTransfer went to the {@code succeeded} state.
+   */
+  @SerializedName("returned")
+  Boolean returned;
+
+  /**
+   * Statement descriptor shown when funds are debited from the source. Not all payment networks
+   * support {@code statement_descriptor}.
+   */
+  @SerializedName("statement_descriptor")
+  String statementDescriptor;
+
+  /**
+   * Status of the InboundTransfer: {@code processing}, {@code succeeded}, {@code failed}, and
+   * {@code canceled}. An InboundTransfer is {@code processing} if it is created and pending. The
+   * status changes to {@code succeeded} once the funds have been &quot;confirmed&quot; and a {@code
+   * transaction} is created and posted. The status changes to {@code failed} if the transfer fails.
+   *
+   * <p>One of {@code canceled}, {@code failed}, {@code processing}, or {@code succeeded}.
+   */
+  @SerializedName("status")
+  String status;
+
+  @SerializedName("status_transitions")
+  StatusTransitions statusTransitions;
+
+  /** The Transaction associated with this object. */
+  @SerializedName("transaction")
+  @Getter(lombok.AccessLevel.NONE)
+  @Setter(lombok.AccessLevel.NONE)
+  ExpandableField<Transaction> transaction;
+
+  /** Get ID of expandable {@code transaction} object. */
+  public String getTransaction() {
+    return (this.transaction != null) ? this.transaction.getId() : null;
+  }
+
+  public void setTransaction(String id) {
+    this.transaction = ApiResource.setExpandableFieldId(id, this.transaction);
+  }
+
+  /** Get expanded {@code transaction}. */
+  public Transaction getTransactionObject() {
+    return (this.transaction != null) ? this.transaction.getExpanded() : null;
+  }
+
+  public void setTransactionObject(Transaction expandableObject) {
+    this.transaction = new ExpandableField<Transaction>(expandableObject.getId(), expandableObject);
+  }
+
+  /** Cancels an InboundTransfer. */
+  public InboundTransfer cancel() throws StripeException {
+    return cancel((Map<String, Object>) null, (RequestOptions) null);
+  }
+
+  /** Cancels an InboundTransfer. */
+  public InboundTransfer cancel(RequestOptions options) throws StripeException {
+    return cancel((Map<String, Object>) null, options);
+  }
+
+  /** Cancels an InboundTransfer. */
+  public InboundTransfer cancel(Map<String, Object> params) throws StripeException {
+    return cancel(params, (RequestOptions) null);
+  }
+
+  /** Cancels an InboundTransfer. */
+  public InboundTransfer cancel(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/treasury/inbound_transfers/%s/cancel", ApiResource.urlEncodeId(this.getId())));
+    return ApiResource.request(
+        ApiResource.RequestMethod.POST, url, params, InboundTransfer.class, options);
+  }
+
+  /** Cancels an InboundTransfer. */
+  public InboundTransfer cancel(InboundTransferCancelParams params) throws StripeException {
+    return cancel(params, (RequestOptions) null);
+  }
+
+  /** Cancels an InboundTransfer. */
+  public InboundTransfer cancel(InboundTransferCancelParams params, RequestOptions options)
+      throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/treasury/inbound_transfers/%s/cancel", ApiResource.urlEncodeId(this.getId())));
+    return ApiResource.request(
+        ApiResource.RequestMethod.POST, url, params, InboundTransfer.class, options);
+  }
+
+  /** Creates an InboundTransfer. */
+  public static InboundTransfer create(Map<String, Object> params) throws StripeException {
+    return create(params, (RequestOptions) null);
+  }
+
+  /** Creates an InboundTransfer. */
+  public static InboundTransfer create(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/treasury/inbound_transfers");
+    return ApiResource.request(
+        ApiResource.RequestMethod.POST, url, params, InboundTransfer.class, options);
+  }
+
+  /** Creates an InboundTransfer. */
+  public static InboundTransfer create(InboundTransferCreateParams params) throws StripeException {
+    return create(params, (RequestOptions) null);
+  }
+
+  /** Creates an InboundTransfer. */
+  public static InboundTransfer create(InboundTransferCreateParams params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/treasury/inbound_transfers");
+    return ApiResource.request(
+        ApiResource.RequestMethod.POST, url, params, InboundTransfer.class, options);
+  }
+
+  /** Retrieves the details of an existing InboundTransfer. */
+  public static InboundTransfer retrieve(String id) throws StripeException {
+    return retrieve(id, (Map<String, Object>) null, (RequestOptions) null);
+  }
+
+  /** Retrieves the details of an existing InboundTransfer. */
+  public static InboundTransfer retrieve(String id, RequestOptions options) throws StripeException {
+    return retrieve(id, (Map<String, Object>) null, options);
+  }
+
+  /** Retrieves the details of an existing InboundTransfer. */
+  public static InboundTransfer retrieve(
+      String id, Map<String, Object> params, RequestOptions options) throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/treasury/inbound_transfers/%s", ApiResource.urlEncodeId(id)));
+    return ApiResource.request(
+        ApiResource.RequestMethod.GET, url, params, InboundTransfer.class, options);
+  }
+
+  /** Retrieves the details of an existing InboundTransfer. */
+  public static InboundTransfer retrieve(
+      String id, InboundTransferRetrieveParams params, RequestOptions options)
+      throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/treasury/inbound_transfers/%s", ApiResource.urlEncodeId(id)));
+    return ApiResource.request(
+        ApiResource.RequestMethod.GET, url, params, InboundTransfer.class, options);
+  }
+
+  /** Returns a list of InboundTransfers sent from the specified FinancialAccount. */
+  public static InboundTransferCollection list(Map<String, Object> params) throws StripeException {
+    return list(params, (RequestOptions) null);
+  }
+
+  /** Returns a list of InboundTransfers sent from the specified FinancialAccount. */
+  public static InboundTransferCollection list(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/treasury/inbound_transfers");
+    return ApiResource.requestCollection(url, params, InboundTransferCollection.class, options);
+  }
+
+  /** Returns a list of InboundTransfers sent from the specified FinancialAccount. */
+  public static InboundTransferCollection list(InboundTransferListParams params)
+      throws StripeException {
+    return list(params, (RequestOptions) null);
+  }
+
+  /** Returns a list of InboundTransfers sent from the specified FinancialAccount. */
+  public static InboundTransferCollection list(
+      InboundTransferListParams params, RequestOptions options) throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/treasury/inbound_transfers");
+    return ApiResource.requestCollection(url, params, InboundTransferCollection.class, options);
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class FailureDetails extends StripeObject {
+    /**
+     * Reason for the failure.
+     *
+     * <p>One of {@code account_closed}, {@code account_frozen}, {@code bank_account_restricted},
+     * {@code bank_ownership_changed}, {@code debit_not_authorized}, {@code
+     * incorrect_account_holder_address}, {@code incorrect_account_holder_name}, {@code
+     * incorrect_account_holder_tax_id}, {@code insufficient_funds}, {@code invalid_account_number},
+     * {@code invalid_currency}, {@code no_account}, or {@code other}.
+     */
+    @SerializedName("code")
+    String code;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class LinkedFlows extends StripeObject {
+    /**
+     * If funds for this flow were returned after the flow went to the {@code succeeded} state, this
+     * field contains a reference to the ReceivedDebit return.
+     */
+    @SerializedName("received_debit")
+    String receivedDebit;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class PaymentMethodDetails extends StripeObject {
+    @SerializedName("billing_details")
+    BillingDetails billingDetails;
+
+    /**
+     * The type of the payment method used in the InboundTransfer.
+     *
+     * <p>Equal to {@code us_bank_account}.
+     */
+    @SerializedName("type")
+    String type;
+
+    @SerializedName("us_bank_account")
+    UsBankAccount usBankAccount;
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class UsBankAccount extends StripeObject {
+      /**
+       * Account holder type: individual or company.
+       *
+       * <p>One of {@code company}, or {@code individual}.
+       */
+      @SerializedName("account_holder_type")
+      String accountHolderType;
+
+      /**
+       * Account type: checkings or savings. Defaults to checking if omitted.
+       *
+       * <p>One of {@code checking}, or {@code savings}.
+       */
+      @SerializedName("account_type")
+      String accountType;
+
+      /** Name of the bank associated with the bank account. */
+      @SerializedName("bank_name")
+      String bankName;
+
+      /**
+       * Uniquely identifies this particular bank account. You can use this attribute to check
+       * whether two bank accounts are the same.
+       */
+      @SerializedName("fingerprint")
+      String fingerprint;
+
+      /** Last four digits of the bank account number. */
+      @SerializedName("last4")
+      String last4;
+
+      /**
+       * The US bank account network used to debit funds.
+       *
+       * <p>Equal to {@code ach}.
+       */
+      @SerializedName("network")
+      String network;
+
+      /** Routing number of the bank account. */
+      @SerializedName("routing_number")
+      String routingNumber;
+    }
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class StatusTransitions extends StripeObject {
+    /** Timestamp describing when an InboundTransfer changed status to {@code canceled}. */
+    @SerializedName("canceled_at")
+    Long canceledAt;
+
+    /** Timestamp describing when an InboundTransfer changed status to {@code failed}. */
+    @SerializedName("failed_at")
+    Long failedAt;
+
+    /** Timestamp describing when an InboundTransfer changed status to {@code succeeded}. */
+    @SerializedName("succeeded_at")
+    Long succeededAt;
+  }
+
+  public TestHelpers getTestHelpers() {
+    return new TestHelpers();
+  }
+
+  public class TestHelpers {
+    /**
+     * Transitions a test mode created InboundTransfer to the <code>succeeded</code> status. The
+     * InboundTransfer must already be in the <code>processing</code> state.
+     */
+    public InboundTransfer succeed() throws StripeException {
+      return succeed((Map<String, Object>) null, (RequestOptions) null);
+    }
+
+    /**
+     * Transitions a test mode created InboundTransfer to the <code>succeeded</code> status. The
+     * InboundTransfer must already be in the <code>processing</code> state.
+     */
+    public InboundTransfer succeed(RequestOptions options) throws StripeException {
+      return succeed((Map<String, Object>) null, options);
+    }
+
+    /**
+     * Transitions a test mode created InboundTransfer to the <code>succeeded</code> status. The
+     * InboundTransfer must already be in the <code>processing</code> state.
+     */
+    public InboundTransfer succeed(Map<String, Object> params) throws StripeException {
+      return succeed(params, (RequestOptions) null);
+    }
+
+    /**
+     * Transitions a test mode created InboundTransfer to the <code>succeeded</code> status. The
+     * InboundTransfer must already be in the <code>processing</code> state.
+     */
+    public InboundTransfer succeed(Map<String, Object> params, RequestOptions options)
+        throws StripeException {
+      String url =
+          String.format(
+              "%s%s",
+              Stripe.getApiBase(),
+              String.format(
+                  "/v1/test_helpers/treasury/inbound_transfers/%s/succeed",
+                  ApiResource.urlEncodeId(InboundTransfer.this.getId())));
+      return ApiResource.request(
+          ApiResource.RequestMethod.POST, url, params, InboundTransfer.class, options);
+    }
+
+    /**
+     * Transitions a test mode created InboundTransfer to the <code>succeeded</code> status. The
+     * InboundTransfer must already be in the <code>processing</code> state.
+     */
+    public InboundTransfer succeed(InboundTransferSucceedParams params) throws StripeException {
+      return succeed(params, (RequestOptions) null);
+    }
+
+    /**
+     * Transitions a test mode created InboundTransfer to the <code>succeeded</code> status. The
+     * InboundTransfer must already be in the <code>processing</code> state.
+     */
+    public InboundTransfer succeed(InboundTransferSucceedParams params, RequestOptions options)
+        throws StripeException {
+      String url =
+          String.format(
+              "%s%s",
+              Stripe.getApiBase(),
+              String.format(
+                  "/v1/test_helpers/treasury/inbound_transfers/%s/succeed",
+                  ApiResource.urlEncodeId(InboundTransfer.this.getId())));
+      return ApiResource.request(
+          ApiResource.RequestMethod.POST, url, params, InboundTransfer.class, options);
+    }
+
+    /**
+     * Transitions a test mode created InboundTransfer to the <code>failed</code> status. The
+     * InboundTransfer must already be in the <code>processing</code> state.
+     */
+    public InboundTransfer fail() throws StripeException {
+      return fail((Map<String, Object>) null, (RequestOptions) null);
+    }
+
+    /**
+     * Transitions a test mode created InboundTransfer to the <code>failed</code> status. The
+     * InboundTransfer must already be in the <code>processing</code> state.
+     */
+    public InboundTransfer fail(RequestOptions options) throws StripeException {
+      return fail((Map<String, Object>) null, options);
+    }
+
+    /**
+     * Transitions a test mode created InboundTransfer to the <code>failed</code> status. The
+     * InboundTransfer must already be in the <code>processing</code> state.
+     */
+    public InboundTransfer fail(Map<String, Object> params) throws StripeException {
+      return fail(params, (RequestOptions) null);
+    }
+
+    /**
+     * Transitions a test mode created InboundTransfer to the <code>failed</code> status. The
+     * InboundTransfer must already be in the <code>processing</code> state.
+     */
+    public InboundTransfer fail(Map<String, Object> params, RequestOptions options)
+        throws StripeException {
+      String url =
+          String.format(
+              "%s%s",
+              Stripe.getApiBase(),
+              String.format(
+                  "/v1/test_helpers/treasury/inbound_transfers/%s/fail",
+                  ApiResource.urlEncodeId(InboundTransfer.this.getId())));
+      return ApiResource.request(
+          ApiResource.RequestMethod.POST, url, params, InboundTransfer.class, options);
+    }
+
+    /**
+     * Transitions a test mode created InboundTransfer to the <code>failed</code> status. The
+     * InboundTransfer must already be in the <code>processing</code> state.
+     */
+    public InboundTransfer fail(InboundTransferFailParams params) throws StripeException {
+      return fail(params, (RequestOptions) null);
+    }
+
+    /**
+     * Transitions a test mode created InboundTransfer to the <code>failed</code> status. The
+     * InboundTransfer must already be in the <code>processing</code> state.
+     */
+    public InboundTransfer fail(InboundTransferFailParams params, RequestOptions options)
+        throws StripeException {
+      String url =
+          String.format(
+              "%s%s",
+              Stripe.getApiBase(),
+              String.format(
+                  "/v1/test_helpers/treasury/inbound_transfers/%s/fail",
+                  ApiResource.urlEncodeId(InboundTransfer.this.getId())));
+      return ApiResource.request(
+          ApiResource.RequestMethod.POST, url, params, InboundTransfer.class, options);
+    }
+
+    /**
+     * Marks the test mode InboundTransfer object as returned and links the InboundTransfer to a
+     * ReceivedDebit. The InboundTransfer must already be in the <code>succeeded</code> state.
+     */
+    public InboundTransfer returnInboundTransfer() throws StripeException {
+      return returnInboundTransfer((Map<String, Object>) null, (RequestOptions) null);
+    }
+
+    /**
+     * Marks the test mode InboundTransfer object as returned and links the InboundTransfer to a
+     * ReceivedDebit. The InboundTransfer must already be in the <code>succeeded</code> state.
+     */
+    public InboundTransfer returnInboundTransfer(RequestOptions options) throws StripeException {
+      return returnInboundTransfer((Map<String, Object>) null, options);
+    }
+
+    /**
+     * Marks the test mode InboundTransfer object as returned and links the InboundTransfer to a
+     * ReceivedDebit. The InboundTransfer must already be in the <code>succeeded</code> state.
+     */
+    public InboundTransfer returnInboundTransfer(Map<String, Object> params)
+        throws StripeException {
+      return returnInboundTransfer(params, (RequestOptions) null);
+    }
+
+    /**
+     * Marks the test mode InboundTransfer object as returned and links the InboundTransfer to a
+     * ReceivedDebit. The InboundTransfer must already be in the <code>succeeded</code> state.
+     */
+    public InboundTransfer returnInboundTransfer(Map<String, Object> params, RequestOptions options)
+        throws StripeException {
+      String url =
+          String.format(
+              "%s%s",
+              Stripe.getApiBase(),
+              String.format(
+                  "/v1/test_helpers/treasury/inbound_transfers/%s/return",
+                  ApiResource.urlEncodeId(InboundTransfer.this.getId())));
+      return ApiResource.request(
+          ApiResource.RequestMethod.POST, url, params, InboundTransfer.class, options);
+    }
+
+    /**
+     * Marks the test mode InboundTransfer object as returned and links the InboundTransfer to a
+     * ReceivedDebit. The InboundTransfer must already be in the <code>succeeded</code> state.
+     */
+    public InboundTransfer returnInboundTransfer(InboundTransferReturnInboundTransferParams params)
+        throws StripeException {
+      return returnInboundTransfer(params, (RequestOptions) null);
+    }
+
+    /**
+     * Marks the test mode InboundTransfer object as returned and links the InboundTransfer to a
+     * ReceivedDebit. The InboundTransfer must already be in the <code>succeeded</code> state.
+     */
+    public InboundTransfer returnInboundTransfer(
+        InboundTransferReturnInboundTransferParams params, RequestOptions options)
+        throws StripeException {
+      String url =
+          String.format(
+              "%s%s",
+              Stripe.getApiBase(),
+              String.format(
+                  "/v1/test_helpers/treasury/inbound_transfers/%s/return",
+                  ApiResource.urlEncodeId(InboundTransfer.this.getId())));
+      return ApiResource.request(
+          ApiResource.RequestMethod.POST, url, params, InboundTransfer.class, options);
+    }
+  }
+}

--- a/src/main/java/com/stripe/model/treasury/InboundTransfer.java
+++ b/src/main/java/com/stripe/model/treasury/InboundTransfer.java
@@ -4,6 +4,7 @@ package com.stripe.model.treasury;
 import com.google.gson.annotations.SerializedName;
 import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
+import com.stripe.model.Address;
 import com.stripe.model.ExpandableField;
 import com.stripe.model.HasId;
 import com.stripe.model.StripeObject;
@@ -100,7 +101,7 @@ public class InboundTransfer extends ApiResource implements HasId {
 
   /** Details about the PaymentMethod for an InboundTransfer. */
   @SerializedName("origin_payment_method_details")
-  PaymentMethodDetails originPaymentMethodDetails;
+  OriginPaymentMethodDetails originPaymentMethodDetails;
 
   /**
    * Returns {@code true} if the funds for an InboundTransfer were returned after the
@@ -318,7 +319,7 @@ public class InboundTransfer extends ApiResource implements HasId {
   @Getter
   @Setter
   @EqualsAndHashCode(callSuper = false)
-  public static class PaymentMethodDetails extends StripeObject {
+  public static class OriginPaymentMethodDetails extends StripeObject {
     @SerializedName("billing_details")
     BillingDetails billingDetails;
 
@@ -332,6 +333,22 @@ public class InboundTransfer extends ApiResource implements HasId {
 
     @SerializedName("us_bank_account")
     UsBankAccount usBankAccount;
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class BillingDetails extends StripeObject {
+      @SerializedName("address")
+      Address address;
+
+      /** Email address. */
+      @SerializedName("email")
+      String email;
+
+      /** Full name. */
+      @SerializedName("name")
+      String name;
+    }
 
     @Getter
     @Setter

--- a/src/main/java/com/stripe/model/treasury/InboundTransferCollection.java
+++ b/src/main/java/com/stripe/model/treasury/InboundTransferCollection.java
@@ -1,0 +1,6 @@
+// File generated from our OpenAPI spec
+package com.stripe.model.treasury;
+
+import com.stripe.model.StripeCollection;
+
+public class InboundTransferCollection extends StripeCollection<InboundTransfer> {}

--- a/src/main/java/com/stripe/model/treasury/InitiatingPaymentMethodDetails.java
+++ b/src/main/java/com/stripe/model/treasury/InitiatingPaymentMethodDetails.java
@@ -1,0 +1,84 @@
+// File generated from our OpenAPI spec
+package com.stripe.model.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.model.HasId;
+import com.stripe.model.StripeObject;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
+public class InitiatingPaymentMethodDetails extends StripeObject {
+  /**
+   * Set when {@code type} is {@code balance}.
+   *
+   * <p>Equal to {@code payments}.
+   */
+  @SerializedName("balance")
+  String balance;
+
+  @SerializedName("billing_details")
+  BillingDetails billingDetails;
+
+  @SerializedName("financial_account")
+  FinancialAccount financialAccount;
+
+  /**
+   * Set when {@code type} is {@code issuing_card}. This is an <a
+   * href="https://stripe.com/docs/api#issuing_cards">Issuing Card</a> ID.
+   */
+  @SerializedName("issuing_card")
+  String issuingCard;
+
+  /**
+   * Polymorphic type matching the originating money movement's source. This can be an external
+   * account, a Stripe balance, or a FinancialAccount.
+   *
+   * <p>One of {@code balance}, {@code financial_account}, {@code issuing_card}, {@code stripe}, or
+   * {@code us_bank_account}.
+   */
+  @SerializedName("type")
+  String type;
+
+  @SerializedName("us_bank_account")
+  USBankAccount usBankAccount;
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class FinancialAccount extends StripeObject implements HasId {
+    /** The FinancialAccount ID. */
+    @Getter(onMethod_ = {@Override})
+    @SerializedName("id")
+    String id;
+
+    /**
+     * The rails the ReceivedCredit was sent over. A FinancialAccount can only send funds over
+     * {@code stripe}.
+     *
+     * <p>Equal to {@code stripe}.
+     */
+    @SerializedName("network")
+    String network;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class USBankAccount extends StripeObject {
+    /** Bank name. */
+    @SerializedName("bank_name")
+    String bankName;
+
+    /** The last four digits of the bank account number. */
+    @SerializedName("last4")
+    String last4;
+
+    /** The routing number for the bank account. */
+    @SerializedName("routing_number")
+    String routingNumber;
+  }
+}

--- a/src/main/java/com/stripe/model/treasury/OutboundPayment.java
+++ b/src/main/java/com/stripe/model/treasury/OutboundPayment.java
@@ -1,0 +1,685 @@
+// File generated from our OpenAPI spec
+package com.stripe.model.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.Stripe;
+import com.stripe.exception.StripeException;
+import com.stripe.model.ExpandableField;
+import com.stripe.model.HasId;
+import com.stripe.model.StripeObject;
+import com.stripe.net.ApiResource;
+import com.stripe.net.RequestOptions;
+import com.stripe.param.treasury.OutboundPaymentCancelParams;
+import com.stripe.param.treasury.OutboundPaymentCreateParams;
+import com.stripe.param.treasury.OutboundPaymentFailParams;
+import com.stripe.param.treasury.OutboundPaymentListParams;
+import com.stripe.param.treasury.OutboundPaymentPostParams;
+import com.stripe.param.treasury.OutboundPaymentRetrieveParams;
+import com.stripe.param.treasury.OutboundPaymentReturnOutboundPaymentParams;
+import java.util.Map;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
+public class OutboundPayment extends ApiResource implements HasId {
+  /** Amount (in cents) transferred. */
+  @SerializedName("amount")
+  Long amount;
+
+  /** Returns {@code true} if the object can be canceled, and {@code false} otherwise. */
+  @SerializedName("cancelable")
+  Boolean cancelable;
+
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  @SerializedName("created")
+  Long created;
+
+  /**
+   * Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency code</a>,
+   * in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported currency</a>.
+   */
+  @SerializedName("currency")
+  String currency;
+
+  /** ID of the customer to whom an OutboundPayment is sent. */
+  @SerializedName("customer")
+  String customer;
+
+  /** An arbitrary string attached to the object. Often useful for displaying to users. */
+  @SerializedName("description")
+  String description;
+
+  /**
+   * The PaymentMethod via which an OutboundPayment is sent. This field can be empty if the
+   * OutboundPayment was created using {@code destination_payment_method_data}.
+   */
+  @SerializedName("destination_payment_method")
+  String destinationPaymentMethod;
+
+  /** Details about the PaymentMethod for an OutboundPayment. */
+  @SerializedName("destination_payment_method_details")
+  PaymentMethodDetails destinationPaymentMethodDetails;
+
+  /** Details about the end user. */
+  @SerializedName("end_user_details")
+  EndUserDetails endUserDetails;
+
+  /** The date when funds are expected to arrive in the destination account. */
+  @SerializedName("expected_arrival_date")
+  Long expectedArrivalDate;
+
+  /** The FinancialAccount that funds were pulled from. */
+  @SerializedName("financial_account")
+  String financialAccount;
+
+  /**
+   * A hosted transaction receipt URL that is provided when money movement is considered regulated
+   * under Stripe's money transmission licenses.
+   */
+  @SerializedName("hosted_regulatory_receipt_url")
+  String hostedRegulatoryReceiptUrl;
+
+  /** Unique identifier for the object. */
+  @Getter(onMethod_ = {@Override})
+  @SerializedName("id")
+  String id;
+
+  /**
+   * Has the value {@code true} if the object exists in live mode or the value {@code false} if the
+   * object exists in test mode.
+   */
+  @SerializedName("livemode")
+  Boolean livemode;
+
+  /**
+   * Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can attach
+   * to an object. This can be useful for storing additional information about the object in a
+   * structured format.
+   */
+  @SerializedName("metadata")
+  Map<String, String> metadata;
+
+  /**
+   * String representing the object's type. Objects of the same type share the same value.
+   *
+   * <p>Equal to {@code treasury.outbound_payment}.
+   */
+  @SerializedName("object")
+  String object;
+
+  /** Details about a returned OutboundPayment. Only set when the status is {@code returned}. */
+  @SerializedName("returned_details")
+  ReturnStatus returnedDetails;
+
+  /**
+   * The description that appears on the receiving end for an OutboundPayment (for example, bank
+   * statement for external bank transfer).
+   */
+  @SerializedName("statement_descriptor")
+  String statementDescriptor;
+
+  /**
+   * Current status of the OutboundPayment: {@code processing}, {@code failed}, {@code posted},
+   * {@code returned}, {@code canceled}. An OutboundPayment is {@code processing} if it has been
+   * created and is pending. The status changes to {@code posted} once the OutboundPayment has been
+   * &quot;confirmed&quot; and funds have left the account, or to {@code failed} or {@code
+   * canceled}. If an OutboundPayment fails to arrive at its destination, its status will change to
+   * {@code returned}.
+   *
+   * <p>One of {@code canceled}, {@code failed}, {@code posted}, {@code processing}, or {@code
+   * returned}.
+   */
+  @SerializedName("status")
+  String status;
+
+  @SerializedName("status_transitions")
+  StatusTransitions statusTransitions;
+
+  /** The Transaction associated with this object. */
+  @SerializedName("transaction")
+  @Getter(lombok.AccessLevel.NONE)
+  @Setter(lombok.AccessLevel.NONE)
+  ExpandableField<Transaction> transaction;
+
+  /** Get ID of expandable {@code transaction} object. */
+  public String getTransaction() {
+    return (this.transaction != null) ? this.transaction.getId() : null;
+  }
+
+  public void setTransaction(String id) {
+    this.transaction = ApiResource.setExpandableFieldId(id, this.transaction);
+  }
+
+  /** Get expanded {@code transaction}. */
+  public Transaction getTransactionObject() {
+    return (this.transaction != null) ? this.transaction.getExpanded() : null;
+  }
+
+  public void setTransactionObject(Transaction expandableObject) {
+    this.transaction = new ExpandableField<Transaction>(expandableObject.getId(), expandableObject);
+  }
+
+  /** Creates an OutboundPayment. */
+  public static OutboundPayment create(Map<String, Object> params) throws StripeException {
+    return create(params, (RequestOptions) null);
+  }
+
+  /** Creates an OutboundPayment. */
+  public static OutboundPayment create(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/treasury/outbound_payments");
+    return ApiResource.request(
+        ApiResource.RequestMethod.POST, url, params, OutboundPayment.class, options);
+  }
+
+  /** Creates an OutboundPayment. */
+  public static OutboundPayment create(OutboundPaymentCreateParams params) throws StripeException {
+    return create(params, (RequestOptions) null);
+  }
+
+  /** Creates an OutboundPayment. */
+  public static OutboundPayment create(OutboundPaymentCreateParams params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/treasury/outbound_payments");
+    return ApiResource.request(
+        ApiResource.RequestMethod.POST, url, params, OutboundPayment.class, options);
+  }
+
+  /**
+   * Retrieves the details of an existing OutboundPayment by passing the unique OutboundPayment ID
+   * from either the OutboundPayment creation request or OutboundPayment list.
+   */
+  public static OutboundPayment retrieve(String id) throws StripeException {
+    return retrieve(id, (Map<String, Object>) null, (RequestOptions) null);
+  }
+
+  /**
+   * Retrieves the details of an existing OutboundPayment by passing the unique OutboundPayment ID
+   * from either the OutboundPayment creation request or OutboundPayment list.
+   */
+  public static OutboundPayment retrieve(String id, RequestOptions options) throws StripeException {
+    return retrieve(id, (Map<String, Object>) null, options);
+  }
+
+  /**
+   * Retrieves the details of an existing OutboundPayment by passing the unique OutboundPayment ID
+   * from either the OutboundPayment creation request or OutboundPayment list.
+   */
+  public static OutboundPayment retrieve(
+      String id, Map<String, Object> params, RequestOptions options) throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/treasury/outbound_payments/%s", ApiResource.urlEncodeId(id)));
+    return ApiResource.request(
+        ApiResource.RequestMethod.GET, url, params, OutboundPayment.class, options);
+  }
+
+  /**
+   * Retrieves the details of an existing OutboundPayment by passing the unique OutboundPayment ID
+   * from either the OutboundPayment creation request or OutboundPayment list.
+   */
+  public static OutboundPayment retrieve(
+      String id, OutboundPaymentRetrieveParams params, RequestOptions options)
+      throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/treasury/outbound_payments/%s", ApiResource.urlEncodeId(id)));
+    return ApiResource.request(
+        ApiResource.RequestMethod.GET, url, params, OutboundPayment.class, options);
+  }
+
+  /** Returns a list of OutboundPayments sent from the specified FinancialAccount. */
+  public static OutboundPaymentCollection list(Map<String, Object> params) throws StripeException {
+    return list(params, (RequestOptions) null);
+  }
+
+  /** Returns a list of OutboundPayments sent from the specified FinancialAccount. */
+  public static OutboundPaymentCollection list(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/treasury/outbound_payments");
+    return ApiResource.requestCollection(url, params, OutboundPaymentCollection.class, options);
+  }
+
+  /** Returns a list of OutboundPayments sent from the specified FinancialAccount. */
+  public static OutboundPaymentCollection list(OutboundPaymentListParams params)
+      throws StripeException {
+    return list(params, (RequestOptions) null);
+  }
+
+  /** Returns a list of OutboundPayments sent from the specified FinancialAccount. */
+  public static OutboundPaymentCollection list(
+      OutboundPaymentListParams params, RequestOptions options) throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/treasury/outbound_payments");
+    return ApiResource.requestCollection(url, params, OutboundPaymentCollection.class, options);
+  }
+
+  /** Cancel an OutboundPayment. */
+  public OutboundPayment cancel() throws StripeException {
+    return cancel((Map<String, Object>) null, (RequestOptions) null);
+  }
+
+  /** Cancel an OutboundPayment. */
+  public OutboundPayment cancel(RequestOptions options) throws StripeException {
+    return cancel((Map<String, Object>) null, options);
+  }
+
+  /** Cancel an OutboundPayment. */
+  public OutboundPayment cancel(Map<String, Object> params) throws StripeException {
+    return cancel(params, (RequestOptions) null);
+  }
+
+  /** Cancel an OutboundPayment. */
+  public OutboundPayment cancel(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/treasury/outbound_payments/%s/cancel", ApiResource.urlEncodeId(this.getId())));
+    return ApiResource.request(
+        ApiResource.RequestMethod.POST, url, params, OutboundPayment.class, options);
+  }
+
+  /** Cancel an OutboundPayment. */
+  public OutboundPayment cancel(OutboundPaymentCancelParams params) throws StripeException {
+    return cancel(params, (RequestOptions) null);
+  }
+
+  /** Cancel an OutboundPayment. */
+  public OutboundPayment cancel(OutboundPaymentCancelParams params, RequestOptions options)
+      throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/treasury/outbound_payments/%s/cancel", ApiResource.urlEncodeId(this.getId())));
+    return ApiResource.request(
+        ApiResource.RequestMethod.POST, url, params, OutboundPayment.class, options);
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class EndUserDetails extends StripeObject {
+    /**
+     * IP address of the user initiating the OutboundPayment. Set if {@code present} is set to
+     * {@code true}. IP address collection is required for risk and compliance reasons. This will be
+     * used to help determine if the OutboundPayment is authorized or should be blocked.
+     */
+    @SerializedName("ip_address")
+    String ipAddress;
+
+    /**
+     * {@code true`` if the OutboundPayment creation request is being made on behalf of an end user
+     * by a platform. Otherwise, }false`.
+     */
+    @SerializedName("present")
+    Boolean present;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class PaymentMethodDetails extends StripeObject {
+    @SerializedName("billing_details")
+    BillingDetails billingDetails;
+
+    @SerializedName("financial_account")
+    FinancialAccount financialAccount;
+
+    /**
+     * The type of the payment method used in the OutboundPayment.
+     *
+     * <p>One of {@code financial_account}, or {@code us_bank_account}.
+     */
+    @SerializedName("type")
+    String type;
+
+    @SerializedName("us_bank_account")
+    UsBankAccount usBankAccount;
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class FinancialAccount extends StripeObject implements HasId {
+      /** Token of the FinancialAccount. */
+      @Getter(onMethod_ = {@Override})
+      @SerializedName("id")
+      String id;
+
+      /**
+       * The rails used to send funds.
+       *
+       * <p>Equal to {@code stripe}.
+       */
+      @SerializedName("network")
+      String network;
+    }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class UsBankAccount extends StripeObject {
+      /**
+       * Account holder type: individual or company.
+       *
+       * <p>One of {@code company}, or {@code individual}.
+       */
+      @SerializedName("account_holder_type")
+      String accountHolderType;
+
+      /**
+       * Account type: checkings or savings. Defaults to checking if omitted.
+       *
+       * <p>One of {@code checking}, or {@code savings}.
+       */
+      @SerializedName("account_type")
+      String accountType;
+
+      /** Name of the bank associated with the bank account. */
+      @SerializedName("bank_name")
+      String bankName;
+
+      /**
+       * Uniquely identifies this particular bank account. You can use this attribute to check
+       * whether two bank accounts are the same.
+       */
+      @SerializedName("fingerprint")
+      String fingerprint;
+
+      /** Last four digits of the bank account number. */
+      @SerializedName("last4")
+      String last4;
+
+      /**
+       * The US bank account network used to send funds.
+       *
+       * <p>One of {@code ach}, or {@code us_domestic_wire}.
+       */
+      @SerializedName("network")
+      String network;
+
+      /** Routing number of the bank account. */
+      @SerializedName("routing_number")
+      String routingNumber;
+    }
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class ReturnStatus extends StripeObject {
+    /**
+     * Reason for the return.
+     *
+     * <p>One of {@code account_closed}, {@code account_frozen}, {@code bank_account_restricted},
+     * {@code bank_ownership_changed}, {@code declined}, {@code incorrect_account_holder_name},
+     * {@code invalid_account_number}, {@code invalid_currency}, {@code no_account}, or {@code
+     * other}.
+     */
+    @SerializedName("code")
+    String code;
+
+    /** The Transaction associated with this object. */
+    @SerializedName("transaction")
+    @Getter(lombok.AccessLevel.NONE)
+    @Setter(lombok.AccessLevel.NONE)
+    ExpandableField<Transaction> transaction;
+
+    /** Get ID of expandable {@code transaction} object. */
+    public String getTransaction() {
+      return (this.transaction != null) ? this.transaction.getId() : null;
+    }
+
+    public void setTransaction(String id) {
+      this.transaction = ApiResource.setExpandableFieldId(id, this.transaction);
+    }
+
+    /** Get expanded {@code transaction}. */
+    public Transaction getTransactionObject() {
+      return (this.transaction != null) ? this.transaction.getExpanded() : null;
+    }
+
+    public void setTransactionObject(Transaction expandableObject) {
+      this.transaction =
+          new ExpandableField<Transaction>(expandableObject.getId(), expandableObject);
+    }
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class StatusTransitions extends StripeObject {
+    /** Timestamp describing when an OutboundPayment changed status to {@code canceled}. */
+    @SerializedName("canceled_at")
+    Long canceledAt;
+
+    /** Timestamp describing when an OutboundPayment changed status to {@code failed}. */
+    @SerializedName("failed_at")
+    Long failedAt;
+
+    /** Timestamp describing when an OutboundPayment changed status to {@code posted}. */
+    @SerializedName("posted_at")
+    Long postedAt;
+
+    /** Timestamp describing when an OutboundPayment changed status to {@code returned}. */
+    @SerializedName("returned_at")
+    Long returnedAt;
+  }
+
+  public TestHelpers getTestHelpers() {
+    return new TestHelpers();
+  }
+
+  public class TestHelpers {
+    /**
+     * Transitions a test mode created OutboundPayment to the <code>failed</code> status. The
+     * OutboundPayment must already be in the <code>processing</code> state.
+     */
+    public OutboundPayment fail() throws StripeException {
+      return fail((Map<String, Object>) null, (RequestOptions) null);
+    }
+
+    /**
+     * Transitions a test mode created OutboundPayment to the <code>failed</code> status. The
+     * OutboundPayment must already be in the <code>processing</code> state.
+     */
+    public OutboundPayment fail(RequestOptions options) throws StripeException {
+      return fail((Map<String, Object>) null, options);
+    }
+
+    /**
+     * Transitions a test mode created OutboundPayment to the <code>failed</code> status. The
+     * OutboundPayment must already be in the <code>processing</code> state.
+     */
+    public OutboundPayment fail(Map<String, Object> params) throws StripeException {
+      return fail(params, (RequestOptions) null);
+    }
+
+    /**
+     * Transitions a test mode created OutboundPayment to the <code>failed</code> status. The
+     * OutboundPayment must already be in the <code>processing</code> state.
+     */
+    public OutboundPayment fail(Map<String, Object> params, RequestOptions options)
+        throws StripeException {
+      String url =
+          String.format(
+              "%s%s",
+              Stripe.getApiBase(),
+              String.format(
+                  "/v1/test_helpers/treasury/outbound_payments/%s/fail",
+                  ApiResource.urlEncodeId(OutboundPayment.this.getId())));
+      return ApiResource.request(
+          ApiResource.RequestMethod.POST, url, params, OutboundPayment.class, options);
+    }
+
+    /**
+     * Transitions a test mode created OutboundPayment to the <code>failed</code> status. The
+     * OutboundPayment must already be in the <code>processing</code> state.
+     */
+    public OutboundPayment fail(OutboundPaymentFailParams params) throws StripeException {
+      return fail(params, (RequestOptions) null);
+    }
+
+    /**
+     * Transitions a test mode created OutboundPayment to the <code>failed</code> status. The
+     * OutboundPayment must already be in the <code>processing</code> state.
+     */
+    public OutboundPayment fail(OutboundPaymentFailParams params, RequestOptions options)
+        throws StripeException {
+      String url =
+          String.format(
+              "%s%s",
+              Stripe.getApiBase(),
+              String.format(
+                  "/v1/test_helpers/treasury/outbound_payments/%s/fail",
+                  ApiResource.urlEncodeId(OutboundPayment.this.getId())));
+      return ApiResource.request(
+          ApiResource.RequestMethod.POST, url, params, OutboundPayment.class, options);
+    }
+
+    /**
+     * Transitions a test mode created OutboundPayment to the <code>posted</code> status. The
+     * OutboundPayment must already be in the <code>processing</code> state.
+     */
+    public OutboundPayment post() throws StripeException {
+      return post((Map<String, Object>) null, (RequestOptions) null);
+    }
+
+    /**
+     * Transitions a test mode created OutboundPayment to the <code>posted</code> status. The
+     * OutboundPayment must already be in the <code>processing</code> state.
+     */
+    public OutboundPayment post(RequestOptions options) throws StripeException {
+      return post((Map<String, Object>) null, options);
+    }
+
+    /**
+     * Transitions a test mode created OutboundPayment to the <code>posted</code> status. The
+     * OutboundPayment must already be in the <code>processing</code> state.
+     */
+    public OutboundPayment post(Map<String, Object> params) throws StripeException {
+      return post(params, (RequestOptions) null);
+    }
+
+    /**
+     * Transitions a test mode created OutboundPayment to the <code>posted</code> status. The
+     * OutboundPayment must already be in the <code>processing</code> state.
+     */
+    public OutboundPayment post(Map<String, Object> params, RequestOptions options)
+        throws StripeException {
+      String url =
+          String.format(
+              "%s%s",
+              Stripe.getApiBase(),
+              String.format(
+                  "/v1/test_helpers/treasury/outbound_payments/%s/post",
+                  ApiResource.urlEncodeId(OutboundPayment.this.getId())));
+      return ApiResource.request(
+          ApiResource.RequestMethod.POST, url, params, OutboundPayment.class, options);
+    }
+
+    /**
+     * Transitions a test mode created OutboundPayment to the <code>posted</code> status. The
+     * OutboundPayment must already be in the <code>processing</code> state.
+     */
+    public OutboundPayment post(OutboundPaymentPostParams params) throws StripeException {
+      return post(params, (RequestOptions) null);
+    }
+
+    /**
+     * Transitions a test mode created OutboundPayment to the <code>posted</code> status. The
+     * OutboundPayment must already be in the <code>processing</code> state.
+     */
+    public OutboundPayment post(OutboundPaymentPostParams params, RequestOptions options)
+        throws StripeException {
+      String url =
+          String.format(
+              "%s%s",
+              Stripe.getApiBase(),
+              String.format(
+                  "/v1/test_helpers/treasury/outbound_payments/%s/post",
+                  ApiResource.urlEncodeId(OutboundPayment.this.getId())));
+      return ApiResource.request(
+          ApiResource.RequestMethod.POST, url, params, OutboundPayment.class, options);
+    }
+
+    /**
+     * Transitions a test mode created OutboundPayment to the <code>returned</code> status. The
+     * OutboundPayment must already be in the <code>processing</code> state.
+     */
+    public OutboundPayment returnOutboundPayment() throws StripeException {
+      return returnOutboundPayment((Map<String, Object>) null, (RequestOptions) null);
+    }
+
+    /**
+     * Transitions a test mode created OutboundPayment to the <code>returned</code> status. The
+     * OutboundPayment must already be in the <code>processing</code> state.
+     */
+    public OutboundPayment returnOutboundPayment(RequestOptions options) throws StripeException {
+      return returnOutboundPayment((Map<String, Object>) null, options);
+    }
+
+    /**
+     * Transitions a test mode created OutboundPayment to the <code>returned</code> status. The
+     * OutboundPayment must already be in the <code>processing</code> state.
+     */
+    public OutboundPayment returnOutboundPayment(Map<String, Object> params)
+        throws StripeException {
+      return returnOutboundPayment(params, (RequestOptions) null);
+    }
+
+    /**
+     * Transitions a test mode created OutboundPayment to the <code>returned</code> status. The
+     * OutboundPayment must already be in the <code>processing</code> state.
+     */
+    public OutboundPayment returnOutboundPayment(Map<String, Object> params, RequestOptions options)
+        throws StripeException {
+      String url =
+          String.format(
+              "%s%s",
+              Stripe.getApiBase(),
+              String.format(
+                  "/v1/test_helpers/treasury/outbound_payments/%s/return",
+                  ApiResource.urlEncodeId(OutboundPayment.this.getId())));
+      return ApiResource.request(
+          ApiResource.RequestMethod.POST, url, params, OutboundPayment.class, options);
+    }
+
+    /**
+     * Transitions a test mode created OutboundPayment to the <code>returned</code> status. The
+     * OutboundPayment must already be in the <code>processing</code> state.
+     */
+    public OutboundPayment returnOutboundPayment(OutboundPaymentReturnOutboundPaymentParams params)
+        throws StripeException {
+      return returnOutboundPayment(params, (RequestOptions) null);
+    }
+
+    /**
+     * Transitions a test mode created OutboundPayment to the <code>returned</code> status. The
+     * OutboundPayment must already be in the <code>processing</code> state.
+     */
+    public OutboundPayment returnOutboundPayment(
+        OutboundPaymentReturnOutboundPaymentParams params, RequestOptions options)
+        throws StripeException {
+      String url =
+          String.format(
+              "%s%s",
+              Stripe.getApiBase(),
+              String.format(
+                  "/v1/test_helpers/treasury/outbound_payments/%s/return",
+                  ApiResource.urlEncodeId(OutboundPayment.this.getId())));
+      return ApiResource.request(
+          ApiResource.RequestMethod.POST, url, params, OutboundPayment.class, options);
+    }
+  }
+}

--- a/src/main/java/com/stripe/model/treasury/OutboundPayment.java
+++ b/src/main/java/com/stripe/model/treasury/OutboundPayment.java
@@ -4,6 +4,7 @@ package com.stripe.model.treasury;
 import com.google.gson.annotations.SerializedName;
 import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
+import com.stripe.model.Address;
 import com.stripe.model.ExpandableField;
 import com.stripe.model.HasId;
 import com.stripe.model.StripeObject;
@@ -61,7 +62,7 @@ public class OutboundPayment extends ApiResource implements HasId {
 
   /** Details about the PaymentMethod for an OutboundPayment. */
   @SerializedName("destination_payment_method_details")
-  PaymentMethodDetails destinationPaymentMethodDetails;
+  DestinationPaymentMethodDetails destinationPaymentMethodDetails;
 
   /** Details about the end user. */
   @SerializedName("end_user_details")
@@ -112,7 +113,7 @@ public class OutboundPayment extends ApiResource implements HasId {
 
   /** Details about a returned OutboundPayment. Only set when the status is {@code returned}. */
   @SerializedName("returned_details")
-  ReturnStatus returnedDetails;
+  ReturnedDetails returnedDetails;
 
   /**
    * The description that appears on the receiving end for an OutboundPayment (for example, bank
@@ -309,27 +310,7 @@ public class OutboundPayment extends ApiResource implements HasId {
   @Getter
   @Setter
   @EqualsAndHashCode(callSuper = false)
-  public static class EndUserDetails extends StripeObject {
-    /**
-     * IP address of the user initiating the OutboundPayment. Set if {@code present} is set to
-     * {@code true}. IP address collection is required for risk and compliance reasons. This will be
-     * used to help determine if the OutboundPayment is authorized or should be blocked.
-     */
-    @SerializedName("ip_address")
-    String ipAddress;
-
-    /**
-     * {@code true`` if the OutboundPayment creation request is being made on behalf of an end user
-     * by a platform. Otherwise, }false`.
-     */
-    @SerializedName("present")
-    Boolean present;
-  }
-
-  @Getter
-  @Setter
-  @EqualsAndHashCode(callSuper = false)
-  public static class PaymentMethodDetails extends StripeObject {
+  public static class DestinationPaymentMethodDetails extends StripeObject {
     @SerializedName("billing_details")
     BillingDetails billingDetails;
 
@@ -346,6 +327,22 @@ public class OutboundPayment extends ApiResource implements HasId {
 
     @SerializedName("us_bank_account")
     UsBankAccount usBankAccount;
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class BillingDetails extends StripeObject {
+      @SerializedName("address")
+      Address address;
+
+      /** Email address. */
+      @SerializedName("email")
+      String email;
+
+      /** Full name. */
+      @SerializedName("name")
+      String name;
+    }
 
     @Getter
     @Setter
@@ -417,7 +414,27 @@ public class OutboundPayment extends ApiResource implements HasId {
   @Getter
   @Setter
   @EqualsAndHashCode(callSuper = false)
-  public static class ReturnStatus extends StripeObject {
+  public static class EndUserDetails extends StripeObject {
+    /**
+     * IP address of the user initiating the OutboundPayment. Set if {@code present} is set to
+     * {@code true}. IP address collection is required for risk and compliance reasons. This will be
+     * used to help determine if the OutboundPayment is authorized or should be blocked.
+     */
+    @SerializedName("ip_address")
+    String ipAddress;
+
+    /**
+     * {@code true`` if the OutboundPayment creation request is being made on behalf of an end user
+     * by a platform. Otherwise, }false`.
+     */
+    @SerializedName("present")
+    Boolean present;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class ReturnedDetails extends StripeObject {
     /**
      * Reason for the return.
      *

--- a/src/main/java/com/stripe/model/treasury/OutboundPaymentCollection.java
+++ b/src/main/java/com/stripe/model/treasury/OutboundPaymentCollection.java
@@ -1,0 +1,6 @@
+// File generated from our OpenAPI spec
+package com.stripe.model.treasury;
+
+import com.stripe.model.StripeCollection;
+
+public class OutboundPaymentCollection extends StripeCollection<OutboundPayment> {}

--- a/src/main/java/com/stripe/model/treasury/OutboundTransfer.java
+++ b/src/main/java/com/stripe/model/treasury/OutboundTransfer.java
@@ -4,6 +4,7 @@ package com.stripe.model.treasury;
 import com.google.gson.annotations.SerializedName;
 import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
+import com.stripe.model.Address;
 import com.stripe.model.ExpandableField;
 import com.stripe.model.HasId;
 import com.stripe.model.StripeObject;
@@ -53,7 +54,7 @@ public class OutboundTransfer extends ApiResource implements HasId {
   String destinationPaymentMethod;
 
   @SerializedName("destination_payment_method_details")
-  PaymentMethodDetails destinationPaymentMethodDetails;
+  DestinationPaymentMethodDetails destinationPaymentMethodDetails;
 
   /** The date when funds are expected to arrive in the destination account. */
   @SerializedName("expected_arrival_date")
@@ -301,7 +302,7 @@ public class OutboundTransfer extends ApiResource implements HasId {
   @Getter
   @Setter
   @EqualsAndHashCode(callSuper = false)
-  public static class PaymentMethodDetails extends StripeObject {
+  public static class DestinationPaymentMethodDetails extends StripeObject {
     @SerializedName("billing_details")
     BillingDetails billingDetails;
 
@@ -315,6 +316,22 @@ public class OutboundTransfer extends ApiResource implements HasId {
 
     @SerializedName("us_bank_account")
     UsBankAccount usBankAccount;
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class BillingDetails extends StripeObject {
+      @SerializedName("address")
+      Address address;
+
+      /** Email address. */
+      @SerializedName("email")
+      String email;
+
+      /** Full name. */
+      @SerializedName("name")
+      String name;
+    }
 
     @Getter
     @Setter

--- a/src/main/java/com/stripe/model/treasury/OutboundTransfer.java
+++ b/src/main/java/com/stripe/model/treasury/OutboundTransfer.java
@@ -1,0 +1,636 @@
+// File generated from our OpenAPI spec
+package com.stripe.model.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.Stripe;
+import com.stripe.exception.StripeException;
+import com.stripe.model.ExpandableField;
+import com.stripe.model.HasId;
+import com.stripe.model.StripeObject;
+import com.stripe.net.ApiResource;
+import com.stripe.net.RequestOptions;
+import com.stripe.param.treasury.OutboundTransferCancelParams;
+import com.stripe.param.treasury.OutboundTransferCreateParams;
+import com.stripe.param.treasury.OutboundTransferFailParams;
+import com.stripe.param.treasury.OutboundTransferListParams;
+import com.stripe.param.treasury.OutboundTransferPostParams;
+import com.stripe.param.treasury.OutboundTransferRetrieveParams;
+import com.stripe.param.treasury.OutboundTransferReturnOutboundTransferParams;
+import java.util.Map;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
+public class OutboundTransfer extends ApiResource implements HasId {
+  /** Amount (in cents) transferred. */
+  @SerializedName("amount")
+  Long amount;
+
+  /** Returns {@code true} if the object can be canceled, and {@code false} otherwise. */
+  @SerializedName("cancelable")
+  Boolean cancelable;
+
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  @SerializedName("created")
+  Long created;
+
+  /**
+   * Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency code</a>,
+   * in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported currency</a>.
+   */
+  @SerializedName("currency")
+  String currency;
+
+  /** An arbitrary string attached to the object. Often useful for displaying to users. */
+  @SerializedName("description")
+  String description;
+
+  /** The PaymentMethod used as the payment instrument for an OutboundTransfer. */
+  @SerializedName("destination_payment_method")
+  String destinationPaymentMethod;
+
+  @SerializedName("destination_payment_method_details")
+  PaymentMethodDetails destinationPaymentMethodDetails;
+
+  /** The date when funds are expected to arrive in the destination account. */
+  @SerializedName("expected_arrival_date")
+  Long expectedArrivalDate;
+
+  /** The FinancialAccount that funds were pulled from. */
+  @SerializedName("financial_account")
+  String financialAccount;
+
+  /**
+   * A hosted transaction receipt URL that is provided when money movement is considered regulated
+   * under Stripe's money transmission licenses.
+   */
+  @SerializedName("hosted_regulatory_receipt_url")
+  String hostedRegulatoryReceiptUrl;
+
+  /** Unique identifier for the object. */
+  @Getter(onMethod_ = {@Override})
+  @SerializedName("id")
+  String id;
+
+  /**
+   * Has the value {@code true} if the object exists in live mode or the value {@code false} if the
+   * object exists in test mode.
+   */
+  @SerializedName("livemode")
+  Boolean livemode;
+
+  /**
+   * Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can attach
+   * to an object. This can be useful for storing additional information about the object in a
+   * structured format.
+   */
+  @SerializedName("metadata")
+  Map<String, String> metadata;
+
+  /**
+   * String representing the object's type. Objects of the same type share the same value.
+   *
+   * <p>Equal to {@code treasury.outbound_transfer}.
+   */
+  @SerializedName("object")
+  String object;
+
+  /** Details about a returned OutboundTransfer. Only set when the status is {@code returned}. */
+  @SerializedName("returned_details")
+  ReturnedDetails returnedDetails;
+
+  /** Information about the OutboundTransfer to be sent to the recipient account. */
+  @SerializedName("statement_descriptor")
+  String statementDescriptor;
+
+  /**
+   * Current status of the OutboundTransfer: {@code processing}, {@code failed}, {@code canceled},
+   * {@code posted}, {@code returned}. An OutboundTransfer is {@code processing} if it has been
+   * created and is pending. The status changes to {@code posted} once the OutboundTransfer has been
+   * &quot;confirmed&quot; and funds have left the account, or to {@code failed} or {@code
+   * canceled}. If an OutboundTransfer fails to arrive at its destination, its status will change to
+   * {@code returned}.
+   *
+   * <p>One of {@code canceled}, {@code failed}, {@code posted}, {@code processing}, or {@code
+   * returned}.
+   */
+  @SerializedName("status")
+  String status;
+
+  @SerializedName("status_transitions")
+  StatusTransitions statusTransitions;
+
+  /** The Transaction associated with this object. */
+  @SerializedName("transaction")
+  @Getter(lombok.AccessLevel.NONE)
+  @Setter(lombok.AccessLevel.NONE)
+  ExpandableField<Transaction> transaction;
+
+  /** Get ID of expandable {@code transaction} object. */
+  public String getTransaction() {
+    return (this.transaction != null) ? this.transaction.getId() : null;
+  }
+
+  public void setTransaction(String id) {
+    this.transaction = ApiResource.setExpandableFieldId(id, this.transaction);
+  }
+
+  /** Get expanded {@code transaction}. */
+  public Transaction getTransactionObject() {
+    return (this.transaction != null) ? this.transaction.getExpanded() : null;
+  }
+
+  public void setTransactionObject(Transaction expandableObject) {
+    this.transaction = new ExpandableField<Transaction>(expandableObject.getId(), expandableObject);
+  }
+
+  /** Creates an OutboundTransfer. */
+  public static OutboundTransfer create(Map<String, Object> params) throws StripeException {
+    return create(params, (RequestOptions) null);
+  }
+
+  /** Creates an OutboundTransfer. */
+  public static OutboundTransfer create(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/treasury/outbound_transfers");
+    return ApiResource.request(
+        ApiResource.RequestMethod.POST, url, params, OutboundTransfer.class, options);
+  }
+
+  /** Creates an OutboundTransfer. */
+  public static OutboundTransfer create(OutboundTransferCreateParams params)
+      throws StripeException {
+    return create(params, (RequestOptions) null);
+  }
+
+  /** Creates an OutboundTransfer. */
+  public static OutboundTransfer create(OutboundTransferCreateParams params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/treasury/outbound_transfers");
+    return ApiResource.request(
+        ApiResource.RequestMethod.POST, url, params, OutboundTransfer.class, options);
+  }
+
+  /**
+   * Retrieves the details of an existing OutboundTransfer by passing the unique OutboundTransfer ID
+   * from either the OutboundTransfer creation request or OutboundTransfer list.
+   */
+  public static OutboundTransfer retrieve(String outboundTransfer) throws StripeException {
+    return retrieve(outboundTransfer, (Map<String, Object>) null, (RequestOptions) null);
+  }
+
+  /**
+   * Retrieves the details of an existing OutboundTransfer by passing the unique OutboundTransfer ID
+   * from either the OutboundTransfer creation request or OutboundTransfer list.
+   */
+  public static OutboundTransfer retrieve(String outboundTransfer, RequestOptions options)
+      throws StripeException {
+    return retrieve(outboundTransfer, (Map<String, Object>) null, options);
+  }
+
+  /**
+   * Retrieves the details of an existing OutboundTransfer by passing the unique OutboundTransfer ID
+   * from either the OutboundTransfer creation request or OutboundTransfer list.
+   */
+  public static OutboundTransfer retrieve(
+      String outboundTransfer, Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/treasury/outbound_transfers/%s", ApiResource.urlEncodeId(outboundTransfer)));
+    return ApiResource.request(
+        ApiResource.RequestMethod.GET, url, params, OutboundTransfer.class, options);
+  }
+
+  /**
+   * Retrieves the details of an existing OutboundTransfer by passing the unique OutboundTransfer ID
+   * from either the OutboundTransfer creation request or OutboundTransfer list.
+   */
+  public static OutboundTransfer retrieve(
+      String outboundTransfer, OutboundTransferRetrieveParams params, RequestOptions options)
+      throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/treasury/outbound_transfers/%s", ApiResource.urlEncodeId(outboundTransfer)));
+    return ApiResource.request(
+        ApiResource.RequestMethod.GET, url, params, OutboundTransfer.class, options);
+  }
+
+  /** Returns a list of OutboundTransfers sent from the specified FinancialAccount. */
+  public static OutboundTransferCollection list(Map<String, Object> params) throws StripeException {
+    return list(params, (RequestOptions) null);
+  }
+
+  /** Returns a list of OutboundTransfers sent from the specified FinancialAccount. */
+  public static OutboundTransferCollection list(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/treasury/outbound_transfers");
+    return ApiResource.requestCollection(url, params, OutboundTransferCollection.class, options);
+  }
+
+  /** Returns a list of OutboundTransfers sent from the specified FinancialAccount. */
+  public static OutboundTransferCollection list(OutboundTransferListParams params)
+      throws StripeException {
+    return list(params, (RequestOptions) null);
+  }
+
+  /** Returns a list of OutboundTransfers sent from the specified FinancialAccount. */
+  public static OutboundTransferCollection list(
+      OutboundTransferListParams params, RequestOptions options) throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/treasury/outbound_transfers");
+    return ApiResource.requestCollection(url, params, OutboundTransferCollection.class, options);
+  }
+
+  /** An OutboundTransfer can be canceled if the funds have not yet been paid out. */
+  public OutboundTransfer cancel() throws StripeException {
+    return cancel((Map<String, Object>) null, (RequestOptions) null);
+  }
+
+  /** An OutboundTransfer can be canceled if the funds have not yet been paid out. */
+  public OutboundTransfer cancel(RequestOptions options) throws StripeException {
+    return cancel((Map<String, Object>) null, options);
+  }
+
+  /** An OutboundTransfer can be canceled if the funds have not yet been paid out. */
+  public OutboundTransfer cancel(Map<String, Object> params) throws StripeException {
+    return cancel(params, (RequestOptions) null);
+  }
+
+  /** An OutboundTransfer can be canceled if the funds have not yet been paid out. */
+  public OutboundTransfer cancel(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/treasury/outbound_transfers/%s/cancel",
+                ApiResource.urlEncodeId(this.getId())));
+    return ApiResource.request(
+        ApiResource.RequestMethod.POST, url, params, OutboundTransfer.class, options);
+  }
+
+  /** An OutboundTransfer can be canceled if the funds have not yet been paid out. */
+  public OutboundTransfer cancel(OutboundTransferCancelParams params) throws StripeException {
+    return cancel(params, (RequestOptions) null);
+  }
+
+  /** An OutboundTransfer can be canceled if the funds have not yet been paid out. */
+  public OutboundTransfer cancel(OutboundTransferCancelParams params, RequestOptions options)
+      throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format(
+                "/v1/treasury/outbound_transfers/%s/cancel",
+                ApiResource.urlEncodeId(this.getId())));
+    return ApiResource.request(
+        ApiResource.RequestMethod.POST, url, params, OutboundTransfer.class, options);
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class PaymentMethodDetails extends StripeObject {
+    @SerializedName("billing_details")
+    BillingDetails billingDetails;
+
+    /**
+     * The type of the payment method used in the OutboundTransfer.
+     *
+     * <p>Equal to {@code us_bank_account}.
+     */
+    @SerializedName("type")
+    String type;
+
+    @SerializedName("us_bank_account")
+    UsBankAccount usBankAccount;
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class UsBankAccount extends StripeObject {
+      /**
+       * Account holder type: individual or company.
+       *
+       * <p>One of {@code company}, or {@code individual}.
+       */
+      @SerializedName("account_holder_type")
+      String accountHolderType;
+
+      /**
+       * Account type: checkings or savings. Defaults to checking if omitted.
+       *
+       * <p>One of {@code checking}, or {@code savings}.
+       */
+      @SerializedName("account_type")
+      String accountType;
+
+      /** Name of the bank associated with the bank account. */
+      @SerializedName("bank_name")
+      String bankName;
+
+      /**
+       * Uniquely identifies this particular bank account. You can use this attribute to check
+       * whether two bank accounts are the same.
+       */
+      @SerializedName("fingerprint")
+      String fingerprint;
+
+      /** Last four digits of the bank account number. */
+      @SerializedName("last4")
+      String last4;
+
+      /**
+       * The US bank account network used to send funds.
+       *
+       * <p>One of {@code ach}, or {@code us_domestic_wire}.
+       */
+      @SerializedName("network")
+      String network;
+
+      /** Routing number of the bank account. */
+      @SerializedName("routing_number")
+      String routingNumber;
+    }
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class ReturnedDetails extends StripeObject {
+    /**
+     * Reason for the return.
+     *
+     * <p>One of {@code account_closed}, {@code account_frozen}, {@code bank_account_restricted},
+     * {@code bank_ownership_changed}, {@code declined}, {@code incorrect_account_holder_name},
+     * {@code invalid_account_number}, {@code invalid_currency}, {@code no_account}, or {@code
+     * other}.
+     */
+    @SerializedName("code")
+    String code;
+
+    /** The Transaction associated with this object. */
+    @SerializedName("transaction")
+    @Getter(lombok.AccessLevel.NONE)
+    @Setter(lombok.AccessLevel.NONE)
+    ExpandableField<Transaction> transaction;
+
+    /** Get ID of expandable {@code transaction} object. */
+    public String getTransaction() {
+      return (this.transaction != null) ? this.transaction.getId() : null;
+    }
+
+    public void setTransaction(String id) {
+      this.transaction = ApiResource.setExpandableFieldId(id, this.transaction);
+    }
+
+    /** Get expanded {@code transaction}. */
+    public Transaction getTransactionObject() {
+      return (this.transaction != null) ? this.transaction.getExpanded() : null;
+    }
+
+    public void setTransactionObject(Transaction expandableObject) {
+      this.transaction =
+          new ExpandableField<Transaction>(expandableObject.getId(), expandableObject);
+    }
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class StatusTransitions extends StripeObject {
+    /** Timestamp describing when an OutboundTransfer changed status to {@code canceled}. */
+    @SerializedName("canceled_at")
+    Long canceledAt;
+
+    /** Timestamp describing when an OutboundTransfer changed status to {@code failed}. */
+    @SerializedName("failed_at")
+    Long failedAt;
+
+    /** Timestamp describing when an OutboundTransfer changed status to {@code posted}. */
+    @SerializedName("posted_at")
+    Long postedAt;
+
+    /** Timestamp describing when an OutboundTransfer changed status to {@code returned}. */
+    @SerializedName("returned_at")
+    Long returnedAt;
+  }
+
+  public TestHelpers getTestHelpers() {
+    return new TestHelpers();
+  }
+
+  public class TestHelpers {
+    /**
+     * Transitions a test mode created OutboundTransfer to the <code>failed</code> status. The
+     * OutboundTransfer must already be in the <code>processing</code> state.
+     */
+    public OutboundTransfer fail() throws StripeException {
+      return fail((Map<String, Object>) null, (RequestOptions) null);
+    }
+
+    /**
+     * Transitions a test mode created OutboundTransfer to the <code>failed</code> status. The
+     * OutboundTransfer must already be in the <code>processing</code> state.
+     */
+    public OutboundTransfer fail(RequestOptions options) throws StripeException {
+      return fail((Map<String, Object>) null, options);
+    }
+
+    /**
+     * Transitions a test mode created OutboundTransfer to the <code>failed</code> status. The
+     * OutboundTransfer must already be in the <code>processing</code> state.
+     */
+    public OutboundTransfer fail(Map<String, Object> params) throws StripeException {
+      return fail(params, (RequestOptions) null);
+    }
+
+    /**
+     * Transitions a test mode created OutboundTransfer to the <code>failed</code> status. The
+     * OutboundTransfer must already be in the <code>processing</code> state.
+     */
+    public OutboundTransfer fail(Map<String, Object> params, RequestOptions options)
+        throws StripeException {
+      String url =
+          String.format(
+              "%s%s",
+              Stripe.getApiBase(),
+              String.format(
+                  "/v1/test_helpers/treasury/outbound_transfers/%s/fail",
+                  ApiResource.urlEncodeId(OutboundTransfer.this.getId())));
+      return ApiResource.request(
+          ApiResource.RequestMethod.POST, url, params, OutboundTransfer.class, options);
+    }
+
+    /**
+     * Transitions a test mode created OutboundTransfer to the <code>failed</code> status. The
+     * OutboundTransfer must already be in the <code>processing</code> state.
+     */
+    public OutboundTransfer fail(OutboundTransferFailParams params) throws StripeException {
+      return fail(params, (RequestOptions) null);
+    }
+
+    /**
+     * Transitions a test mode created OutboundTransfer to the <code>failed</code> status. The
+     * OutboundTransfer must already be in the <code>processing</code> state.
+     */
+    public OutboundTransfer fail(OutboundTransferFailParams params, RequestOptions options)
+        throws StripeException {
+      String url =
+          String.format(
+              "%s%s",
+              Stripe.getApiBase(),
+              String.format(
+                  "/v1/test_helpers/treasury/outbound_transfers/%s/fail",
+                  ApiResource.urlEncodeId(OutboundTransfer.this.getId())));
+      return ApiResource.request(
+          ApiResource.RequestMethod.POST, url, params, OutboundTransfer.class, options);
+    }
+
+    /**
+     * Transitions a test mode created OutboundTransfer to the <code>posted</code> status. The
+     * OutboundTransfer must already be in the <code>processing</code> state.
+     */
+    public OutboundTransfer post() throws StripeException {
+      return post((Map<String, Object>) null, (RequestOptions) null);
+    }
+
+    /**
+     * Transitions a test mode created OutboundTransfer to the <code>posted</code> status. The
+     * OutboundTransfer must already be in the <code>processing</code> state.
+     */
+    public OutboundTransfer post(RequestOptions options) throws StripeException {
+      return post((Map<String, Object>) null, options);
+    }
+
+    /**
+     * Transitions a test mode created OutboundTransfer to the <code>posted</code> status. The
+     * OutboundTransfer must already be in the <code>processing</code> state.
+     */
+    public OutboundTransfer post(Map<String, Object> params) throws StripeException {
+      return post(params, (RequestOptions) null);
+    }
+
+    /**
+     * Transitions a test mode created OutboundTransfer to the <code>posted</code> status. The
+     * OutboundTransfer must already be in the <code>processing</code> state.
+     */
+    public OutboundTransfer post(Map<String, Object> params, RequestOptions options)
+        throws StripeException {
+      String url =
+          String.format(
+              "%s%s",
+              Stripe.getApiBase(),
+              String.format(
+                  "/v1/test_helpers/treasury/outbound_transfers/%s/post",
+                  ApiResource.urlEncodeId(OutboundTransfer.this.getId())));
+      return ApiResource.request(
+          ApiResource.RequestMethod.POST, url, params, OutboundTransfer.class, options);
+    }
+
+    /**
+     * Transitions a test mode created OutboundTransfer to the <code>posted</code> status. The
+     * OutboundTransfer must already be in the <code>processing</code> state.
+     */
+    public OutboundTransfer post(OutboundTransferPostParams params) throws StripeException {
+      return post(params, (RequestOptions) null);
+    }
+
+    /**
+     * Transitions a test mode created OutboundTransfer to the <code>posted</code> status. The
+     * OutboundTransfer must already be in the <code>processing</code> state.
+     */
+    public OutboundTransfer post(OutboundTransferPostParams params, RequestOptions options)
+        throws StripeException {
+      String url =
+          String.format(
+              "%s%s",
+              Stripe.getApiBase(),
+              String.format(
+                  "/v1/test_helpers/treasury/outbound_transfers/%s/post",
+                  ApiResource.urlEncodeId(OutboundTransfer.this.getId())));
+      return ApiResource.request(
+          ApiResource.RequestMethod.POST, url, params, OutboundTransfer.class, options);
+    }
+
+    /**
+     * Transitions a test mode created OutboundTransfer to the <code>returned</code> status. The
+     * OutboundTransfer must already be in the <code>processing</code> state.
+     */
+    public OutboundTransfer returnOutboundTransfer() throws StripeException {
+      return returnOutboundTransfer((Map<String, Object>) null, (RequestOptions) null);
+    }
+
+    /**
+     * Transitions a test mode created OutboundTransfer to the <code>returned</code> status. The
+     * OutboundTransfer must already be in the <code>processing</code> state.
+     */
+    public OutboundTransfer returnOutboundTransfer(RequestOptions options) throws StripeException {
+      return returnOutboundTransfer((Map<String, Object>) null, options);
+    }
+
+    /**
+     * Transitions a test mode created OutboundTransfer to the <code>returned</code> status. The
+     * OutboundTransfer must already be in the <code>processing</code> state.
+     */
+    public OutboundTransfer returnOutboundTransfer(Map<String, Object> params)
+        throws StripeException {
+      return returnOutboundTransfer(params, (RequestOptions) null);
+    }
+
+    /**
+     * Transitions a test mode created OutboundTransfer to the <code>returned</code> status. The
+     * OutboundTransfer must already be in the <code>processing</code> state.
+     */
+    public OutboundTransfer returnOutboundTransfer(
+        Map<String, Object> params, RequestOptions options) throws StripeException {
+      String url =
+          String.format(
+              "%s%s",
+              Stripe.getApiBase(),
+              String.format(
+                  "/v1/test_helpers/treasury/outbound_transfers/%s/return",
+                  ApiResource.urlEncodeId(OutboundTransfer.this.getId())));
+      return ApiResource.request(
+          ApiResource.RequestMethod.POST, url, params, OutboundTransfer.class, options);
+    }
+
+    /**
+     * Transitions a test mode created OutboundTransfer to the <code>returned</code> status. The
+     * OutboundTransfer must already be in the <code>processing</code> state.
+     */
+    public OutboundTransfer returnOutboundTransfer(
+        OutboundTransferReturnOutboundTransferParams params) throws StripeException {
+      return returnOutboundTransfer(params, (RequestOptions) null);
+    }
+
+    /**
+     * Transitions a test mode created OutboundTransfer to the <code>returned</code> status. The
+     * OutboundTransfer must already be in the <code>processing</code> state.
+     */
+    public OutboundTransfer returnOutboundTransfer(
+        OutboundTransferReturnOutboundTransferParams params, RequestOptions options)
+        throws StripeException {
+      String url =
+          String.format(
+              "%s%s",
+              Stripe.getApiBase(),
+              String.format(
+                  "/v1/test_helpers/treasury/outbound_transfers/%s/return",
+                  ApiResource.urlEncodeId(OutboundTransfer.this.getId())));
+      return ApiResource.request(
+          ApiResource.RequestMethod.POST, url, params, OutboundTransfer.class, options);
+    }
+  }
+}

--- a/src/main/java/com/stripe/model/treasury/OutboundTransferCollection.java
+++ b/src/main/java/com/stripe/model/treasury/OutboundTransferCollection.java
@@ -1,0 +1,6 @@
+// File generated from our OpenAPI spec
+package com.stripe.model.treasury;
+
+import com.stripe.model.StripeCollection;
+
+public class OutboundTransferCollection extends StripeCollection<OutboundTransfer> {}

--- a/src/main/java/com/stripe/model/treasury/ReceivedCredit.java
+++ b/src/main/java/com/stripe/model/treasury/ReceivedCredit.java
@@ -1,0 +1,341 @@
+// File generated from our OpenAPI spec
+package com.stripe.model.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.Stripe;
+import com.stripe.exception.StripeException;
+import com.stripe.model.ExpandableField;
+import com.stripe.model.HasId;
+import com.stripe.model.Payout;
+import com.stripe.model.StripeObject;
+import com.stripe.net.ApiResource;
+import com.stripe.net.RequestOptions;
+import com.stripe.param.treasury.ReceivedCreditCreateParams;
+import com.stripe.param.treasury.ReceivedCreditListParams;
+import com.stripe.param.treasury.ReceivedCreditRetrieveParams;
+import java.util.Map;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
+public class ReceivedCredit extends ApiResource implements HasId {
+  /** Amount (in cents) transferred. */
+  @SerializedName("amount")
+  Long amount;
+
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  @SerializedName("created")
+  Long created;
+
+  /**
+   * Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency code</a>,
+   * in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported currency</a>.
+   */
+  @SerializedName("currency")
+  String currency;
+
+  /** An arbitrary string attached to the object. Often useful for displaying to users. */
+  @SerializedName("description")
+  String description;
+
+  /**
+   * Reason for the failure. A ReceivedCredit might fail because the receiving FinancialAccount is
+   * closed or frozen.
+   *
+   * <p>One of {@code account_closed}, {@code account_frozen}, or {@code other}.
+   */
+  @SerializedName("failure_code")
+  String failureCode;
+
+  /** The FinancialAccount that received the funds. */
+  @SerializedName("financial_account")
+  String financialAccount;
+
+  /** Unique identifier for the object. */
+  @Getter(onMethod_ = {@Override})
+  @SerializedName("id")
+  String id;
+
+  @SerializedName("initiating_payment_method_details")
+  InitiatingPaymentMethodDetails initiatingPaymentMethodDetails;
+
+  @SerializedName("linked_flows")
+  LinkedFlows linkedFlows;
+
+  /**
+   * Has the value {@code true} if the object exists in live mode or the value {@code false} if the
+   * object exists in test mode.
+   */
+  @SerializedName("livemode")
+  Boolean livemode;
+
+  /**
+   * The rails used to send the funds.
+   *
+   * <p>One of {@code ach}, {@code card}, {@code stripe}, or {@code us_domestic_wire}.
+   */
+  @SerializedName("network")
+  String network;
+
+  /**
+   * String representing the object's type. Objects of the same type share the same value.
+   *
+   * <p>Equal to {@code treasury.received_credit}.
+   */
+  @SerializedName("object")
+  String object;
+
+  /**
+   * Status of the ReceivedCredit. ReceivedCredits are created either {@code succeeded} (approved)
+   * or {@code failed} (declined). If a ReceivedCredit is declined, the failure reason can be found
+   * in the {@code failure_code} field.
+   *
+   * <p>One of {@code failed}, or {@code succeeded}.
+   */
+  @SerializedName("status")
+  String status;
+
+  /** The Transaction associated with this object. */
+  @SerializedName("transaction")
+  @Getter(lombok.AccessLevel.NONE)
+  @Setter(lombok.AccessLevel.NONE)
+  ExpandableField<Transaction> transaction;
+
+  /** Get ID of expandable {@code transaction} object. */
+  public String getTransaction() {
+    return (this.transaction != null) ? this.transaction.getId() : null;
+  }
+
+  public void setTransaction(String id) {
+    this.transaction = ApiResource.setExpandableFieldId(id, this.transaction);
+  }
+
+  /** Get expanded {@code transaction}. */
+  public Transaction getTransactionObject() {
+    return (this.transaction != null) ? this.transaction.getExpanded() : null;
+  }
+
+  public void setTransactionObject(Transaction expandableObject) {
+    this.transaction = new ExpandableField<Transaction>(expandableObject.getId(), expandableObject);
+  }
+
+  /** Returns a list of ReceivedCredits. */
+  public static ReceivedCreditCollection list(Map<String, Object> params) throws StripeException {
+    return list(params, (RequestOptions) null);
+  }
+
+  /** Returns a list of ReceivedCredits. */
+  public static ReceivedCreditCollection list(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/treasury/received_credits");
+    return ApiResource.requestCollection(url, params, ReceivedCreditCollection.class, options);
+  }
+
+  /** Returns a list of ReceivedCredits. */
+  public static ReceivedCreditCollection list(ReceivedCreditListParams params)
+      throws StripeException {
+    return list(params, (RequestOptions) null);
+  }
+
+  /** Returns a list of ReceivedCredits. */
+  public static ReceivedCreditCollection list(
+      ReceivedCreditListParams params, RequestOptions options) throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/treasury/received_credits");
+    return ApiResource.requestCollection(url, params, ReceivedCreditCollection.class, options);
+  }
+
+  /**
+   * Retrieves the details of an existing ReceivedCredit by passing the unique ReceivedCredit ID
+   * from the ReceivedCredit list.
+   */
+  public static ReceivedCredit retrieve(String id) throws StripeException {
+    return retrieve(id, (Map<String, Object>) null, (RequestOptions) null);
+  }
+
+  /**
+   * Retrieves the details of an existing ReceivedCredit by passing the unique ReceivedCredit ID
+   * from the ReceivedCredit list.
+   */
+  public static ReceivedCredit retrieve(String id, RequestOptions options) throws StripeException {
+    return retrieve(id, (Map<String, Object>) null, options);
+  }
+
+  /**
+   * Retrieves the details of an existing ReceivedCredit by passing the unique ReceivedCredit ID
+   * from the ReceivedCredit list.
+   */
+  public static ReceivedCredit retrieve(
+      String id, Map<String, Object> params, RequestOptions options) throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/treasury/received_credits/%s", ApiResource.urlEncodeId(id)));
+    return ApiResource.request(
+        ApiResource.RequestMethod.GET, url, params, ReceivedCredit.class, options);
+  }
+
+  /**
+   * Retrieves the details of an existing ReceivedCredit by passing the unique ReceivedCredit ID
+   * from the ReceivedCredit list.
+   */
+  public static ReceivedCredit retrieve(
+      String id, ReceivedCreditRetrieveParams params, RequestOptions options)
+      throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/treasury/received_credits/%s", ApiResource.urlEncodeId(id)));
+    return ApiResource.request(
+        ApiResource.RequestMethod.GET, url, params, ReceivedCredit.class, options);
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class LinkedFlows extends StripeObject {
+    /** The CreditReversal created as a result of this ReceivedCredit being reversed. */
+    @SerializedName("credit_reversal")
+    String creditReversal;
+
+    /**
+     * Set if the ReceivedCredit was created due to an <a
+     * href="https://stripe.com/docs/api#issuing_authorizations">Issuing Authorization</a> object.
+     */
+    @SerializedName("issuing_authorization")
+    String issuingAuthorization;
+
+    /**
+     * Set if the ReceivedCredit is also viewable as an <a
+     * href="https://stripe.com/docs/api#issuing_transactions">Issuing transaction</a> object.
+     */
+    @SerializedName("issuing_transaction")
+    String issuingTransaction;
+
+    /**
+     * ID of the source flow. Set if {@code network} is {@code stripe} and the source flow is
+     * visible to the merchant. Examples of source flows include OutboundPayments, payouts, or
+     * CreditReversals.
+     */
+    @SerializedName("source_flow")
+    String sourceFlow;
+
+    /** The expandable object of the source flow. */
+    @SerializedName("source_flow_details")
+    SourceFlowsDetails sourceFlowDetails;
+
+    /**
+     * The type of flow that originated the ReceivedCredit (for example, {@code outbound_payment}).
+     */
+    @SerializedName("source_flow_type")
+    String sourceFlowType;
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class SourceFlowsDetails extends StripeObject {
+      /**
+       * You can reverse some <a
+       * href="https://stripe.com/docs/api#received_credits">ReceivedCredits</a> depending on their
+       * network and source flow. Reversing a ReceivedCredit leads to the creation of a new object
+       * known as a CreditReversal.
+       */
+      @SerializedName("credit_reversal")
+      CreditReversal creditReversal;
+
+      /**
+       * Use OutboundPayments to send funds to another party's external bank account or <a
+       * href="https://stripe.com/docs/api#financial_accounts">FinancialAccount</a>. To send money
+       * to an account belonging to the same user, use an <a
+       * href="https://stripe.com/docs/api#outbound_transfers">OutboundTransfer</a>.
+       *
+       * <p>Simulate OutboundPayment state changes with the {@code
+       * /v1/test_helpers/treasury/outbound_payments} endpoints. These methods can only be called on
+       * test mode objects.
+       */
+      @SerializedName("outbound_payment")
+      OutboundPayment outboundPayment;
+
+      /**
+       * A {@code Payout} object is created when you receive funds from Stripe, or when you initiate
+       * a payout to either a bank account or debit card of a <a
+       * href="https://stripe.com/docs/connect/bank-debit-card-payouts">connected Stripe
+       * account</a>. You can retrieve individual payouts, as well as list all payouts. Payouts are
+       * made on <a href="https://stripe.com/docs/connect/manage-payout-schedule">varying
+       * schedules</a>, depending on your country and industry.
+       *
+       * <p>Related guide: <a href="https://stripe.com/docs/payouts">Receiving Payouts</a>.
+       */
+      @SerializedName("payout")
+      Payout payout;
+
+      /**
+       * The type of the source flow that originated the ReceivedCredit.
+       *
+       * <p>One of {@code credit_reversal}, {@code other}, {@code outbound_payment}, or {@code
+       * payout}.
+       */
+      @SerializedName("type")
+      String type;
+    }
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class StatusTransitions extends StripeObject {
+    /** Timestamp describing when the CreditReversal changed status to {@code posted}. */
+    @SerializedName("posted_at")
+    Long postedAt;
+  }
+
+  public TestHelpers getTestHelpers() {
+    return new TestHelpers();
+  }
+
+  public class TestHelpers {
+    /**
+     * Use this endpoint to simulate a test mode ReceivedCredit initiated by a third party. In live
+     * mode, you can’t directly create ReceivedCredits initiated by third parties.
+     */
+    public static ReceivedCredit create(Map<String, Object> params) throws StripeException {
+      return create(params, (RequestOptions) null);
+    }
+
+    /**
+     * Use this endpoint to simulate a test mode ReceivedCredit initiated by a third party. In live
+     * mode, you can’t directly create ReceivedCredits initiated by third parties.
+     */
+    public static ReceivedCredit create(Map<String, Object> params, RequestOptions options)
+        throws StripeException {
+      String url =
+          String.format("%s%s", Stripe.getApiBase(), "/v1/test_helpers/treasury/received_credits");
+      return ApiResource.request(
+          ApiResource.RequestMethod.POST, url, params, ReceivedCredit.class, options);
+    }
+
+    /**
+     * Use this endpoint to simulate a test mode ReceivedCredit initiated by a third party. In live
+     * mode, you can’t directly create ReceivedCredits initiated by third parties.
+     */
+    public static ReceivedCredit create(ReceivedCreditCreateParams params) throws StripeException {
+      return create(params, (RequestOptions) null);
+    }
+
+    /**
+     * Use this endpoint to simulate a test mode ReceivedCredit initiated by a third party. In live
+     * mode, you can’t directly create ReceivedCredits initiated by third parties.
+     */
+    public static ReceivedCredit create(ReceivedCreditCreateParams params, RequestOptions options)
+        throws StripeException {
+      String url =
+          String.format("%s%s", Stripe.getApiBase(), "/v1/test_helpers/treasury/received_credits");
+      return ApiResource.request(
+          ApiResource.RequestMethod.POST, url, params, ReceivedCredit.class, options);
+    }
+  }
+}

--- a/src/main/java/com/stripe/model/treasury/ReceivedCredit.java
+++ b/src/main/java/com/stripe/model/treasury/ReceivedCredit.java
@@ -4,6 +4,7 @@ package com.stripe.model.treasury;
 import com.google.gson.annotations.SerializedName;
 import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
+import com.stripe.model.Address;
 import com.stripe.model.ExpandableField;
 import com.stripe.model.HasId;
 import com.stripe.model.Payout;
@@ -197,6 +198,97 @@ public class ReceivedCredit extends ApiResource implements HasId {
   @Getter
   @Setter
   @EqualsAndHashCode(callSuper = false)
+  public static class InitiatingPaymentMethodDetails extends StripeObject {
+    /**
+     * Set when {@code type} is {@code balance}.
+     *
+     * <p>Equal to {@code payments}.
+     */
+    @SerializedName("balance")
+    String balance;
+
+    @SerializedName("billing_details")
+    BillingDetails billingDetails;
+
+    @SerializedName("financial_account")
+    FinancialAccount financialAccount;
+
+    /**
+     * Set when {@code type} is {@code issuing_card}. This is an <a
+     * href="https://stripe.com/docs/api#issuing_cards">Issuing Card</a> ID.
+     */
+    @SerializedName("issuing_card")
+    String issuingCard;
+
+    /**
+     * Polymorphic type matching the originating money movement's source. This can be an external
+     * account, a Stripe balance, or a FinancialAccount.
+     *
+     * <p>One of {@code balance}, {@code financial_account}, {@code issuing_card}, {@code stripe},
+     * or {@code us_bank_account}.
+     */
+    @SerializedName("type")
+    String type;
+
+    @SerializedName("us_bank_account")
+    UsBankAccount usBankAccount;
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class BillingDetails extends StripeObject {
+      @SerializedName("address")
+      Address address;
+
+      /** Email address. */
+      @SerializedName("email")
+      String email;
+
+      /** Full name. */
+      @SerializedName("name")
+      String name;
+    }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class FinancialAccount extends StripeObject implements HasId {
+      /** The FinancialAccount ID. */
+      @Getter(onMethod_ = {@Override})
+      @SerializedName("id")
+      String id;
+
+      /**
+       * The rails the ReceivedCredit was sent over. A FinancialAccount can only send funds over
+       * {@code stripe}.
+       *
+       * <p>Equal to {@code stripe}.
+       */
+      @SerializedName("network")
+      String network;
+    }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class UsBankAccount extends StripeObject {
+      /** Bank name. */
+      @SerializedName("bank_name")
+      String bankName;
+
+      /** The last four digits of the bank account number. */
+      @SerializedName("last4")
+      String last4;
+
+      /** The routing number for the bank account. */
+      @SerializedName("routing_number")
+      String routingNumber;
+    }
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
   public static class LinkedFlows extends StripeObject {
     /** The CreditReversal created as a result of this ReceivedCredit being reversed. */
     @SerializedName("credit_reversal")
@@ -226,7 +318,7 @@ public class ReceivedCredit extends ApiResource implements HasId {
 
     /** The expandable object of the source flow. */
     @SerializedName("source_flow_details")
-    SourceFlowsDetails sourceFlowDetails;
+    SourceFlowDetails sourceFlowDetails;
 
     /**
      * The type of flow that originated the ReceivedCredit (for example, {@code outbound_payment}).
@@ -237,7 +329,7 @@ public class ReceivedCredit extends ApiResource implements HasId {
     @Getter
     @Setter
     @EqualsAndHashCode(callSuper = false)
-    public static class SourceFlowsDetails extends StripeObject {
+    public static class SourceFlowDetails extends StripeObject {
       /**
        * You can reverse some <a
        * href="https://stripe.com/docs/api#received_credits">ReceivedCredits</a> depending on their

--- a/src/main/java/com/stripe/model/treasury/ReceivedCredit.java
+++ b/src/main/java/com/stripe/model/treasury/ReceivedCredit.java
@@ -11,7 +11,6 @@ import com.stripe.model.Payout;
 import com.stripe.model.StripeObject;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
-import com.stripe.param.treasury.ReceivedCreditCreateParams;
 import com.stripe.param.treasury.ReceivedCreditListParams;
 import com.stripe.param.treasury.ReceivedCreditRetrieveParams;
 import java.util.Map;
@@ -383,51 +382,5 @@ public class ReceivedCredit extends ApiResource implements HasId {
     /** Timestamp describing when the CreditReversal changed status to {@code posted}. */
     @SerializedName("posted_at")
     Long postedAt;
-  }
-
-  public TestHelpers getTestHelpers() {
-    return new TestHelpers();
-  }
-
-  public class TestHelpers {
-    /**
-     * Use this endpoint to simulate a test mode ReceivedCredit initiated by a third party. In live
-     * mode, you can’t directly create ReceivedCredits initiated by third parties.
-     */
-    public static ReceivedCredit create(Map<String, Object> params) throws StripeException {
-      return create(params, (RequestOptions) null);
-    }
-
-    /**
-     * Use this endpoint to simulate a test mode ReceivedCredit initiated by a third party. In live
-     * mode, you can’t directly create ReceivedCredits initiated by third parties.
-     */
-    public static ReceivedCredit create(Map<String, Object> params, RequestOptions options)
-        throws StripeException {
-      String url =
-          String.format("%s%s", Stripe.getApiBase(), "/v1/test_helpers/treasury/received_credits");
-      return ApiResource.request(
-          ApiResource.RequestMethod.POST, url, params, ReceivedCredit.class, options);
-    }
-
-    /**
-     * Use this endpoint to simulate a test mode ReceivedCredit initiated by a third party. In live
-     * mode, you can’t directly create ReceivedCredits initiated by third parties.
-     */
-    public static ReceivedCredit create(ReceivedCreditCreateParams params) throws StripeException {
-      return create(params, (RequestOptions) null);
-    }
-
-    /**
-     * Use this endpoint to simulate a test mode ReceivedCredit initiated by a third party. In live
-     * mode, you can’t directly create ReceivedCredits initiated by third parties.
-     */
-    public static ReceivedCredit create(ReceivedCreditCreateParams params, RequestOptions options)
-        throws StripeException {
-      String url =
-          String.format("%s%s", Stripe.getApiBase(), "/v1/test_helpers/treasury/received_credits");
-      return ApiResource.request(
-          ApiResource.RequestMethod.POST, url, params, ReceivedCredit.class, options);
-    }
   }
 }

--- a/src/main/java/com/stripe/model/treasury/ReceivedCreditCollection.java
+++ b/src/main/java/com/stripe/model/treasury/ReceivedCreditCollection.java
@@ -1,0 +1,6 @@
+// File generated from our OpenAPI spec
+package com.stripe.model.treasury;
+
+import com.stripe.model.StripeCollection;
+
+public class ReceivedCreditCollection extends StripeCollection<ReceivedCredit> {}

--- a/src/main/java/com/stripe/model/treasury/ReceivedDebit.java
+++ b/src/main/java/com/stripe/model/treasury/ReceivedDebit.java
@@ -4,6 +4,7 @@ package com.stripe.model.treasury;
 import com.google.gson.annotations.SerializedName;
 import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
+import com.stripe.model.Address;
 import com.stripe.model.ExpandableField;
 import com.stripe.model.HasId;
 import com.stripe.model.StripeObject;
@@ -192,6 +193,97 @@ public class ReceivedDebit extends ApiResource implements HasId {
             String.format("/v1/treasury/received_debits/%s", ApiResource.urlEncodeId(id)));
     return ApiResource.request(
         ApiResource.RequestMethod.GET, url, params, ReceivedDebit.class, options);
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class InitiatingPaymentMethodDetails extends StripeObject {
+    /**
+     * Set when {@code type} is {@code balance}.
+     *
+     * <p>Equal to {@code payments}.
+     */
+    @SerializedName("balance")
+    String balance;
+
+    @SerializedName("billing_details")
+    BillingDetails billingDetails;
+
+    @SerializedName("financial_account")
+    FinancialAccount financialAccount;
+
+    /**
+     * Set when {@code type} is {@code issuing_card}. This is an <a
+     * href="https://stripe.com/docs/api#issuing_cards">Issuing Card</a> ID.
+     */
+    @SerializedName("issuing_card")
+    String issuingCard;
+
+    /**
+     * Polymorphic type matching the originating money movement's source. This can be an external
+     * account, a Stripe balance, or a FinancialAccount.
+     *
+     * <p>One of {@code balance}, {@code financial_account}, {@code issuing_card}, {@code stripe},
+     * or {@code us_bank_account}.
+     */
+    @SerializedName("type")
+    String type;
+
+    @SerializedName("us_bank_account")
+    ReceivedCredit.InitiatingPaymentMethodDetails.UsBankAccount usBankAccount;
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class BillingDetails extends StripeObject {
+      @SerializedName("address")
+      Address address;
+
+      /** Email address. */
+      @SerializedName("email")
+      String email;
+
+      /** Full name. */
+      @SerializedName("name")
+      String name;
+    }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class FinancialAccount extends StripeObject implements HasId {
+      /** The FinancialAccount ID. */
+      @Getter(onMethod_ = {@Override})
+      @SerializedName("id")
+      String id;
+
+      /**
+       * The rails the ReceivedCredit was sent over. A FinancialAccount can only send funds over
+       * {@code stripe}.
+       *
+       * <p>Equal to {@code stripe}.
+       */
+      @SerializedName("network")
+      String network;
+    }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class UsBankAccount extends StripeObject {
+      /** Bank name. */
+      @SerializedName("bank_name")
+      String bankName;
+
+      /** The last four digits of the bank account number. */
+      @SerializedName("last4")
+      String last4;
+
+      /** The routing number for the bank account. */
+      @SerializedName("routing_number")
+      String routingNumber;
+    }
   }
 
   @Getter

--- a/src/main/java/com/stripe/model/treasury/ReceivedDebit.java
+++ b/src/main/java/com/stripe/model/treasury/ReceivedDebit.java
@@ -1,0 +1,274 @@
+// File generated from our OpenAPI spec
+package com.stripe.model.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.Stripe;
+import com.stripe.exception.StripeException;
+import com.stripe.model.ExpandableField;
+import com.stripe.model.HasId;
+import com.stripe.model.StripeObject;
+import com.stripe.net.ApiResource;
+import com.stripe.net.RequestOptions;
+import com.stripe.param.treasury.ReceivedDebitCreateParams;
+import com.stripe.param.treasury.ReceivedDebitListParams;
+import com.stripe.param.treasury.ReceivedDebitRetrieveParams;
+import java.util.Map;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
+public class ReceivedDebit extends ApiResource implements HasId {
+  /** Amount (in cents) transferred. */
+  @SerializedName("amount")
+  Long amount;
+
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  @SerializedName("created")
+  Long created;
+
+  /**
+   * Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency code</a>,
+   * in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported currency</a>.
+   */
+  @SerializedName("currency")
+  String currency;
+
+  /** An arbitrary string attached to the object. Often useful for displaying to users. */
+  @SerializedName("description")
+  String description;
+
+  /**
+   * Reason for the failure. A ReceivedDebit might fail because the FinancialAccount doesn't have
+   * sufficient funds, is closed, or is frozen.
+   *
+   * <p>One of {@code account_closed}, {@code account_frozen}, {@code insufficient_funds}, or {@code
+   * other}.
+   */
+  @SerializedName("failure_code")
+  String failureCode;
+
+  /** The FinancialAccount that funds were pulled from. */
+  @SerializedName("financial_account")
+  String financialAccount;
+
+  /** Unique identifier for the object. */
+  @Getter(onMethod_ = {@Override})
+  @SerializedName("id")
+  String id;
+
+  @SerializedName("initiating_payment_method_details")
+  InitiatingPaymentMethodDetails initiatingPaymentMethodDetails;
+
+  @SerializedName("linked_flows")
+  LinkedFlows linkedFlows;
+
+  /**
+   * Has the value {@code true} if the object exists in live mode or the value {@code false} if the
+   * object exists in test mode.
+   */
+  @SerializedName("livemode")
+  Boolean livemode;
+
+  /**
+   * The network used for the ReceivedDebit.
+   *
+   * <p>One of {@code ach}, {@code card}, or {@code stripe}.
+   */
+  @SerializedName("network")
+  String network;
+
+  /**
+   * String representing the object's type. Objects of the same type share the same value.
+   *
+   * <p>Equal to {@code treasury.received_debit}.
+   */
+  @SerializedName("object")
+  String object;
+
+  /**
+   * Status of the ReceivedDebit. ReceivedDebits are created with a status of either {@code
+   * succeeded} (approved) or {@code failed} (declined). The failure reason can be found under the
+   * {@code failure_code}.
+   *
+   * <p>One of {@code failed}, or {@code succeeded}.
+   */
+  @SerializedName("status")
+  String status;
+
+  /** The Transaction associated with this object. */
+  @SerializedName("transaction")
+  @Getter(lombok.AccessLevel.NONE)
+  @Setter(lombok.AccessLevel.NONE)
+  ExpandableField<Transaction> transaction;
+
+  /** Get ID of expandable {@code transaction} object. */
+  public String getTransaction() {
+    return (this.transaction != null) ? this.transaction.getId() : null;
+  }
+
+  public void setTransaction(String id) {
+    this.transaction = ApiResource.setExpandableFieldId(id, this.transaction);
+  }
+
+  /** Get expanded {@code transaction}. */
+  public Transaction getTransactionObject() {
+    return (this.transaction != null) ? this.transaction.getExpanded() : null;
+  }
+
+  public void setTransactionObject(Transaction expandableObject) {
+    this.transaction = new ExpandableField<Transaction>(expandableObject.getId(), expandableObject);
+  }
+
+  /** Returns a list of ReceivedDebits. */
+  public static ReceivedDebitCollection list(Map<String, Object> params) throws StripeException {
+    return list(params, (RequestOptions) null);
+  }
+
+  /** Returns a list of ReceivedDebits. */
+  public static ReceivedDebitCollection list(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/treasury/received_debits");
+    return ApiResource.requestCollection(url, params, ReceivedDebitCollection.class, options);
+  }
+
+  /** Returns a list of ReceivedDebits. */
+  public static ReceivedDebitCollection list(ReceivedDebitListParams params)
+      throws StripeException {
+    return list(params, (RequestOptions) null);
+  }
+
+  /** Returns a list of ReceivedDebits. */
+  public static ReceivedDebitCollection list(ReceivedDebitListParams params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/treasury/received_debits");
+    return ApiResource.requestCollection(url, params, ReceivedDebitCollection.class, options);
+  }
+
+  /**
+   * Retrieves the details of an existing ReceivedDebit by passing the unique ReceivedDebit ID from
+   * the ReceivedDebit list.
+   */
+  public static ReceivedDebit retrieve(String id) throws StripeException {
+    return retrieve(id, (Map<String, Object>) null, (RequestOptions) null);
+  }
+
+  /**
+   * Retrieves the details of an existing ReceivedDebit by passing the unique ReceivedDebit ID from
+   * the ReceivedDebit list.
+   */
+  public static ReceivedDebit retrieve(String id, RequestOptions options) throws StripeException {
+    return retrieve(id, (Map<String, Object>) null, options);
+  }
+
+  /**
+   * Retrieves the details of an existing ReceivedDebit by passing the unique ReceivedDebit ID from
+   * the ReceivedDebit list.
+   */
+  public static ReceivedDebit retrieve(
+      String id, Map<String, Object> params, RequestOptions options) throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/treasury/received_debits/%s", ApiResource.urlEncodeId(id)));
+    return ApiResource.request(
+        ApiResource.RequestMethod.GET, url, params, ReceivedDebit.class, options);
+  }
+
+  /**
+   * Retrieves the details of an existing ReceivedDebit by passing the unique ReceivedDebit ID from
+   * the ReceivedDebit list.
+   */
+  public static ReceivedDebit retrieve(
+      String id, ReceivedDebitRetrieveParams params, RequestOptions options)
+      throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/treasury/received_debits/%s", ApiResource.urlEncodeId(id)));
+    return ApiResource.request(
+        ApiResource.RequestMethod.GET, url, params, ReceivedDebit.class, options);
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class LinkedFlows extends StripeObject {
+    /** Set if the ReceivedDebit is associated with an InboundTransfer's return of funds. */
+    @SerializedName("inbound_transfer")
+    String inboundTransfer;
+
+    /**
+     * Set if the ReceivedCredit was created due to an <a
+     * href="https://stripe.com/docs/api#issuing_authorizations">Issuing Authorization</a> object.
+     */
+    @SerializedName("issuing_authorization")
+    String issuingAuthorization;
+
+    /**
+     * Set if the ReceivedDebit is also viewable as an <a
+     * href="https://stripe.com/docs/api#issuing_disputes">Issuing Dispute</a> object.
+     */
+    @SerializedName("issuing_transaction")
+    String issuingTransaction;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class StatusTransitions extends StripeObject {
+    /** Timestamp describing when the DebitReversal changed status to {@code completed}. */
+    @SerializedName("completed_at")
+    Long completedAt;
+  }
+
+  public TestHelpers getTestHelpers() {
+    return new TestHelpers();
+  }
+
+  public class TestHelpers {
+    /**
+     * Use this endpoint to simulate a test mode ReceivedDebit initiated by a third party. In live
+     * mode, you can’t directly create ReceivedDebits initiated by third parties.
+     */
+    public static ReceivedDebit create(Map<String, Object> params) throws StripeException {
+      return create(params, (RequestOptions) null);
+    }
+
+    /**
+     * Use this endpoint to simulate a test mode ReceivedDebit initiated by a third party. In live
+     * mode, you can’t directly create ReceivedDebits initiated by third parties.
+     */
+    public static ReceivedDebit create(Map<String, Object> params, RequestOptions options)
+        throws StripeException {
+      String url =
+          String.format("%s%s", Stripe.getApiBase(), "/v1/test_helpers/treasury/received_debits");
+      return ApiResource.request(
+          ApiResource.RequestMethod.POST, url, params, ReceivedDebit.class, options);
+    }
+
+    /**
+     * Use this endpoint to simulate a test mode ReceivedDebit initiated by a third party. In live
+     * mode, you can’t directly create ReceivedDebits initiated by third parties.
+     */
+    public static ReceivedDebit create(ReceivedDebitCreateParams params) throws StripeException {
+      return create(params, (RequestOptions) null);
+    }
+
+    /**
+     * Use this endpoint to simulate a test mode ReceivedDebit initiated by a third party. In live
+     * mode, you can’t directly create ReceivedDebits initiated by third parties.
+     */
+    public static ReceivedDebit create(ReceivedDebitCreateParams params, RequestOptions options)
+        throws StripeException {
+      String url =
+          String.format("%s%s", Stripe.getApiBase(), "/v1/test_helpers/treasury/received_debits");
+      return ApiResource.request(
+          ApiResource.RequestMethod.POST, url, params, ReceivedDebit.class, options);
+    }
+  }
+}

--- a/src/main/java/com/stripe/model/treasury/ReceivedDebit.java
+++ b/src/main/java/com/stripe/model/treasury/ReceivedDebit.java
@@ -10,7 +10,6 @@ import com.stripe.model.HasId;
 import com.stripe.model.StripeObject;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
-import com.stripe.param.treasury.ReceivedDebitCreateParams;
 import com.stripe.param.treasury.ReceivedDebitListParams;
 import com.stripe.param.treasury.ReceivedDebitRetrieveParams;
 import java.util.Map;
@@ -316,51 +315,5 @@ public class ReceivedDebit extends ApiResource implements HasId {
     /** Timestamp describing when the DebitReversal changed status to {@code completed}. */
     @SerializedName("completed_at")
     Long completedAt;
-  }
-
-  public TestHelpers getTestHelpers() {
-    return new TestHelpers();
-  }
-
-  public class TestHelpers {
-    /**
-     * Use this endpoint to simulate a test mode ReceivedDebit initiated by a third party. In live
-     * mode, you can’t directly create ReceivedDebits initiated by third parties.
-     */
-    public static ReceivedDebit create(Map<String, Object> params) throws StripeException {
-      return create(params, (RequestOptions) null);
-    }
-
-    /**
-     * Use this endpoint to simulate a test mode ReceivedDebit initiated by a third party. In live
-     * mode, you can’t directly create ReceivedDebits initiated by third parties.
-     */
-    public static ReceivedDebit create(Map<String, Object> params, RequestOptions options)
-        throws StripeException {
-      String url =
-          String.format("%s%s", Stripe.getApiBase(), "/v1/test_helpers/treasury/received_debits");
-      return ApiResource.request(
-          ApiResource.RequestMethod.POST, url, params, ReceivedDebit.class, options);
-    }
-
-    /**
-     * Use this endpoint to simulate a test mode ReceivedDebit initiated by a third party. In live
-     * mode, you can’t directly create ReceivedDebits initiated by third parties.
-     */
-    public static ReceivedDebit create(ReceivedDebitCreateParams params) throws StripeException {
-      return create(params, (RequestOptions) null);
-    }
-
-    /**
-     * Use this endpoint to simulate a test mode ReceivedDebit initiated by a third party. In live
-     * mode, you can’t directly create ReceivedDebits initiated by third parties.
-     */
-    public static ReceivedDebit create(ReceivedDebitCreateParams params, RequestOptions options)
-        throws StripeException {
-      String url =
-          String.format("%s%s", Stripe.getApiBase(), "/v1/test_helpers/treasury/received_debits");
-      return ApiResource.request(
-          ApiResource.RequestMethod.POST, url, params, ReceivedDebit.class, options);
-    }
   }
 }

--- a/src/main/java/com/stripe/model/treasury/ReceivedDebitCollection.java
+++ b/src/main/java/com/stripe/model/treasury/ReceivedDebitCollection.java
@@ -1,0 +1,6 @@
+// File generated from our OpenAPI spec
+package com.stripe.model.treasury;
+
+import com.stripe.model.StripeCollection;
+
+public class ReceivedDebitCollection extends StripeCollection<ReceivedDebit> {}

--- a/src/main/java/com/stripe/model/treasury/Transaction.java
+++ b/src/main/java/com/stripe/model/treasury/Transaction.java
@@ -1,0 +1,198 @@
+// File generated from our OpenAPI spec
+package com.stripe.model.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.Stripe;
+import com.stripe.exception.StripeException;
+import com.stripe.model.HasId;
+import com.stripe.model.StripeObject;
+import com.stripe.net.ApiResource;
+import com.stripe.net.RequestOptions;
+import com.stripe.param.treasury.TransactionListParams;
+import com.stripe.param.treasury.TransactionRetrieveParams;
+import java.util.Map;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
+public class Transaction extends ApiResource implements HasId {
+  /** Amount (in cents) transferred. */
+  @SerializedName("amount")
+  Long amount;
+
+  /** Change to a FinancialAccount's balance. */
+  @SerializedName("balance_impact")
+  BalanceImpact balanceImpact;
+
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  @SerializedName("created")
+  Long created;
+
+  /**
+   * Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency code</a>,
+   * in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported currency</a>.
+   */
+  @SerializedName("currency")
+  String currency;
+
+  /** An arbitrary string attached to the object. Often useful for displaying to users. */
+  @SerializedName("description")
+  String description;
+
+  /**
+   * A list of TransactionEntries that are part of this Transaction. This cannot be expanded in any
+   * list endpoints.
+   */
+  @SerializedName("entries")
+  TransactionEntryCollection entries;
+
+  /** The FinancialAccount associated with this object. */
+  @SerializedName("financial_account")
+  String financialAccount;
+
+  /** ID of the flow that created the Transaction. */
+  @SerializedName("flow")
+  String flow;
+
+  /** Details of the flow that created the Transaction. */
+  @SerializedName("flow_details")
+  FlowDetails flowDetails;
+
+  /**
+   * Type of the flow that created the Transaction.
+   *
+   * <p>One of {@code credit_reversal}, {@code debit_reversal}, {@code inbound_transfer}, {@code
+   * issuing_authorization}, {@code other}, {@code outbound_payment}, {@code outbound_transfer},
+   * {@code received_credit}, or {@code received_debit}.
+   */
+  @SerializedName("flow_type")
+  String flowType;
+
+  /** Unique identifier for the object. */
+  @Getter(onMethod_ = {@Override})
+  @SerializedName("id")
+  String id;
+
+  /**
+   * Has the value {@code true} if the object exists in live mode or the value {@code false} if the
+   * object exists in test mode.
+   */
+  @SerializedName("livemode")
+  Boolean livemode;
+
+  /**
+   * String representing the object's type. Objects of the same type share the same value.
+   *
+   * <p>Equal to {@code treasury.transaction}.
+   */
+  @SerializedName("object")
+  String object;
+
+  /**
+   * Status of the Transaction.
+   *
+   * <p>One of {@code open}, {@code posted}, or {@code void}.
+   */
+  @SerializedName("status")
+  String status;
+
+  @SerializedName("status_transitions")
+  StatusTransitions statusTransitions;
+
+  /** Retrieves the details of an existing Transaction. */
+  public static Transaction retrieve(String id) throws StripeException {
+    return retrieve(id, (Map<String, Object>) null, (RequestOptions) null);
+  }
+
+  /** Retrieves the details of an existing Transaction. */
+  public static Transaction retrieve(String id, RequestOptions options) throws StripeException {
+    return retrieve(id, (Map<String, Object>) null, options);
+  }
+
+  /** Retrieves the details of an existing Transaction. */
+  public static Transaction retrieve(String id, Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/treasury/transactions/%s", ApiResource.urlEncodeId(id)));
+    return ApiResource.request(
+        ApiResource.RequestMethod.GET, url, params, Transaction.class, options);
+  }
+
+  /** Retrieves the details of an existing Transaction. */
+  public static Transaction retrieve(
+      String id, TransactionRetrieveParams params, RequestOptions options) throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/treasury/transactions/%s", ApiResource.urlEncodeId(id)));
+    return ApiResource.request(
+        ApiResource.RequestMethod.GET, url, params, Transaction.class, options);
+  }
+
+  /** Retrieves a list of Transaction objects. */
+  public static TransactionCollection list(Map<String, Object> params) throws StripeException {
+    return list(params, (RequestOptions) null);
+  }
+
+  /** Retrieves a list of Transaction objects. */
+  public static TransactionCollection list(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/treasury/transactions");
+    return ApiResource.requestCollection(url, params, TransactionCollection.class, options);
+  }
+
+  /** Retrieves a list of Transaction objects. */
+  public static TransactionCollection list(TransactionListParams params) throws StripeException {
+    return list(params, (RequestOptions) null);
+  }
+
+  /** Retrieves a list of Transaction objects. */
+  public static TransactionCollection list(TransactionListParams params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/treasury/transactions");
+    return ApiResource.requestCollection(url, params, TransactionCollection.class, options);
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class BalanceImpact extends StripeObject {
+    /** The change made to funds the user can spend right now. */
+    @SerializedName("cash")
+    Long cash;
+
+    /**
+     * The change made to funds that are not spendable yet, but will become available at a later
+     * time.
+     */
+    @SerializedName("inbound_pending")
+    Long inboundPending;
+
+    /**
+     * The change made to funds in the account, but not spendable because they are being held for
+     * pending outbound flows.
+     */
+    @SerializedName("outbound_pending")
+    Long outboundPending;
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class StatusTransitions extends StripeObject {
+    /** Timestamp describing when the Transaction changed status to {@code posted}. */
+    @SerializedName("posted_at")
+    Long postedAt;
+
+    /** Timestamp describing when the Transaction changed status to {@code void}. */
+    @SerializedName("void_at")
+    Long voidAt;
+  }
+}

--- a/src/main/java/com/stripe/model/treasury/TransactionCollection.java
+++ b/src/main/java/com/stripe/model/treasury/TransactionCollection.java
@@ -1,0 +1,6 @@
+// File generated from our OpenAPI spec
+package com.stripe.model.treasury;
+
+import com.stripe.model.StripeCollection;
+
+public class TransactionCollection extends StripeCollection<Transaction> {}

--- a/src/main/java/com/stripe/model/treasury/TransactionEntry.java
+++ b/src/main/java/com/stripe/model/treasury/TransactionEntry.java
@@ -6,6 +6,7 @@ import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
 import com.stripe.model.ExpandableField;
 import com.stripe.model.HasId;
+import com.stripe.model.StripeObject;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 import com.stripe.param.treasury.TransactionEntryListParams;
@@ -21,7 +22,7 @@ import lombok.Setter;
 public class TransactionEntry extends ApiResource implements HasId {
   /** Change to a FinancialAccount's balance. */
   @SerializedName("balance_impact")
-  Transaction.BalanceImpact balanceImpact;
+  BalanceImpact balanceImpact;
 
   /** Time at which the object was created. Measured in seconds since the Unix epoch. */
   @SerializedName("created")
@@ -178,5 +179,28 @@ public class TransactionEntry extends ApiResource implements HasId {
       TransactionEntryListParams params, RequestOptions options) throws StripeException {
     String url = String.format("%s%s", Stripe.getApiBase(), "/v1/treasury/transaction_entries");
     return ApiResource.requestCollection(url, params, TransactionEntryCollection.class, options);
+  }
+
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class BalanceImpact extends StripeObject {
+    /** The change made to funds the user can spend right now. */
+    @SerializedName("cash")
+    Long cash;
+
+    /**
+     * The change made to funds that are not spendable yet, but will become available at a later
+     * time.
+     */
+    @SerializedName("inbound_pending")
+    Long inboundPending;
+
+    /**
+     * The change made to funds in the account, but not spendable because they are being held for
+     * pending outbound flows.
+     */
+    @SerializedName("outbound_pending")
+    Long outboundPending;
   }
 }

--- a/src/main/java/com/stripe/model/treasury/TransactionEntry.java
+++ b/src/main/java/com/stripe/model/treasury/TransactionEntry.java
@@ -1,0 +1,182 @@
+// File generated from our OpenAPI spec
+package com.stripe.model.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.Stripe;
+import com.stripe.exception.StripeException;
+import com.stripe.model.ExpandableField;
+import com.stripe.model.HasId;
+import com.stripe.net.ApiResource;
+import com.stripe.net.RequestOptions;
+import com.stripe.param.treasury.TransactionEntryListParams;
+import com.stripe.param.treasury.TransactionEntryRetrieveParams;
+import java.util.Map;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
+public class TransactionEntry extends ApiResource implements HasId {
+  /** Change to a FinancialAccount's balance. */
+  @SerializedName("balance_impact")
+  Transaction.BalanceImpact balanceImpact;
+
+  /** Time at which the object was created. Measured in seconds since the Unix epoch. */
+  @SerializedName("created")
+  Long created;
+
+  /**
+   * Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency code</a>,
+   * in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported currency</a>.
+   */
+  @SerializedName("currency")
+  String currency;
+
+  /** When the TransactionEntry will impact the FinancialAccount's balance. */
+  @SerializedName("effective_at")
+  Long effectiveAt;
+
+  /** The FinancialAccount associated with this object. */
+  @SerializedName("financial_account")
+  String financialAccount;
+
+  /** Token of the flow associated with the TransactionEntry. */
+  @SerializedName("flow")
+  String flow;
+
+  /** Details of the flow associated with the TransactionEntry. */
+  @SerializedName("flow_details")
+  FlowDetails flowDetails;
+
+  /**
+   * Type of the flow associated with the TransactionEntry.
+   *
+   * <p>One of {@code credit_reversal}, {@code debit_reversal}, {@code inbound_transfer}, {@code
+   * issuing_authorization}, {@code other}, {@code outbound_payment}, {@code outbound_transfer},
+   * {@code received_credit}, or {@code received_debit}.
+   */
+  @SerializedName("flow_type")
+  String flowType;
+
+  /** Unique identifier for the object. */
+  @Getter(onMethod_ = {@Override})
+  @SerializedName("id")
+  String id;
+
+  /**
+   * Has the value {@code true} if the object exists in live mode or the value {@code false} if the
+   * object exists in test mode.
+   */
+  @SerializedName("livemode")
+  Boolean livemode;
+
+  /**
+   * String representing the object's type. Objects of the same type share the same value.
+   *
+   * <p>Equal to {@code treasury.transaction_entry}.
+   */
+  @SerializedName("object")
+  String object;
+
+  /** The Transaction associated with this object. */
+  @SerializedName("transaction")
+  @Getter(lombok.AccessLevel.NONE)
+  @Setter(lombok.AccessLevel.NONE)
+  ExpandableField<Transaction> transaction;
+
+  /**
+   * The specific money movement that generated the TransactionEntry.
+   *
+   * <p>One of {@code credit_reversal}, {@code credit_reversal_posting}, {@code debit_reversal},
+   * {@code inbound_transfer}, {@code inbound_transfer_return}, {@code issuing_authorization_hold},
+   * {@code issuing_authorization_release}, {@code other}, {@code outbound_payment}, {@code
+   * outbound_payment_cancellation}, {@code outbound_payment_failure}, {@code
+   * outbound_payment_posting}, {@code outbound_payment_return}, {@code outbound_transfer}, {@code
+   * outbound_transfer_cancellation}, {@code outbound_transfer_failure}, {@code
+   * outbound_transfer_posting}, {@code outbound_transfer_return}, {@code received_credit}, or
+   * {@code received_debit}.
+   */
+  @SerializedName("type")
+  String type;
+
+  /** Get ID of expandable {@code transaction} object. */
+  public String getTransaction() {
+    return (this.transaction != null) ? this.transaction.getId() : null;
+  }
+
+  public void setTransaction(String id) {
+    this.transaction = ApiResource.setExpandableFieldId(id, this.transaction);
+  }
+
+  /** Get expanded {@code transaction}. */
+  public Transaction getTransactionObject() {
+    return (this.transaction != null) ? this.transaction.getExpanded() : null;
+  }
+
+  public void setTransactionObject(Transaction expandableObject) {
+    this.transaction = new ExpandableField<Transaction>(expandableObject.getId(), expandableObject);
+  }
+
+  /** Retrieves a TransactionEntry object. */
+  public static TransactionEntry retrieve(String id) throws StripeException {
+    return retrieve(id, (Map<String, Object>) null, (RequestOptions) null);
+  }
+
+  /** Retrieves a TransactionEntry object. */
+  public static TransactionEntry retrieve(String id, RequestOptions options)
+      throws StripeException {
+    return retrieve(id, (Map<String, Object>) null, options);
+  }
+
+  /** Retrieves a TransactionEntry object. */
+  public static TransactionEntry retrieve(
+      String id, Map<String, Object> params, RequestOptions options) throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/treasury/transaction_entries/%s", ApiResource.urlEncodeId(id)));
+    return ApiResource.request(
+        ApiResource.RequestMethod.GET, url, params, TransactionEntry.class, options);
+  }
+
+  /** Retrieves a TransactionEntry object. */
+  public static TransactionEntry retrieve(
+      String id, TransactionEntryRetrieveParams params, RequestOptions options)
+      throws StripeException {
+    String url =
+        String.format(
+            "%s%s",
+            Stripe.getApiBase(),
+            String.format("/v1/treasury/transaction_entries/%s", ApiResource.urlEncodeId(id)));
+    return ApiResource.request(
+        ApiResource.RequestMethod.GET, url, params, TransactionEntry.class, options);
+  }
+
+  /** Retrieves a list of TransactionEntry objects. */
+  public static TransactionEntryCollection list(Map<String, Object> params) throws StripeException {
+    return list(params, (RequestOptions) null);
+  }
+
+  /** Retrieves a list of TransactionEntry objects. */
+  public static TransactionEntryCollection list(Map<String, Object> params, RequestOptions options)
+      throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/treasury/transaction_entries");
+    return ApiResource.requestCollection(url, params, TransactionEntryCollection.class, options);
+  }
+
+  /** Retrieves a list of TransactionEntry objects. */
+  public static TransactionEntryCollection list(TransactionEntryListParams params)
+      throws StripeException {
+    return list(params, (RequestOptions) null);
+  }
+
+  /** Retrieves a list of TransactionEntry objects. */
+  public static TransactionEntryCollection list(
+      TransactionEntryListParams params, RequestOptions options) throws StripeException {
+    String url = String.format("%s%s", Stripe.getApiBase(), "/v1/treasury/transaction_entries");
+    return ApiResource.requestCollection(url, params, TransactionEntryCollection.class, options);
+  }
+}

--- a/src/main/java/com/stripe/model/treasury/TransactionEntryCollection.java
+++ b/src/main/java/com/stripe/model/treasury/TransactionEntryCollection.java
@@ -1,0 +1,6 @@
+// File generated from our OpenAPI spec
+package com.stripe.model.treasury;
+
+import com.stripe.model.StripeCollection;
+
+public class TransactionEntryCollection extends StripeCollection<TransactionEntry> {}

--- a/src/main/java/com/stripe/param/AccountCreateParams.java
+++ b/src/main/java/com/stripe/param/AccountCreateParams.java
@@ -48,7 +48,10 @@ public class AccountCreateParams extends ApiRequestParams {
    * The country in which the account holder resides, or in which the business is legally
    * established. This should be an ISO 3166-1 alpha-2 country code. For example, if you are in the
    * United States and the business for which you're creating an account is legally represented in
-   * Canada, you would use {@code CA} as the country for the account being created.
+   * Canada, you would use {@code CA} as the country for the account being created. Available
+   * countries include <a href="https://stripe.com/global">Stripe's global markets</a> as well as
+   * countries where <a href="https://stripe.com/docs/connect/cross-border-payouts">cross-border
+   * payouts</a> are supported.
    */
   @SerializedName("country")
   String country;
@@ -285,6 +288,10 @@ public class AccountCreateParams extends ApiRequestParams {
      * established. This should be an ISO 3166-1 alpha-2 country code. For example, if you are in
      * the United States and the business for which you're creating an account is legally
      * represented in Canada, you would use {@code CA} as the country for the account being created.
+     * Available countries include <a href="https://stripe.com/global">Stripe's global markets</a>
+     * as well as countries where <a
+     * href="https://stripe.com/docs/connect/cross-border-payouts">cross-border payouts</a> are
+     * supported.
      */
     public Builder setCountry(String country) {
       this.country = country;
@@ -5649,11 +5656,11 @@ public class AccountCreateParams extends ApiRequestParams {
     @SerializedName("last_name")
     String lastName;
 
-    /** The Kana varation of the individual's last name (Japan only). */
+    /** The Kana variation of the individual's last name (Japan only). */
     @SerializedName("last_name_kana")
     String lastNameKana;
 
-    /** The Kanji varation of the individual's last name (Japan only). */
+    /** The Kanji variation of the individual's last name (Japan only). */
     @SerializedName("last_name_kanji")
     String lastNameKanji;
 
@@ -5964,13 +5971,13 @@ public class AccountCreateParams extends ApiRequestParams {
         return this;
       }
 
-      /** The Kana varation of the individual's last name (Japan only). */
+      /** The Kana variation of the individual's last name (Japan only). */
       public Builder setLastNameKana(String lastNameKana) {
         this.lastNameKana = lastNameKana;
         return this;
       }
 
-      /** The Kanji varation of the individual's last name (Japan only). */
+      /** The Kanji variation of the individual's last name (Japan only). */
       public Builder setLastNameKanji(String lastNameKanji) {
         this.lastNameKanji = lastNameKanji;
         return this;

--- a/src/main/java/com/stripe/param/AccountUpdateParams.java
+++ b/src/main/java/com/stripe/param/AccountUpdateParams.java
@@ -5960,11 +5960,11 @@ public class AccountUpdateParams extends ApiRequestParams {
     @SerializedName("last_name")
     Object lastName;
 
-    /** The Kana varation of the individual's last name (Japan only). */
+    /** The Kana variation of the individual's last name (Japan only). */
     @SerializedName("last_name_kana")
     Object lastNameKana;
 
-    /** The Kanji varation of the individual's last name (Japan only). */
+    /** The Kanji variation of the individual's last name (Japan only). */
     @SerializedName("last_name_kanji")
     Object lastNameKanji;
 
@@ -6326,25 +6326,25 @@ public class AccountUpdateParams extends ApiRequestParams {
         return this;
       }
 
-      /** The Kana varation of the individual's last name (Japan only). */
+      /** The Kana variation of the individual's last name (Japan only). */
       public Builder setLastNameKana(String lastNameKana) {
         this.lastNameKana = lastNameKana;
         return this;
       }
 
-      /** The Kana varation of the individual's last name (Japan only). */
+      /** The Kana variation of the individual's last name (Japan only). */
       public Builder setLastNameKana(EmptyParam lastNameKana) {
         this.lastNameKana = lastNameKana;
         return this;
       }
 
-      /** The Kanji varation of the individual's last name (Japan only). */
+      /** The Kanji variation of the individual's last name (Japan only). */
       public Builder setLastNameKanji(String lastNameKanji) {
         this.lastNameKanji = lastNameKanji;
         return this;
       }
 
-      /** The Kanji varation of the individual's last name (Japan only). */
+      /** The Kanji variation of the individual's last name (Japan only). */
       public Builder setLastNameKanji(EmptyParam lastNameKanji) {
         this.lastNameKanji = lastNameKanji;
         return this;

--- a/src/main/java/com/stripe/param/CashBalanceRetrieveCashBalanceParams.java
+++ b/src/main/java/com/stripe/param/CashBalanceRetrieveCashBalanceParams.java
@@ -1,0 +1,99 @@
+// File generated from our OpenAPI spec
+package com.stripe.param;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class CashBalanceRetrieveCashBalanceParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  private CashBalanceRetrieveCashBalanceParams(
+      List<String> expand, Map<String, Object> extraParams) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public CashBalanceRetrieveCashBalanceParams build() {
+      return new CashBalanceRetrieveCashBalanceParams(this.expand, this.extraParams);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * CashBalanceRetrieveCashBalanceParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * CashBalanceRetrieveCashBalanceParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * CashBalanceRetrieveCashBalanceParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link CashBalanceRetrieveCashBalanceParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/CustomerRetrievePaymentMethodParams.java
+++ b/src/main/java/com/stripe/param/CustomerRetrievePaymentMethodParams.java
@@ -1,0 +1,99 @@
+// File generated from our OpenAPI spec
+package com.stripe.param;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class CustomerRetrievePaymentMethodParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  private CustomerRetrievePaymentMethodParams(
+      List<String> expand, Map<String, Object> extraParams) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public CustomerRetrievePaymentMethodParams build() {
+      return new CustomerRetrievePaymentMethodParams(this.expand, this.extraParams);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * CustomerRetrievePaymentMethodParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * CustomerRetrievePaymentMethodParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * CustomerRetrievePaymentMethodParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link CustomerRetrievePaymentMethodParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
@@ -9490,6 +9490,10 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       @SerializedName("financial_connections")
       FinancialConnections financialConnections;
 
+      /** Additional fields for network related functions. */
+      @SerializedName("networks")
+      Networks networks;
+
       /**
        * Indicates that you intend to make future payments with this PaymentIntent's payment method.
        *
@@ -9519,10 +9523,12 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       private UsBankAccount(
           Map<String, Object> extraParams,
           FinancialConnections financialConnections,
+          Networks networks,
           EnumParam setupFutureUsage,
           VerificationMethod verificationMethod) {
         this.extraParams = extraParams;
         this.financialConnections = financialConnections;
+        this.networks = networks;
         this.setupFutureUsage = setupFutureUsage;
         this.verificationMethod = verificationMethod;
       }
@@ -9536,6 +9542,8 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
 
         private FinancialConnections financialConnections;
 
+        private Networks networks;
+
         private EnumParam setupFutureUsage;
 
         private VerificationMethod verificationMethod;
@@ -9545,6 +9553,7 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
           return new UsBankAccount(
               this.extraParams,
               this.financialConnections,
+              this.networks,
               this.setupFutureUsage,
               this.verificationMethod);
         }
@@ -9582,6 +9591,12 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
         /** Additional fields for Financial Connections Session creation. */
         public Builder setFinancialConnections(FinancialConnections financialConnections) {
           this.financialConnections = financialConnections;
+          return this;
+        }
+
+        /** Additional fields for network related functions. */
+        public Builder setNetworks(Networks networks) {
+          this.networks = networks;
           return this;
         }
 
@@ -9778,6 +9793,116 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
           private final String value;
 
           Permission(String value) {
+            this.value = value;
+          }
+        }
+      }
+
+      @Getter
+      public static class Networks {
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /** Triggers validations to run across the selected networks. */
+        @SerializedName("requested")
+        List<Requested> requested;
+
+        private Networks(Map<String, Object> extraParams, List<Requested> requested) {
+          this.extraParams = extraParams;
+          this.requested = requested;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Map<String, Object> extraParams;
+
+          private List<Requested> requested;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public Networks build() {
+            return new Networks(this.extraParams, this.requested);
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * PaymentIntentConfirmParams.PaymentMethodOptions.UsBankAccount.Networks#extraParams} for
+           * the field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * PaymentIntentConfirmParams.PaymentMethodOptions.UsBankAccount.Networks#extraParams} for
+           * the field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /**
+           * Add an element to `requested` list. A list is initialized for the first `add/addAll`
+           * call, and subsequent calls adds additional elements to the original list. See {@link
+           * PaymentIntentConfirmParams.PaymentMethodOptions.UsBankAccount.Networks#requested} for
+           * the field documentation.
+           */
+          public Builder addRequested(Requested element) {
+            if (this.requested == null) {
+              this.requested = new ArrayList<>();
+            }
+            this.requested.add(element);
+            return this;
+          }
+
+          /**
+           * Add all elements to `requested` list. A list is initialized for the first `add/addAll`
+           * call, and subsequent calls adds additional elements to the original list. See {@link
+           * PaymentIntentConfirmParams.PaymentMethodOptions.UsBankAccount.Networks#requested} for
+           * the field documentation.
+           */
+          public Builder addAllRequested(List<Requested> elements) {
+            if (this.requested == null) {
+              this.requested = new ArrayList<>();
+            }
+            this.requested.addAll(elements);
+            return this;
+          }
+        }
+
+        public enum Requested implements ApiRequestParams.EnumParam {
+          @SerializedName("ach")
+          ACH("ach"),
+
+          @SerializedName("us_domestic_wire")
+          US_DOMESTIC_WIRE("us_domestic_wire");
+
+          @Getter(onMethod_ = {@Override})
+          private final String value;
+
+          Requested(String value) {
             this.value = value;
           }
         }

--- a/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
@@ -182,7 +182,9 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
 
   /**
    * The list of payment method types (e.g. card) that this PaymentIntent is allowed to use. If this
-   * is not provided, defaults to [&quot;card&quot;].
+   * is not provided, defaults to [&quot;card&quot;]. Use automatic_payment_methods to manage
+   * payment methods from the <a href="https://dashboard.stripe.com/settings/payment_methods">Stripe
+   * Dashboard</a>.
    */
   @SerializedName("payment_method_types")
   List<String> paymentMethodTypes;
@@ -9952,6 +9954,10 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       @SerializedName("financial_connections")
       FinancialConnections financialConnections;
 
+      /** Additional fields for network related functions. */
+      @SerializedName("networks")
+      Networks networks;
+
       /**
        * Indicates that you intend to make future payments with this PaymentIntent's payment method.
        *
@@ -9981,10 +9987,12 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       private UsBankAccount(
           Map<String, Object> extraParams,
           FinancialConnections financialConnections,
+          Networks networks,
           EnumParam setupFutureUsage,
           VerificationMethod verificationMethod) {
         this.extraParams = extraParams;
         this.financialConnections = financialConnections;
+        this.networks = networks;
         this.setupFutureUsage = setupFutureUsage;
         this.verificationMethod = verificationMethod;
       }
@@ -9998,6 +10006,8 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
 
         private FinancialConnections financialConnections;
 
+        private Networks networks;
+
         private EnumParam setupFutureUsage;
 
         private VerificationMethod verificationMethod;
@@ -10007,6 +10017,7 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
           return new UsBankAccount(
               this.extraParams,
               this.financialConnections,
+              this.networks,
               this.setupFutureUsage,
               this.verificationMethod);
         }
@@ -10042,6 +10053,12 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
         /** Additional fields for Financial Connections Session creation. */
         public Builder setFinancialConnections(FinancialConnections financialConnections) {
           this.financialConnections = financialConnections;
+          return this;
+        }
+
+        /** Additional fields for network related functions. */
+        public Builder setNetworks(Networks networks) {
+          this.networks = networks;
           return this;
         }
 
@@ -10238,6 +10255,116 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
           private final String value;
 
           Permission(String value) {
+            this.value = value;
+          }
+        }
+      }
+
+      @Getter
+      public static class Networks {
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /** Triggers validations to run across the selected networks. */
+        @SerializedName("requested")
+        List<Requested> requested;
+
+        private Networks(Map<String, Object> extraParams, List<Requested> requested) {
+          this.extraParams = extraParams;
+          this.requested = requested;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Map<String, Object> extraParams;
+
+          private List<Requested> requested;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public Networks build() {
+            return new Networks(this.extraParams, this.requested);
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * PaymentIntentCreateParams.PaymentMethodOptions.UsBankAccount.Networks#extraParams} for
+           * the field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * PaymentIntentCreateParams.PaymentMethodOptions.UsBankAccount.Networks#extraParams} for
+           * the field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /**
+           * Add an element to `requested` list. A list is initialized for the first `add/addAll`
+           * call, and subsequent calls adds additional elements to the original list. See {@link
+           * PaymentIntentCreateParams.PaymentMethodOptions.UsBankAccount.Networks#requested} for
+           * the field documentation.
+           */
+          public Builder addRequested(Requested element) {
+            if (this.requested == null) {
+              this.requested = new ArrayList<>();
+            }
+            this.requested.add(element);
+            return this;
+          }
+
+          /**
+           * Add all elements to `requested` list. A list is initialized for the first `add/addAll`
+           * call, and subsequent calls adds additional elements to the original list. See {@link
+           * PaymentIntentCreateParams.PaymentMethodOptions.UsBankAccount.Networks#requested} for
+           * the field documentation.
+           */
+          public Builder addAllRequested(List<Requested> elements) {
+            if (this.requested == null) {
+              this.requested = new ArrayList<>();
+            }
+            this.requested.addAll(elements);
+            return this;
+          }
+        }
+
+        public enum Requested implements ApiRequestParams.EnumParam {
+          @SerializedName("ach")
+          ACH("ach"),
+
+          @SerializedName("us_domestic_wire")
+          US_DOMESTIC_WIRE("us_domestic_wire");
+
+          @Getter(onMethod_ = {@Override})
+          private final String value;
+
+          Requested(String value) {
             this.value = value;
           }
         }

--- a/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
@@ -102,7 +102,11 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
   @SerializedName("payment_method_options")
   PaymentMethodOptions paymentMethodOptions;
 
-  /** The list of payment method types (e.g. card) that this PaymentIntent is allowed to use. */
+  /**
+   * The list of payment method types (e.g. card) that this PaymentIntent is allowed to use. Use
+   * automatic_payment_methods to manage payment methods from the <a
+   * href="https://dashboard.stripe.com/settings/payment_methods">Stripe Dashboard</a>.
+   */
   @SerializedName("payment_method_types")
   List<String> paymentMethodTypes;
 
@@ -9582,6 +9586,10 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       @SerializedName("financial_connections")
       FinancialConnections financialConnections;
 
+      /** Additional fields for network related functions. */
+      @SerializedName("networks")
+      Networks networks;
+
       /**
        * Indicates that you intend to make future payments with this PaymentIntent's payment method.
        *
@@ -9611,10 +9619,12 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       private UsBankAccount(
           Map<String, Object> extraParams,
           FinancialConnections financialConnections,
+          Networks networks,
           EnumParam setupFutureUsage,
           VerificationMethod verificationMethod) {
         this.extraParams = extraParams;
         this.financialConnections = financialConnections;
+        this.networks = networks;
         this.setupFutureUsage = setupFutureUsage;
         this.verificationMethod = verificationMethod;
       }
@@ -9628,6 +9638,8 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
 
         private FinancialConnections financialConnections;
 
+        private Networks networks;
+
         private EnumParam setupFutureUsage;
 
         private VerificationMethod verificationMethod;
@@ -9637,6 +9649,7 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
           return new UsBankAccount(
               this.extraParams,
               this.financialConnections,
+              this.networks,
               this.setupFutureUsage,
               this.verificationMethod);
         }
@@ -9672,6 +9685,12 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
         /** Additional fields for Financial Connections Session creation. */
         public Builder setFinancialConnections(FinancialConnections financialConnections) {
           this.financialConnections = financialConnections;
+          return this;
+        }
+
+        /** Additional fields for network related functions. */
+        public Builder setNetworks(Networks networks) {
+          this.networks = networks;
           return this;
         }
 
@@ -9877,6 +9896,116 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
           private final String value;
 
           Permission(String value) {
+            this.value = value;
+          }
+        }
+      }
+
+      @Getter
+      public static class Networks {
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /** Triggers validations to run across the selected networks. */
+        @SerializedName("requested")
+        List<Requested> requested;
+
+        private Networks(Map<String, Object> extraParams, List<Requested> requested) {
+          this.extraParams = extraParams;
+          this.requested = requested;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Map<String, Object> extraParams;
+
+          private List<Requested> requested;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public Networks build() {
+            return new Networks(this.extraParams, this.requested);
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * PaymentIntentUpdateParams.PaymentMethodOptions.UsBankAccount.Networks#extraParams} for
+           * the field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * PaymentIntentUpdateParams.PaymentMethodOptions.UsBankAccount.Networks#extraParams} for
+           * the field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /**
+           * Add an element to `requested` list. A list is initialized for the first `add/addAll`
+           * call, and subsequent calls adds additional elements to the original list. See {@link
+           * PaymentIntentUpdateParams.PaymentMethodOptions.UsBankAccount.Networks#requested} for
+           * the field documentation.
+           */
+          public Builder addRequested(Requested element) {
+            if (this.requested == null) {
+              this.requested = new ArrayList<>();
+            }
+            this.requested.add(element);
+            return this;
+          }
+
+          /**
+           * Add all elements to `requested` list. A list is initialized for the first `add/addAll`
+           * call, and subsequent calls adds additional elements to the original list. See {@link
+           * PaymentIntentUpdateParams.PaymentMethodOptions.UsBankAccount.Networks#requested} for
+           * the field documentation.
+           */
+          public Builder addAllRequested(List<Requested> elements) {
+            if (this.requested == null) {
+              this.requested = new ArrayList<>();
+            }
+            this.requested.addAll(elements);
+            return this;
+          }
+        }
+
+        public enum Requested implements ApiRequestParams.EnumParam {
+          @SerializedName("ach")
+          ACH("ach"),
+
+          @SerializedName("us_domestic_wire")
+          US_DOMESTIC_WIRE("us_domestic_wire");
+
+          @Getter(onMethod_ = {@Override})
+          private final String value;
+
+          Requested(String value) {
             this.value = value;
           }
         }

--- a/src/main/java/com/stripe/param/SetupIntentConfirmParams.java
+++ b/src/main/java/com/stripe/param/SetupIntentConfirmParams.java
@@ -4751,6 +4751,10 @@ public class SetupIntentConfirmParams extends ApiRequestParams {
       @SerializedName("financial_connections")
       FinancialConnections financialConnections;
 
+      /** Additional fields for network related functions. */
+      @SerializedName("networks")
+      Networks networks;
+
       /** Verification method for the intent. */
       @SerializedName("verification_method")
       VerificationMethod verificationMethod;
@@ -4758,9 +4762,11 @@ public class SetupIntentConfirmParams extends ApiRequestParams {
       private UsBankAccount(
           Map<String, Object> extraParams,
           FinancialConnections financialConnections,
+          Networks networks,
           VerificationMethod verificationMethod) {
         this.extraParams = extraParams;
         this.financialConnections = financialConnections;
+        this.networks = networks;
         this.verificationMethod = verificationMethod;
       }
 
@@ -4773,12 +4779,14 @@ public class SetupIntentConfirmParams extends ApiRequestParams {
 
         private FinancialConnections financialConnections;
 
+        private Networks networks;
+
         private VerificationMethod verificationMethod;
 
         /** Finalize and obtain parameter instance from this builder. */
         public UsBankAccount build() {
           return new UsBankAccount(
-              this.extraParams, this.financialConnections, this.verificationMethod);
+              this.extraParams, this.financialConnections, this.networks, this.verificationMethod);
         }
 
         /**
@@ -4812,6 +4820,12 @@ public class SetupIntentConfirmParams extends ApiRequestParams {
         /** Additional fields for Financial Connections Session creation. */
         public Builder setFinancialConnections(FinancialConnections financialConnections) {
           this.financialConnections = financialConnections;
+          return this;
+        }
+
+        /** Additional fields for network related functions. */
+        public Builder setNetworks(Networks networks) {
+          this.networks = networks;
           return this;
         }
 
@@ -4958,6 +4972,116 @@ public class SetupIntentConfirmParams extends ApiRequestParams {
           private final String value;
 
           Permission(String value) {
+            this.value = value;
+          }
+        }
+      }
+
+      @Getter
+      public static class Networks {
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /** Triggers validations to run across the selected networks. */
+        @SerializedName("requested")
+        List<Requested> requested;
+
+        private Networks(Map<String, Object> extraParams, List<Requested> requested) {
+          this.extraParams = extraParams;
+          this.requested = requested;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Map<String, Object> extraParams;
+
+          private List<Requested> requested;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public Networks build() {
+            return new Networks(this.extraParams, this.requested);
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * SetupIntentConfirmParams.PaymentMethodOptions.UsBankAccount.Networks#extraParams} for
+           * the field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * SetupIntentConfirmParams.PaymentMethodOptions.UsBankAccount.Networks#extraParams} for
+           * the field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /**
+           * Add an element to `requested` list. A list is initialized for the first `add/addAll`
+           * call, and subsequent calls adds additional elements to the original list. See {@link
+           * SetupIntentConfirmParams.PaymentMethodOptions.UsBankAccount.Networks#requested} for the
+           * field documentation.
+           */
+          public Builder addRequested(Requested element) {
+            if (this.requested == null) {
+              this.requested = new ArrayList<>();
+            }
+            this.requested.add(element);
+            return this;
+          }
+
+          /**
+           * Add all elements to `requested` list. A list is initialized for the first `add/addAll`
+           * call, and subsequent calls adds additional elements to the original list. See {@link
+           * SetupIntentConfirmParams.PaymentMethodOptions.UsBankAccount.Networks#requested} for the
+           * field documentation.
+           */
+          public Builder addAllRequested(List<Requested> elements) {
+            if (this.requested == null) {
+              this.requested = new ArrayList<>();
+            }
+            this.requested.addAll(elements);
+            return this;
+          }
+        }
+
+        public enum Requested implements ApiRequestParams.EnumParam {
+          @SerializedName("ach")
+          ACH("ach"),
+
+          @SerializedName("us_domestic_wire")
+          US_DOMESTIC_WIRE("us_domestic_wire");
+
+          @Getter(onMethod_ = {@Override})
+          private final String value;
+
+          Requested(String value) {
             this.value = value;
           }
         }

--- a/src/main/java/com/stripe/param/SetupIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/SetupIntentCreateParams.java
@@ -4955,6 +4955,10 @@ public class SetupIntentCreateParams extends ApiRequestParams {
       @SerializedName("financial_connections")
       FinancialConnections financialConnections;
 
+      /** Additional fields for network related functions. */
+      @SerializedName("networks")
+      Networks networks;
+
       /** Verification method for the intent. */
       @SerializedName("verification_method")
       VerificationMethod verificationMethod;
@@ -4962,9 +4966,11 @@ public class SetupIntentCreateParams extends ApiRequestParams {
       private UsBankAccount(
           Map<String, Object> extraParams,
           FinancialConnections financialConnections,
+          Networks networks,
           VerificationMethod verificationMethod) {
         this.extraParams = extraParams;
         this.financialConnections = financialConnections;
+        this.networks = networks;
         this.verificationMethod = verificationMethod;
       }
 
@@ -4977,12 +4983,14 @@ public class SetupIntentCreateParams extends ApiRequestParams {
 
         private FinancialConnections financialConnections;
 
+        private Networks networks;
+
         private VerificationMethod verificationMethod;
 
         /** Finalize and obtain parameter instance from this builder. */
         public UsBankAccount build() {
           return new UsBankAccount(
-              this.extraParams, this.financialConnections, this.verificationMethod);
+              this.extraParams, this.financialConnections, this.networks, this.verificationMethod);
         }
 
         /**
@@ -5016,6 +5024,12 @@ public class SetupIntentCreateParams extends ApiRequestParams {
         /** Additional fields for Financial Connections Session creation. */
         public Builder setFinancialConnections(FinancialConnections financialConnections) {
           this.financialConnections = financialConnections;
+          return this;
+        }
+
+        /** Additional fields for network related functions. */
+        public Builder setNetworks(Networks networks) {
+          this.networks = networks;
           return this;
         }
 
@@ -5162,6 +5176,116 @@ public class SetupIntentCreateParams extends ApiRequestParams {
           private final String value;
 
           Permission(String value) {
+            this.value = value;
+          }
+        }
+      }
+
+      @Getter
+      public static class Networks {
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /** Triggers validations to run across the selected networks. */
+        @SerializedName("requested")
+        List<Requested> requested;
+
+        private Networks(Map<String, Object> extraParams, List<Requested> requested) {
+          this.extraParams = extraParams;
+          this.requested = requested;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Map<String, Object> extraParams;
+
+          private List<Requested> requested;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public Networks build() {
+            return new Networks(this.extraParams, this.requested);
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * SetupIntentCreateParams.PaymentMethodOptions.UsBankAccount.Networks#extraParams} for
+           * the field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * SetupIntentCreateParams.PaymentMethodOptions.UsBankAccount.Networks#extraParams} for
+           * the field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /**
+           * Add an element to `requested` list. A list is initialized for the first `add/addAll`
+           * call, and subsequent calls adds additional elements to the original list. See {@link
+           * SetupIntentCreateParams.PaymentMethodOptions.UsBankAccount.Networks#requested} for the
+           * field documentation.
+           */
+          public Builder addRequested(Requested element) {
+            if (this.requested == null) {
+              this.requested = new ArrayList<>();
+            }
+            this.requested.add(element);
+            return this;
+          }
+
+          /**
+           * Add all elements to `requested` list. A list is initialized for the first `add/addAll`
+           * call, and subsequent calls adds additional elements to the original list. See {@link
+           * SetupIntentCreateParams.PaymentMethodOptions.UsBankAccount.Networks#requested} for the
+           * field documentation.
+           */
+          public Builder addAllRequested(List<Requested> elements) {
+            if (this.requested == null) {
+              this.requested = new ArrayList<>();
+            }
+            this.requested.addAll(elements);
+            return this;
+          }
+        }
+
+        public enum Requested implements ApiRequestParams.EnumParam {
+          @SerializedName("ach")
+          ACH("ach"),
+
+          @SerializedName("us_domestic_wire")
+          US_DOMESTIC_WIRE("us_domestic_wire");
+
+          @Getter(onMethod_ = {@Override})
+          private final String value;
+
+          Requested(String value) {
             this.value = value;
           }
         }

--- a/src/main/java/com/stripe/param/SetupIntentUpdateParams.java
+++ b/src/main/java/com/stripe/param/SetupIntentUpdateParams.java
@@ -4679,6 +4679,10 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
       @SerializedName("financial_connections")
       FinancialConnections financialConnections;
 
+      /** Additional fields for network related functions. */
+      @SerializedName("networks")
+      Networks networks;
+
       /** Verification method for the intent. */
       @SerializedName("verification_method")
       VerificationMethod verificationMethod;
@@ -4686,9 +4690,11 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
       private UsBankAccount(
           Map<String, Object> extraParams,
           FinancialConnections financialConnections,
+          Networks networks,
           VerificationMethod verificationMethod) {
         this.extraParams = extraParams;
         this.financialConnections = financialConnections;
+        this.networks = networks;
         this.verificationMethod = verificationMethod;
       }
 
@@ -4701,12 +4707,14 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
 
         private FinancialConnections financialConnections;
 
+        private Networks networks;
+
         private VerificationMethod verificationMethod;
 
         /** Finalize and obtain parameter instance from this builder. */
         public UsBankAccount build() {
           return new UsBankAccount(
-              this.extraParams, this.financialConnections, this.verificationMethod);
+              this.extraParams, this.financialConnections, this.networks, this.verificationMethod);
         }
 
         /**
@@ -4740,6 +4748,12 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
         /** Additional fields for Financial Connections Session creation. */
         public Builder setFinancialConnections(FinancialConnections financialConnections) {
           this.financialConnections = financialConnections;
+          return this;
+        }
+
+        /** Additional fields for network related functions. */
+        public Builder setNetworks(Networks networks) {
+          this.networks = networks;
           return this;
         }
 
@@ -4895,6 +4909,116 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
           private final String value;
 
           Permission(String value) {
+            this.value = value;
+          }
+        }
+      }
+
+      @Getter
+      public static class Networks {
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /** Triggers validations to run across the selected networks. */
+        @SerializedName("requested")
+        List<Requested> requested;
+
+        private Networks(Map<String, Object> extraParams, List<Requested> requested) {
+          this.extraParams = extraParams;
+          this.requested = requested;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Map<String, Object> extraParams;
+
+          private List<Requested> requested;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public Networks build() {
+            return new Networks(this.extraParams, this.requested);
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * SetupIntentUpdateParams.PaymentMethodOptions.UsBankAccount.Networks#extraParams} for
+           * the field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * SetupIntentUpdateParams.PaymentMethodOptions.UsBankAccount.Networks#extraParams} for
+           * the field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /**
+           * Add an element to `requested` list. A list is initialized for the first `add/addAll`
+           * call, and subsequent calls adds additional elements to the original list. See {@link
+           * SetupIntentUpdateParams.PaymentMethodOptions.UsBankAccount.Networks#requested} for the
+           * field documentation.
+           */
+          public Builder addRequested(Requested element) {
+            if (this.requested == null) {
+              this.requested = new ArrayList<>();
+            }
+            this.requested.add(element);
+            return this;
+          }
+
+          /**
+           * Add all elements to `requested` list. A list is initialized for the first `add/addAll`
+           * call, and subsequent calls adds additional elements to the original list. See {@link
+           * SetupIntentUpdateParams.PaymentMethodOptions.UsBankAccount.Networks#requested} for the
+           * field documentation.
+           */
+          public Builder addAllRequested(List<Requested> elements) {
+            if (this.requested == null) {
+              this.requested = new ArrayList<>();
+            }
+            this.requested.addAll(elements);
+            return this;
+          }
+        }
+
+        public enum Requested implements ApiRequestParams.EnumParam {
+          @SerializedName("ach")
+          ACH("ach"),
+
+          @SerializedName("us_domestic_wire")
+          US_DOMESTIC_WIRE("us_domestic_wire");
+
+          @Getter(onMethod_ = {@Override})
+          private final String value;
+
+          Requested(String value) {
             this.value = value;
           }
         }

--- a/src/main/java/com/stripe/param/SubscriptionCreateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionCreateParams.java
@@ -31,7 +31,10 @@ public class SubscriptionCreateParams extends ApiRequestParams {
   @SerializedName("application_fee_percent")
   BigDecimal applicationFeePercent;
 
-  /** Automatic tax settings for this subscription. */
+  /**
+   * Automatic tax settings for this subscription. We recommend you only include this parameter when
+   * the existing value is being changed.
+   */
   @SerializedName("automatic_tax")
   AutomaticTax automaticTax;
 
@@ -472,7 +475,10 @@ public class SubscriptionCreateParams extends ApiRequestParams {
       return this;
     }
 
-    /** Automatic tax settings for this subscription. */
+    /**
+     * Automatic tax settings for this subscription. We recommend you only include this parameter
+     * when the existing value is being changed.
+     */
     public Builder setAutomaticTax(AutomaticTax automaticTax) {
       this.automaticTax = automaticTax;
       return this;
@@ -2106,13 +2112,22 @@ public class SubscriptionCreateParams extends ApiRequestParams {
     @SerializedName("payment_method_types")
     Object paymentMethodTypes;
 
+    /**
+     * Either {@code off}, or {@code on_subscription}. With {@code on_subscription} Stripe updates
+     * {@code subscription.default_payment_method} when a subscription payment succeeds.
+     */
+    @SerializedName("save_default_payment_method")
+    SaveDefaultPaymentMethod saveDefaultPaymentMethod;
+
     private PaymentSettings(
         Map<String, Object> extraParams,
         PaymentMethodOptions paymentMethodOptions,
-        Object paymentMethodTypes) {
+        Object paymentMethodTypes,
+        SaveDefaultPaymentMethod saveDefaultPaymentMethod) {
       this.extraParams = extraParams;
       this.paymentMethodOptions = paymentMethodOptions;
       this.paymentMethodTypes = paymentMethodTypes;
+      this.saveDefaultPaymentMethod = saveDefaultPaymentMethod;
     }
 
     public static Builder builder() {
@@ -2126,10 +2141,15 @@ public class SubscriptionCreateParams extends ApiRequestParams {
 
       private Object paymentMethodTypes;
 
+      private SaveDefaultPaymentMethod saveDefaultPaymentMethod;
+
       /** Finalize and obtain parameter instance from this builder. */
       public PaymentSettings build() {
         return new PaymentSettings(
-            this.extraParams, this.paymentMethodOptions, this.paymentMethodTypes);
+            this.extraParams,
+            this.paymentMethodOptions,
+            this.paymentMethodTypes,
+            this.saveDefaultPaymentMethod);
       }
 
       /**
@@ -2222,6 +2242,16 @@ public class SubscriptionCreateParams extends ApiRequestParams {
        */
       public Builder setPaymentMethodTypes(List<PaymentMethodType> paymentMethodTypes) {
         this.paymentMethodTypes = paymentMethodTypes;
+        return this;
+      }
+
+      /**
+       * Either {@code off}, or {@code on_subscription}. With {@code on_subscription} Stripe updates
+       * {@code subscription.default_payment_method} when a subscription payment succeeds.
+       */
+      public Builder setSaveDefaultPaymentMethod(
+          SaveDefaultPaymentMethod saveDefaultPaymentMethod) {
+        this.saveDefaultPaymentMethod = saveDefaultPaymentMethod;
         return this;
       }
     }
@@ -3557,6 +3587,21 @@ public class SubscriptionCreateParams extends ApiRequestParams {
       private final String value;
 
       PaymentMethodType(String value) {
+        this.value = value;
+      }
+    }
+
+    public enum SaveDefaultPaymentMethod implements ApiRequestParams.EnumParam {
+      @SerializedName("off")
+      OFF("off"),
+
+      @SerializedName("on_subscription")
+      ON_SUBSCRIPTION("on_subscription");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      SaveDefaultPaymentMethod(String value) {
         this.value = value;
       }
     }

--- a/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
+++ b/src/main/java/com/stripe/param/SubscriptionUpdateParams.java
@@ -31,7 +31,10 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
   @SerializedName("application_fee_percent")
   BigDecimal applicationFeePercent;
 
-  /** Automatic tax settings for this subscription. */
+  /**
+   * Automatic tax settings for this subscription. We recommend you only include this parameter when
+   * the existing value is being changed.
+   */
   @SerializedName("automatic_tax")
   AutomaticTax automaticTax;
 
@@ -463,7 +466,10 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
       return this;
     }
 
-    /** Automatic tax settings for this subscription. */
+    /**
+     * Automatic tax settings for this subscription. We recommend you only include this parameter
+     * when the existing value is being changed.
+     */
     public Builder setAutomaticTax(AutomaticTax automaticTax) {
       this.automaticTax = automaticTax;
       return this;
@@ -2435,13 +2441,22 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
     @SerializedName("payment_method_types")
     Object paymentMethodTypes;
 
+    /**
+     * Either {@code off}, or {@code on_subscription}. With {@code on_subscription} Stripe updates
+     * {@code subscription.default_payment_method} when a subscription payment succeeds.
+     */
+    @SerializedName("save_default_payment_method")
+    SaveDefaultPaymentMethod saveDefaultPaymentMethod;
+
     private PaymentSettings(
         Map<String, Object> extraParams,
         PaymentMethodOptions paymentMethodOptions,
-        Object paymentMethodTypes) {
+        Object paymentMethodTypes,
+        SaveDefaultPaymentMethod saveDefaultPaymentMethod) {
       this.extraParams = extraParams;
       this.paymentMethodOptions = paymentMethodOptions;
       this.paymentMethodTypes = paymentMethodTypes;
+      this.saveDefaultPaymentMethod = saveDefaultPaymentMethod;
     }
 
     public static Builder builder() {
@@ -2455,10 +2470,15 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
 
       private Object paymentMethodTypes;
 
+      private SaveDefaultPaymentMethod saveDefaultPaymentMethod;
+
       /** Finalize and obtain parameter instance from this builder. */
       public PaymentSettings build() {
         return new PaymentSettings(
-            this.extraParams, this.paymentMethodOptions, this.paymentMethodTypes);
+            this.extraParams,
+            this.paymentMethodOptions,
+            this.paymentMethodTypes,
+            this.saveDefaultPaymentMethod);
       }
 
       /**
@@ -2551,6 +2571,16 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
        */
       public Builder setPaymentMethodTypes(List<PaymentMethodType> paymentMethodTypes) {
         this.paymentMethodTypes = paymentMethodTypes;
+        return this;
+      }
+
+      /**
+       * Either {@code off}, or {@code on_subscription}. With {@code on_subscription} Stripe updates
+       * {@code subscription.default_payment_method} when a subscription payment succeeds.
+       */
+      public Builder setSaveDefaultPaymentMethod(
+          SaveDefaultPaymentMethod saveDefaultPaymentMethod) {
+        this.saveDefaultPaymentMethod = saveDefaultPaymentMethod;
         return this;
       }
     }
@@ -3916,6 +3946,21 @@ public class SubscriptionUpdateParams extends ApiRequestParams {
       private final String value;
 
       PaymentMethodType(String value) {
+        this.value = value;
+      }
+    }
+
+    public enum SaveDefaultPaymentMethod implements ApiRequestParams.EnumParam {
+      @SerializedName("off")
+      OFF("off"),
+
+      @SerializedName("on_subscription")
+      ON_SUBSCRIPTION("on_subscription");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      SaveDefaultPaymentMethod(String value) {
         this.value = value;
       }
     }

--- a/src/main/java/com/stripe/param/TokenCreateParams.java
+++ b/src/main/java/com/stripe/param/TokenCreateParams.java
@@ -1678,11 +1678,11 @@ public class TokenCreateParams extends ApiRequestParams {
       @SerializedName("last_name")
       String lastName;
 
-      /** The Kana varation of the individual's last name (Japan only). */
+      /** The Kana variation of the individual's last name (Japan only). */
       @SerializedName("last_name_kana")
       String lastNameKana;
 
-      /** The Kanji varation of the individual's last name (Japan only). */
+      /** The Kanji variation of the individual's last name (Japan only). */
       @SerializedName("last_name_kanji")
       String lastNameKanji;
 
@@ -1997,13 +1997,13 @@ public class TokenCreateParams extends ApiRequestParams {
           return this;
         }
 
-        /** The Kana varation of the individual's last name (Japan only). */
+        /** The Kana variation of the individual's last name (Japan only). */
         public Builder setLastNameKana(String lastNameKana) {
           this.lastNameKana = lastNameKana;
           return this;
         }
 
-        /** The Kanji varation of the individual's last name (Japan only). */
+        /** The Kanji variation of the individual's last name (Japan only). */
         public Builder setLastNameKanji(String lastNameKanji) {
           this.lastNameKanji = lastNameKanji;
           return this;

--- a/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
+++ b/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
@@ -1141,7 +1141,98 @@ public class WebhookEndpointCreateParams extends ApiRequestParams {
     TRANSFER__REVERSED("transfer.reversed"),
 
     @SerializedName("transfer.updated")
-    TRANSFER__UPDATED("transfer.updated");
+    TRANSFER__UPDATED("transfer.updated"),
+
+    @SerializedName("treasury.credit_reversal.created")
+    TREASURY__CREDIT_REVERSAL__CREATED("treasury.credit_reversal.created"),
+
+    @SerializedName("treasury.credit_reversal.posted")
+    TREASURY__CREDIT_REVERSAL__POSTED("treasury.credit_reversal.posted"),
+
+    @SerializedName("treasury.debit_reversal.completed")
+    TREASURY__DEBIT_REVERSAL__COMPLETED("treasury.debit_reversal.completed"),
+
+    @SerializedName("treasury.debit_reversal.created")
+    TREASURY__DEBIT_REVERSAL__CREATED("treasury.debit_reversal.created"),
+
+    @SerializedName("treasury.debit_reversal.initial_credit_granted")
+    TREASURY__DEBIT_REVERSAL__INITIAL_CREDIT_GRANTED(
+        "treasury.debit_reversal.initial_credit_granted"),
+
+    @SerializedName("treasury.financial_account.closed")
+    TREASURY__FINANCIAL_ACCOUNT__CLOSED("treasury.financial_account.closed"),
+
+    @SerializedName("treasury.financial_account.created")
+    TREASURY__FINANCIAL_ACCOUNT__CREATED("treasury.financial_account.created"),
+
+    @SerializedName("treasury.financial_account.features_status_updated")
+    TREASURY__FINANCIAL_ACCOUNT__FEATURES_STATUS_UPDATED(
+        "treasury.financial_account.features_status_updated"),
+
+    @SerializedName("treasury.inbound_transfer.canceled")
+    TREASURY__INBOUND_TRANSFER__CANCELED("treasury.inbound_transfer.canceled"),
+
+    @SerializedName("treasury.inbound_transfer.created")
+    TREASURY__INBOUND_TRANSFER__CREATED("treasury.inbound_transfer.created"),
+
+    @SerializedName("treasury.inbound_transfer.failed")
+    TREASURY__INBOUND_TRANSFER__FAILED("treasury.inbound_transfer.failed"),
+
+    @SerializedName("treasury.inbound_transfer.succeeded")
+    TREASURY__INBOUND_TRANSFER__SUCCEEDED("treasury.inbound_transfer.succeeded"),
+
+    @SerializedName("treasury.outbound_payment.canceled")
+    TREASURY__OUTBOUND_PAYMENT__CANCELED("treasury.outbound_payment.canceled"),
+
+    @SerializedName("treasury.outbound_payment.created")
+    TREASURY__OUTBOUND_PAYMENT__CREATED("treasury.outbound_payment.created"),
+
+    @SerializedName("treasury.outbound_payment.expected_arrival_date_updated")
+    TREASURY__OUTBOUND_PAYMENT__EXPECTED_ARRIVAL_DATE_UPDATED(
+        "treasury.outbound_payment.expected_arrival_date_updated"),
+
+    @SerializedName("treasury.outbound_payment.failed")
+    TREASURY__OUTBOUND_PAYMENT__FAILED("treasury.outbound_payment.failed"),
+
+    @SerializedName("treasury.outbound_payment.posted")
+    TREASURY__OUTBOUND_PAYMENT__POSTED("treasury.outbound_payment.posted"),
+
+    @SerializedName("treasury.outbound_payment.returned")
+    TREASURY__OUTBOUND_PAYMENT__RETURNED("treasury.outbound_payment.returned"),
+
+    @SerializedName("treasury.outbound_transfer.canceled")
+    TREASURY__OUTBOUND_TRANSFER__CANCELED("treasury.outbound_transfer.canceled"),
+
+    @SerializedName("treasury.outbound_transfer.created")
+    TREASURY__OUTBOUND_TRANSFER__CREATED("treasury.outbound_transfer.created"),
+
+    @SerializedName("treasury.outbound_transfer.expected_arrival_date_updated")
+    TREASURY__OUTBOUND_TRANSFER__EXPECTED_ARRIVAL_DATE_UPDATED(
+        "treasury.outbound_transfer.expected_arrival_date_updated"),
+
+    @SerializedName("treasury.outbound_transfer.failed")
+    TREASURY__OUTBOUND_TRANSFER__FAILED("treasury.outbound_transfer.failed"),
+
+    @SerializedName("treasury.outbound_transfer.posted")
+    TREASURY__OUTBOUND_TRANSFER__POSTED("treasury.outbound_transfer.posted"),
+
+    @SerializedName("treasury.outbound_transfer.returned")
+    TREASURY__OUTBOUND_TRANSFER__RETURNED("treasury.outbound_transfer.returned"),
+
+    @SerializedName("treasury.received_credit.created")
+    TREASURY__RECEIVED_CREDIT__CREATED("treasury.received_credit.created"),
+
+    @SerializedName("treasury.received_credit.failed")
+    TREASURY__RECEIVED_CREDIT__FAILED("treasury.received_credit.failed"),
+
+    @SerializedName("treasury.received_credit.reversed")
+    TREASURY__RECEIVED_CREDIT__REVERSED("treasury.received_credit.reversed"),
+
+    @SerializedName("treasury.received_credit.succeeded")
+    TREASURY__RECEIVED_CREDIT__SUCCEEDED("treasury.received_credit.succeeded"),
+
+    @SerializedName("treasury.received_debit.created")
+    TREASURY__RECEIVED_DEBIT__CREATED("treasury.received_debit.created");
 
     @Getter(onMethod_ = {@Override})
     private final String value;

--- a/src/main/java/com/stripe/param/WebhookEndpointUpdateParams.java
+++ b/src/main/java/com/stripe/param/WebhookEndpointUpdateParams.java
@@ -829,7 +829,98 @@ public class WebhookEndpointUpdateParams extends ApiRequestParams {
     TRANSFER__REVERSED("transfer.reversed"),
 
     @SerializedName("transfer.updated")
-    TRANSFER__UPDATED("transfer.updated");
+    TRANSFER__UPDATED("transfer.updated"),
+
+    @SerializedName("treasury.credit_reversal.created")
+    TREASURY__CREDIT_REVERSAL__CREATED("treasury.credit_reversal.created"),
+
+    @SerializedName("treasury.credit_reversal.posted")
+    TREASURY__CREDIT_REVERSAL__POSTED("treasury.credit_reversal.posted"),
+
+    @SerializedName("treasury.debit_reversal.completed")
+    TREASURY__DEBIT_REVERSAL__COMPLETED("treasury.debit_reversal.completed"),
+
+    @SerializedName("treasury.debit_reversal.created")
+    TREASURY__DEBIT_REVERSAL__CREATED("treasury.debit_reversal.created"),
+
+    @SerializedName("treasury.debit_reversal.initial_credit_granted")
+    TREASURY__DEBIT_REVERSAL__INITIAL_CREDIT_GRANTED(
+        "treasury.debit_reversal.initial_credit_granted"),
+
+    @SerializedName("treasury.financial_account.closed")
+    TREASURY__FINANCIAL_ACCOUNT__CLOSED("treasury.financial_account.closed"),
+
+    @SerializedName("treasury.financial_account.created")
+    TREASURY__FINANCIAL_ACCOUNT__CREATED("treasury.financial_account.created"),
+
+    @SerializedName("treasury.financial_account.features_status_updated")
+    TREASURY__FINANCIAL_ACCOUNT__FEATURES_STATUS_UPDATED(
+        "treasury.financial_account.features_status_updated"),
+
+    @SerializedName("treasury.inbound_transfer.canceled")
+    TREASURY__INBOUND_TRANSFER__CANCELED("treasury.inbound_transfer.canceled"),
+
+    @SerializedName("treasury.inbound_transfer.created")
+    TREASURY__INBOUND_TRANSFER__CREATED("treasury.inbound_transfer.created"),
+
+    @SerializedName("treasury.inbound_transfer.failed")
+    TREASURY__INBOUND_TRANSFER__FAILED("treasury.inbound_transfer.failed"),
+
+    @SerializedName("treasury.inbound_transfer.succeeded")
+    TREASURY__INBOUND_TRANSFER__SUCCEEDED("treasury.inbound_transfer.succeeded"),
+
+    @SerializedName("treasury.outbound_payment.canceled")
+    TREASURY__OUTBOUND_PAYMENT__CANCELED("treasury.outbound_payment.canceled"),
+
+    @SerializedName("treasury.outbound_payment.created")
+    TREASURY__OUTBOUND_PAYMENT__CREATED("treasury.outbound_payment.created"),
+
+    @SerializedName("treasury.outbound_payment.expected_arrival_date_updated")
+    TREASURY__OUTBOUND_PAYMENT__EXPECTED_ARRIVAL_DATE_UPDATED(
+        "treasury.outbound_payment.expected_arrival_date_updated"),
+
+    @SerializedName("treasury.outbound_payment.failed")
+    TREASURY__OUTBOUND_PAYMENT__FAILED("treasury.outbound_payment.failed"),
+
+    @SerializedName("treasury.outbound_payment.posted")
+    TREASURY__OUTBOUND_PAYMENT__POSTED("treasury.outbound_payment.posted"),
+
+    @SerializedName("treasury.outbound_payment.returned")
+    TREASURY__OUTBOUND_PAYMENT__RETURNED("treasury.outbound_payment.returned"),
+
+    @SerializedName("treasury.outbound_transfer.canceled")
+    TREASURY__OUTBOUND_TRANSFER__CANCELED("treasury.outbound_transfer.canceled"),
+
+    @SerializedName("treasury.outbound_transfer.created")
+    TREASURY__OUTBOUND_TRANSFER__CREATED("treasury.outbound_transfer.created"),
+
+    @SerializedName("treasury.outbound_transfer.expected_arrival_date_updated")
+    TREASURY__OUTBOUND_TRANSFER__EXPECTED_ARRIVAL_DATE_UPDATED(
+        "treasury.outbound_transfer.expected_arrival_date_updated"),
+
+    @SerializedName("treasury.outbound_transfer.failed")
+    TREASURY__OUTBOUND_TRANSFER__FAILED("treasury.outbound_transfer.failed"),
+
+    @SerializedName("treasury.outbound_transfer.posted")
+    TREASURY__OUTBOUND_TRANSFER__POSTED("treasury.outbound_transfer.posted"),
+
+    @SerializedName("treasury.outbound_transfer.returned")
+    TREASURY__OUTBOUND_TRANSFER__RETURNED("treasury.outbound_transfer.returned"),
+
+    @SerializedName("treasury.received_credit.created")
+    TREASURY__RECEIVED_CREDIT__CREATED("treasury.received_credit.created"),
+
+    @SerializedName("treasury.received_credit.failed")
+    TREASURY__RECEIVED_CREDIT__FAILED("treasury.received_credit.failed"),
+
+    @SerializedName("treasury.received_credit.reversed")
+    TREASURY__RECEIVED_CREDIT__REVERSED("treasury.received_credit.reversed"),
+
+    @SerializedName("treasury.received_credit.succeeded")
+    TREASURY__RECEIVED_CREDIT__SUCCEEDED("treasury.received_credit.succeeded"),
+
+    @SerializedName("treasury.received_debit.created")
+    TREASURY__RECEIVED_DEBIT__CREATED("treasury.received_debit.created");
 
     @Getter(onMethod_ = {@Override})
     private final String value;

--- a/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
+++ b/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
@@ -187,6 +187,9 @@ public class SessionCreateParams extends ApiRequestParams {
   /**
    * A list of the types of payment methods (e.g., {@code card}) this Checkout Session can accept.
    *
+   * <p>Do not include this attribute if you prefer to manage your payment methods from the <a
+   * href="https://dashboard.stripe.com/settings/payment_methods">Stripe Dashboard</a>.
+   *
    * <p>Read more about the supported payment methods and their requirements in our <a
    * href="https://stripe.com/docs/payments/checkout/payment-methods">payment method details
    * guide</a>.

--- a/src/main/java/com/stripe/param/financialconnections/AccountListOwnersParams.java
+++ b/src/main/java/com/stripe/param/financialconnections/AccountListOwnersParams.java
@@ -1,0 +1,188 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.financialconnections;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class AccountListOwnersParams extends ApiRequestParams {
+  /**
+   * A cursor for use in pagination. {@code ending_before} is an object ID that defines your place
+   * in the list. For instance, if you make a list request and receive 100 objects, starting with
+   * {@code obj_bar}, your subsequent call can include {@code ending_before=obj_bar} in order to
+   * fetch the previous page of the list.
+   */
+  @SerializedName("ending_before")
+  String endingBefore;
+
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  /**
+   * A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+   * default is 10.
+   */
+  @SerializedName("limit")
+  Long limit;
+
+  /** The ID of the ownership object to fetch owners from. */
+  @SerializedName("ownership")
+  String ownership;
+
+  /**
+   * A cursor for use in pagination. {@code starting_after} is an object ID that defines your place
+   * in the list. For instance, if you make a list request and receive 100 objects, ending with
+   * {@code obj_foo}, your subsequent call can include {@code starting_after=obj_foo} in order to
+   * fetch the next page of the list.
+   */
+  @SerializedName("starting_after")
+  String startingAfter;
+
+  private AccountListOwnersParams(
+      String endingBefore,
+      List<String> expand,
+      Map<String, Object> extraParams,
+      Long limit,
+      String ownership,
+      String startingAfter) {
+    this.endingBefore = endingBefore;
+    this.expand = expand;
+    this.extraParams = extraParams;
+    this.limit = limit;
+    this.ownership = ownership;
+    this.startingAfter = startingAfter;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String endingBefore;
+
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    private Long limit;
+
+    private String ownership;
+
+    private String startingAfter;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public AccountListOwnersParams build() {
+      return new AccountListOwnersParams(
+          this.endingBefore,
+          this.expand,
+          this.extraParams,
+          this.limit,
+          this.ownership,
+          this.startingAfter);
+    }
+
+    /**
+     * A cursor for use in pagination. {@code ending_before} is an object ID that defines your place
+     * in the list. For instance, if you make a list request and receive 100 objects, starting with
+     * {@code obj_bar}, your subsequent call can include {@code ending_before=obj_bar} in order to
+     * fetch the previous page of the list.
+     */
+    public Builder setEndingBefore(String endingBefore) {
+      this.endingBefore = endingBefore;
+      return this;
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * AccountListOwnersParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * AccountListOwnersParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * AccountListOwnersParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link AccountListOwnersParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /**
+     * A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+     * default is 10.
+     */
+    public Builder setLimit(Long limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    /** The ID of the ownership object to fetch owners from. */
+    public Builder setOwnership(String ownership) {
+      this.ownership = ownership;
+      return this;
+    }
+
+    /**
+     * A cursor for use in pagination. {@code starting_after} is an object ID that defines your
+     * place in the list. For instance, if you make a list request and receive 100 objects, ending
+     * with {@code obj_foo}, your subsequent call can include {@code starting_after=obj_foo} in
+     * order to fetch the next page of the list.
+     */
+    public Builder setStartingAfter(String startingAfter) {
+      this.startingAfter = startingAfter;
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/financialconnections/AccountListParams.java
+++ b/src/main/java/com/stripe/param/financialconnections/AccountListParams.java
@@ -1,0 +1,290 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.financialconnections;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class AccountListParams extends ApiRequestParams {
+  /**
+   * If present, only return accounts that belong to the specified account holder. {@code
+   * account_holder[customer]} and {@code account_holder[account]} are mutually exclusive.
+   */
+  @SerializedName("account_holder")
+  AccountHolder accountHolder;
+
+  /**
+   * A cursor for use in pagination. {@code ending_before} is an object ID that defines your place
+   * in the list. For instance, if you make a list request and receive 100 objects, starting with
+   * {@code obj_bar}, your subsequent call can include {@code ending_before=obj_bar} in order to
+   * fetch the previous page of the list.
+   */
+  @SerializedName("ending_before")
+  String endingBefore;
+
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  /**
+   * A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+   * default is 10.
+   */
+  @SerializedName("limit")
+  Long limit;
+
+  /** If present, only return accounts that were collected as part of the given session. */
+  @SerializedName("session")
+  String session;
+
+  /**
+   * A cursor for use in pagination. {@code starting_after} is an object ID that defines your place
+   * in the list. For instance, if you make a list request and receive 100 objects, ending with
+   * {@code obj_foo}, your subsequent call can include {@code starting_after=obj_foo} in order to
+   * fetch the next page of the list.
+   */
+  @SerializedName("starting_after")
+  String startingAfter;
+
+  private AccountListParams(
+      AccountHolder accountHolder,
+      String endingBefore,
+      List<String> expand,
+      Map<String, Object> extraParams,
+      Long limit,
+      String session,
+      String startingAfter) {
+    this.accountHolder = accountHolder;
+    this.endingBefore = endingBefore;
+    this.expand = expand;
+    this.extraParams = extraParams;
+    this.limit = limit;
+    this.session = session;
+    this.startingAfter = startingAfter;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private AccountHolder accountHolder;
+
+    private String endingBefore;
+
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    private Long limit;
+
+    private String session;
+
+    private String startingAfter;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public AccountListParams build() {
+      return new AccountListParams(
+          this.accountHolder,
+          this.endingBefore,
+          this.expand,
+          this.extraParams,
+          this.limit,
+          this.session,
+          this.startingAfter);
+    }
+
+    /**
+     * If present, only return accounts that belong to the specified account holder. {@code
+     * account_holder[customer]} and {@code account_holder[account]} are mutually exclusive.
+     */
+    public Builder setAccountHolder(AccountHolder accountHolder) {
+      this.accountHolder = accountHolder;
+      return this;
+    }
+
+    /**
+     * A cursor for use in pagination. {@code ending_before} is an object ID that defines your place
+     * in the list. For instance, if you make a list request and receive 100 objects, starting with
+     * {@code obj_bar}, your subsequent call can include {@code ending_before=obj_bar} in order to
+     * fetch the previous page of the list.
+     */
+    public Builder setEndingBefore(String endingBefore) {
+      this.endingBefore = endingBefore;
+      return this;
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * AccountListParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * AccountListParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * AccountListParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link AccountListParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /**
+     * A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+     * default is 10.
+     */
+    public Builder setLimit(Long limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    /** If present, only return accounts that were collected as part of the given session. */
+    public Builder setSession(String session) {
+      this.session = session;
+      return this;
+    }
+
+    /**
+     * A cursor for use in pagination. {@code starting_after} is an object ID that defines your
+     * place in the list. For instance, if you make a list request and receive 100 objects, ending
+     * with {@code obj_foo}, your subsequent call can include {@code starting_after=obj_foo} in
+     * order to fetch the next page of the list.
+     */
+    public Builder setStartingAfter(String startingAfter) {
+      this.startingAfter = startingAfter;
+      return this;
+    }
+  }
+
+  @Getter
+  public static class AccountHolder {
+    /** The ID of the Stripe account whose accounts will be retrieved. */
+    @SerializedName("account")
+    String account;
+
+    /** The ID of the Stripe customer whose accounts will be retrieved. */
+    @SerializedName("customer")
+    String customer;
+
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    private AccountHolder(String account, String customer, Map<String, Object> extraParams) {
+      this.account = account;
+      this.customer = customer;
+      this.extraParams = extraParams;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private String account;
+
+      private String customer;
+
+      private Map<String, Object> extraParams;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public AccountHolder build() {
+        return new AccountHolder(this.account, this.customer, this.extraParams);
+      }
+
+      /** The ID of the Stripe account whose accounts will be retrieved. */
+      public Builder setAccount(String account) {
+        this.account = account;
+        return this;
+      }
+
+      /** The ID of the Stripe customer whose accounts will be retrieved. */
+      public Builder setCustomer(String customer) {
+        this.customer = customer;
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * AccountListParams.AccountHolder#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link AccountListParams.AccountHolder#extraParams} for the field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/issuing/CardCreateParams.java
+++ b/src/main/java/com/stripe/param/issuing/CardCreateParams.java
@@ -35,6 +35,9 @@ public class CardCreateParams extends ApiRequestParams {
   @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
   Map<String, Object> extraParams;
 
+  @SerializedName("financial_account")
+  String financialAccount;
+
   /**
    * Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can attach
    * to an object. This can be useful for storing additional information about the object in a
@@ -79,6 +82,7 @@ public class CardCreateParams extends ApiRequestParams {
       String currency,
       List<String> expand,
       Map<String, Object> extraParams,
+      String financialAccount,
       Map<String, String> metadata,
       String replacementFor,
       ReplacementReason replacementReason,
@@ -90,6 +94,7 @@ public class CardCreateParams extends ApiRequestParams {
     this.currency = currency;
     this.expand = expand;
     this.extraParams = extraParams;
+    this.financialAccount = financialAccount;
     this.metadata = metadata;
     this.replacementFor = replacementFor;
     this.replacementReason = replacementReason;
@@ -112,6 +117,8 @@ public class CardCreateParams extends ApiRequestParams {
 
     private Map<String, Object> extraParams;
 
+    private String financialAccount;
+
     private Map<String, String> metadata;
 
     private String replacementFor;
@@ -133,6 +140,7 @@ public class CardCreateParams extends ApiRequestParams {
           this.currency,
           this.expand,
           this.extraParams,
+          this.financialAccount,
           this.metadata,
           this.replacementFor,
           this.replacementReason,
@@ -206,6 +214,11 @@ public class CardCreateParams extends ApiRequestParams {
         this.extraParams = new HashMap<>();
       }
       this.extraParams.putAll(map);
+      return this;
+    }
+
+    public Builder setFinancialAccount(String financialAccount) {
+      this.financialAccount = financialAccount;
       return this;
     }
 

--- a/src/main/java/com/stripe/param/issuing/DisputeCreateParams.java
+++ b/src/main/java/com/stripe/param/issuing/DisputeCreateParams.java
@@ -46,17 +46,23 @@ public class DisputeCreateParams extends ApiRequestParams {
   @SerializedName("transaction")
   String transaction;
 
+  /** Params for disputes related to Treasury FinancialAccounts. */
+  @SerializedName("treasury")
+  Treasury treasury;
+
   private DisputeCreateParams(
       Evidence evidence,
       List<String> expand,
       Map<String, Object> extraParams,
       Map<String, String> metadata,
-      String transaction) {
+      String transaction,
+      Treasury treasury) {
     this.evidence = evidence;
     this.expand = expand;
     this.extraParams = extraParams;
     this.metadata = metadata;
     this.transaction = transaction;
+    this.treasury = treasury;
   }
 
   public static Builder builder() {
@@ -74,10 +80,17 @@ public class DisputeCreateParams extends ApiRequestParams {
 
     private String transaction;
 
+    private Treasury treasury;
+
     /** Finalize and obtain parameter instance from this builder. */
     public DisputeCreateParams build() {
       return new DisputeCreateParams(
-          this.evidence, this.expand, this.extraParams, this.metadata, this.transaction);
+          this.evidence,
+          this.expand,
+          this.extraParams,
+          this.metadata,
+          this.transaction,
+          this.treasury);
     }
 
     /** Evidence provided for the dispute. */
@@ -170,6 +183,12 @@ public class DisputeCreateParams extends ApiRequestParams {
      */
     public Builder setTransaction(String transaction) {
       this.transaction = transaction;
+      return this;
+    }
+
+    /** Params for disputes related to Treasury FinancialAccounts. */
+    public Builder setTreasury(Treasury treasury) {
+      this.treasury = treasury;
       return this;
     }
   }
@@ -1719,6 +1738,74 @@ public class DisputeCreateParams extends ApiRequestParams {
 
       Reason(String value) {
         this.value = value;
+      }
+    }
+  }
+
+  @Getter
+  public static class Treasury {
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /** The ID of the ReceivedDebit to initiate an Issuings dispute for. */
+    @SerializedName("received_debit")
+    String receivedDebit;
+
+    private Treasury(Map<String, Object> extraParams, String receivedDebit) {
+      this.extraParams = extraParams;
+      this.receivedDebit = receivedDebit;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Map<String, Object> extraParams;
+
+      private String receivedDebit;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public Treasury build() {
+        return new Treasury(this.extraParams, this.receivedDebit);
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * DisputeCreateParams.Treasury#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link DisputeCreateParams.Treasury#extraParams} for the field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** The ID of the ReceivedDebit to initiate an Issuings dispute for. */
+      public Builder setReceivedDebit(String receivedDebit) {
+        this.receivedDebit = receivedDebit;
+        return this;
       }
     }
   }

--- a/src/main/java/com/stripe/param/terminal/ConfigurationCreateParams.java
+++ b/src/main/java/com/stripe/param/terminal/ConfigurationCreateParams.java
@@ -237,6 +237,10 @@ public class ConfigurationCreateParams extends ApiRequestParams {
     @SerializedName("chf")
     Chf chf;
 
+    /** Tipping configuration for CZK. */
+    @SerializedName("czk")
+    Czk czk;
+
     /** Tipping configuration for DKK. */
     @SerializedName("dkk")
     Dkk dkk;
@@ -290,6 +294,7 @@ public class ConfigurationCreateParams extends ApiRequestParams {
         Aud aud,
         Cad cad,
         Chf chf,
+        Czk czk,
         Dkk dkk,
         Eur eur,
         Map<String, Object> extraParams,
@@ -304,6 +309,7 @@ public class ConfigurationCreateParams extends ApiRequestParams {
       this.aud = aud;
       this.cad = cad;
       this.chf = chf;
+      this.czk = czk;
       this.dkk = dkk;
       this.eur = eur;
       this.extraParams = extraParams;
@@ -327,6 +333,8 @@ public class ConfigurationCreateParams extends ApiRequestParams {
       private Cad cad;
 
       private Chf chf;
+
+      private Czk czk;
 
       private Dkk dkk;
 
@@ -356,6 +364,7 @@ public class ConfigurationCreateParams extends ApiRequestParams {
             this.aud,
             this.cad,
             this.chf,
+            this.czk,
             this.dkk,
             this.eur,
             this.extraParams,
@@ -384,6 +393,12 @@ public class ConfigurationCreateParams extends ApiRequestParams {
       /** Tipping configuration for CHF. */
       public Builder setChf(Chf chf) {
         this.chf = chf;
+        return this;
+      }
+
+      /** Tipping configuration for CZK. */
+      public Builder setCzk(Czk czk) {
+        this.czk = czk;
         return this;
       }
 
@@ -895,6 +910,153 @@ public class ConfigurationCreateParams extends ApiRequestParams {
          * Add all elements to `percentages` list. A list is initialized for the first `add/addAll`
          * call, and subsequent calls adds additional elements to the original list. See {@link
          * ConfigurationCreateParams.Tipping.Chf#percentages} for the field documentation.
+         */
+        public Builder addAllPercentage(List<Long> elements) {
+          if (this.percentages == null) {
+            this.percentages = new ArrayList<>();
+          }
+          this.percentages.addAll(elements);
+          return this;
+        }
+
+        /**
+         * Below this amount, fixed amounts will be displayed; above it, percentages will be
+         * displayed.
+         */
+        public Builder setSmartTipThreshold(Long smartTipThreshold) {
+          this.smartTipThreshold = smartTipThreshold;
+          return this;
+        }
+      }
+    }
+
+    @Getter
+    public static class Czk {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Fixed amounts displayed when collecting a tip. */
+      @SerializedName("fixed_amounts")
+      List<Long> fixedAmounts;
+
+      /** Percentages displayed when collecting a tip. */
+      @SerializedName("percentages")
+      List<Long> percentages;
+
+      /**
+       * Below this amount, fixed amounts will be displayed; above it, percentages will be
+       * displayed.
+       */
+      @SerializedName("smart_tip_threshold")
+      Long smartTipThreshold;
+
+      private Czk(
+          Map<String, Object> extraParams,
+          List<Long> fixedAmounts,
+          List<Long> percentages,
+          Long smartTipThreshold) {
+        this.extraParams = extraParams;
+        this.fixedAmounts = fixedAmounts;
+        this.percentages = percentages;
+        this.smartTipThreshold = smartTipThreshold;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private List<Long> fixedAmounts;
+
+        private List<Long> percentages;
+
+        private Long smartTipThreshold;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Czk build() {
+          return new Czk(
+              this.extraParams, this.fixedAmounts, this.percentages, this.smartTipThreshold);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link ConfigurationCreateParams.Tipping.Czk#extraParams} for the field
+         * documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link ConfigurationCreateParams.Tipping.Czk#extraParams} for the field
+         * documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /**
+         * Add an element to `fixedAmounts` list. A list is initialized for the first `add/addAll`
+         * call, and subsequent calls adds additional elements to the original list. See {@link
+         * ConfigurationCreateParams.Tipping.Czk#fixedAmounts} for the field documentation.
+         */
+        public Builder addFixedAmount(Long element) {
+          if (this.fixedAmounts == null) {
+            this.fixedAmounts = new ArrayList<>();
+          }
+          this.fixedAmounts.add(element);
+          return this;
+        }
+
+        /**
+         * Add all elements to `fixedAmounts` list. A list is initialized for the first `add/addAll`
+         * call, and subsequent calls adds additional elements to the original list. See {@link
+         * ConfigurationCreateParams.Tipping.Czk#fixedAmounts} for the field documentation.
+         */
+        public Builder addAllFixedAmount(List<Long> elements) {
+          if (this.fixedAmounts == null) {
+            this.fixedAmounts = new ArrayList<>();
+          }
+          this.fixedAmounts.addAll(elements);
+          return this;
+        }
+
+        /**
+         * Add an element to `percentages` list. A list is initialized for the first `add/addAll`
+         * call, and subsequent calls adds additional elements to the original list. See {@link
+         * ConfigurationCreateParams.Tipping.Czk#percentages} for the field documentation.
+         */
+        public Builder addPercentage(Long element) {
+          if (this.percentages == null) {
+            this.percentages = new ArrayList<>();
+          }
+          this.percentages.add(element);
+          return this;
+        }
+
+        /**
+         * Add all elements to `percentages` list. A list is initialized for the first `add/addAll`
+         * call, and subsequent calls adds additional elements to the original list. See {@link
+         * ConfigurationCreateParams.Tipping.Czk#percentages} for the field documentation.
          */
         public Builder addAllPercentage(List<Long> elements) {
           if (this.percentages == null) {

--- a/src/main/java/com/stripe/param/terminal/ConfigurationUpdateParams.java
+++ b/src/main/java/com/stripe/param/terminal/ConfigurationUpdateParams.java
@@ -249,6 +249,10 @@ public class ConfigurationUpdateParams extends ApiRequestParams {
     @SerializedName("chf")
     Chf chf;
 
+    /** Tipping configuration for CZK. */
+    @SerializedName("czk")
+    Czk czk;
+
     /** Tipping configuration for DKK. */
     @SerializedName("dkk")
     Dkk dkk;
@@ -302,6 +306,7 @@ public class ConfigurationUpdateParams extends ApiRequestParams {
         Aud aud,
         Cad cad,
         Chf chf,
+        Czk czk,
         Dkk dkk,
         Eur eur,
         Map<String, Object> extraParams,
@@ -316,6 +321,7 @@ public class ConfigurationUpdateParams extends ApiRequestParams {
       this.aud = aud;
       this.cad = cad;
       this.chf = chf;
+      this.czk = czk;
       this.dkk = dkk;
       this.eur = eur;
       this.extraParams = extraParams;
@@ -339,6 +345,8 @@ public class ConfigurationUpdateParams extends ApiRequestParams {
       private Cad cad;
 
       private Chf chf;
+
+      private Czk czk;
 
       private Dkk dkk;
 
@@ -368,6 +376,7 @@ public class ConfigurationUpdateParams extends ApiRequestParams {
             this.aud,
             this.cad,
             this.chf,
+            this.czk,
             this.dkk,
             this.eur,
             this.extraParams,
@@ -396,6 +405,12 @@ public class ConfigurationUpdateParams extends ApiRequestParams {
       /** Tipping configuration for CHF. */
       public Builder setChf(Chf chf) {
         this.chf = chf;
+        return this;
+      }
+
+      /** Tipping configuration for CZK. */
+      public Builder setCzk(Czk czk) {
+        this.czk = czk;
         return this;
       }
 
@@ -907,6 +922,153 @@ public class ConfigurationUpdateParams extends ApiRequestParams {
          * Add all elements to `percentages` list. A list is initialized for the first `add/addAll`
          * call, and subsequent calls adds additional elements to the original list. See {@link
          * ConfigurationUpdateParams.Tipping.Chf#percentages} for the field documentation.
+         */
+        public Builder addAllPercentage(List<Long> elements) {
+          if (this.percentages == null) {
+            this.percentages = new ArrayList<>();
+          }
+          this.percentages.addAll(elements);
+          return this;
+        }
+
+        /**
+         * Below this amount, fixed amounts will be displayed; above it, percentages will be
+         * displayed.
+         */
+        public Builder setSmartTipThreshold(Long smartTipThreshold) {
+          this.smartTipThreshold = smartTipThreshold;
+          return this;
+        }
+      }
+    }
+
+    @Getter
+    public static class Czk {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Fixed amounts displayed when collecting a tip. */
+      @SerializedName("fixed_amounts")
+      List<Long> fixedAmounts;
+
+      /** Percentages displayed when collecting a tip. */
+      @SerializedName("percentages")
+      List<Long> percentages;
+
+      /**
+       * Below this amount, fixed amounts will be displayed; above it, percentages will be
+       * displayed.
+       */
+      @SerializedName("smart_tip_threshold")
+      Long smartTipThreshold;
+
+      private Czk(
+          Map<String, Object> extraParams,
+          List<Long> fixedAmounts,
+          List<Long> percentages,
+          Long smartTipThreshold) {
+        this.extraParams = extraParams;
+        this.fixedAmounts = fixedAmounts;
+        this.percentages = percentages;
+        this.smartTipThreshold = smartTipThreshold;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private List<Long> fixedAmounts;
+
+        private List<Long> percentages;
+
+        private Long smartTipThreshold;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Czk build() {
+          return new Czk(
+              this.extraParams, this.fixedAmounts, this.percentages, this.smartTipThreshold);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link ConfigurationUpdateParams.Tipping.Czk#extraParams} for the field
+         * documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link ConfigurationUpdateParams.Tipping.Czk#extraParams} for the field
+         * documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /**
+         * Add an element to `fixedAmounts` list. A list is initialized for the first `add/addAll`
+         * call, and subsequent calls adds additional elements to the original list. See {@link
+         * ConfigurationUpdateParams.Tipping.Czk#fixedAmounts} for the field documentation.
+         */
+        public Builder addFixedAmount(Long element) {
+          if (this.fixedAmounts == null) {
+            this.fixedAmounts = new ArrayList<>();
+          }
+          this.fixedAmounts.add(element);
+          return this;
+        }
+
+        /**
+         * Add all elements to `fixedAmounts` list. A list is initialized for the first `add/addAll`
+         * call, and subsequent calls adds additional elements to the original list. See {@link
+         * ConfigurationUpdateParams.Tipping.Czk#fixedAmounts} for the field documentation.
+         */
+        public Builder addAllFixedAmount(List<Long> elements) {
+          if (this.fixedAmounts == null) {
+            this.fixedAmounts = new ArrayList<>();
+          }
+          this.fixedAmounts.addAll(elements);
+          return this;
+        }
+
+        /**
+         * Add an element to `percentages` list. A list is initialized for the first `add/addAll`
+         * call, and subsequent calls adds additional elements to the original list. See {@link
+         * ConfigurationUpdateParams.Tipping.Czk#percentages} for the field documentation.
+         */
+        public Builder addPercentage(Long element) {
+          if (this.percentages == null) {
+            this.percentages = new ArrayList<>();
+          }
+          this.percentages.add(element);
+          return this;
+        }
+
+        /**
+         * Add all elements to `percentages` list. A list is initialized for the first `add/addAll`
+         * call, and subsequent calls adds additional elements to the original list. See {@link
+         * ConfigurationUpdateParams.Tipping.Czk#percentages} for the field documentation.
          */
         public Builder addAllPercentage(List<Long> elements) {
           if (this.percentages == null) {

--- a/src/main/java/com/stripe/param/treasury/CreditReversalCreateParams.java
+++ b/src/main/java/com/stripe/param/treasury/CreditReversalCreateParams.java
@@ -1,0 +1,154 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class CreditReversalCreateParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  /**
+   * Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can attach
+   * to an object. This can be useful for storing additional information about the object in a
+   * structured format. Individual keys can be unset by posting an empty value to them. All keys can
+   * be unset by posting an empty value to {@code metadata}.
+   */
+  @SerializedName("metadata")
+  Map<String, String> metadata;
+
+  /** The ReceivedCredit to reverse. */
+  @SerializedName("received_credit")
+  String receivedCredit;
+
+  private CreditReversalCreateParams(
+      List<String> expand,
+      Map<String, Object> extraParams,
+      Map<String, String> metadata,
+      String receivedCredit) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+    this.metadata = metadata;
+    this.receivedCredit = receivedCredit;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    private Map<String, String> metadata;
+
+    private String receivedCredit;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public CreditReversalCreateParams build() {
+      return new CreditReversalCreateParams(
+          this.expand, this.extraParams, this.metadata, this.receivedCredit);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * CreditReversalCreateParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * CreditReversalCreateParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * CreditReversalCreateParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link CreditReversalCreateParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `metadata` map. A map is initialized for the first `put/putAll` call,
+     * and subsequent calls add additional key/value pairs to the original map. See {@link
+     * CreditReversalCreateParams#metadata} for the field documentation.
+     */
+    public Builder putMetadata(String key, String value) {
+      if (this.metadata == null) {
+        this.metadata = new HashMap<>();
+      }
+      this.metadata.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `metadata` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link CreditReversalCreateParams#metadata} for the field documentation.
+     */
+    public Builder putAllMetadata(Map<String, String> map) {
+      if (this.metadata == null) {
+        this.metadata = new HashMap<>();
+      }
+      this.metadata.putAll(map);
+      return this;
+    }
+
+    /** The ReceivedCredit to reverse. */
+    public Builder setReceivedCredit(String receivedCredit) {
+      this.receivedCredit = receivedCredit;
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/CreditReversalListParams.java
+++ b/src/main/java/com/stripe/param/treasury/CreditReversalListParams.java
@@ -1,0 +1,236 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class CreditReversalListParams extends ApiRequestParams {
+  /**
+   * A cursor for use in pagination. {@code ending_before} is an object ID that defines your place
+   * in the list. For instance, if you make a list request and receive 100 objects, starting with
+   * {@code obj_bar}, your subsequent call can include {@code ending_before=obj_bar} in order to
+   * fetch the previous page of the list.
+   */
+  @SerializedName("ending_before")
+  String endingBefore;
+
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  /** Returns objects associated with this FinancialAccount. */
+  @SerializedName("financial_account")
+  String financialAccount;
+
+  /**
+   * A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+   * default is 10.
+   */
+  @SerializedName("limit")
+  Long limit;
+
+  /** Only return CreditReversals for the ReceivedCredit ID. */
+  @SerializedName("received_credit")
+  String receivedCredit;
+
+  /**
+   * A cursor for use in pagination. {@code starting_after} is an object ID that defines your place
+   * in the list. For instance, if you make a list request and receive 100 objects, ending with
+   * {@code obj_foo}, your subsequent call can include {@code starting_after=obj_foo} in order to
+   * fetch the next page of the list.
+   */
+  @SerializedName("starting_after")
+  String startingAfter;
+
+  /** Only return CreditReversals for a given status. */
+  @SerializedName("status")
+  Status status;
+
+  private CreditReversalListParams(
+      String endingBefore,
+      List<String> expand,
+      Map<String, Object> extraParams,
+      String financialAccount,
+      Long limit,
+      String receivedCredit,
+      String startingAfter,
+      Status status) {
+    this.endingBefore = endingBefore;
+    this.expand = expand;
+    this.extraParams = extraParams;
+    this.financialAccount = financialAccount;
+    this.limit = limit;
+    this.receivedCredit = receivedCredit;
+    this.startingAfter = startingAfter;
+    this.status = status;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String endingBefore;
+
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    private String financialAccount;
+
+    private Long limit;
+
+    private String receivedCredit;
+
+    private String startingAfter;
+
+    private Status status;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public CreditReversalListParams build() {
+      return new CreditReversalListParams(
+          this.endingBefore,
+          this.expand,
+          this.extraParams,
+          this.financialAccount,
+          this.limit,
+          this.receivedCredit,
+          this.startingAfter,
+          this.status);
+    }
+
+    /**
+     * A cursor for use in pagination. {@code ending_before} is an object ID that defines your place
+     * in the list. For instance, if you make a list request and receive 100 objects, starting with
+     * {@code obj_bar}, your subsequent call can include {@code ending_before=obj_bar} in order to
+     * fetch the previous page of the list.
+     */
+    public Builder setEndingBefore(String endingBefore) {
+      this.endingBefore = endingBefore;
+      return this;
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * CreditReversalListParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * CreditReversalListParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * CreditReversalListParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link CreditReversalListParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /** Returns objects associated with this FinancialAccount. */
+    public Builder setFinancialAccount(String financialAccount) {
+      this.financialAccount = financialAccount;
+      return this;
+    }
+
+    /**
+     * A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+     * default is 10.
+     */
+    public Builder setLimit(Long limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    /** Only return CreditReversals for the ReceivedCredit ID. */
+    public Builder setReceivedCredit(String receivedCredit) {
+      this.receivedCredit = receivedCredit;
+      return this;
+    }
+
+    /**
+     * A cursor for use in pagination. {@code starting_after} is an object ID that defines your
+     * place in the list. For instance, if you make a list request and receive 100 objects, ending
+     * with {@code obj_foo}, your subsequent call can include {@code starting_after=obj_foo} in
+     * order to fetch the next page of the list.
+     */
+    public Builder setStartingAfter(String startingAfter) {
+      this.startingAfter = startingAfter;
+      return this;
+    }
+
+    /** Only return CreditReversals for a given status. */
+    public Builder setStatus(Status status) {
+      this.status = status;
+      return this;
+    }
+  }
+
+  public enum Status implements ApiRequestParams.EnumParam {
+    @SerializedName("canceled")
+    CANCELED("canceled"),
+
+    @SerializedName("posted")
+    POSTED("posted"),
+
+    @SerializedName("processing")
+    PROCESSING("processing");
+
+    @Getter(onMethod_ = {@Override})
+    private final String value;
+
+    Status(String value) {
+      this.value = value;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/CreditReversalRetrieveParams.java
+++ b/src/main/java/com/stripe/param/treasury/CreditReversalRetrieveParams.java
@@ -1,0 +1,98 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class CreditReversalRetrieveParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  private CreditReversalRetrieveParams(List<String> expand, Map<String, Object> extraParams) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public CreditReversalRetrieveParams build() {
+      return new CreditReversalRetrieveParams(this.expand, this.extraParams);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * CreditReversalRetrieveParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * CreditReversalRetrieveParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * CreditReversalRetrieveParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link CreditReversalRetrieveParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/DebitReversalCreateParams.java
+++ b/src/main/java/com/stripe/param/treasury/DebitReversalCreateParams.java
@@ -1,0 +1,154 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class DebitReversalCreateParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  /**
+   * Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can attach
+   * to an object. This can be useful for storing additional information about the object in a
+   * structured format. Individual keys can be unset by posting an empty value to them. All keys can
+   * be unset by posting an empty value to {@code metadata}.
+   */
+  @SerializedName("metadata")
+  Map<String, String> metadata;
+
+  /** The ReceivedDebit to reverse. */
+  @SerializedName("received_debit")
+  String receivedDebit;
+
+  private DebitReversalCreateParams(
+      List<String> expand,
+      Map<String, Object> extraParams,
+      Map<String, String> metadata,
+      String receivedDebit) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+    this.metadata = metadata;
+    this.receivedDebit = receivedDebit;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    private Map<String, String> metadata;
+
+    private String receivedDebit;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public DebitReversalCreateParams build() {
+      return new DebitReversalCreateParams(
+          this.expand, this.extraParams, this.metadata, this.receivedDebit);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * DebitReversalCreateParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * DebitReversalCreateParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * DebitReversalCreateParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link DebitReversalCreateParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `metadata` map. A map is initialized for the first `put/putAll` call,
+     * and subsequent calls add additional key/value pairs to the original map. See {@link
+     * DebitReversalCreateParams#metadata} for the field documentation.
+     */
+    public Builder putMetadata(String key, String value) {
+      if (this.metadata == null) {
+        this.metadata = new HashMap<>();
+      }
+      this.metadata.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `metadata` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link DebitReversalCreateParams#metadata} for the field documentation.
+     */
+    public Builder putAllMetadata(Map<String, String> map) {
+      if (this.metadata == null) {
+        this.metadata = new HashMap<>();
+      }
+      this.metadata.putAll(map);
+      return this;
+    }
+
+    /** The ReceivedDebit to reverse. */
+    public Builder setReceivedDebit(String receivedDebit) {
+      this.receivedDebit = receivedDebit;
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/DebitReversalListParams.java
+++ b/src/main/java/com/stripe/param/treasury/DebitReversalListParams.java
@@ -1,0 +1,266 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class DebitReversalListParams extends ApiRequestParams {
+  /**
+   * A cursor for use in pagination. {@code ending_before} is an object ID that defines your place
+   * in the list. For instance, if you make a list request and receive 100 objects, starting with
+   * {@code obj_bar}, your subsequent call can include {@code ending_before=obj_bar} in order to
+   * fetch the previous page of the list.
+   */
+  @SerializedName("ending_before")
+  String endingBefore;
+
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  /** Returns objects associated with this FinancialAccount. */
+  @SerializedName("financial_account")
+  String financialAccount;
+
+  /**
+   * A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+   * default is 10.
+   */
+  @SerializedName("limit")
+  Long limit;
+
+  /** Only return DebitReversals for the ReceivedDebit ID. */
+  @SerializedName("received_debit")
+  String receivedDebit;
+
+  /** Only return DebitReversals for a given resolution. */
+  @SerializedName("resolution")
+  Resolution resolution;
+
+  /**
+   * A cursor for use in pagination. {@code starting_after} is an object ID that defines your place
+   * in the list. For instance, if you make a list request and receive 100 objects, ending with
+   * {@code obj_foo}, your subsequent call can include {@code starting_after=obj_foo} in order to
+   * fetch the next page of the list.
+   */
+  @SerializedName("starting_after")
+  String startingAfter;
+
+  /** Only return DebitReversals for a given status. */
+  @SerializedName("status")
+  Status status;
+
+  private DebitReversalListParams(
+      String endingBefore,
+      List<String> expand,
+      Map<String, Object> extraParams,
+      String financialAccount,
+      Long limit,
+      String receivedDebit,
+      Resolution resolution,
+      String startingAfter,
+      Status status) {
+    this.endingBefore = endingBefore;
+    this.expand = expand;
+    this.extraParams = extraParams;
+    this.financialAccount = financialAccount;
+    this.limit = limit;
+    this.receivedDebit = receivedDebit;
+    this.resolution = resolution;
+    this.startingAfter = startingAfter;
+    this.status = status;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String endingBefore;
+
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    private String financialAccount;
+
+    private Long limit;
+
+    private String receivedDebit;
+
+    private Resolution resolution;
+
+    private String startingAfter;
+
+    private Status status;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public DebitReversalListParams build() {
+      return new DebitReversalListParams(
+          this.endingBefore,
+          this.expand,
+          this.extraParams,
+          this.financialAccount,
+          this.limit,
+          this.receivedDebit,
+          this.resolution,
+          this.startingAfter,
+          this.status);
+    }
+
+    /**
+     * A cursor for use in pagination. {@code ending_before} is an object ID that defines your place
+     * in the list. For instance, if you make a list request and receive 100 objects, starting with
+     * {@code obj_bar}, your subsequent call can include {@code ending_before=obj_bar} in order to
+     * fetch the previous page of the list.
+     */
+    public Builder setEndingBefore(String endingBefore) {
+      this.endingBefore = endingBefore;
+      return this;
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * DebitReversalListParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * DebitReversalListParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * DebitReversalListParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link DebitReversalListParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /** Returns objects associated with this FinancialAccount. */
+    public Builder setFinancialAccount(String financialAccount) {
+      this.financialAccount = financialAccount;
+      return this;
+    }
+
+    /**
+     * A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+     * default is 10.
+     */
+    public Builder setLimit(Long limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    /** Only return DebitReversals for the ReceivedDebit ID. */
+    public Builder setReceivedDebit(String receivedDebit) {
+      this.receivedDebit = receivedDebit;
+      return this;
+    }
+
+    /** Only return DebitReversals for a given resolution. */
+    public Builder setResolution(Resolution resolution) {
+      this.resolution = resolution;
+      return this;
+    }
+
+    /**
+     * A cursor for use in pagination. {@code starting_after} is an object ID that defines your
+     * place in the list. For instance, if you make a list request and receive 100 objects, ending
+     * with {@code obj_foo}, your subsequent call can include {@code starting_after=obj_foo} in
+     * order to fetch the next page of the list.
+     */
+    public Builder setStartingAfter(String startingAfter) {
+      this.startingAfter = startingAfter;
+      return this;
+    }
+
+    /** Only return DebitReversals for a given status. */
+    public Builder setStatus(Status status) {
+      this.status = status;
+      return this;
+    }
+  }
+
+  public enum Resolution implements ApiRequestParams.EnumParam {
+    @SerializedName("lost")
+    LOST("lost"),
+
+    @SerializedName("won")
+    WON("won");
+
+    @Getter(onMethod_ = {@Override})
+    private final String value;
+
+    Resolution(String value) {
+      this.value = value;
+    }
+  }
+
+  public enum Status implements ApiRequestParams.EnumParam {
+    @SerializedName("canceled")
+    CANCELED("canceled"),
+
+    @SerializedName("completed")
+    COMPLETED("completed"),
+
+    @SerializedName("processing")
+    PROCESSING("processing");
+
+    @Getter(onMethod_ = {@Override})
+    private final String value;
+
+    Status(String value) {
+      this.value = value;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/DebitReversalRetrieveParams.java
+++ b/src/main/java/com/stripe/param/treasury/DebitReversalRetrieveParams.java
@@ -1,0 +1,98 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class DebitReversalRetrieveParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  private DebitReversalRetrieveParams(List<String> expand, Map<String, Object> extraParams) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public DebitReversalRetrieveParams build() {
+      return new DebitReversalRetrieveParams(this.expand, this.extraParams);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * DebitReversalRetrieveParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * DebitReversalRetrieveParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * DebitReversalRetrieveParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link DebitReversalRetrieveParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/FinancialAccountCreateParams.java
+++ b/src/main/java/com/stripe/param/treasury/FinancialAccountCreateParams.java
@@ -1,0 +1,1385 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class FinancialAccountCreateParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  /**
+   * Encodes whether a FinancialAccount has access to a particular feature. Stripe or the platform
+   * can control features via the requested field.
+   */
+  @SerializedName("features")
+  Features features;
+
+  /**
+   * Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can attach
+   * to an object. This can be useful for storing additional information about the object in a
+   * structured format. Individual keys can be unset by posting an empty value to them. All keys can
+   * be unset by posting an empty value to {@code metadata}.
+   */
+  @SerializedName("metadata")
+  Map<String, String> metadata;
+
+  /** The set of functionalities that the platform can restrict on the FinancialAccount. */
+  @SerializedName("platform_restrictions")
+  PlatformRestrictions platformRestrictions;
+
+  /** The currencies the FinancialAccount can hold a balance in. */
+  @SerializedName("supported_currencies")
+  List<String> supportedCurrencies;
+
+  private FinancialAccountCreateParams(
+      List<String> expand,
+      Map<String, Object> extraParams,
+      Features features,
+      Map<String, String> metadata,
+      PlatformRestrictions platformRestrictions,
+      List<String> supportedCurrencies) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+    this.features = features;
+    this.metadata = metadata;
+    this.platformRestrictions = platformRestrictions;
+    this.supportedCurrencies = supportedCurrencies;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    private Features features;
+
+    private Map<String, String> metadata;
+
+    private PlatformRestrictions platformRestrictions;
+
+    private List<String> supportedCurrencies;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public FinancialAccountCreateParams build() {
+      return new FinancialAccountCreateParams(
+          this.expand,
+          this.extraParams,
+          this.features,
+          this.metadata,
+          this.platformRestrictions,
+          this.supportedCurrencies);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * FinancialAccountCreateParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * FinancialAccountCreateParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * FinancialAccountCreateParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link FinancialAccountCreateParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /**
+     * Encodes whether a FinancialAccount has access to a particular feature. Stripe or the platform
+     * can control features via the requested field.
+     */
+    public Builder setFeatures(Features features) {
+      this.features = features;
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `metadata` map. A map is initialized for the first `put/putAll` call,
+     * and subsequent calls add additional key/value pairs to the original map. See {@link
+     * FinancialAccountCreateParams#metadata} for the field documentation.
+     */
+    public Builder putMetadata(String key, String value) {
+      if (this.metadata == null) {
+        this.metadata = new HashMap<>();
+      }
+      this.metadata.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `metadata` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link FinancialAccountCreateParams#metadata} for the field documentation.
+     */
+    public Builder putAllMetadata(Map<String, String> map) {
+      if (this.metadata == null) {
+        this.metadata = new HashMap<>();
+      }
+      this.metadata.putAll(map);
+      return this;
+    }
+
+    /** The set of functionalities that the platform can restrict on the FinancialAccount. */
+    public Builder setPlatformRestrictions(PlatformRestrictions platformRestrictions) {
+      this.platformRestrictions = platformRestrictions;
+      return this;
+    }
+
+    /**
+     * Add an element to `supportedCurrencies` list. A list is initialized for the first
+     * `add/addAll` call, and subsequent calls adds additional elements to the original list. See
+     * {@link FinancialAccountCreateParams#supportedCurrencies} for the field documentation.
+     */
+    public Builder addSupportedCurrency(String element) {
+      if (this.supportedCurrencies == null) {
+        this.supportedCurrencies = new ArrayList<>();
+      }
+      this.supportedCurrencies.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `supportedCurrencies` list. A list is initialized for the first
+     * `add/addAll` call, and subsequent calls adds additional elements to the original list. See
+     * {@link FinancialAccountCreateParams#supportedCurrencies} for the field documentation.
+     */
+    public Builder addAllSupportedCurrency(List<String> elements) {
+      if (this.supportedCurrencies == null) {
+        this.supportedCurrencies = new ArrayList<>();
+      }
+      this.supportedCurrencies.addAll(elements);
+      return this;
+    }
+  }
+
+  @Getter
+  public static class Features {
+    /**
+     * Represents whether this FinancialAccount is eligible for deposit insurance. Various factors
+     * determine the insurance amount.
+     */
+    @SerializedName("deposit_insurance")
+    DepositInsurance depositInsurance;
+
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /** Contains Features that add FinancialAddresses to the FinancialAccount. */
+    @SerializedName("financial_addresses")
+    FinancialAddresses financialAddresses;
+
+    /**
+     * Contains settings related to adding funds to a FinancialAccount from another Account with the
+     * same owner.
+     */
+    @SerializedName("inbound_transfers")
+    InboundTransfers inboundTransfers;
+
+    /**
+     * Represents the ability for the FinancialAccount to send money to, or receive money from other
+     * FinancialAccounts (for example, via OutboundPayment).
+     */
+    @SerializedName("intra_stripe_flows")
+    IntraStripeFlows intraStripeFlows;
+
+    /**
+     * Includes Features related to initiating money movement out of the FinancialAccount to someone
+     * else's bucket of money.
+     */
+    @SerializedName("outbound_payments")
+    OutboundPayments outboundPayments;
+
+    /**
+     * Contains a Feature and settings related to moving money out of the FinancialAccount into
+     * another Account with the same owner.
+     */
+    @SerializedName("outbound_transfers")
+    OutboundTransfers outboundTransfers;
+
+    private Features(
+        DepositInsurance depositInsurance,
+        Map<String, Object> extraParams,
+        FinancialAddresses financialAddresses,
+        InboundTransfers inboundTransfers,
+        IntraStripeFlows intraStripeFlows,
+        OutboundPayments outboundPayments,
+        OutboundTransfers outboundTransfers) {
+      this.depositInsurance = depositInsurance;
+      this.extraParams = extraParams;
+      this.financialAddresses = financialAddresses;
+      this.inboundTransfers = inboundTransfers;
+      this.intraStripeFlows = intraStripeFlows;
+      this.outboundPayments = outboundPayments;
+      this.outboundTransfers = outboundTransfers;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private DepositInsurance depositInsurance;
+
+      private Map<String, Object> extraParams;
+
+      private FinancialAddresses financialAddresses;
+
+      private InboundTransfers inboundTransfers;
+
+      private IntraStripeFlows intraStripeFlows;
+
+      private OutboundPayments outboundPayments;
+
+      private OutboundTransfers outboundTransfers;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public Features build() {
+        return new Features(
+            this.depositInsurance,
+            this.extraParams,
+            this.financialAddresses,
+            this.inboundTransfers,
+            this.intraStripeFlows,
+            this.outboundPayments,
+            this.outboundTransfers);
+      }
+
+      /**
+       * Represents whether this FinancialAccount is eligible for deposit insurance. Various factors
+       * determine the insurance amount.
+       */
+      public Builder setDepositInsurance(DepositInsurance depositInsurance) {
+        this.depositInsurance = depositInsurance;
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * FinancialAccountCreateParams.Features#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link FinancialAccountCreateParams.Features#extraParams} for the field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** Contains Features that add FinancialAddresses to the FinancialAccount. */
+      public Builder setFinancialAddresses(FinancialAddresses financialAddresses) {
+        this.financialAddresses = financialAddresses;
+        return this;
+      }
+
+      /**
+       * Contains settings related to adding funds to a FinancialAccount from another Account with
+       * the same owner.
+       */
+      public Builder setInboundTransfers(InboundTransfers inboundTransfers) {
+        this.inboundTransfers = inboundTransfers;
+        return this;
+      }
+
+      /**
+       * Represents the ability for the FinancialAccount to send money to, or receive money from
+       * other FinancialAccounts (for example, via OutboundPayment).
+       */
+      public Builder setIntraStripeFlows(IntraStripeFlows intraStripeFlows) {
+        this.intraStripeFlows = intraStripeFlows;
+        return this;
+      }
+
+      /**
+       * Includes Features related to initiating money movement out of the FinancialAccount to
+       * someone else's bucket of money.
+       */
+      public Builder setOutboundPayments(OutboundPayments outboundPayments) {
+        this.outboundPayments = outboundPayments;
+        return this;
+      }
+
+      /**
+       * Contains a Feature and settings related to moving money out of the FinancialAccount into
+       * another Account with the same owner.
+       */
+      public Builder setOutboundTransfers(OutboundTransfers outboundTransfers) {
+        this.outboundTransfers = outboundTransfers;
+        return this;
+      }
+    }
+
+    @Getter
+    public static class DepositInsurance {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Whether the FinancialAccount should have the Feature. */
+      @SerializedName("requested")
+      Boolean requested;
+
+      private DepositInsurance(Map<String, Object> extraParams, Boolean requested) {
+        this.extraParams = extraParams;
+        this.requested = requested;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private Boolean requested;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public DepositInsurance build() {
+          return new DepositInsurance(this.extraParams, this.requested);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link FinancialAccountCreateParams.Features.DepositInsurance#extraParams} for
+         * the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link FinancialAccountCreateParams.Features.DepositInsurance#extraParams} for
+         * the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Whether the FinancialAccount should have the Feature. */
+        public Builder setRequested(Boolean requested) {
+          this.requested = requested;
+          return this;
+        }
+      }
+    }
+
+    @Getter
+    public static class FinancialAddresses {
+      /** Adds an ABA FinancialAddress to the FinancialAccount. */
+      @SerializedName("aba")
+      Aba aba;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private FinancialAddresses(Aba aba, Map<String, Object> extraParams) {
+        this.aba = aba;
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Aba aba;
+
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public FinancialAddresses build() {
+          return new FinancialAddresses(this.aba, this.extraParams);
+        }
+
+        /** Adds an ABA FinancialAddress to the FinancialAccount. */
+        public Builder setAba(Aba aba) {
+          this.aba = aba;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link FinancialAccountCreateParams.Features.FinancialAddresses#extraParams} for
+         * the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link FinancialAccountCreateParams.Features.FinancialAddresses#extraParams} for
+         * the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+      }
+
+      @Getter
+      public static class Aba {
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /** Whether the FinancialAccount should have the Feature. */
+        @SerializedName("requested")
+        Boolean requested;
+
+        private Aba(Map<String, Object> extraParams, Boolean requested) {
+          this.extraParams = extraParams;
+          this.requested = requested;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Map<String, Object> extraParams;
+
+          private Boolean requested;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public Aba build() {
+            return new Aba(this.extraParams, this.requested);
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * FinancialAccountCreateParams.Features.FinancialAddresses.Aba#extraParams} for the field
+           * documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * FinancialAccountCreateParams.Features.FinancialAddresses.Aba#extraParams} for the field
+           * documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /** Whether the FinancialAccount should have the Feature. */
+          public Builder setRequested(Boolean requested) {
+            this.requested = requested;
+            return this;
+          }
+        }
+      }
+    }
+
+    @Getter
+    public static class InboundTransfers {
+      /** Enables ACH Debits via the InboundTransfers API. */
+      @SerializedName("ach")
+      Ach ach;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private InboundTransfers(Ach ach, Map<String, Object> extraParams) {
+        this.ach = ach;
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Ach ach;
+
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public InboundTransfers build() {
+          return new InboundTransfers(this.ach, this.extraParams);
+        }
+
+        /** Enables ACH Debits via the InboundTransfers API. */
+        public Builder setAch(Ach ach) {
+          this.ach = ach;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link FinancialAccountCreateParams.Features.InboundTransfers#extraParams} for
+         * the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link FinancialAccountCreateParams.Features.InboundTransfers#extraParams} for
+         * the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+      }
+
+      @Getter
+      public static class Ach {
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /** Whether the FinancialAccount should have the Feature. */
+        @SerializedName("requested")
+        Boolean requested;
+
+        private Ach(Map<String, Object> extraParams, Boolean requested) {
+          this.extraParams = extraParams;
+          this.requested = requested;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Map<String, Object> extraParams;
+
+          private Boolean requested;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public Ach build() {
+            return new Ach(this.extraParams, this.requested);
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link FinancialAccountCreateParams.Features.InboundTransfers.Ach#extraParams}
+           * for the field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link FinancialAccountCreateParams.Features.InboundTransfers.Ach#extraParams}
+           * for the field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /** Whether the FinancialAccount should have the Feature. */
+          public Builder setRequested(Boolean requested) {
+            this.requested = requested;
+            return this;
+          }
+        }
+      }
+    }
+
+    @Getter
+    public static class IntraStripeFlows {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Whether the FinancialAccount should have the Feature. */
+      @SerializedName("requested")
+      Boolean requested;
+
+      private IntraStripeFlows(Map<String, Object> extraParams, Boolean requested) {
+        this.extraParams = extraParams;
+        this.requested = requested;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private Boolean requested;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public IntraStripeFlows build() {
+          return new IntraStripeFlows(this.extraParams, this.requested);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link FinancialAccountCreateParams.Features.IntraStripeFlows#extraParams} for
+         * the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link FinancialAccountCreateParams.Features.IntraStripeFlows#extraParams} for
+         * the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Whether the FinancialAccount should have the Feature. */
+        public Builder setRequested(Boolean requested) {
+          this.requested = requested;
+          return this;
+        }
+      }
+    }
+
+    @Getter
+    public static class OutboundPayments {
+      /** Enables ACH transfers via the OutboundPayments API. */
+      @SerializedName("ach")
+      Ach ach;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Enables US domestic wire tranfers via the OutboundPayments API. */
+      @SerializedName("us_domestic_wire")
+      UsDomesticWire usDomesticWire;
+
+      private OutboundPayments(
+          Ach ach, Map<String, Object> extraParams, UsDomesticWire usDomesticWire) {
+        this.ach = ach;
+        this.extraParams = extraParams;
+        this.usDomesticWire = usDomesticWire;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Ach ach;
+
+        private Map<String, Object> extraParams;
+
+        private UsDomesticWire usDomesticWire;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public OutboundPayments build() {
+          return new OutboundPayments(this.ach, this.extraParams, this.usDomesticWire);
+        }
+
+        /** Enables ACH transfers via the OutboundPayments API. */
+        public Builder setAch(Ach ach) {
+          this.ach = ach;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link FinancialAccountCreateParams.Features.OutboundPayments#extraParams} for
+         * the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link FinancialAccountCreateParams.Features.OutboundPayments#extraParams} for
+         * the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Enables US domestic wire tranfers via the OutboundPayments API. */
+        public Builder setUsDomesticWire(UsDomesticWire usDomesticWire) {
+          this.usDomesticWire = usDomesticWire;
+          return this;
+        }
+      }
+
+      @Getter
+      public static class Ach {
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /** Whether the FinancialAccount should have the Feature. */
+        @SerializedName("requested")
+        Boolean requested;
+
+        private Ach(Map<String, Object> extraParams, Boolean requested) {
+          this.extraParams = extraParams;
+          this.requested = requested;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Map<String, Object> extraParams;
+
+          private Boolean requested;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public Ach build() {
+            return new Ach(this.extraParams, this.requested);
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link FinancialAccountCreateParams.Features.OutboundPayments.Ach#extraParams}
+           * for the field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link FinancialAccountCreateParams.Features.OutboundPayments.Ach#extraParams}
+           * for the field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /** Whether the FinancialAccount should have the Feature. */
+          public Builder setRequested(Boolean requested) {
+            this.requested = requested;
+            return this;
+          }
+        }
+      }
+
+      @Getter
+      public static class UsDomesticWire {
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /** Whether the FinancialAccount should have the Feature. */
+        @SerializedName("requested")
+        Boolean requested;
+
+        private UsDomesticWire(Map<String, Object> extraParams, Boolean requested) {
+          this.extraParams = extraParams;
+          this.requested = requested;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Map<String, Object> extraParams;
+
+          private Boolean requested;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public UsDomesticWire build() {
+            return new UsDomesticWire(this.extraParams, this.requested);
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * FinancialAccountCreateParams.Features.OutboundPayments.UsDomesticWire#extraParams} for
+           * the field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * FinancialAccountCreateParams.Features.OutboundPayments.UsDomesticWire#extraParams} for
+           * the field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /** Whether the FinancialAccount should have the Feature. */
+          public Builder setRequested(Boolean requested) {
+            this.requested = requested;
+            return this;
+          }
+        }
+      }
+    }
+
+    @Getter
+    public static class OutboundTransfers {
+      /** Enables ACH transfers via the OutboundTransfers API. */
+      @SerializedName("ach")
+      Ach ach;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Enables US domestic wire tranfers via the OutboundTransfers API. */
+      @SerializedName("us_domestic_wire")
+      UsDomesticWire usDomesticWire;
+
+      private OutboundTransfers(
+          Ach ach, Map<String, Object> extraParams, UsDomesticWire usDomesticWire) {
+        this.ach = ach;
+        this.extraParams = extraParams;
+        this.usDomesticWire = usDomesticWire;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Ach ach;
+
+        private Map<String, Object> extraParams;
+
+        private UsDomesticWire usDomesticWire;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public OutboundTransfers build() {
+          return new OutboundTransfers(this.ach, this.extraParams, this.usDomesticWire);
+        }
+
+        /** Enables ACH transfers via the OutboundTransfers API. */
+        public Builder setAch(Ach ach) {
+          this.ach = ach;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link FinancialAccountCreateParams.Features.OutboundTransfers#extraParams} for
+         * the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link FinancialAccountCreateParams.Features.OutboundTransfers#extraParams} for
+         * the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Enables US domestic wire tranfers via the OutboundTransfers API. */
+        public Builder setUsDomesticWire(UsDomesticWire usDomesticWire) {
+          this.usDomesticWire = usDomesticWire;
+          return this;
+        }
+      }
+
+      @Getter
+      public static class Ach {
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /** Whether the FinancialAccount should have the Feature. */
+        @SerializedName("requested")
+        Boolean requested;
+
+        private Ach(Map<String, Object> extraParams, Boolean requested) {
+          this.extraParams = extraParams;
+          this.requested = requested;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Map<String, Object> extraParams;
+
+          private Boolean requested;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public Ach build() {
+            return new Ach(this.extraParams, this.requested);
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * FinancialAccountCreateParams.Features.OutboundTransfers.Ach#extraParams} for the field
+           * documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * FinancialAccountCreateParams.Features.OutboundTransfers.Ach#extraParams} for the field
+           * documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /** Whether the FinancialAccount should have the Feature. */
+          public Builder setRequested(Boolean requested) {
+            this.requested = requested;
+            return this;
+          }
+        }
+      }
+
+      @Getter
+      public static class UsDomesticWire {
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /** Whether the FinancialAccount should have the Feature. */
+        @SerializedName("requested")
+        Boolean requested;
+
+        private UsDomesticWire(Map<String, Object> extraParams, Boolean requested) {
+          this.extraParams = extraParams;
+          this.requested = requested;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Map<String, Object> extraParams;
+
+          private Boolean requested;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public UsDomesticWire build() {
+            return new UsDomesticWire(this.extraParams, this.requested);
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * FinancialAccountCreateParams.Features.OutboundTransfers.UsDomesticWire#extraParams} for
+           * the field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * FinancialAccountCreateParams.Features.OutboundTransfers.UsDomesticWire#extraParams} for
+           * the field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /** Whether the FinancialAccount should have the Feature. */
+          public Builder setRequested(Boolean requested) {
+            this.requested = requested;
+            return this;
+          }
+        }
+      }
+    }
+  }
+
+  @Getter
+  public static class PlatformRestrictions {
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /** Restricts all inbound money movement. */
+    @SerializedName("inbound_flows")
+    InboundFlows inboundFlows;
+
+    /** Restricts all outbound money movement. */
+    @SerializedName("outbound_flows")
+    OutboundFlows outboundFlows;
+
+    private PlatformRestrictions(
+        Map<String, Object> extraParams, InboundFlows inboundFlows, OutboundFlows outboundFlows) {
+      this.extraParams = extraParams;
+      this.inboundFlows = inboundFlows;
+      this.outboundFlows = outboundFlows;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Map<String, Object> extraParams;
+
+      private InboundFlows inboundFlows;
+
+      private OutboundFlows outboundFlows;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public PlatformRestrictions build() {
+        return new PlatformRestrictions(this.extraParams, this.inboundFlows, this.outboundFlows);
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * FinancialAccountCreateParams.PlatformRestrictions#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link FinancialAccountCreateParams.PlatformRestrictions#extraParams} for the field
+       * documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** Restricts all inbound money movement. */
+      public Builder setInboundFlows(InboundFlows inboundFlows) {
+        this.inboundFlows = inboundFlows;
+        return this;
+      }
+
+      /** Restricts all outbound money movement. */
+      public Builder setOutboundFlows(OutboundFlows outboundFlows) {
+        this.outboundFlows = outboundFlows;
+        return this;
+      }
+    }
+
+    public enum InboundFlows implements ApiRequestParams.EnumParam {
+      @SerializedName("restricted")
+      RESTRICTED("restricted"),
+
+      @SerializedName("unrestricted")
+      UNRESTRICTED("unrestricted");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      InboundFlows(String value) {
+        this.value = value;
+      }
+    }
+
+    public enum OutboundFlows implements ApiRequestParams.EnumParam {
+      @SerializedName("restricted")
+      RESTRICTED("restricted"),
+
+      @SerializedName("unrestricted")
+      UNRESTRICTED("unrestricted");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      OutboundFlows(String value) {
+        this.value = value;
+      }
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/FinancialAccountListParams.java
+++ b/src/main/java/com/stripe/param/treasury/FinancialAccountListParams.java
@@ -1,0 +1,272 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class FinancialAccountListParams extends ApiRequestParams {
+  @SerializedName("created")
+  Object created;
+
+  /** An object ID cursor for use in pagination. */
+  @SerializedName("ending_before")
+  String endingBefore;
+
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  /** A limit ranging from 1 to 100 (defaults to 10). */
+  @SerializedName("limit")
+  Long limit;
+
+  /** An object ID cursor for use in pagination. */
+  @SerializedName("starting_after")
+  String startingAfter;
+
+  private FinancialAccountListParams(
+      Object created,
+      String endingBefore,
+      List<String> expand,
+      Map<String, Object> extraParams,
+      Long limit,
+      String startingAfter) {
+    this.created = created;
+    this.endingBefore = endingBefore;
+    this.expand = expand;
+    this.extraParams = extraParams;
+    this.limit = limit;
+    this.startingAfter = startingAfter;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Object created;
+
+    private String endingBefore;
+
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    private Long limit;
+
+    private String startingAfter;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public FinancialAccountListParams build() {
+      return new FinancialAccountListParams(
+          this.created,
+          this.endingBefore,
+          this.expand,
+          this.extraParams,
+          this.limit,
+          this.startingAfter);
+    }
+
+    public Builder setCreated(Created created) {
+      this.created = created;
+      return this;
+    }
+
+    public Builder setCreated(Long created) {
+      this.created = created;
+      return this;
+    }
+
+    /** An object ID cursor for use in pagination. */
+    public Builder setEndingBefore(String endingBefore) {
+      this.endingBefore = endingBefore;
+      return this;
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * FinancialAccountListParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * FinancialAccountListParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * FinancialAccountListParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link FinancialAccountListParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /** A limit ranging from 1 to 100 (defaults to 10). */
+    public Builder setLimit(Long limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    /** An object ID cursor for use in pagination. */
+    public Builder setStartingAfter(String startingAfter) {
+      this.startingAfter = startingAfter;
+      return this;
+    }
+  }
+
+  @Getter
+  public static class Created {
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /** Minimum value to filter by (exclusive). */
+    @SerializedName("gt")
+    Long gt;
+
+    /** Minimum value to filter by (inclusive). */
+    @SerializedName("gte")
+    Long gte;
+
+    /** Maximum value to filter by (exclusive). */
+    @SerializedName("lt")
+    Long lt;
+
+    /** Maximum value to filter by (inclusive). */
+    @SerializedName("lte")
+    Long lte;
+
+    private Created(Map<String, Object> extraParams, Long gt, Long gte, Long lt, Long lte) {
+      this.extraParams = extraParams;
+      this.gt = gt;
+      this.gte = gte;
+      this.lt = lt;
+      this.lte = lte;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Map<String, Object> extraParams;
+
+      private Long gt;
+
+      private Long gte;
+
+      private Long lt;
+
+      private Long lte;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public Created build() {
+        return new Created(this.extraParams, this.gt, this.gte, this.lt, this.lte);
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * FinancialAccountListParams.Created#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link FinancialAccountListParams.Created#extraParams} for the field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** Minimum value to filter by (exclusive). */
+      public Builder setGt(Long gt) {
+        this.gt = gt;
+        return this;
+      }
+
+      /** Minimum value to filter by (inclusive). */
+      public Builder setGte(Long gte) {
+        this.gte = gte;
+        return this;
+      }
+
+      /** Maximum value to filter by (exclusive). */
+      public Builder setLt(Long lt) {
+        this.lt = lt;
+        return this;
+      }
+
+      /** Maximum value to filter by (inclusive). */
+      public Builder setLte(Long lte) {
+        this.lte = lte;
+        return this;
+      }
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/FinancialAccountRetrieveFeaturesParams.java
+++ b/src/main/java/com/stripe/param/treasury/FinancialAccountRetrieveFeaturesParams.java
@@ -1,0 +1,99 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class FinancialAccountRetrieveFeaturesParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  private FinancialAccountRetrieveFeaturesParams(
+      List<String> expand, Map<String, Object> extraParams) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public FinancialAccountRetrieveFeaturesParams build() {
+      return new FinancialAccountRetrieveFeaturesParams(this.expand, this.extraParams);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * FinancialAccountRetrieveFeaturesParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * FinancialAccountRetrieveFeaturesParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * FinancialAccountRetrieveFeaturesParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link FinancialAccountRetrieveFeaturesParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/FinancialAccountRetrieveParams.java
+++ b/src/main/java/com/stripe/param/treasury/FinancialAccountRetrieveParams.java
@@ -1,0 +1,98 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class FinancialAccountRetrieveParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  private FinancialAccountRetrieveParams(List<String> expand, Map<String, Object> extraParams) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public FinancialAccountRetrieveParams build() {
+      return new FinancialAccountRetrieveParams(this.expand, this.extraParams);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * FinancialAccountRetrieveParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * FinancialAccountRetrieveParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * FinancialAccountRetrieveParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link FinancialAccountRetrieveParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/FinancialAccountUpdateFeaturesParams.java
+++ b/src/main/java/com/stripe/param/treasury/FinancialAccountUpdateFeaturesParams.java
@@ -1,0 +1,1094 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class FinancialAccountUpdateFeaturesParams extends ApiRequestParams {
+  /**
+   * Represents whether this FinancialAccount is eligible for deposit insurance. Various factors
+   * determine the insurance amount.
+   */
+  @SerializedName("deposit_insurance")
+  DepositInsurance depositInsurance;
+
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  /** Contains Features that add FinancialAddresses to the FinancialAccount. */
+  @SerializedName("financial_addresses")
+  FinancialAddresses financialAddresses;
+
+  /**
+   * Contains settings related to adding funds to a FinancialAccount from another Account with the
+   * same owner.
+   */
+  @SerializedName("inbound_transfers")
+  InboundTransfers inboundTransfers;
+
+  /**
+   * Represents the ability for the FinancialAccount to send money to, or receive money from other
+   * FinancialAccounts (for example, via OutboundPayment).
+   */
+  @SerializedName("intra_stripe_flows")
+  IntraStripeFlows intraStripeFlows;
+
+  /**
+   * Includes Features related to initiating money movement out of the FinancialAccount to someone
+   * else's bucket of money.
+   */
+  @SerializedName("outbound_payments")
+  OutboundPayments outboundPayments;
+
+  /**
+   * Contains a Feature and settings related to moving money out of the FinancialAccount into
+   * another Account with the same owner.
+   */
+  @SerializedName("outbound_transfers")
+  OutboundTransfers outboundTransfers;
+
+  private FinancialAccountUpdateFeaturesParams(
+      DepositInsurance depositInsurance,
+      List<String> expand,
+      Map<String, Object> extraParams,
+      FinancialAddresses financialAddresses,
+      InboundTransfers inboundTransfers,
+      IntraStripeFlows intraStripeFlows,
+      OutboundPayments outboundPayments,
+      OutboundTransfers outboundTransfers) {
+    this.depositInsurance = depositInsurance;
+    this.expand = expand;
+    this.extraParams = extraParams;
+    this.financialAddresses = financialAddresses;
+    this.inboundTransfers = inboundTransfers;
+    this.intraStripeFlows = intraStripeFlows;
+    this.outboundPayments = outboundPayments;
+    this.outboundTransfers = outboundTransfers;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private DepositInsurance depositInsurance;
+
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    private FinancialAddresses financialAddresses;
+
+    private InboundTransfers inboundTransfers;
+
+    private IntraStripeFlows intraStripeFlows;
+
+    private OutboundPayments outboundPayments;
+
+    private OutboundTransfers outboundTransfers;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public FinancialAccountUpdateFeaturesParams build() {
+      return new FinancialAccountUpdateFeaturesParams(
+          this.depositInsurance,
+          this.expand,
+          this.extraParams,
+          this.financialAddresses,
+          this.inboundTransfers,
+          this.intraStripeFlows,
+          this.outboundPayments,
+          this.outboundTransfers);
+    }
+
+    /**
+     * Represents whether this FinancialAccount is eligible for deposit insurance. Various factors
+     * determine the insurance amount.
+     */
+    public Builder setDepositInsurance(DepositInsurance depositInsurance) {
+      this.depositInsurance = depositInsurance;
+      return this;
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * FinancialAccountUpdateFeaturesParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * FinancialAccountUpdateFeaturesParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * FinancialAccountUpdateFeaturesParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link FinancialAccountUpdateFeaturesParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /** Contains Features that add FinancialAddresses to the FinancialAccount. */
+    public Builder setFinancialAddresses(FinancialAddresses financialAddresses) {
+      this.financialAddresses = financialAddresses;
+      return this;
+    }
+
+    /**
+     * Contains settings related to adding funds to a FinancialAccount from another Account with the
+     * same owner.
+     */
+    public Builder setInboundTransfers(InboundTransfers inboundTransfers) {
+      this.inboundTransfers = inboundTransfers;
+      return this;
+    }
+
+    /**
+     * Represents the ability for the FinancialAccount to send money to, or receive money from other
+     * FinancialAccounts (for example, via OutboundPayment).
+     */
+    public Builder setIntraStripeFlows(IntraStripeFlows intraStripeFlows) {
+      this.intraStripeFlows = intraStripeFlows;
+      return this;
+    }
+
+    /**
+     * Includes Features related to initiating money movement out of the FinancialAccount to someone
+     * else's bucket of money.
+     */
+    public Builder setOutboundPayments(OutboundPayments outboundPayments) {
+      this.outboundPayments = outboundPayments;
+      return this;
+    }
+
+    /**
+     * Contains a Feature and settings related to moving money out of the FinancialAccount into
+     * another Account with the same owner.
+     */
+    public Builder setOutboundTransfers(OutboundTransfers outboundTransfers) {
+      this.outboundTransfers = outboundTransfers;
+      return this;
+    }
+  }
+
+  @Getter
+  public static class DepositInsurance {
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /** Whether the FinancialAccount should have the Feature. */
+    @SerializedName("requested")
+    Boolean requested;
+
+    private DepositInsurance(Map<String, Object> extraParams, Boolean requested) {
+      this.extraParams = extraParams;
+      this.requested = requested;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Map<String, Object> extraParams;
+
+      private Boolean requested;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public DepositInsurance build() {
+        return new DepositInsurance(this.extraParams, this.requested);
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * FinancialAccountUpdateFeaturesParams.DepositInsurance#extraParams} for the field
+       * documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link FinancialAccountUpdateFeaturesParams.DepositInsurance#extraParams} for the field
+       * documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** Whether the FinancialAccount should have the Feature. */
+      public Builder setRequested(Boolean requested) {
+        this.requested = requested;
+        return this;
+      }
+    }
+  }
+
+  @Getter
+  public static class FinancialAddresses {
+    /** Adds an ABA FinancialAddress to the FinancialAccount. */
+    @SerializedName("aba")
+    Aba aba;
+
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    private FinancialAddresses(Aba aba, Map<String, Object> extraParams) {
+      this.aba = aba;
+      this.extraParams = extraParams;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Aba aba;
+
+      private Map<String, Object> extraParams;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public FinancialAddresses build() {
+        return new FinancialAddresses(this.aba, this.extraParams);
+      }
+
+      /** Adds an ABA FinancialAddress to the FinancialAccount. */
+      public Builder setAba(Aba aba) {
+        this.aba = aba;
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * FinancialAccountUpdateFeaturesParams.FinancialAddresses#extraParams} for the field
+       * documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link FinancialAccountUpdateFeaturesParams.FinancialAddresses#extraParams} for the
+       * field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+    }
+
+    @Getter
+    public static class Aba {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Whether the FinancialAccount should have the Feature. */
+      @SerializedName("requested")
+      Boolean requested;
+
+      private Aba(Map<String, Object> extraParams, Boolean requested) {
+        this.extraParams = extraParams;
+        this.requested = requested;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private Boolean requested;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Aba build() {
+          return new Aba(this.extraParams, this.requested);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link FinancialAccountUpdateFeaturesParams.FinancialAddresses.Aba#extraParams}
+         * for the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link FinancialAccountUpdateFeaturesParams.FinancialAddresses.Aba#extraParams}
+         * for the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Whether the FinancialAccount should have the Feature. */
+        public Builder setRequested(Boolean requested) {
+          this.requested = requested;
+          return this;
+        }
+      }
+    }
+  }
+
+  @Getter
+  public static class InboundTransfers {
+    /** Enables ACH Debits via the InboundTransfers API. */
+    @SerializedName("ach")
+    Ach ach;
+
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    private InboundTransfers(Ach ach, Map<String, Object> extraParams) {
+      this.ach = ach;
+      this.extraParams = extraParams;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Ach ach;
+
+      private Map<String, Object> extraParams;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public InboundTransfers build() {
+        return new InboundTransfers(this.ach, this.extraParams);
+      }
+
+      /** Enables ACH Debits via the InboundTransfers API. */
+      public Builder setAch(Ach ach) {
+        this.ach = ach;
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * FinancialAccountUpdateFeaturesParams.InboundTransfers#extraParams} for the field
+       * documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link FinancialAccountUpdateFeaturesParams.InboundTransfers#extraParams} for the field
+       * documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+    }
+
+    @Getter
+    public static class Ach {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Whether the FinancialAccount should have the Feature. */
+      @SerializedName("requested")
+      Boolean requested;
+
+      private Ach(Map<String, Object> extraParams, Boolean requested) {
+        this.extraParams = extraParams;
+        this.requested = requested;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private Boolean requested;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Ach build() {
+          return new Ach(this.extraParams, this.requested);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link FinancialAccountUpdateFeaturesParams.InboundTransfers.Ach#extraParams}
+         * for the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link FinancialAccountUpdateFeaturesParams.InboundTransfers.Ach#extraParams}
+         * for the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Whether the FinancialAccount should have the Feature. */
+        public Builder setRequested(Boolean requested) {
+          this.requested = requested;
+          return this;
+        }
+      }
+    }
+  }
+
+  @Getter
+  public static class IntraStripeFlows {
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /** Whether the FinancialAccount should have the Feature. */
+    @SerializedName("requested")
+    Boolean requested;
+
+    private IntraStripeFlows(Map<String, Object> extraParams, Boolean requested) {
+      this.extraParams = extraParams;
+      this.requested = requested;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Map<String, Object> extraParams;
+
+      private Boolean requested;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public IntraStripeFlows build() {
+        return new IntraStripeFlows(this.extraParams, this.requested);
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * FinancialAccountUpdateFeaturesParams.IntraStripeFlows#extraParams} for the field
+       * documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link FinancialAccountUpdateFeaturesParams.IntraStripeFlows#extraParams} for the field
+       * documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** Whether the FinancialAccount should have the Feature. */
+      public Builder setRequested(Boolean requested) {
+        this.requested = requested;
+        return this;
+      }
+    }
+  }
+
+  @Getter
+  public static class OutboundPayments {
+    /** Enables ACH transfers via the OutboundPayments API. */
+    @SerializedName("ach")
+    Ach ach;
+
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /** Enables US domestic wire tranfers via the OutboundPayments API. */
+    @SerializedName("us_domestic_wire")
+    UsDomesticWire usDomesticWire;
+
+    private OutboundPayments(
+        Ach ach, Map<String, Object> extraParams, UsDomesticWire usDomesticWire) {
+      this.ach = ach;
+      this.extraParams = extraParams;
+      this.usDomesticWire = usDomesticWire;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Ach ach;
+
+      private Map<String, Object> extraParams;
+
+      private UsDomesticWire usDomesticWire;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public OutboundPayments build() {
+        return new OutboundPayments(this.ach, this.extraParams, this.usDomesticWire);
+      }
+
+      /** Enables ACH transfers via the OutboundPayments API. */
+      public Builder setAch(Ach ach) {
+        this.ach = ach;
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * FinancialAccountUpdateFeaturesParams.OutboundPayments#extraParams} for the field
+       * documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link FinancialAccountUpdateFeaturesParams.OutboundPayments#extraParams} for the field
+       * documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** Enables US domestic wire tranfers via the OutboundPayments API. */
+      public Builder setUsDomesticWire(UsDomesticWire usDomesticWire) {
+        this.usDomesticWire = usDomesticWire;
+        return this;
+      }
+    }
+
+    @Getter
+    public static class Ach {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Whether the FinancialAccount should have the Feature. */
+      @SerializedName("requested")
+      Boolean requested;
+
+      private Ach(Map<String, Object> extraParams, Boolean requested) {
+        this.extraParams = extraParams;
+        this.requested = requested;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private Boolean requested;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Ach build() {
+          return new Ach(this.extraParams, this.requested);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link FinancialAccountUpdateFeaturesParams.OutboundPayments.Ach#extraParams}
+         * for the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link FinancialAccountUpdateFeaturesParams.OutboundPayments.Ach#extraParams}
+         * for the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Whether the FinancialAccount should have the Feature. */
+        public Builder setRequested(Boolean requested) {
+          this.requested = requested;
+          return this;
+        }
+      }
+    }
+
+    @Getter
+    public static class UsDomesticWire {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Whether the FinancialAccount should have the Feature. */
+      @SerializedName("requested")
+      Boolean requested;
+
+      private UsDomesticWire(Map<String, Object> extraParams, Boolean requested) {
+        this.extraParams = extraParams;
+        this.requested = requested;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private Boolean requested;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public UsDomesticWire build() {
+          return new UsDomesticWire(this.extraParams, this.requested);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * FinancialAccountUpdateFeaturesParams.OutboundPayments.UsDomesticWire#extraParams} for the
+         * field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * FinancialAccountUpdateFeaturesParams.OutboundPayments.UsDomesticWire#extraParams} for the
+         * field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Whether the FinancialAccount should have the Feature. */
+        public Builder setRequested(Boolean requested) {
+          this.requested = requested;
+          return this;
+        }
+      }
+    }
+  }
+
+  @Getter
+  public static class OutboundTransfers {
+    /** Enables ACH transfers via the OutboundTransfers API. */
+    @SerializedName("ach")
+    Ach ach;
+
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /** Enables US domestic wire tranfers via the OutboundTransfers API. */
+    @SerializedName("us_domestic_wire")
+    UsDomesticWire usDomesticWire;
+
+    private OutboundTransfers(
+        Ach ach, Map<String, Object> extraParams, UsDomesticWire usDomesticWire) {
+      this.ach = ach;
+      this.extraParams = extraParams;
+      this.usDomesticWire = usDomesticWire;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Ach ach;
+
+      private Map<String, Object> extraParams;
+
+      private UsDomesticWire usDomesticWire;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public OutboundTransfers build() {
+        return new OutboundTransfers(this.ach, this.extraParams, this.usDomesticWire);
+      }
+
+      /** Enables ACH transfers via the OutboundTransfers API. */
+      public Builder setAch(Ach ach) {
+        this.ach = ach;
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * FinancialAccountUpdateFeaturesParams.OutboundTransfers#extraParams} for the field
+       * documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link FinancialAccountUpdateFeaturesParams.OutboundTransfers#extraParams} for the
+       * field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** Enables US domestic wire tranfers via the OutboundTransfers API. */
+      public Builder setUsDomesticWire(UsDomesticWire usDomesticWire) {
+        this.usDomesticWire = usDomesticWire;
+        return this;
+      }
+    }
+
+    @Getter
+    public static class Ach {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Whether the FinancialAccount should have the Feature. */
+      @SerializedName("requested")
+      Boolean requested;
+
+      private Ach(Map<String, Object> extraParams, Boolean requested) {
+        this.extraParams = extraParams;
+        this.requested = requested;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private Boolean requested;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public Ach build() {
+          return new Ach(this.extraParams, this.requested);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link FinancialAccountUpdateFeaturesParams.OutboundTransfers.Ach#extraParams}
+         * for the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link FinancialAccountUpdateFeaturesParams.OutboundTransfers.Ach#extraParams}
+         * for the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Whether the FinancialAccount should have the Feature. */
+        public Builder setRequested(Boolean requested) {
+          this.requested = requested;
+          return this;
+        }
+      }
+    }
+
+    @Getter
+    public static class UsDomesticWire {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Whether the FinancialAccount should have the Feature. */
+      @SerializedName("requested")
+      Boolean requested;
+
+      private UsDomesticWire(Map<String, Object> extraParams, Boolean requested) {
+        this.extraParams = extraParams;
+        this.requested = requested;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private Boolean requested;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public UsDomesticWire build() {
+          return new UsDomesticWire(this.extraParams, this.requested);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * FinancialAccountUpdateFeaturesParams.OutboundTransfers.UsDomesticWire#extraParams} for
+         * the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * FinancialAccountUpdateFeaturesParams.OutboundTransfers.UsDomesticWire#extraParams} for
+         * the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Whether the FinancialAccount should have the Feature. */
+        public Builder setRequested(Boolean requested) {
+          this.requested = requested;
+          return this;
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/FinancialAccountUpdateParams.java
+++ b/src/main/java/com/stripe/param/treasury/FinancialAccountUpdateParams.java
@@ -1,0 +1,1348 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class FinancialAccountUpdateParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  /**
+   * Encodes whether a FinancialAccount has access to a particular feature, with a status enum and
+   * associated {@code status_details}. Stripe or the platform may control features via the
+   * requested field.
+   */
+  @SerializedName("features")
+  Features features;
+
+  /**
+   * Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can attach
+   * to an object. This can be useful for storing additional information about the object in a
+   * structured format. Individual keys can be unset by posting an empty value to them. All keys can
+   * be unset by posting an empty value to {@code metadata}.
+   */
+  @SerializedName("metadata")
+  Map<String, String> metadata;
+
+  /** The set of functionalities that the platform can restrict on the FinancialAccount. */
+  @SerializedName("platform_restrictions")
+  PlatformRestrictions platformRestrictions;
+
+  private FinancialAccountUpdateParams(
+      List<String> expand,
+      Map<String, Object> extraParams,
+      Features features,
+      Map<String, String> metadata,
+      PlatformRestrictions platformRestrictions) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+    this.features = features;
+    this.metadata = metadata;
+    this.platformRestrictions = platformRestrictions;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    private Features features;
+
+    private Map<String, String> metadata;
+
+    private PlatformRestrictions platformRestrictions;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public FinancialAccountUpdateParams build() {
+      return new FinancialAccountUpdateParams(
+          this.expand, this.extraParams, this.features, this.metadata, this.platformRestrictions);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * FinancialAccountUpdateParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * FinancialAccountUpdateParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * FinancialAccountUpdateParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link FinancialAccountUpdateParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /**
+     * Encodes whether a FinancialAccount has access to a particular feature, with a status enum and
+     * associated {@code status_details}. Stripe or the platform may control features via the
+     * requested field.
+     */
+    public Builder setFeatures(Features features) {
+      this.features = features;
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `metadata` map. A map is initialized for the first `put/putAll` call,
+     * and subsequent calls add additional key/value pairs to the original map. See {@link
+     * FinancialAccountUpdateParams#metadata} for the field documentation.
+     */
+    public Builder putMetadata(String key, String value) {
+      if (this.metadata == null) {
+        this.metadata = new HashMap<>();
+      }
+      this.metadata.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `metadata` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link FinancialAccountUpdateParams#metadata} for the field documentation.
+     */
+    public Builder putAllMetadata(Map<String, String> map) {
+      if (this.metadata == null) {
+        this.metadata = new HashMap<>();
+      }
+      this.metadata.putAll(map);
+      return this;
+    }
+
+    /** The set of functionalities that the platform can restrict on the FinancialAccount. */
+    public Builder setPlatformRestrictions(PlatformRestrictions platformRestrictions) {
+      this.platformRestrictions = platformRestrictions;
+      return this;
+    }
+  }
+
+  @Getter
+  public static class Features {
+    /**
+     * Represents whether this FinancialAccount is eligible for deposit insurance. Various factors
+     * determine the insurance amount.
+     */
+    @SerializedName("deposit_insurance")
+    DepositInsurance depositInsurance;
+
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /** Contains Features that add FinancialAddresses to the FinancialAccount. */
+    @SerializedName("financial_addresses")
+    FinancialAddresses financialAddresses;
+
+    /**
+     * Contains settings related to adding funds to a FinancialAccount from another Account with the
+     * same owner.
+     */
+    @SerializedName("inbound_transfers")
+    InboundTransfers inboundTransfers;
+
+    /**
+     * Represents the ability for the FinancialAccount to send money to, or receive money from other
+     * FinancialAccounts (for example, via OutboundPayment).
+     */
+    @SerializedName("intra_stripe_flows")
+    IntraStripeFlows intraStripeFlows;
+
+    /**
+     * Includes Features related to initiating money movement out of the FinancialAccount to someone
+     * else's bucket of money.
+     */
+    @SerializedName("outbound_payments")
+    OutboundPayments outboundPayments;
+
+    /**
+     * Contains a Feature and settings related to moving money out of the FinancialAccount into
+     * another Account with the same owner.
+     */
+    @SerializedName("outbound_transfers")
+    OutboundTransfers outboundTransfers;
+
+    private Features(
+        DepositInsurance depositInsurance,
+        Map<String, Object> extraParams,
+        FinancialAddresses financialAddresses,
+        InboundTransfers inboundTransfers,
+        IntraStripeFlows intraStripeFlows,
+        OutboundPayments outboundPayments,
+        OutboundTransfers outboundTransfers) {
+      this.depositInsurance = depositInsurance;
+      this.extraParams = extraParams;
+      this.financialAddresses = financialAddresses;
+      this.inboundTransfers = inboundTransfers;
+      this.intraStripeFlows = intraStripeFlows;
+      this.outboundPayments = outboundPayments;
+      this.outboundTransfers = outboundTransfers;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private DepositInsurance depositInsurance;
+
+      private Map<String, Object> extraParams;
+
+      private FinancialAddresses financialAddresses;
+
+      private InboundTransfers inboundTransfers;
+
+      private IntraStripeFlows intraStripeFlows;
+
+      private OutboundPayments outboundPayments;
+
+      private OutboundTransfers outboundTransfers;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public Features build() {
+        return new Features(
+            this.depositInsurance,
+            this.extraParams,
+            this.financialAddresses,
+            this.inboundTransfers,
+            this.intraStripeFlows,
+            this.outboundPayments,
+            this.outboundTransfers);
+      }
+
+      /**
+       * Represents whether this FinancialAccount is eligible for deposit insurance. Various factors
+       * determine the insurance amount.
+       */
+      public Builder setDepositInsurance(DepositInsurance depositInsurance) {
+        this.depositInsurance = depositInsurance;
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * FinancialAccountUpdateParams.Features#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link FinancialAccountUpdateParams.Features#extraParams} for the field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** Contains Features that add FinancialAddresses to the FinancialAccount. */
+      public Builder setFinancialAddresses(FinancialAddresses financialAddresses) {
+        this.financialAddresses = financialAddresses;
+        return this;
+      }
+
+      /**
+       * Contains settings related to adding funds to a FinancialAccount from another Account with
+       * the same owner.
+       */
+      public Builder setInboundTransfers(InboundTransfers inboundTransfers) {
+        this.inboundTransfers = inboundTransfers;
+        return this;
+      }
+
+      /**
+       * Represents the ability for the FinancialAccount to send money to, or receive money from
+       * other FinancialAccounts (for example, via OutboundPayment).
+       */
+      public Builder setIntraStripeFlows(IntraStripeFlows intraStripeFlows) {
+        this.intraStripeFlows = intraStripeFlows;
+        return this;
+      }
+
+      /**
+       * Includes Features related to initiating money movement out of the FinancialAccount to
+       * someone else's bucket of money.
+       */
+      public Builder setOutboundPayments(OutboundPayments outboundPayments) {
+        this.outboundPayments = outboundPayments;
+        return this;
+      }
+
+      /**
+       * Contains a Feature and settings related to moving money out of the FinancialAccount into
+       * another Account with the same owner.
+       */
+      public Builder setOutboundTransfers(OutboundTransfers outboundTransfers) {
+        this.outboundTransfers = outboundTransfers;
+        return this;
+      }
+    }
+
+    @Getter
+    public static class DepositInsurance {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Whether the FinancialAccount should have the Feature. */
+      @SerializedName("requested")
+      Boolean requested;
+
+      private DepositInsurance(Map<String, Object> extraParams, Boolean requested) {
+        this.extraParams = extraParams;
+        this.requested = requested;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private Boolean requested;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public DepositInsurance build() {
+          return new DepositInsurance(this.extraParams, this.requested);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link FinancialAccountUpdateParams.Features.DepositInsurance#extraParams} for
+         * the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link FinancialAccountUpdateParams.Features.DepositInsurance#extraParams} for
+         * the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Whether the FinancialAccount should have the Feature. */
+        public Builder setRequested(Boolean requested) {
+          this.requested = requested;
+          return this;
+        }
+      }
+    }
+
+    @Getter
+    public static class FinancialAddresses {
+      /** Adds an ABA FinancialAddress to the FinancialAccount. */
+      @SerializedName("aba")
+      Aba aba;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private FinancialAddresses(Aba aba, Map<String, Object> extraParams) {
+        this.aba = aba;
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Aba aba;
+
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public FinancialAddresses build() {
+          return new FinancialAddresses(this.aba, this.extraParams);
+        }
+
+        /** Adds an ABA FinancialAddress to the FinancialAccount. */
+        public Builder setAba(Aba aba) {
+          this.aba = aba;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link FinancialAccountUpdateParams.Features.FinancialAddresses#extraParams} for
+         * the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link FinancialAccountUpdateParams.Features.FinancialAddresses#extraParams} for
+         * the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+      }
+
+      @Getter
+      public static class Aba {
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /** Whether the FinancialAccount should have the Feature. */
+        @SerializedName("requested")
+        Boolean requested;
+
+        private Aba(Map<String, Object> extraParams, Boolean requested) {
+          this.extraParams = extraParams;
+          this.requested = requested;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Map<String, Object> extraParams;
+
+          private Boolean requested;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public Aba build() {
+            return new Aba(this.extraParams, this.requested);
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * FinancialAccountUpdateParams.Features.FinancialAddresses.Aba#extraParams} for the field
+           * documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * FinancialAccountUpdateParams.Features.FinancialAddresses.Aba#extraParams} for the field
+           * documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /** Whether the FinancialAccount should have the Feature. */
+          public Builder setRequested(Boolean requested) {
+            this.requested = requested;
+            return this;
+          }
+        }
+      }
+    }
+
+    @Getter
+    public static class InboundTransfers {
+      /** Enables ACH Debits via the InboundTransfers API. */
+      @SerializedName("ach")
+      Ach ach;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private InboundTransfers(Ach ach, Map<String, Object> extraParams) {
+        this.ach = ach;
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Ach ach;
+
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public InboundTransfers build() {
+          return new InboundTransfers(this.ach, this.extraParams);
+        }
+
+        /** Enables ACH Debits via the InboundTransfers API. */
+        public Builder setAch(Ach ach) {
+          this.ach = ach;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link FinancialAccountUpdateParams.Features.InboundTransfers#extraParams} for
+         * the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link FinancialAccountUpdateParams.Features.InboundTransfers#extraParams} for
+         * the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+      }
+
+      @Getter
+      public static class Ach {
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /** Whether the FinancialAccount should have the Feature. */
+        @SerializedName("requested")
+        Boolean requested;
+
+        private Ach(Map<String, Object> extraParams, Boolean requested) {
+          this.extraParams = extraParams;
+          this.requested = requested;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Map<String, Object> extraParams;
+
+          private Boolean requested;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public Ach build() {
+            return new Ach(this.extraParams, this.requested);
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link FinancialAccountUpdateParams.Features.InboundTransfers.Ach#extraParams}
+           * for the field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link FinancialAccountUpdateParams.Features.InboundTransfers.Ach#extraParams}
+           * for the field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /** Whether the FinancialAccount should have the Feature. */
+          public Builder setRequested(Boolean requested) {
+            this.requested = requested;
+            return this;
+          }
+        }
+      }
+    }
+
+    @Getter
+    public static class IntraStripeFlows {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Whether the FinancialAccount should have the Feature. */
+      @SerializedName("requested")
+      Boolean requested;
+
+      private IntraStripeFlows(Map<String, Object> extraParams, Boolean requested) {
+        this.extraParams = extraParams;
+        this.requested = requested;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private Boolean requested;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public IntraStripeFlows build() {
+          return new IntraStripeFlows(this.extraParams, this.requested);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link FinancialAccountUpdateParams.Features.IntraStripeFlows#extraParams} for
+         * the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link FinancialAccountUpdateParams.Features.IntraStripeFlows#extraParams} for
+         * the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Whether the FinancialAccount should have the Feature. */
+        public Builder setRequested(Boolean requested) {
+          this.requested = requested;
+          return this;
+        }
+      }
+    }
+
+    @Getter
+    public static class OutboundPayments {
+      /** Enables ACH transfers via the OutboundPayments API. */
+      @SerializedName("ach")
+      Ach ach;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Enables US domestic wire tranfers via the OutboundPayments API. */
+      @SerializedName("us_domestic_wire")
+      UsDomesticWire usDomesticWire;
+
+      private OutboundPayments(
+          Ach ach, Map<String, Object> extraParams, UsDomesticWire usDomesticWire) {
+        this.ach = ach;
+        this.extraParams = extraParams;
+        this.usDomesticWire = usDomesticWire;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Ach ach;
+
+        private Map<String, Object> extraParams;
+
+        private UsDomesticWire usDomesticWire;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public OutboundPayments build() {
+          return new OutboundPayments(this.ach, this.extraParams, this.usDomesticWire);
+        }
+
+        /** Enables ACH transfers via the OutboundPayments API. */
+        public Builder setAch(Ach ach) {
+          this.ach = ach;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link FinancialAccountUpdateParams.Features.OutboundPayments#extraParams} for
+         * the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link FinancialAccountUpdateParams.Features.OutboundPayments#extraParams} for
+         * the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Enables US domestic wire tranfers via the OutboundPayments API. */
+        public Builder setUsDomesticWire(UsDomesticWire usDomesticWire) {
+          this.usDomesticWire = usDomesticWire;
+          return this;
+        }
+      }
+
+      @Getter
+      public static class Ach {
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /** Whether the FinancialAccount should have the Feature. */
+        @SerializedName("requested")
+        Boolean requested;
+
+        private Ach(Map<String, Object> extraParams, Boolean requested) {
+          this.extraParams = extraParams;
+          this.requested = requested;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Map<String, Object> extraParams;
+
+          private Boolean requested;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public Ach build() {
+            return new Ach(this.extraParams, this.requested);
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link FinancialAccountUpdateParams.Features.OutboundPayments.Ach#extraParams}
+           * for the field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link FinancialAccountUpdateParams.Features.OutboundPayments.Ach#extraParams}
+           * for the field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /** Whether the FinancialAccount should have the Feature. */
+          public Builder setRequested(Boolean requested) {
+            this.requested = requested;
+            return this;
+          }
+        }
+      }
+
+      @Getter
+      public static class UsDomesticWire {
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /** Whether the FinancialAccount should have the Feature. */
+        @SerializedName("requested")
+        Boolean requested;
+
+        private UsDomesticWire(Map<String, Object> extraParams, Boolean requested) {
+          this.extraParams = extraParams;
+          this.requested = requested;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Map<String, Object> extraParams;
+
+          private Boolean requested;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public UsDomesticWire build() {
+            return new UsDomesticWire(this.extraParams, this.requested);
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * FinancialAccountUpdateParams.Features.OutboundPayments.UsDomesticWire#extraParams} for
+           * the field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * FinancialAccountUpdateParams.Features.OutboundPayments.UsDomesticWire#extraParams} for
+           * the field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /** Whether the FinancialAccount should have the Feature. */
+          public Builder setRequested(Boolean requested) {
+            this.requested = requested;
+            return this;
+          }
+        }
+      }
+    }
+
+    @Getter
+    public static class OutboundTransfers {
+      /** Enables ACH transfers via the OutboundTransfers API. */
+      @SerializedName("ach")
+      Ach ach;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Enables US domestic wire tranfers via the OutboundTransfers API. */
+      @SerializedName("us_domestic_wire")
+      UsDomesticWire usDomesticWire;
+
+      private OutboundTransfers(
+          Ach ach, Map<String, Object> extraParams, UsDomesticWire usDomesticWire) {
+        this.ach = ach;
+        this.extraParams = extraParams;
+        this.usDomesticWire = usDomesticWire;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Ach ach;
+
+        private Map<String, Object> extraParams;
+
+        private UsDomesticWire usDomesticWire;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public OutboundTransfers build() {
+          return new OutboundTransfers(this.ach, this.extraParams, this.usDomesticWire);
+        }
+
+        /** Enables ACH transfers via the OutboundTransfers API. */
+        public Builder setAch(Ach ach) {
+          this.ach = ach;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link FinancialAccountUpdateParams.Features.OutboundTransfers#extraParams} for
+         * the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link FinancialAccountUpdateParams.Features.OutboundTransfers#extraParams} for
+         * the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Enables US domestic wire tranfers via the OutboundTransfers API. */
+        public Builder setUsDomesticWire(UsDomesticWire usDomesticWire) {
+          this.usDomesticWire = usDomesticWire;
+          return this;
+        }
+      }
+
+      @Getter
+      public static class Ach {
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /** Whether the FinancialAccount should have the Feature. */
+        @SerializedName("requested")
+        Boolean requested;
+
+        private Ach(Map<String, Object> extraParams, Boolean requested) {
+          this.extraParams = extraParams;
+          this.requested = requested;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Map<String, Object> extraParams;
+
+          private Boolean requested;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public Ach build() {
+            return new Ach(this.extraParams, this.requested);
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * FinancialAccountUpdateParams.Features.OutboundTransfers.Ach#extraParams} for the field
+           * documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * FinancialAccountUpdateParams.Features.OutboundTransfers.Ach#extraParams} for the field
+           * documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /** Whether the FinancialAccount should have the Feature. */
+          public Builder setRequested(Boolean requested) {
+            this.requested = requested;
+            return this;
+          }
+        }
+      }
+
+      @Getter
+      public static class UsDomesticWire {
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /** Whether the FinancialAccount should have the Feature. */
+        @SerializedName("requested")
+        Boolean requested;
+
+        private UsDomesticWire(Map<String, Object> extraParams, Boolean requested) {
+          this.extraParams = extraParams;
+          this.requested = requested;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Map<String, Object> extraParams;
+
+          private Boolean requested;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public UsDomesticWire build() {
+            return new UsDomesticWire(this.extraParams, this.requested);
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * FinancialAccountUpdateParams.Features.OutboundTransfers.UsDomesticWire#extraParams} for
+           * the field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * FinancialAccountUpdateParams.Features.OutboundTransfers.UsDomesticWire#extraParams} for
+           * the field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /** Whether the FinancialAccount should have the Feature. */
+          public Builder setRequested(Boolean requested) {
+            this.requested = requested;
+            return this;
+          }
+        }
+      }
+    }
+  }
+
+  @Getter
+  public static class PlatformRestrictions {
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /** Restricts all inbound money movement. */
+    @SerializedName("inbound_flows")
+    InboundFlows inboundFlows;
+
+    /** Restricts all outbound money movement. */
+    @SerializedName("outbound_flows")
+    OutboundFlows outboundFlows;
+
+    private PlatformRestrictions(
+        Map<String, Object> extraParams, InboundFlows inboundFlows, OutboundFlows outboundFlows) {
+      this.extraParams = extraParams;
+      this.inboundFlows = inboundFlows;
+      this.outboundFlows = outboundFlows;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Map<String, Object> extraParams;
+
+      private InboundFlows inboundFlows;
+
+      private OutboundFlows outboundFlows;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public PlatformRestrictions build() {
+        return new PlatformRestrictions(this.extraParams, this.inboundFlows, this.outboundFlows);
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * FinancialAccountUpdateParams.PlatformRestrictions#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link FinancialAccountUpdateParams.PlatformRestrictions#extraParams} for the field
+       * documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** Restricts all inbound money movement. */
+      public Builder setInboundFlows(InboundFlows inboundFlows) {
+        this.inboundFlows = inboundFlows;
+        return this;
+      }
+
+      /** Restricts all outbound money movement. */
+      public Builder setOutboundFlows(OutboundFlows outboundFlows) {
+        this.outboundFlows = outboundFlows;
+        return this;
+      }
+    }
+
+    public enum InboundFlows implements ApiRequestParams.EnumParam {
+      @SerializedName("restricted")
+      RESTRICTED("restricted"),
+
+      @SerializedName("unrestricted")
+      UNRESTRICTED("unrestricted");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      InboundFlows(String value) {
+        this.value = value;
+      }
+    }
+
+    public enum OutboundFlows implements ApiRequestParams.EnumParam {
+      @SerializedName("restricted")
+      RESTRICTED("restricted"),
+
+      @SerializedName("unrestricted")
+      UNRESTRICTED("unrestricted");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      OutboundFlows(String value) {
+        this.value = value;
+      }
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/InboundTransferCancelParams.java
+++ b/src/main/java/com/stripe/param/treasury/InboundTransferCancelParams.java
@@ -1,0 +1,98 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class InboundTransferCancelParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  private InboundTransferCancelParams(List<String> expand, Map<String, Object> extraParams) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public InboundTransferCancelParams build() {
+      return new InboundTransferCancelParams(this.expand, this.extraParams);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * InboundTransferCancelParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * InboundTransferCancelParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * InboundTransferCancelParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link InboundTransferCancelParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/InboundTransferCreateParams.java
+++ b/src/main/java/com/stripe/param/treasury/InboundTransferCreateParams.java
@@ -1,0 +1,245 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class InboundTransferCreateParams extends ApiRequestParams {
+  /** Amount (in cents) to be transferred. */
+  @SerializedName("amount")
+  Long amount;
+
+  /**
+   * Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency code</a>,
+   * in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported currency</a>.
+   */
+  @SerializedName("currency")
+  String currency;
+
+  /** An arbitrary string attached to the object. Often useful for displaying to users. */
+  @SerializedName("description")
+  String description;
+
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  /** The FinancialAccount to send funds to. */
+  @SerializedName("financial_account")
+  String financialAccount;
+
+  /**
+   * Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can attach
+   * to an object. This can be useful for storing additional information about the object in a
+   * structured format. Individual keys can be unset by posting an empty value to them. All keys can
+   * be unset by posting an empty value to {@code metadata}.
+   */
+  @SerializedName("metadata")
+  Map<String, String> metadata;
+
+  /** The origin payment method to be debited for the InboundTransfer. */
+  @SerializedName("origin_payment_method")
+  String originPaymentMethod;
+
+  /**
+   * The complete description that appears on your customers' statements. Must contain at least one
+   * letter, maximum 10 characters.
+   */
+  @SerializedName("statement_descriptor")
+  String statementDescriptor;
+
+  private InboundTransferCreateParams(
+      Long amount,
+      String currency,
+      String description,
+      List<String> expand,
+      Map<String, Object> extraParams,
+      String financialAccount,
+      Map<String, String> metadata,
+      String originPaymentMethod,
+      String statementDescriptor) {
+    this.amount = amount;
+    this.currency = currency;
+    this.description = description;
+    this.expand = expand;
+    this.extraParams = extraParams;
+    this.financialAccount = financialAccount;
+    this.metadata = metadata;
+    this.originPaymentMethod = originPaymentMethod;
+    this.statementDescriptor = statementDescriptor;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Long amount;
+
+    private String currency;
+
+    private String description;
+
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    private String financialAccount;
+
+    private Map<String, String> metadata;
+
+    private String originPaymentMethod;
+
+    private String statementDescriptor;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public InboundTransferCreateParams build() {
+      return new InboundTransferCreateParams(
+          this.amount,
+          this.currency,
+          this.description,
+          this.expand,
+          this.extraParams,
+          this.financialAccount,
+          this.metadata,
+          this.originPaymentMethod,
+          this.statementDescriptor);
+    }
+
+    /** Amount (in cents) to be transferred. */
+    public Builder setAmount(Long amount) {
+      this.amount = amount;
+      return this;
+    }
+
+    /**
+     * Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency
+     * code</a>, in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported
+     * currency</a>.
+     */
+    public Builder setCurrency(String currency) {
+      this.currency = currency;
+      return this;
+    }
+
+    /** An arbitrary string attached to the object. Often useful for displaying to users. */
+    public Builder setDescription(String description) {
+      this.description = description;
+      return this;
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * InboundTransferCreateParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * InboundTransferCreateParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * InboundTransferCreateParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link InboundTransferCreateParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /** The FinancialAccount to send funds to. */
+    public Builder setFinancialAccount(String financialAccount) {
+      this.financialAccount = financialAccount;
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `metadata` map. A map is initialized for the first `put/putAll` call,
+     * and subsequent calls add additional key/value pairs to the original map. See {@link
+     * InboundTransferCreateParams#metadata} for the field documentation.
+     */
+    public Builder putMetadata(String key, String value) {
+      if (this.metadata == null) {
+        this.metadata = new HashMap<>();
+      }
+      this.metadata.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `metadata` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link InboundTransferCreateParams#metadata} for the field documentation.
+     */
+    public Builder putAllMetadata(Map<String, String> map) {
+      if (this.metadata == null) {
+        this.metadata = new HashMap<>();
+      }
+      this.metadata.putAll(map);
+      return this;
+    }
+
+    /** The origin payment method to be debited for the InboundTransfer. */
+    public Builder setOriginPaymentMethod(String originPaymentMethod) {
+      this.originPaymentMethod = originPaymentMethod;
+      return this;
+    }
+
+    /**
+     * The complete description that appears on your customers' statements. Must contain at least
+     * one letter, maximum 10 characters.
+     */
+    public Builder setStatementDescriptor(String statementDescriptor) {
+      this.statementDescriptor = statementDescriptor;
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/InboundTransferCreateParams.java
+++ b/src/main/java/com/stripe/param/treasury/InboundTransferCreateParams.java
@@ -56,10 +56,7 @@ public class InboundTransferCreateParams extends ApiRequestParams {
   @SerializedName("origin_payment_method")
   String originPaymentMethod;
 
-  /**
-   * The complete description that appears on your customers' statements. Must contain at least one
-   * letter, maximum 10 characters.
-   */
+  /** The complete description that appears on your customers' statements. Maximum 10 characters. */
   @SerializedName("statement_descriptor")
   String statementDescriptor;
 
@@ -234,8 +231,7 @@ public class InboundTransferCreateParams extends ApiRequestParams {
     }
 
     /**
-     * The complete description that appears on your customers' statements. Must contain at least
-     * one letter, maximum 10 characters.
+     * The complete description that appears on your customers' statements. Maximum 10 characters.
      */
     public Builder setStatementDescriptor(String statementDescriptor) {
       this.statementDescriptor = statementDescriptor;

--- a/src/main/java/com/stripe/param/treasury/InboundTransferFailParams.java
+++ b/src/main/java/com/stripe/param/treasury/InboundTransferFailParams.java
@@ -1,0 +1,229 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class InboundTransferFailParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  /** Details about a failed InboundTransfer. */
+  @SerializedName("failure_details")
+  FailureDetails failureDetails;
+
+  private InboundTransferFailParams(
+      List<String> expand, Map<String, Object> extraParams, FailureDetails failureDetails) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+    this.failureDetails = failureDetails;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    private FailureDetails failureDetails;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public InboundTransferFailParams build() {
+      return new InboundTransferFailParams(this.expand, this.extraParams, this.failureDetails);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * InboundTransferFailParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * InboundTransferFailParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * InboundTransferFailParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link InboundTransferFailParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /** Details about a failed InboundTransfer. */
+    public Builder setFailureDetails(FailureDetails failureDetails) {
+      this.failureDetails = failureDetails;
+      return this;
+    }
+  }
+
+  @Getter
+  public static class FailureDetails {
+    /** Reason for the failure. */
+    @SerializedName("code")
+    Code code;
+
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    private FailureDetails(Code code, Map<String, Object> extraParams) {
+      this.code = code;
+      this.extraParams = extraParams;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Code code;
+
+      private Map<String, Object> extraParams;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public FailureDetails build() {
+        return new FailureDetails(this.code, this.extraParams);
+      }
+
+      /** Reason for the failure. */
+      public Builder setCode(Code code) {
+        this.code = code;
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * InboundTransferFailParams.FailureDetails#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link InboundTransferFailParams.FailureDetails#extraParams} for the field
+       * documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+    }
+
+    public enum Code implements ApiRequestParams.EnumParam {
+      @SerializedName("account_closed")
+      ACCOUNT_CLOSED("account_closed"),
+
+      @SerializedName("account_frozen")
+      ACCOUNT_FROZEN("account_frozen"),
+
+      @SerializedName("bank_account_restricted")
+      BANK_ACCOUNT_RESTRICTED("bank_account_restricted"),
+
+      @SerializedName("bank_ownership_changed")
+      BANK_OWNERSHIP_CHANGED("bank_ownership_changed"),
+
+      @SerializedName("debit_not_authorized")
+      DEBIT_NOT_AUTHORIZED("debit_not_authorized"),
+
+      @SerializedName("incorrect_account_holder_address")
+      INCORRECT_ACCOUNT_HOLDER_ADDRESS("incorrect_account_holder_address"),
+
+      @SerializedName("incorrect_account_holder_name")
+      INCORRECT_ACCOUNT_HOLDER_NAME("incorrect_account_holder_name"),
+
+      @SerializedName("incorrect_account_holder_tax_id")
+      INCORRECT_ACCOUNT_HOLDER_TAX_ID("incorrect_account_holder_tax_id"),
+
+      @SerializedName("insufficient_funds")
+      INSUFFICIENT_FUNDS("insufficient_funds"),
+
+      @SerializedName("invalid_account_number")
+      INVALID_ACCOUNT_NUMBER("invalid_account_number"),
+
+      @SerializedName("invalid_currency")
+      INVALID_CURRENCY("invalid_currency"),
+
+      @SerializedName("no_account")
+      NO_ACCOUNT("no_account"),
+
+      @SerializedName("other")
+      OTHER("other");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      Code(String value) {
+        this.value = value;
+      }
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/InboundTransferListParams.java
+++ b/src/main/java/com/stripe/param/treasury/InboundTransferListParams.java
@@ -1,0 +1,230 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class InboundTransferListParams extends ApiRequestParams {
+  /**
+   * A cursor for use in pagination. {@code ending_before} is an object ID that defines your place
+   * in the list. For instance, if you make a list request and receive 100 objects, starting with
+   * {@code obj_bar}, your subsequent call can include {@code ending_before=obj_bar} in order to
+   * fetch the previous page of the list.
+   */
+  @SerializedName("ending_before")
+  String endingBefore;
+
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  /** Returns objects associated with this FinancialAccount. */
+  @SerializedName("financial_account")
+  String financialAccount;
+
+  /**
+   * A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+   * default is 10.
+   */
+  @SerializedName("limit")
+  Long limit;
+
+  /**
+   * A cursor for use in pagination. {@code starting_after} is an object ID that defines your place
+   * in the list. For instance, if you make a list request and receive 100 objects, ending with
+   * {@code obj_foo}, your subsequent call can include {@code starting_after=obj_foo} in order to
+   * fetch the next page of the list.
+   */
+  @SerializedName("starting_after")
+  String startingAfter;
+
+  /**
+   * Only return InboundTransfers that have the given status: {@code processing}, {@code succeeded},
+   * {@code failed} or {@code canceled}.
+   */
+  @SerializedName("status")
+  Status status;
+
+  private InboundTransferListParams(
+      String endingBefore,
+      List<String> expand,
+      Map<String, Object> extraParams,
+      String financialAccount,
+      Long limit,
+      String startingAfter,
+      Status status) {
+    this.endingBefore = endingBefore;
+    this.expand = expand;
+    this.extraParams = extraParams;
+    this.financialAccount = financialAccount;
+    this.limit = limit;
+    this.startingAfter = startingAfter;
+    this.status = status;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String endingBefore;
+
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    private String financialAccount;
+
+    private Long limit;
+
+    private String startingAfter;
+
+    private Status status;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public InboundTransferListParams build() {
+      return new InboundTransferListParams(
+          this.endingBefore,
+          this.expand,
+          this.extraParams,
+          this.financialAccount,
+          this.limit,
+          this.startingAfter,
+          this.status);
+    }
+
+    /**
+     * A cursor for use in pagination. {@code ending_before} is an object ID that defines your place
+     * in the list. For instance, if you make a list request and receive 100 objects, starting with
+     * {@code obj_bar}, your subsequent call can include {@code ending_before=obj_bar} in order to
+     * fetch the previous page of the list.
+     */
+    public Builder setEndingBefore(String endingBefore) {
+      this.endingBefore = endingBefore;
+      return this;
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * InboundTransferListParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * InboundTransferListParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * InboundTransferListParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link InboundTransferListParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /** Returns objects associated with this FinancialAccount. */
+    public Builder setFinancialAccount(String financialAccount) {
+      this.financialAccount = financialAccount;
+      return this;
+    }
+
+    /**
+     * A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+     * default is 10.
+     */
+    public Builder setLimit(Long limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    /**
+     * A cursor for use in pagination. {@code starting_after} is an object ID that defines your
+     * place in the list. For instance, if you make a list request and receive 100 objects, ending
+     * with {@code obj_foo}, your subsequent call can include {@code starting_after=obj_foo} in
+     * order to fetch the next page of the list.
+     */
+    public Builder setStartingAfter(String startingAfter) {
+      this.startingAfter = startingAfter;
+      return this;
+    }
+
+    /**
+     * Only return InboundTransfers that have the given status: {@code processing}, {@code
+     * succeeded}, {@code failed} or {@code canceled}.
+     */
+    public Builder setStatus(Status status) {
+      this.status = status;
+      return this;
+    }
+  }
+
+  public enum Status implements ApiRequestParams.EnumParam {
+    @SerializedName("canceled")
+    CANCELED("canceled"),
+
+    @SerializedName("failed")
+    FAILED("failed"),
+
+    @SerializedName("processing")
+    PROCESSING("processing"),
+
+    @SerializedName("succeeded")
+    SUCCEEDED("succeeded");
+
+    @Getter(onMethod_ = {@Override})
+    private final String value;
+
+    Status(String value) {
+      this.value = value;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/InboundTransferRetrieveParams.java
+++ b/src/main/java/com/stripe/param/treasury/InboundTransferRetrieveParams.java
@@ -1,0 +1,98 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class InboundTransferRetrieveParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  private InboundTransferRetrieveParams(List<String> expand, Map<String, Object> extraParams) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public InboundTransferRetrieveParams build() {
+      return new InboundTransferRetrieveParams(this.expand, this.extraParams);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * InboundTransferRetrieveParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * InboundTransferRetrieveParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * InboundTransferRetrieveParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link InboundTransferRetrieveParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/InboundTransferReturnInboundTransferParams.java
+++ b/src/main/java/com/stripe/param/treasury/InboundTransferReturnInboundTransferParams.java
@@ -1,0 +1,100 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class InboundTransferReturnInboundTransferParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  private InboundTransferReturnInboundTransferParams(
+      List<String> expand, Map<String, Object> extraParams) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public InboundTransferReturnInboundTransferParams build() {
+      return new InboundTransferReturnInboundTransferParams(this.expand, this.extraParams);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * InboundTransferReturnInboundTransferParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * InboundTransferReturnInboundTransferParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * InboundTransferReturnInboundTransferParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link InboundTransferReturnInboundTransferParams#extraParams} for the field
+     * documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/InboundTransferSucceedParams.java
+++ b/src/main/java/com/stripe/param/treasury/InboundTransferSucceedParams.java
@@ -1,0 +1,98 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class InboundTransferSucceedParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  private InboundTransferSucceedParams(List<String> expand, Map<String, Object> extraParams) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public InboundTransferSucceedParams build() {
+      return new InboundTransferSucceedParams(this.expand, this.extraParams);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * InboundTransferSucceedParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * InboundTransferSucceedParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * InboundTransferSucceedParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link InboundTransferSucceedParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/OutboundPaymentCancelParams.java
+++ b/src/main/java/com/stripe/param/treasury/OutboundPaymentCancelParams.java
@@ -1,0 +1,98 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class OutboundPaymentCancelParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  private OutboundPaymentCancelParams(List<String> expand, Map<String, Object> extraParams) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public OutboundPaymentCancelParams build() {
+      return new OutboundPaymentCancelParams(this.expand, this.extraParams);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * OutboundPaymentCancelParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * OutboundPaymentCancelParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * OutboundPaymentCancelParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link OutboundPaymentCancelParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/OutboundPaymentCreateParams.java
+++ b/src/main/java/com/stripe/param/treasury/OutboundPaymentCreateParams.java
@@ -1,0 +1,1238 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import com.stripe.param.common.EmptyParam;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class OutboundPaymentCreateParams extends ApiRequestParams {
+  /** Amount (in cents) to be transferred. */
+  @SerializedName("amount")
+  Long amount;
+
+  /**
+   * Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency code</a>,
+   * in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported currency</a>.
+   */
+  @SerializedName("currency")
+  String currency;
+
+  /**
+   * ID of the customer to whom the OutboundPayment is sent. Must match the Customer attached to the
+   * {@code destination_payment_method} passed in.
+   */
+  @SerializedName("customer")
+  String customer;
+
+  /** An arbitrary string attached to the object. Often useful for displaying to users. */
+  @SerializedName("description")
+  String description;
+
+  /**
+   * The PaymentMethod to use as the payment instrument for the OutboundPayment. Exclusive with
+   * {@code destination_payment_method_data}.
+   */
+  @SerializedName("destination_payment_method")
+  String destinationPaymentMethod;
+
+  /**
+   * Hash used to generate the PaymentMethod to be used for this OutboundPayment. Exclusive with
+   * {@code destination_payment_method}.
+   */
+  @SerializedName("destination_payment_method_data")
+  DestinationPaymentMethodData destinationPaymentMethodData;
+
+  /** Payment method-specific configuration for this OutboundPayment. */
+  @SerializedName("destination_payment_method_options")
+  DestinationPaymentMethodOptions destinationPaymentMethodOptions;
+
+  /** End user details. */
+  @SerializedName("end_user_details")
+  EndUserDetails endUserDetails;
+
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  /** The FinancialAccount to pull funds from. */
+  @SerializedName("financial_account")
+  String financialAccount;
+
+  /**
+   * Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can attach
+   * to an object. This can be useful for storing additional information about the object in a
+   * structured format. Individual keys can be unset by posting an empty value to them. All keys can
+   * be unset by posting an empty value to {@code metadata}.
+   */
+  @SerializedName("metadata")
+  Map<String, String> metadata;
+
+  /**
+   * The description that appears on the receiving end for this OutboundPayment (for example, bank
+   * statement for external bank transfer).
+   */
+  @SerializedName("statement_descriptor")
+  String statementDescriptor;
+
+  private OutboundPaymentCreateParams(
+      Long amount,
+      String currency,
+      String customer,
+      String description,
+      String destinationPaymentMethod,
+      DestinationPaymentMethodData destinationPaymentMethodData,
+      DestinationPaymentMethodOptions destinationPaymentMethodOptions,
+      EndUserDetails endUserDetails,
+      List<String> expand,
+      Map<String, Object> extraParams,
+      String financialAccount,
+      Map<String, String> metadata,
+      String statementDescriptor) {
+    this.amount = amount;
+    this.currency = currency;
+    this.customer = customer;
+    this.description = description;
+    this.destinationPaymentMethod = destinationPaymentMethod;
+    this.destinationPaymentMethodData = destinationPaymentMethodData;
+    this.destinationPaymentMethodOptions = destinationPaymentMethodOptions;
+    this.endUserDetails = endUserDetails;
+    this.expand = expand;
+    this.extraParams = extraParams;
+    this.financialAccount = financialAccount;
+    this.metadata = metadata;
+    this.statementDescriptor = statementDescriptor;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Long amount;
+
+    private String currency;
+
+    private String customer;
+
+    private String description;
+
+    private String destinationPaymentMethod;
+
+    private DestinationPaymentMethodData destinationPaymentMethodData;
+
+    private DestinationPaymentMethodOptions destinationPaymentMethodOptions;
+
+    private EndUserDetails endUserDetails;
+
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    private String financialAccount;
+
+    private Map<String, String> metadata;
+
+    private String statementDescriptor;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public OutboundPaymentCreateParams build() {
+      return new OutboundPaymentCreateParams(
+          this.amount,
+          this.currency,
+          this.customer,
+          this.description,
+          this.destinationPaymentMethod,
+          this.destinationPaymentMethodData,
+          this.destinationPaymentMethodOptions,
+          this.endUserDetails,
+          this.expand,
+          this.extraParams,
+          this.financialAccount,
+          this.metadata,
+          this.statementDescriptor);
+    }
+
+    /** Amount (in cents) to be transferred. */
+    public Builder setAmount(Long amount) {
+      this.amount = amount;
+      return this;
+    }
+
+    /**
+     * Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency
+     * code</a>, in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported
+     * currency</a>.
+     */
+    public Builder setCurrency(String currency) {
+      this.currency = currency;
+      return this;
+    }
+
+    /**
+     * ID of the customer to whom the OutboundPayment is sent. Must match the Customer attached to
+     * the {@code destination_payment_method} passed in.
+     */
+    public Builder setCustomer(String customer) {
+      this.customer = customer;
+      return this;
+    }
+
+    /** An arbitrary string attached to the object. Often useful for displaying to users. */
+    public Builder setDescription(String description) {
+      this.description = description;
+      return this;
+    }
+
+    /**
+     * The PaymentMethod to use as the payment instrument for the OutboundPayment. Exclusive with
+     * {@code destination_payment_method_data}.
+     */
+    public Builder setDestinationPaymentMethod(String destinationPaymentMethod) {
+      this.destinationPaymentMethod = destinationPaymentMethod;
+      return this;
+    }
+
+    /**
+     * Hash used to generate the PaymentMethod to be used for this OutboundPayment. Exclusive with
+     * {@code destination_payment_method}.
+     */
+    public Builder setDestinationPaymentMethodData(
+        DestinationPaymentMethodData destinationPaymentMethodData) {
+      this.destinationPaymentMethodData = destinationPaymentMethodData;
+      return this;
+    }
+
+    /** Payment method-specific configuration for this OutboundPayment. */
+    public Builder setDestinationPaymentMethodOptions(
+        DestinationPaymentMethodOptions destinationPaymentMethodOptions) {
+      this.destinationPaymentMethodOptions = destinationPaymentMethodOptions;
+      return this;
+    }
+
+    /** End user details. */
+    public Builder setEndUserDetails(EndUserDetails endUserDetails) {
+      this.endUserDetails = endUserDetails;
+      return this;
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * OutboundPaymentCreateParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * OutboundPaymentCreateParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * OutboundPaymentCreateParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link OutboundPaymentCreateParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /** The FinancialAccount to pull funds from. */
+    public Builder setFinancialAccount(String financialAccount) {
+      this.financialAccount = financialAccount;
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `metadata` map. A map is initialized for the first `put/putAll` call,
+     * and subsequent calls add additional key/value pairs to the original map. See {@link
+     * OutboundPaymentCreateParams#metadata} for the field documentation.
+     */
+    public Builder putMetadata(String key, String value) {
+      if (this.metadata == null) {
+        this.metadata = new HashMap<>();
+      }
+      this.metadata.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `metadata` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link OutboundPaymentCreateParams#metadata} for the field documentation.
+     */
+    public Builder putAllMetadata(Map<String, String> map) {
+      if (this.metadata == null) {
+        this.metadata = new HashMap<>();
+      }
+      this.metadata.putAll(map);
+      return this;
+    }
+
+    /**
+     * The description that appears on the receiving end for this OutboundPayment (for example, bank
+     * statement for external bank transfer).
+     */
+    public Builder setStatementDescriptor(String statementDescriptor) {
+      this.statementDescriptor = statementDescriptor;
+      return this;
+    }
+  }
+
+  @Getter
+  public static class DestinationPaymentMethodData {
+    /**
+     * Billing information associated with the PaymentMethod that may be used or required by
+     * particular types of payment methods.
+     */
+    @SerializedName("billing_details")
+    BillingDetails billingDetails;
+
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /**
+     * Required if type is set to {@code financial_account}. The FinancialAccount ID to send funds
+     * to.
+     */
+    @SerializedName("financial_account")
+    String financialAccount;
+
+    /**
+     * Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can attach
+     * to an object. This can be useful for storing additional information about the object in a
+     * structured format. Individual keys can be unset by posting an empty value to them. All keys
+     * can be unset by posting an empty value to {@code metadata}.
+     */
+    @SerializedName("metadata")
+    Map<String, String> metadata;
+
+    /**
+     * The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a
+     * name matching this value. It contains additional information specific to the PaymentMethod
+     * type.
+     */
+    @SerializedName("type")
+    Type type;
+
+    /** Required hash if type is set to {@code us_bank_account}. */
+    @SerializedName("us_bank_account")
+    UsBankAccount usBankAccount;
+
+    private DestinationPaymentMethodData(
+        BillingDetails billingDetails,
+        Map<String, Object> extraParams,
+        String financialAccount,
+        Map<String, String> metadata,
+        Type type,
+        UsBankAccount usBankAccount) {
+      this.billingDetails = billingDetails;
+      this.extraParams = extraParams;
+      this.financialAccount = financialAccount;
+      this.metadata = metadata;
+      this.type = type;
+      this.usBankAccount = usBankAccount;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private BillingDetails billingDetails;
+
+      private Map<String, Object> extraParams;
+
+      private String financialAccount;
+
+      private Map<String, String> metadata;
+
+      private Type type;
+
+      private UsBankAccount usBankAccount;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public DestinationPaymentMethodData build() {
+        return new DestinationPaymentMethodData(
+            this.billingDetails,
+            this.extraParams,
+            this.financialAccount,
+            this.metadata,
+            this.type,
+            this.usBankAccount);
+      }
+
+      /**
+       * Billing information associated with the PaymentMethod that may be used or required by
+       * particular types of payment methods.
+       */
+      public Builder setBillingDetails(BillingDetails billingDetails) {
+        this.billingDetails = billingDetails;
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * OutboundPaymentCreateParams.DestinationPaymentMethodData#extraParams} for the field
+       * documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link OutboundPaymentCreateParams.DestinationPaymentMethodData#extraParams} for the
+       * field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /**
+       * Required if type is set to {@code financial_account}. The FinancialAccount ID to send funds
+       * to.
+       */
+      public Builder setFinancialAccount(String financialAccount) {
+        this.financialAccount = financialAccount;
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `metadata` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * OutboundPaymentCreateParams.DestinationPaymentMethodData#metadata} for the field
+       * documentation.
+       */
+      public Builder putMetadata(String key, String value) {
+        if (this.metadata == null) {
+          this.metadata = new HashMap<>();
+        }
+        this.metadata.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `metadata` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link OutboundPaymentCreateParams.DestinationPaymentMethodData#metadata} for the field
+       * documentation.
+       */
+      public Builder putAllMetadata(Map<String, String> map) {
+        if (this.metadata == null) {
+          this.metadata = new HashMap<>();
+        }
+        this.metadata.putAll(map);
+        return this;
+      }
+
+      /**
+       * The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a
+       * name matching this value. It contains additional information specific to the PaymentMethod
+       * type.
+       */
+      public Builder setType(Type type) {
+        this.type = type;
+        return this;
+      }
+
+      /** Required hash if type is set to {@code us_bank_account}. */
+      public Builder setUsBankAccount(UsBankAccount usBankAccount) {
+        this.usBankAccount = usBankAccount;
+        return this;
+      }
+    }
+
+    @Getter
+    public static class BillingDetails {
+      /** Billing address. */
+      @SerializedName("address")
+      Object address;
+
+      /** Email address. */
+      @SerializedName("email")
+      Object email;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Full name. */
+      @SerializedName("name")
+      String name;
+
+      /** Billing phone number (including extension). */
+      @SerializedName("phone")
+      String phone;
+
+      private BillingDetails(
+          Object address,
+          Object email,
+          Map<String, Object> extraParams,
+          String name,
+          String phone) {
+        this.address = address;
+        this.email = email;
+        this.extraParams = extraParams;
+        this.name = name;
+        this.phone = phone;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Object address;
+
+        private Object email;
+
+        private Map<String, Object> extraParams;
+
+        private String name;
+
+        private String phone;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public BillingDetails build() {
+          return new BillingDetails(
+              this.address, this.email, this.extraParams, this.name, this.phone);
+        }
+
+        /** Billing address. */
+        public Builder setAddress(Address address) {
+          this.address = address;
+          return this;
+        }
+
+        /** Billing address. */
+        public Builder setAddress(EmptyParam address) {
+          this.address = address;
+          return this;
+        }
+
+        /** Email address. */
+        public Builder setEmail(String email) {
+          this.email = email;
+          return this;
+        }
+
+        /** Email address. */
+        public Builder setEmail(EmptyParam email) {
+          this.email = email;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * OutboundPaymentCreateParams.DestinationPaymentMethodData.BillingDetails#extraParams} for
+         * the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * OutboundPaymentCreateParams.DestinationPaymentMethodData.BillingDetails#extraParams} for
+         * the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Full name. */
+        public Builder setName(String name) {
+          this.name = name;
+          return this;
+        }
+
+        /** Billing phone number (including extension). */
+        public Builder setPhone(String phone) {
+          this.phone = phone;
+          return this;
+        }
+      }
+
+      @Getter
+      public static class Address {
+        /** City, district, suburb, town, or village. */
+        @SerializedName("city")
+        String city;
+
+        /**
+         * Two-letter country code (<a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO
+         * 3166-1 alpha-2</a>).
+         */
+        @SerializedName("country")
+        String country;
+
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /** Address line 1 (e.g., street, PO Box, or company name). */
+        @SerializedName("line1")
+        String line1;
+
+        /** Address line 2 (e.g., apartment, suite, unit, or building). */
+        @SerializedName("line2")
+        String line2;
+
+        /** ZIP or postal code. */
+        @SerializedName("postal_code")
+        String postalCode;
+
+        /** State, county, province, or region. */
+        @SerializedName("state")
+        String state;
+
+        private Address(
+            String city,
+            String country,
+            Map<String, Object> extraParams,
+            String line1,
+            String line2,
+            String postalCode,
+            String state) {
+          this.city = city;
+          this.country = country;
+          this.extraParams = extraParams;
+          this.line1 = line1;
+          this.line2 = line2;
+          this.postalCode = postalCode;
+          this.state = state;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private String city;
+
+          private String country;
+
+          private Map<String, Object> extraParams;
+
+          private String line1;
+
+          private String line2;
+
+          private String postalCode;
+
+          private String state;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public Address build() {
+            return new Address(
+                this.city,
+                this.country,
+                this.extraParams,
+                this.line1,
+                this.line2,
+                this.postalCode,
+                this.state);
+          }
+
+          /** City, district, suburb, town, or village. */
+          public Builder setCity(String city) {
+            this.city = city;
+            return this;
+          }
+
+          /**
+           * Two-letter country code (<a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO
+           * 3166-1 alpha-2</a>).
+           */
+          public Builder setCountry(String country) {
+            this.country = country;
+            return this;
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * OutboundPaymentCreateParams.DestinationPaymentMethodData.BillingDetails.Address#extraParams}
+           * for the field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link
+           * OutboundPaymentCreateParams.DestinationPaymentMethodData.BillingDetails.Address#extraParams}
+           * for the field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /** Address line 1 (e.g., street, PO Box, or company name). */
+          public Builder setLine1(String line1) {
+            this.line1 = line1;
+            return this;
+          }
+
+          /** Address line 2 (e.g., apartment, suite, unit, or building). */
+          public Builder setLine2(String line2) {
+            this.line2 = line2;
+            return this;
+          }
+
+          /** ZIP or postal code. */
+          public Builder setPostalCode(String postalCode) {
+            this.postalCode = postalCode;
+            return this;
+          }
+
+          /** State, county, province, or region. */
+          public Builder setState(String state) {
+            this.state = state;
+            return this;
+          }
+        }
+      }
+    }
+
+    @Getter
+    public static class UsBankAccount {
+      /** Account holder type: individual or company. */
+      @SerializedName("account_holder_type")
+      AccountHolderType accountHolderType;
+
+      /** Account number of the bank account. */
+      @SerializedName("account_number")
+      String accountNumber;
+
+      /** Account type: checkings or savings. Defaults to checking if omitted. */
+      @SerializedName("account_type")
+      AccountType accountType;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** The ID of a Financial Connections Account to use as a payment method. */
+      @SerializedName("financial_connections_account")
+      String financialConnectionsAccount;
+
+      /** Routing number of the bank account. */
+      @SerializedName("routing_number")
+      String routingNumber;
+
+      private UsBankAccount(
+          AccountHolderType accountHolderType,
+          String accountNumber,
+          AccountType accountType,
+          Map<String, Object> extraParams,
+          String financialConnectionsAccount,
+          String routingNumber) {
+        this.accountHolderType = accountHolderType;
+        this.accountNumber = accountNumber;
+        this.accountType = accountType;
+        this.extraParams = extraParams;
+        this.financialConnectionsAccount = financialConnectionsAccount;
+        this.routingNumber = routingNumber;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private AccountHolderType accountHolderType;
+
+        private String accountNumber;
+
+        private AccountType accountType;
+
+        private Map<String, Object> extraParams;
+
+        private String financialConnectionsAccount;
+
+        private String routingNumber;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public UsBankAccount build() {
+          return new UsBankAccount(
+              this.accountHolderType,
+              this.accountNumber,
+              this.accountType,
+              this.extraParams,
+              this.financialConnectionsAccount,
+              this.routingNumber);
+        }
+
+        /** Account holder type: individual or company. */
+        public Builder setAccountHolderType(AccountHolderType accountHolderType) {
+          this.accountHolderType = accountHolderType;
+          return this;
+        }
+
+        /** Account number of the bank account. */
+        public Builder setAccountNumber(String accountNumber) {
+          this.accountNumber = accountNumber;
+          return this;
+        }
+
+        /** Account type: checkings or savings. Defaults to checking if omitted. */
+        public Builder setAccountType(AccountType accountType) {
+          this.accountType = accountType;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * OutboundPaymentCreateParams.DestinationPaymentMethodData.UsBankAccount#extraParams} for
+         * the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * OutboundPaymentCreateParams.DestinationPaymentMethodData.UsBankAccount#extraParams} for
+         * the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** The ID of a Financial Connections Account to use as a payment method. */
+        public Builder setFinancialConnectionsAccount(String financialConnectionsAccount) {
+          this.financialConnectionsAccount = financialConnectionsAccount;
+          return this;
+        }
+
+        /** Routing number of the bank account. */
+        public Builder setRoutingNumber(String routingNumber) {
+          this.routingNumber = routingNumber;
+          return this;
+        }
+      }
+
+      public enum AccountHolderType implements ApiRequestParams.EnumParam {
+        @SerializedName("company")
+        COMPANY("company"),
+
+        @SerializedName("individual")
+        INDIVIDUAL("individual");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        AccountHolderType(String value) {
+          this.value = value;
+        }
+      }
+
+      public enum AccountType implements ApiRequestParams.EnumParam {
+        @SerializedName("checking")
+        CHECKING("checking"),
+
+        @SerializedName("savings")
+        SAVINGS("savings");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        AccountType(String value) {
+          this.value = value;
+        }
+      }
+    }
+
+    public enum Type implements ApiRequestParams.EnumParam {
+      @SerializedName("financial_account")
+      FINANCIAL_ACCOUNT("financial_account"),
+
+      @SerializedName("us_bank_account")
+      US_BANK_ACCOUNT("us_bank_account");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      Type(String value) {
+        this.value = value;
+      }
+    }
+  }
+
+  @Getter
+  public static class DestinationPaymentMethodOptions {
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /** Optional fields for {@code us_bank_account}. */
+    @SerializedName("us_bank_account")
+    Object usBankAccount;
+
+    private DestinationPaymentMethodOptions(Map<String, Object> extraParams, Object usBankAccount) {
+      this.extraParams = extraParams;
+      this.usBankAccount = usBankAccount;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Map<String, Object> extraParams;
+
+      private Object usBankAccount;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public DestinationPaymentMethodOptions build() {
+        return new DestinationPaymentMethodOptions(this.extraParams, this.usBankAccount);
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * OutboundPaymentCreateParams.DestinationPaymentMethodOptions#extraParams} for the field
+       * documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link OutboundPaymentCreateParams.DestinationPaymentMethodOptions#extraParams} for the
+       * field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** Optional fields for {@code us_bank_account}. */
+      public Builder setUsBankAccount(UsBankAccount usBankAccount) {
+        this.usBankAccount = usBankAccount;
+        return this;
+      }
+
+      /** Optional fields for {@code us_bank_account}. */
+      public Builder setUsBankAccount(EmptyParam usBankAccount) {
+        this.usBankAccount = usBankAccount;
+        return this;
+      }
+    }
+
+    @Getter
+    public static class UsBankAccount {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /**
+       * The US bank account network that must be used for this OutboundPayment. If not set, we will
+       * default to the PaymentMethod's preferred network.
+       */
+      @SerializedName("network")
+      Network network;
+
+      private UsBankAccount(Map<String, Object> extraParams, Network network) {
+        this.extraParams = extraParams;
+        this.network = network;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private Network network;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public UsBankAccount build() {
+          return new UsBankAccount(this.extraParams, this.network);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * OutboundPaymentCreateParams.DestinationPaymentMethodOptions.UsBankAccount#extraParams}
+         * for the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * OutboundPaymentCreateParams.DestinationPaymentMethodOptions.UsBankAccount#extraParams}
+         * for the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /**
+         * The US bank account network that must be used for this OutboundPayment. If not set, we
+         * will default to the PaymentMethod's preferred network.
+         */
+        public Builder setNetwork(Network network) {
+          this.network = network;
+          return this;
+        }
+      }
+
+      public enum Network implements ApiRequestParams.EnumParam {
+        @SerializedName("ach")
+        ACH("ach"),
+
+        @SerializedName("us_domestic_wire")
+        US_DOMESTIC_WIRE("us_domestic_wire");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        Network(String value) {
+          this.value = value;
+        }
+      }
+    }
+  }
+
+  @Getter
+  public static class EndUserDetails {
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /**
+     * IP address of the user initiating the OutboundPayment. Must be supplied if {@code present} is
+     * set to {@code true}.
+     */
+    @SerializedName("ip_address")
+    String ipAddress;
+
+    /**
+     * {@code True} if the OutboundPayment creation request is being made on behalf of an end user
+     * by a platform. Otherwise, {@code false}.
+     */
+    @SerializedName("present")
+    Boolean present;
+
+    private EndUserDetails(Map<String, Object> extraParams, String ipAddress, Boolean present) {
+      this.extraParams = extraParams;
+      this.ipAddress = ipAddress;
+      this.present = present;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Map<String, Object> extraParams;
+
+      private String ipAddress;
+
+      private Boolean present;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public EndUserDetails build() {
+        return new EndUserDetails(this.extraParams, this.ipAddress, this.present);
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * OutboundPaymentCreateParams.EndUserDetails#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link OutboundPaymentCreateParams.EndUserDetails#extraParams} for the field
+       * documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /**
+       * IP address of the user initiating the OutboundPayment. Must be supplied if {@code present}
+       * is set to {@code true}.
+       */
+      public Builder setIpAddress(String ipAddress) {
+        this.ipAddress = ipAddress;
+        return this;
+      }
+
+      /**
+       * {@code True} if the OutboundPayment creation request is being made on behalf of an end user
+       * by a platform. Otherwise, {@code false}.
+       */
+      public Builder setPresent(Boolean present) {
+        this.present = present;
+        return this;
+      }
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/OutboundPaymentCreateParams.java
+++ b/src/main/java/com/stripe/param/treasury/OutboundPaymentCreateParams.java
@@ -84,7 +84,9 @@ public class OutboundPaymentCreateParams extends ApiRequestParams {
 
   /**
    * The description that appears on the receiving end for this OutboundPayment (for example, bank
-   * statement for external bank transfer).
+   * statement for external bank transfer). Maximum 10 characters for {@code ach} payments, 140
+   * characters for {@code wire} payments, or 500 characters for {@code stripe} network transfers.
+   * The default value is {@code payment}.
    */
   @SerializedName("statement_descriptor")
   String statementDescriptor;
@@ -316,7 +318,9 @@ public class OutboundPaymentCreateParams extends ApiRequestParams {
 
     /**
      * The description that appears on the receiving end for this OutboundPayment (for example, bank
-     * statement for external bank transfer).
+     * statement for external bank transfer). Maximum 10 characters for {@code ach} payments, 140
+     * characters for {@code wire} payments, or 500 characters for {@code stripe} network transfers.
+     * The default value is {@code payment}.
      */
     public Builder setStatementDescriptor(String statementDescriptor) {
       this.statementDescriptor = statementDescriptor;

--- a/src/main/java/com/stripe/param/treasury/OutboundPaymentFailParams.java
+++ b/src/main/java/com/stripe/param/treasury/OutboundPaymentFailParams.java
@@ -1,0 +1,98 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class OutboundPaymentFailParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  private OutboundPaymentFailParams(List<String> expand, Map<String, Object> extraParams) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public OutboundPaymentFailParams build() {
+      return new OutboundPaymentFailParams(this.expand, this.extraParams);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * OutboundPaymentFailParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * OutboundPaymentFailParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * OutboundPaymentFailParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link OutboundPaymentFailParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/OutboundPaymentListParams.java
+++ b/src/main/java/com/stripe/param/treasury/OutboundPaymentListParams.java
@@ -1,0 +1,248 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class OutboundPaymentListParams extends ApiRequestParams {
+  /** Only return OutboundPayments sent to this customer. */
+  @SerializedName("customer")
+  String customer;
+
+  /**
+   * A cursor for use in pagination. {@code ending_before} is an object ID that defines your place
+   * in the list. For instance, if you make a list request and receive 100 objects, starting with
+   * {@code obj_bar}, your subsequent call can include {@code ending_before=obj_bar} in order to
+   * fetch the previous page of the list.
+   */
+  @SerializedName("ending_before")
+  String endingBefore;
+
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  /** Returns objects associated with this FinancialAccount. */
+  @SerializedName("financial_account")
+  String financialAccount;
+
+  /**
+   * A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+   * default is 10.
+   */
+  @SerializedName("limit")
+  Long limit;
+
+  /**
+   * A cursor for use in pagination. {@code starting_after} is an object ID that defines your place
+   * in the list. For instance, if you make a list request and receive 100 objects, ending with
+   * {@code obj_foo}, your subsequent call can include {@code starting_after=obj_foo} in order to
+   * fetch the next page of the list.
+   */
+  @SerializedName("starting_after")
+  String startingAfter;
+
+  /**
+   * Only return OutboundPayments that have the given status: {@code processing}, {@code failed},
+   * {@code posted}, {@code returned}, or {@code canceled}.
+   */
+  @SerializedName("status")
+  Status status;
+
+  private OutboundPaymentListParams(
+      String customer,
+      String endingBefore,
+      List<String> expand,
+      Map<String, Object> extraParams,
+      String financialAccount,
+      Long limit,
+      String startingAfter,
+      Status status) {
+    this.customer = customer;
+    this.endingBefore = endingBefore;
+    this.expand = expand;
+    this.extraParams = extraParams;
+    this.financialAccount = financialAccount;
+    this.limit = limit;
+    this.startingAfter = startingAfter;
+    this.status = status;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String customer;
+
+    private String endingBefore;
+
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    private String financialAccount;
+
+    private Long limit;
+
+    private String startingAfter;
+
+    private Status status;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public OutboundPaymentListParams build() {
+      return new OutboundPaymentListParams(
+          this.customer,
+          this.endingBefore,
+          this.expand,
+          this.extraParams,
+          this.financialAccount,
+          this.limit,
+          this.startingAfter,
+          this.status);
+    }
+
+    /** Only return OutboundPayments sent to this customer. */
+    public Builder setCustomer(String customer) {
+      this.customer = customer;
+      return this;
+    }
+
+    /**
+     * A cursor for use in pagination. {@code ending_before} is an object ID that defines your place
+     * in the list. For instance, if you make a list request and receive 100 objects, starting with
+     * {@code obj_bar}, your subsequent call can include {@code ending_before=obj_bar} in order to
+     * fetch the previous page of the list.
+     */
+    public Builder setEndingBefore(String endingBefore) {
+      this.endingBefore = endingBefore;
+      return this;
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * OutboundPaymentListParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * OutboundPaymentListParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * OutboundPaymentListParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link OutboundPaymentListParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /** Returns objects associated with this FinancialAccount. */
+    public Builder setFinancialAccount(String financialAccount) {
+      this.financialAccount = financialAccount;
+      return this;
+    }
+
+    /**
+     * A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+     * default is 10.
+     */
+    public Builder setLimit(Long limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    /**
+     * A cursor for use in pagination. {@code starting_after} is an object ID that defines your
+     * place in the list. For instance, if you make a list request and receive 100 objects, ending
+     * with {@code obj_foo}, your subsequent call can include {@code starting_after=obj_foo} in
+     * order to fetch the next page of the list.
+     */
+    public Builder setStartingAfter(String startingAfter) {
+      this.startingAfter = startingAfter;
+      return this;
+    }
+
+    /**
+     * Only return OutboundPayments that have the given status: {@code processing}, {@code failed},
+     * {@code posted}, {@code returned}, or {@code canceled}.
+     */
+    public Builder setStatus(Status status) {
+      this.status = status;
+      return this;
+    }
+  }
+
+  public enum Status implements ApiRequestParams.EnumParam {
+    @SerializedName("canceled")
+    CANCELED("canceled"),
+
+    @SerializedName("failed")
+    FAILED("failed"),
+
+    @SerializedName("posted")
+    POSTED("posted"),
+
+    @SerializedName("processing")
+    PROCESSING("processing"),
+
+    @SerializedName("returned")
+    RETURNED("returned");
+
+    @Getter(onMethod_ = {@Override})
+    private final String value;
+
+    Status(String value) {
+      this.value = value;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/OutboundPaymentPostParams.java
+++ b/src/main/java/com/stripe/param/treasury/OutboundPaymentPostParams.java
@@ -1,0 +1,98 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class OutboundPaymentPostParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  private OutboundPaymentPostParams(List<String> expand, Map<String, Object> extraParams) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public OutboundPaymentPostParams build() {
+      return new OutboundPaymentPostParams(this.expand, this.extraParams);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * OutboundPaymentPostParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * OutboundPaymentPostParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * OutboundPaymentPostParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link OutboundPaymentPostParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/OutboundPaymentRetrieveParams.java
+++ b/src/main/java/com/stripe/param/treasury/OutboundPaymentRetrieveParams.java
@@ -1,0 +1,98 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class OutboundPaymentRetrieveParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  private OutboundPaymentRetrieveParams(List<String> expand, Map<String, Object> extraParams) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public OutboundPaymentRetrieveParams build() {
+      return new OutboundPaymentRetrieveParams(this.expand, this.extraParams);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * OutboundPaymentRetrieveParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * OutboundPaymentRetrieveParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * OutboundPaymentRetrieveParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link OutboundPaymentRetrieveParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/OutboundPaymentReturnOutboundPaymentParams.java
+++ b/src/main/java/com/stripe/param/treasury/OutboundPaymentReturnOutboundPaymentParams.java
@@ -1,0 +1,223 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class OutboundPaymentReturnOutboundPaymentParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  /** Optional hash to set the the return code. */
+  @SerializedName("returned_details")
+  ReturnedDetails returnedDetails;
+
+  private OutboundPaymentReturnOutboundPaymentParams(
+      List<String> expand, Map<String, Object> extraParams, ReturnedDetails returnedDetails) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+    this.returnedDetails = returnedDetails;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    private ReturnedDetails returnedDetails;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public OutboundPaymentReturnOutboundPaymentParams build() {
+      return new OutboundPaymentReturnOutboundPaymentParams(
+          this.expand, this.extraParams, this.returnedDetails);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * OutboundPaymentReturnOutboundPaymentParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * OutboundPaymentReturnOutboundPaymentParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * OutboundPaymentReturnOutboundPaymentParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link OutboundPaymentReturnOutboundPaymentParams#extraParams} for the field
+     * documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /** Optional hash to set the the return code. */
+    public Builder setReturnedDetails(ReturnedDetails returnedDetails) {
+      this.returnedDetails = returnedDetails;
+      return this;
+    }
+  }
+
+  @Getter
+  public static class ReturnedDetails {
+    /** The return code to be set on the OutboundPayment object. */
+    @SerializedName("code")
+    Code code;
+
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    private ReturnedDetails(Code code, Map<String, Object> extraParams) {
+      this.code = code;
+      this.extraParams = extraParams;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Code code;
+
+      private Map<String, Object> extraParams;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public ReturnedDetails build() {
+        return new ReturnedDetails(this.code, this.extraParams);
+      }
+
+      /** The return code to be set on the OutboundPayment object. */
+      public Builder setCode(Code code) {
+        this.code = code;
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * OutboundPaymentReturnOutboundPaymentParams.ReturnedDetails#extraParams} for the field
+       * documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link OutboundPaymentReturnOutboundPaymentParams.ReturnedDetails#extraParams} for the
+       * field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+    }
+
+    public enum Code implements ApiRequestParams.EnumParam {
+      @SerializedName("account_closed")
+      ACCOUNT_CLOSED("account_closed"),
+
+      @SerializedName("account_frozen")
+      ACCOUNT_FROZEN("account_frozen"),
+
+      @SerializedName("bank_account_restricted")
+      BANK_ACCOUNT_RESTRICTED("bank_account_restricted"),
+
+      @SerializedName("bank_ownership_changed")
+      BANK_OWNERSHIP_CHANGED("bank_ownership_changed"),
+
+      @SerializedName("declined")
+      DECLINED("declined"),
+
+      @SerializedName("incorrect_account_holder_name")
+      INCORRECT_ACCOUNT_HOLDER_NAME("incorrect_account_holder_name"),
+
+      @SerializedName("invalid_account_number")
+      INVALID_ACCOUNT_NUMBER("invalid_account_number"),
+
+      @SerializedName("invalid_currency")
+      INVALID_CURRENCY("invalid_currency"),
+
+      @SerializedName("no_account")
+      NO_ACCOUNT("no_account"),
+
+      @SerializedName("other")
+      OTHER("other");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      Code(String value) {
+        this.value = value;
+      }
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/OutboundTransferCancelParams.java
+++ b/src/main/java/com/stripe/param/treasury/OutboundTransferCancelParams.java
@@ -1,0 +1,98 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class OutboundTransferCancelParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  private OutboundTransferCancelParams(List<String> expand, Map<String, Object> extraParams) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public OutboundTransferCancelParams build() {
+      return new OutboundTransferCancelParams(this.expand, this.extraParams);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * OutboundTransferCancelParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * OutboundTransferCancelParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * OutboundTransferCancelParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link OutboundTransferCancelParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/OutboundTransferCreateParams.java
+++ b/src/main/java/com/stripe/param/treasury/OutboundTransferCreateParams.java
@@ -1,0 +1,419 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import com.stripe.param.common.EmptyParam;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class OutboundTransferCreateParams extends ApiRequestParams {
+  /** Amount (in cents) to be transferred. */
+  @SerializedName("amount")
+  Long amount;
+
+  /**
+   * Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency code</a>,
+   * in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported currency</a>.
+   */
+  @SerializedName("currency")
+  String currency;
+
+  /** An arbitrary string attached to the object. Often useful for displaying to users. */
+  @SerializedName("description")
+  String description;
+
+  /** The PaymentMethod to use as the payment instrument for the OutboundTransfer. */
+  @SerializedName("destination_payment_method")
+  String destinationPaymentMethod;
+
+  /** Hash describing payment method configuration details. */
+  @SerializedName("destination_payment_method_options")
+  DestinationPaymentMethodOptions destinationPaymentMethodOptions;
+
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  /** The FinancialAccount to pull funds from. */
+  @SerializedName("financial_account")
+  String financialAccount;
+
+  /**
+   * Set of <a href="https://stripe.com/docs/api/metadata">key-value pairs</a> that you can attach
+   * to an object. This can be useful for storing additional information about the object in a
+   * structured format. Individual keys can be unset by posting an empty value to them. All keys can
+   * be unset by posting an empty value to {@code metadata}.
+   */
+  @SerializedName("metadata")
+  Map<String, String> metadata;
+
+  /** Statement descriptor to be shown on the receiving end of an OutboundTransfer. */
+  @SerializedName("statement_descriptor")
+  String statementDescriptor;
+
+  private OutboundTransferCreateParams(
+      Long amount,
+      String currency,
+      String description,
+      String destinationPaymentMethod,
+      DestinationPaymentMethodOptions destinationPaymentMethodOptions,
+      List<String> expand,
+      Map<String, Object> extraParams,
+      String financialAccount,
+      Map<String, String> metadata,
+      String statementDescriptor) {
+    this.amount = amount;
+    this.currency = currency;
+    this.description = description;
+    this.destinationPaymentMethod = destinationPaymentMethod;
+    this.destinationPaymentMethodOptions = destinationPaymentMethodOptions;
+    this.expand = expand;
+    this.extraParams = extraParams;
+    this.financialAccount = financialAccount;
+    this.metadata = metadata;
+    this.statementDescriptor = statementDescriptor;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Long amount;
+
+    private String currency;
+
+    private String description;
+
+    private String destinationPaymentMethod;
+
+    private DestinationPaymentMethodOptions destinationPaymentMethodOptions;
+
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    private String financialAccount;
+
+    private Map<String, String> metadata;
+
+    private String statementDescriptor;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public OutboundTransferCreateParams build() {
+      return new OutboundTransferCreateParams(
+          this.amount,
+          this.currency,
+          this.description,
+          this.destinationPaymentMethod,
+          this.destinationPaymentMethodOptions,
+          this.expand,
+          this.extraParams,
+          this.financialAccount,
+          this.metadata,
+          this.statementDescriptor);
+    }
+
+    /** Amount (in cents) to be transferred. */
+    public Builder setAmount(Long amount) {
+      this.amount = amount;
+      return this;
+    }
+
+    /**
+     * Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency
+     * code</a>, in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported
+     * currency</a>.
+     */
+    public Builder setCurrency(String currency) {
+      this.currency = currency;
+      return this;
+    }
+
+    /** An arbitrary string attached to the object. Often useful for displaying to users. */
+    public Builder setDescription(String description) {
+      this.description = description;
+      return this;
+    }
+
+    /** The PaymentMethod to use as the payment instrument for the OutboundTransfer. */
+    public Builder setDestinationPaymentMethod(String destinationPaymentMethod) {
+      this.destinationPaymentMethod = destinationPaymentMethod;
+      return this;
+    }
+
+    /** Hash describing payment method configuration details. */
+    public Builder setDestinationPaymentMethodOptions(
+        DestinationPaymentMethodOptions destinationPaymentMethodOptions) {
+      this.destinationPaymentMethodOptions = destinationPaymentMethodOptions;
+      return this;
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * OutboundTransferCreateParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * OutboundTransferCreateParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * OutboundTransferCreateParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link OutboundTransferCreateParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /** The FinancialAccount to pull funds from. */
+    public Builder setFinancialAccount(String financialAccount) {
+      this.financialAccount = financialAccount;
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `metadata` map. A map is initialized for the first `put/putAll` call,
+     * and subsequent calls add additional key/value pairs to the original map. See {@link
+     * OutboundTransferCreateParams#metadata} for the field documentation.
+     */
+    public Builder putMetadata(String key, String value) {
+      if (this.metadata == null) {
+        this.metadata = new HashMap<>();
+      }
+      this.metadata.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `metadata` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link OutboundTransferCreateParams#metadata} for the field documentation.
+     */
+    public Builder putAllMetadata(Map<String, String> map) {
+      if (this.metadata == null) {
+        this.metadata = new HashMap<>();
+      }
+      this.metadata.putAll(map);
+      return this;
+    }
+
+    /** Statement descriptor to be shown on the receiving end of an OutboundTransfer. */
+    public Builder setStatementDescriptor(String statementDescriptor) {
+      this.statementDescriptor = statementDescriptor;
+      return this;
+    }
+  }
+
+  @Getter
+  public static class DestinationPaymentMethodOptions {
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /** Optional fields for {@code us_bank_account}. */
+    @SerializedName("us_bank_account")
+    Object usBankAccount;
+
+    private DestinationPaymentMethodOptions(Map<String, Object> extraParams, Object usBankAccount) {
+      this.extraParams = extraParams;
+      this.usBankAccount = usBankAccount;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Map<String, Object> extraParams;
+
+      private Object usBankAccount;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public DestinationPaymentMethodOptions build() {
+        return new DestinationPaymentMethodOptions(this.extraParams, this.usBankAccount);
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * OutboundTransferCreateParams.DestinationPaymentMethodOptions#extraParams} for the field
+       * documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link OutboundTransferCreateParams.DestinationPaymentMethodOptions#extraParams} for
+       * the field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** Optional fields for {@code us_bank_account}. */
+      public Builder setUsBankAccount(UsBankAccount usBankAccount) {
+        this.usBankAccount = usBankAccount;
+        return this;
+      }
+
+      /** Optional fields for {@code us_bank_account}. */
+      public Builder setUsBankAccount(EmptyParam usBankAccount) {
+        this.usBankAccount = usBankAccount;
+        return this;
+      }
+    }
+
+    @Getter
+    public static class UsBankAccount {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Designate the OutboundTransfer as using a US bank account network configuration. */
+      @SerializedName("network")
+      Network network;
+
+      private UsBankAccount(Map<String, Object> extraParams, Network network) {
+        this.extraParams = extraParams;
+        this.network = network;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private Network network;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public UsBankAccount build() {
+          return new UsBankAccount(this.extraParams, this.network);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * OutboundTransferCreateParams.DestinationPaymentMethodOptions.UsBankAccount#extraParams}
+         * for the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * OutboundTransferCreateParams.DestinationPaymentMethodOptions.UsBankAccount#extraParams}
+         * for the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Designate the OutboundTransfer as using a US bank account network configuration. */
+        public Builder setNetwork(Network network) {
+          this.network = network;
+          return this;
+        }
+      }
+
+      public enum Network implements ApiRequestParams.EnumParam {
+        @SerializedName("ach")
+        ACH("ach"),
+
+        @SerializedName("us_domestic_wire")
+        US_DOMESTIC_WIRE("us_domestic_wire");
+
+        @Getter(onMethod_ = {@Override})
+        private final String value;
+
+        Network(String value) {
+          this.value = value;
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/OutboundTransferCreateParams.java
+++ b/src/main/java/com/stripe/param/treasury/OutboundTransferCreateParams.java
@@ -61,7 +61,11 @@ public class OutboundTransferCreateParams extends ApiRequestParams {
   @SerializedName("metadata")
   Map<String, String> metadata;
 
-  /** Statement descriptor to be shown on the receiving end of an OutboundTransfer. */
+  /**
+   * Statement descriptor to be shown on the receiving end of an OutboundTransfer. Maximum 10
+   * characters for {@code ach} transfers or 140 characters for {@code wire} transfers. The default
+   * value is {@code transfer}.
+   */
   @SerializedName("statement_descriptor")
   String statementDescriptor;
 
@@ -247,7 +251,11 @@ public class OutboundTransferCreateParams extends ApiRequestParams {
       return this;
     }
 
-    /** Statement descriptor to be shown on the receiving end of an OutboundTransfer. */
+    /**
+     * Statement descriptor to be shown on the receiving end of an OutboundTransfer. Maximum 10
+     * characters for {@code ach} transfers or 140 characters for {@code wire} transfers. The
+     * default value is {@code transfer}.
+     */
     public Builder setStatementDescriptor(String statementDescriptor) {
       this.statementDescriptor = statementDescriptor;
       return this;

--- a/src/main/java/com/stripe/param/treasury/OutboundTransferFailParams.java
+++ b/src/main/java/com/stripe/param/treasury/OutboundTransferFailParams.java
@@ -1,0 +1,98 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class OutboundTransferFailParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  private OutboundTransferFailParams(List<String> expand, Map<String, Object> extraParams) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public OutboundTransferFailParams build() {
+      return new OutboundTransferFailParams(this.expand, this.extraParams);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * OutboundTransferFailParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * OutboundTransferFailParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * OutboundTransferFailParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link OutboundTransferFailParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/OutboundTransferListParams.java
+++ b/src/main/java/com/stripe/param/treasury/OutboundTransferListParams.java
@@ -1,0 +1,233 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class OutboundTransferListParams extends ApiRequestParams {
+  /**
+   * A cursor for use in pagination. {@code ending_before} is an object ID that defines your place
+   * in the list. For instance, if you make a list request and receive 100 objects, starting with
+   * {@code obj_bar}, your subsequent call can include {@code ending_before=obj_bar} in order to
+   * fetch the previous page of the list.
+   */
+  @SerializedName("ending_before")
+  String endingBefore;
+
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  /** Returns objects associated with this FinancialAccount. */
+  @SerializedName("financial_account")
+  String financialAccount;
+
+  /**
+   * A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+   * default is 10.
+   */
+  @SerializedName("limit")
+  Long limit;
+
+  /**
+   * A cursor for use in pagination. {@code starting_after} is an object ID that defines your place
+   * in the list. For instance, if you make a list request and receive 100 objects, ending with
+   * {@code obj_foo}, your subsequent call can include {@code starting_after=obj_foo} in order to
+   * fetch the next page of the list.
+   */
+  @SerializedName("starting_after")
+  String startingAfter;
+
+  /**
+   * Only return OutboundTransfers that have the given status: {@code processing}, {@code canceled},
+   * {@code failed}, {@code posted}, or {@code returned}.
+   */
+  @SerializedName("status")
+  Status status;
+
+  private OutboundTransferListParams(
+      String endingBefore,
+      List<String> expand,
+      Map<String, Object> extraParams,
+      String financialAccount,
+      Long limit,
+      String startingAfter,
+      Status status) {
+    this.endingBefore = endingBefore;
+    this.expand = expand;
+    this.extraParams = extraParams;
+    this.financialAccount = financialAccount;
+    this.limit = limit;
+    this.startingAfter = startingAfter;
+    this.status = status;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String endingBefore;
+
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    private String financialAccount;
+
+    private Long limit;
+
+    private String startingAfter;
+
+    private Status status;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public OutboundTransferListParams build() {
+      return new OutboundTransferListParams(
+          this.endingBefore,
+          this.expand,
+          this.extraParams,
+          this.financialAccount,
+          this.limit,
+          this.startingAfter,
+          this.status);
+    }
+
+    /**
+     * A cursor for use in pagination. {@code ending_before} is an object ID that defines your place
+     * in the list. For instance, if you make a list request and receive 100 objects, starting with
+     * {@code obj_bar}, your subsequent call can include {@code ending_before=obj_bar} in order to
+     * fetch the previous page of the list.
+     */
+    public Builder setEndingBefore(String endingBefore) {
+      this.endingBefore = endingBefore;
+      return this;
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * OutboundTransferListParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * OutboundTransferListParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * OutboundTransferListParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link OutboundTransferListParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /** Returns objects associated with this FinancialAccount. */
+    public Builder setFinancialAccount(String financialAccount) {
+      this.financialAccount = financialAccount;
+      return this;
+    }
+
+    /**
+     * A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+     * default is 10.
+     */
+    public Builder setLimit(Long limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    /**
+     * A cursor for use in pagination. {@code starting_after} is an object ID that defines your
+     * place in the list. For instance, if you make a list request and receive 100 objects, ending
+     * with {@code obj_foo}, your subsequent call can include {@code starting_after=obj_foo} in
+     * order to fetch the next page of the list.
+     */
+    public Builder setStartingAfter(String startingAfter) {
+      this.startingAfter = startingAfter;
+      return this;
+    }
+
+    /**
+     * Only return OutboundTransfers that have the given status: {@code processing}, {@code
+     * canceled}, {@code failed}, {@code posted}, or {@code returned}.
+     */
+    public Builder setStatus(Status status) {
+      this.status = status;
+      return this;
+    }
+  }
+
+  public enum Status implements ApiRequestParams.EnumParam {
+    @SerializedName("canceled")
+    CANCELED("canceled"),
+
+    @SerializedName("failed")
+    FAILED("failed"),
+
+    @SerializedName("posted")
+    POSTED("posted"),
+
+    @SerializedName("processing")
+    PROCESSING("processing"),
+
+    @SerializedName("returned")
+    RETURNED("returned");
+
+    @Getter(onMethod_ = {@Override})
+    private final String value;
+
+    Status(String value) {
+      this.value = value;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/OutboundTransferPostParams.java
+++ b/src/main/java/com/stripe/param/treasury/OutboundTransferPostParams.java
@@ -1,0 +1,98 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class OutboundTransferPostParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  private OutboundTransferPostParams(List<String> expand, Map<String, Object> extraParams) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public OutboundTransferPostParams build() {
+      return new OutboundTransferPostParams(this.expand, this.extraParams);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * OutboundTransferPostParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * OutboundTransferPostParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * OutboundTransferPostParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link OutboundTransferPostParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/OutboundTransferRetrieveParams.java
+++ b/src/main/java/com/stripe/param/treasury/OutboundTransferRetrieveParams.java
@@ -1,0 +1,98 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class OutboundTransferRetrieveParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  private OutboundTransferRetrieveParams(List<String> expand, Map<String, Object> extraParams) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public OutboundTransferRetrieveParams build() {
+      return new OutboundTransferRetrieveParams(this.expand, this.extraParams);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * OutboundTransferRetrieveParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * OutboundTransferRetrieveParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * OutboundTransferRetrieveParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link OutboundTransferRetrieveParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/OutboundTransferReturnOutboundTransferParams.java
+++ b/src/main/java/com/stripe/param/treasury/OutboundTransferReturnOutboundTransferParams.java
@@ -1,0 +1,223 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class OutboundTransferReturnOutboundTransferParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  /** Details about a returned OutboundTransfer. */
+  @SerializedName("returned_details")
+  ReturnedDetails returnedDetails;
+
+  private OutboundTransferReturnOutboundTransferParams(
+      List<String> expand, Map<String, Object> extraParams, ReturnedDetails returnedDetails) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+    this.returnedDetails = returnedDetails;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    private ReturnedDetails returnedDetails;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public OutboundTransferReturnOutboundTransferParams build() {
+      return new OutboundTransferReturnOutboundTransferParams(
+          this.expand, this.extraParams, this.returnedDetails);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * OutboundTransferReturnOutboundTransferParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * OutboundTransferReturnOutboundTransferParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * OutboundTransferReturnOutboundTransferParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link OutboundTransferReturnOutboundTransferParams#extraParams} for the field
+     * documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /** Details about a returned OutboundTransfer. */
+    public Builder setReturnedDetails(ReturnedDetails returnedDetails) {
+      this.returnedDetails = returnedDetails;
+      return this;
+    }
+  }
+
+  @Getter
+  public static class ReturnedDetails {
+    /** Reason for the return. */
+    @SerializedName("code")
+    Code code;
+
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    private ReturnedDetails(Code code, Map<String, Object> extraParams) {
+      this.code = code;
+      this.extraParams = extraParams;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Code code;
+
+      private Map<String, Object> extraParams;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public ReturnedDetails build() {
+        return new ReturnedDetails(this.code, this.extraParams);
+      }
+
+      /** Reason for the return. */
+      public Builder setCode(Code code) {
+        this.code = code;
+        return this;
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * OutboundTransferReturnOutboundTransferParams.ReturnedDetails#extraParams} for the field
+       * documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link OutboundTransferReturnOutboundTransferParams.ReturnedDetails#extraParams} for
+       * the field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+    }
+
+    public enum Code implements ApiRequestParams.EnumParam {
+      @SerializedName("account_closed")
+      ACCOUNT_CLOSED("account_closed"),
+
+      @SerializedName("account_frozen")
+      ACCOUNT_FROZEN("account_frozen"),
+
+      @SerializedName("bank_account_restricted")
+      BANK_ACCOUNT_RESTRICTED("bank_account_restricted"),
+
+      @SerializedName("bank_ownership_changed")
+      BANK_OWNERSHIP_CHANGED("bank_ownership_changed"),
+
+      @SerializedName("declined")
+      DECLINED("declined"),
+
+      @SerializedName("incorrect_account_holder_name")
+      INCORRECT_ACCOUNT_HOLDER_NAME("incorrect_account_holder_name"),
+
+      @SerializedName("invalid_account_number")
+      INVALID_ACCOUNT_NUMBER("invalid_account_number"),
+
+      @SerializedName("invalid_currency")
+      INVALID_CURRENCY("invalid_currency"),
+
+      @SerializedName("no_account")
+      NO_ACCOUNT("no_account"),
+
+      @SerializedName("other")
+      OTHER("other");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      Code(String value) {
+        this.value = value;
+      }
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/ReceivedCreditCreateParams.java
+++ b/src/main/java/com/stripe/param/treasury/ReceivedCreditCreateParams.java
@@ -1,0 +1,414 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class ReceivedCreditCreateParams extends ApiRequestParams {
+  /** Amount (in cents) to be transferred. */
+  @SerializedName("amount")
+  Long amount;
+
+  /**
+   * Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency code</a>,
+   * in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported currency</a>.
+   */
+  @SerializedName("currency")
+  String currency;
+
+  /** An arbitrary string attached to the object. Often useful for displaying to users. */
+  @SerializedName("description")
+  String description;
+
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  /** The FinancialAccount to send funds to. */
+  @SerializedName("financial_account")
+  String financialAccount;
+
+  /** Initiating payment method details for the object. */
+  @SerializedName("initiating_payment_method_details")
+  InitiatingPaymentMethodDetails initiatingPaymentMethodDetails;
+
+  /** The rails used for the object. */
+  @SerializedName("network")
+  Network network;
+
+  private ReceivedCreditCreateParams(
+      Long amount,
+      String currency,
+      String description,
+      List<String> expand,
+      Map<String, Object> extraParams,
+      String financialAccount,
+      InitiatingPaymentMethodDetails initiatingPaymentMethodDetails,
+      Network network) {
+    this.amount = amount;
+    this.currency = currency;
+    this.description = description;
+    this.expand = expand;
+    this.extraParams = extraParams;
+    this.financialAccount = financialAccount;
+    this.initiatingPaymentMethodDetails = initiatingPaymentMethodDetails;
+    this.network = network;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Long amount;
+
+    private String currency;
+
+    private String description;
+
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    private String financialAccount;
+
+    private InitiatingPaymentMethodDetails initiatingPaymentMethodDetails;
+
+    private Network network;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public ReceivedCreditCreateParams build() {
+      return new ReceivedCreditCreateParams(
+          this.amount,
+          this.currency,
+          this.description,
+          this.expand,
+          this.extraParams,
+          this.financialAccount,
+          this.initiatingPaymentMethodDetails,
+          this.network);
+    }
+
+    /** Amount (in cents) to be transferred. */
+    public Builder setAmount(Long amount) {
+      this.amount = amount;
+      return this;
+    }
+
+    /**
+     * Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency
+     * code</a>, in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported
+     * currency</a>.
+     */
+    public Builder setCurrency(String currency) {
+      this.currency = currency;
+      return this;
+    }
+
+    /** An arbitrary string attached to the object. Often useful for displaying to users. */
+    public Builder setDescription(String description) {
+      this.description = description;
+      return this;
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * ReceivedCreditCreateParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * ReceivedCreditCreateParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * ReceivedCreditCreateParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link ReceivedCreditCreateParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /** The FinancialAccount to send funds to. */
+    public Builder setFinancialAccount(String financialAccount) {
+      this.financialAccount = financialAccount;
+      return this;
+    }
+
+    /** Initiating payment method details for the object. */
+    public Builder setInitiatingPaymentMethodDetails(
+        InitiatingPaymentMethodDetails initiatingPaymentMethodDetails) {
+      this.initiatingPaymentMethodDetails = initiatingPaymentMethodDetails;
+      return this;
+    }
+
+    /** The rails used for the object. */
+    public Builder setNetwork(Network network) {
+      this.network = network;
+      return this;
+    }
+  }
+
+  @Getter
+  public static class InitiatingPaymentMethodDetails {
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /** The source type. */
+    @SerializedName("type")
+    Type type;
+
+    /** Optional fields for {@code us_bank_account}. */
+    @SerializedName("us_bank_account")
+    UsBankAccount usBankAccount;
+
+    private InitiatingPaymentMethodDetails(
+        Map<String, Object> extraParams, Type type, UsBankAccount usBankAccount) {
+      this.extraParams = extraParams;
+      this.type = type;
+      this.usBankAccount = usBankAccount;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Map<String, Object> extraParams;
+
+      private Type type;
+
+      private UsBankAccount usBankAccount;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public InitiatingPaymentMethodDetails build() {
+        return new InitiatingPaymentMethodDetails(this.extraParams, this.type, this.usBankAccount);
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * ReceivedCreditCreateParams.InitiatingPaymentMethodDetails#extraParams} for the field
+       * documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link ReceivedCreditCreateParams.InitiatingPaymentMethodDetails#extraParams} for the
+       * field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** The source type. */
+      public Builder setType(Type type) {
+        this.type = type;
+        return this;
+      }
+
+      /** Optional fields for {@code us_bank_account}. */
+      public Builder setUsBankAccount(UsBankAccount usBankAccount) {
+        this.usBankAccount = usBankAccount;
+        return this;
+      }
+    }
+
+    @Getter
+    public static class UsBankAccount {
+      /** The bank account holder's name. */
+      @SerializedName("account_holder_name")
+      String accountHolderName;
+
+      /** The bank account number. */
+      @SerializedName("account_number")
+      String accountNumber;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** The bank account's routing number. */
+      @SerializedName("routing_number")
+      String routingNumber;
+
+      private UsBankAccount(
+          String accountHolderName,
+          String accountNumber,
+          Map<String, Object> extraParams,
+          String routingNumber) {
+        this.accountHolderName = accountHolderName;
+        this.accountNumber = accountNumber;
+        this.extraParams = extraParams;
+        this.routingNumber = routingNumber;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private String accountHolderName;
+
+        private String accountNumber;
+
+        private Map<String, Object> extraParams;
+
+        private String routingNumber;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public UsBankAccount build() {
+          return new UsBankAccount(
+              this.accountHolderName, this.accountNumber, this.extraParams, this.routingNumber);
+        }
+
+        /** The bank account holder's name. */
+        public Builder setAccountHolderName(String accountHolderName) {
+          this.accountHolderName = accountHolderName;
+          return this;
+        }
+
+        /** The bank account number. */
+        public Builder setAccountNumber(String accountNumber) {
+          this.accountNumber = accountNumber;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * ReceivedCreditCreateParams.InitiatingPaymentMethodDetails.UsBankAccount#extraParams} for
+         * the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * ReceivedCreditCreateParams.InitiatingPaymentMethodDetails.UsBankAccount#extraParams} for
+         * the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** The bank account's routing number. */
+        public Builder setRoutingNumber(String routingNumber) {
+          this.routingNumber = routingNumber;
+          return this;
+        }
+      }
+    }
+
+    public enum Type implements ApiRequestParams.EnumParam {
+      @SerializedName("us_bank_account")
+      US_BANK_ACCOUNT("us_bank_account");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      Type(String value) {
+        this.value = value;
+      }
+    }
+  }
+
+  public enum Network implements ApiRequestParams.EnumParam {
+    @SerializedName("ach")
+    ACH("ach"),
+
+    @SerializedName("us_domestic_wire")
+    US_DOMESTIC_WIRE("us_domestic_wire");
+
+    @Getter(onMethod_ = {@Override})
+    private final String value;
+
+    Network(String value) {
+      this.value = value;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/ReceivedCreditListParams.java
+++ b/src/main/java/com/stripe/param/treasury/ReceivedCreditListParams.java
@@ -1,0 +1,326 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class ReceivedCreditListParams extends ApiRequestParams {
+  /**
+   * A cursor for use in pagination. {@code ending_before} is an object ID that defines your place
+   * in the list. For instance, if you make a list request and receive 100 objects, starting with
+   * {@code obj_bar}, your subsequent call can include {@code ending_before=obj_bar} in order to
+   * fetch the previous page of the list.
+   */
+  @SerializedName("ending_before")
+  String endingBefore;
+
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  /** The FinancialAccount that received the funds. */
+  @SerializedName("financial_account")
+  String financialAccount;
+
+  /**
+   * A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+   * default is 10.
+   */
+  @SerializedName("limit")
+  Long limit;
+
+  /** Only return ReceivedCredits described by the flow. */
+  @SerializedName("linked_flows")
+  LinkedFlows linkedFlows;
+
+  /**
+   * A cursor for use in pagination. {@code starting_after} is an object ID that defines your place
+   * in the list. For instance, if you make a list request and receive 100 objects, ending with
+   * {@code obj_foo}, your subsequent call can include {@code starting_after=obj_foo} in order to
+   * fetch the next page of the list.
+   */
+  @SerializedName("starting_after")
+  String startingAfter;
+
+  /**
+   * Only return ReceivedCredits that have the given status: {@code succeeded} or {@code failed}.
+   */
+  @SerializedName("status")
+  Status status;
+
+  private ReceivedCreditListParams(
+      String endingBefore,
+      List<String> expand,
+      Map<String, Object> extraParams,
+      String financialAccount,
+      Long limit,
+      LinkedFlows linkedFlows,
+      String startingAfter,
+      Status status) {
+    this.endingBefore = endingBefore;
+    this.expand = expand;
+    this.extraParams = extraParams;
+    this.financialAccount = financialAccount;
+    this.limit = limit;
+    this.linkedFlows = linkedFlows;
+    this.startingAfter = startingAfter;
+    this.status = status;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String endingBefore;
+
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    private String financialAccount;
+
+    private Long limit;
+
+    private LinkedFlows linkedFlows;
+
+    private String startingAfter;
+
+    private Status status;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public ReceivedCreditListParams build() {
+      return new ReceivedCreditListParams(
+          this.endingBefore,
+          this.expand,
+          this.extraParams,
+          this.financialAccount,
+          this.limit,
+          this.linkedFlows,
+          this.startingAfter,
+          this.status);
+    }
+
+    /**
+     * A cursor for use in pagination. {@code ending_before} is an object ID that defines your place
+     * in the list. For instance, if you make a list request and receive 100 objects, starting with
+     * {@code obj_bar}, your subsequent call can include {@code ending_before=obj_bar} in order to
+     * fetch the previous page of the list.
+     */
+    public Builder setEndingBefore(String endingBefore) {
+      this.endingBefore = endingBefore;
+      return this;
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * ReceivedCreditListParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * ReceivedCreditListParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * ReceivedCreditListParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link ReceivedCreditListParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /** The FinancialAccount that received the funds. */
+    public Builder setFinancialAccount(String financialAccount) {
+      this.financialAccount = financialAccount;
+      return this;
+    }
+
+    /**
+     * A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+     * default is 10.
+     */
+    public Builder setLimit(Long limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    /** Only return ReceivedCredits described by the flow. */
+    public Builder setLinkedFlows(LinkedFlows linkedFlows) {
+      this.linkedFlows = linkedFlows;
+      return this;
+    }
+
+    /**
+     * A cursor for use in pagination. {@code starting_after} is an object ID that defines your
+     * place in the list. For instance, if you make a list request and receive 100 objects, ending
+     * with {@code obj_foo}, your subsequent call can include {@code starting_after=obj_foo} in
+     * order to fetch the next page of the list.
+     */
+    public Builder setStartingAfter(String startingAfter) {
+      this.startingAfter = startingAfter;
+      return this;
+    }
+
+    /**
+     * Only return ReceivedCredits that have the given status: {@code succeeded} or {@code failed}.
+     */
+    public Builder setStatus(Status status) {
+      this.status = status;
+      return this;
+    }
+  }
+
+  @Getter
+  public static class LinkedFlows {
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /** The source flow type. */
+    @SerializedName("source_flow_type")
+    SourceFlowType sourceFlowType;
+
+    private LinkedFlows(Map<String, Object> extraParams, SourceFlowType sourceFlowType) {
+      this.extraParams = extraParams;
+      this.sourceFlowType = sourceFlowType;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Map<String, Object> extraParams;
+
+      private SourceFlowType sourceFlowType;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public LinkedFlows build() {
+        return new LinkedFlows(this.extraParams, this.sourceFlowType);
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * ReceivedCreditListParams.LinkedFlows#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link ReceivedCreditListParams.LinkedFlows#extraParams} for the field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** The source flow type. */
+      public Builder setSourceFlowType(SourceFlowType sourceFlowType) {
+        this.sourceFlowType = sourceFlowType;
+        return this;
+      }
+    }
+
+    public enum SourceFlowType implements ApiRequestParams.EnumParam {
+      @SerializedName("credit_reversal")
+      CREDIT_REVERSAL("credit_reversal"),
+
+      @SerializedName("other")
+      OTHER("other"),
+
+      @SerializedName("outbound_payment")
+      OUTBOUND_PAYMENT("outbound_payment"),
+
+      @SerializedName("payout")
+      PAYOUT("payout");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      SourceFlowType(String value) {
+        this.value = value;
+      }
+    }
+  }
+
+  public enum Status implements ApiRequestParams.EnumParam {
+    @SerializedName("failed")
+    FAILED("failed"),
+
+    @SerializedName("succeeded")
+    SUCCEEDED("succeeded");
+
+    @Getter(onMethod_ = {@Override})
+    private final String value;
+
+    Status(String value) {
+      this.value = value;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/ReceivedCreditRetrieveParams.java
+++ b/src/main/java/com/stripe/param/treasury/ReceivedCreditRetrieveParams.java
@@ -1,0 +1,98 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class ReceivedCreditRetrieveParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  private ReceivedCreditRetrieveParams(List<String> expand, Map<String, Object> extraParams) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public ReceivedCreditRetrieveParams build() {
+      return new ReceivedCreditRetrieveParams(this.expand, this.extraParams);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * ReceivedCreditRetrieveParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * ReceivedCreditRetrieveParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * ReceivedCreditRetrieveParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link ReceivedCreditRetrieveParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/ReceivedDebitCreateParams.java
+++ b/src/main/java/com/stripe/param/treasury/ReceivedDebitCreateParams.java
@@ -1,0 +1,411 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class ReceivedDebitCreateParams extends ApiRequestParams {
+  /** Amount (in cents) to be transferred. */
+  @SerializedName("amount")
+  Long amount;
+
+  /**
+   * Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency code</a>,
+   * in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported currency</a>.
+   */
+  @SerializedName("currency")
+  String currency;
+
+  /** An arbitrary string attached to the object. Often useful for displaying to users. */
+  @SerializedName("description")
+  String description;
+
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  /** The FinancialAccount to pull funds from. */
+  @SerializedName("financial_account")
+  String financialAccount;
+
+  /** Initiating payment method details for the object. */
+  @SerializedName("initiating_payment_method_details")
+  InitiatingPaymentMethodDetails initiatingPaymentMethodDetails;
+
+  /** The rails used for the object. */
+  @SerializedName("network")
+  Network network;
+
+  private ReceivedDebitCreateParams(
+      Long amount,
+      String currency,
+      String description,
+      List<String> expand,
+      Map<String, Object> extraParams,
+      String financialAccount,
+      InitiatingPaymentMethodDetails initiatingPaymentMethodDetails,
+      Network network) {
+    this.amount = amount;
+    this.currency = currency;
+    this.description = description;
+    this.expand = expand;
+    this.extraParams = extraParams;
+    this.financialAccount = financialAccount;
+    this.initiatingPaymentMethodDetails = initiatingPaymentMethodDetails;
+    this.network = network;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Long amount;
+
+    private String currency;
+
+    private String description;
+
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    private String financialAccount;
+
+    private InitiatingPaymentMethodDetails initiatingPaymentMethodDetails;
+
+    private Network network;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public ReceivedDebitCreateParams build() {
+      return new ReceivedDebitCreateParams(
+          this.amount,
+          this.currency,
+          this.description,
+          this.expand,
+          this.extraParams,
+          this.financialAccount,
+          this.initiatingPaymentMethodDetails,
+          this.network);
+    }
+
+    /** Amount (in cents) to be transferred. */
+    public Builder setAmount(Long amount) {
+      this.amount = amount;
+      return this;
+    }
+
+    /**
+     * Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO currency
+     * code</a>, in lowercase. Must be a <a href="https://stripe.com/docs/currencies">supported
+     * currency</a>.
+     */
+    public Builder setCurrency(String currency) {
+      this.currency = currency;
+      return this;
+    }
+
+    /** An arbitrary string attached to the object. Often useful for displaying to users. */
+    public Builder setDescription(String description) {
+      this.description = description;
+      return this;
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * ReceivedDebitCreateParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * ReceivedDebitCreateParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * ReceivedDebitCreateParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link ReceivedDebitCreateParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /** The FinancialAccount to pull funds from. */
+    public Builder setFinancialAccount(String financialAccount) {
+      this.financialAccount = financialAccount;
+      return this;
+    }
+
+    /** Initiating payment method details for the object. */
+    public Builder setInitiatingPaymentMethodDetails(
+        InitiatingPaymentMethodDetails initiatingPaymentMethodDetails) {
+      this.initiatingPaymentMethodDetails = initiatingPaymentMethodDetails;
+      return this;
+    }
+
+    /** The rails used for the object. */
+    public Builder setNetwork(Network network) {
+      this.network = network;
+      return this;
+    }
+  }
+
+  @Getter
+  public static class InitiatingPaymentMethodDetails {
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /** The source type. */
+    @SerializedName("type")
+    Type type;
+
+    /** Optional fields for {@code us_bank_account}. */
+    @SerializedName("us_bank_account")
+    UsBankAccount usBankAccount;
+
+    private InitiatingPaymentMethodDetails(
+        Map<String, Object> extraParams, Type type, UsBankAccount usBankAccount) {
+      this.extraParams = extraParams;
+      this.type = type;
+      this.usBankAccount = usBankAccount;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Map<String, Object> extraParams;
+
+      private Type type;
+
+      private UsBankAccount usBankAccount;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public InitiatingPaymentMethodDetails build() {
+        return new InitiatingPaymentMethodDetails(this.extraParams, this.type, this.usBankAccount);
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * ReceivedDebitCreateParams.InitiatingPaymentMethodDetails#extraParams} for the field
+       * documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link ReceivedDebitCreateParams.InitiatingPaymentMethodDetails#extraParams} for the
+       * field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** The source type. */
+      public Builder setType(Type type) {
+        this.type = type;
+        return this;
+      }
+
+      /** Optional fields for {@code us_bank_account}. */
+      public Builder setUsBankAccount(UsBankAccount usBankAccount) {
+        this.usBankAccount = usBankAccount;
+        return this;
+      }
+    }
+
+    @Getter
+    public static class UsBankAccount {
+      /** The bank account holder's name. */
+      @SerializedName("account_holder_name")
+      String accountHolderName;
+
+      /** The bank account number. */
+      @SerializedName("account_number")
+      String accountNumber;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** The bank account's routing number. */
+      @SerializedName("routing_number")
+      String routingNumber;
+
+      private UsBankAccount(
+          String accountHolderName,
+          String accountNumber,
+          Map<String, Object> extraParams,
+          String routingNumber) {
+        this.accountHolderName = accountHolderName;
+        this.accountNumber = accountNumber;
+        this.extraParams = extraParams;
+        this.routingNumber = routingNumber;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private String accountHolderName;
+
+        private String accountNumber;
+
+        private Map<String, Object> extraParams;
+
+        private String routingNumber;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public UsBankAccount build() {
+          return new UsBankAccount(
+              this.accountHolderName, this.accountNumber, this.extraParams, this.routingNumber);
+        }
+
+        /** The bank account holder's name. */
+        public Builder setAccountHolderName(String accountHolderName) {
+          this.accountHolderName = accountHolderName;
+          return this;
+        }
+
+        /** The bank account number. */
+        public Builder setAccountNumber(String accountNumber) {
+          this.accountNumber = accountNumber;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * ReceivedDebitCreateParams.InitiatingPaymentMethodDetails.UsBankAccount#extraParams} for
+         * the field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link
+         * ReceivedDebitCreateParams.InitiatingPaymentMethodDetails.UsBankAccount#extraParams} for
+         * the field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** The bank account's routing number. */
+        public Builder setRoutingNumber(String routingNumber) {
+          this.routingNumber = routingNumber;
+          return this;
+        }
+      }
+    }
+
+    public enum Type implements ApiRequestParams.EnumParam {
+      @SerializedName("us_bank_account")
+      US_BANK_ACCOUNT("us_bank_account");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      Type(String value) {
+        this.value = value;
+      }
+    }
+  }
+
+  public enum Network implements ApiRequestParams.EnumParam {
+    @SerializedName("ach")
+    ACH("ach");
+
+    @Getter(onMethod_ = {@Override})
+    private final String value;
+
+    Network(String value) {
+      this.value = value;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/ReceivedDebitListParams.java
+++ b/src/main/java/com/stripe/param/treasury/ReceivedDebitListParams.java
@@ -1,0 +1,220 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class ReceivedDebitListParams extends ApiRequestParams {
+  /**
+   * A cursor for use in pagination. {@code ending_before} is an object ID that defines your place
+   * in the list. For instance, if you make a list request and receive 100 objects, starting with
+   * {@code obj_bar}, your subsequent call can include {@code ending_before=obj_bar} in order to
+   * fetch the previous page of the list.
+   */
+  @SerializedName("ending_before")
+  String endingBefore;
+
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  /** The FinancialAccount that funds were pulled from. */
+  @SerializedName("financial_account")
+  String financialAccount;
+
+  /**
+   * A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+   * default is 10.
+   */
+  @SerializedName("limit")
+  Long limit;
+
+  /**
+   * A cursor for use in pagination. {@code starting_after} is an object ID that defines your place
+   * in the list. For instance, if you make a list request and receive 100 objects, ending with
+   * {@code obj_foo}, your subsequent call can include {@code starting_after=obj_foo} in order to
+   * fetch the next page of the list.
+   */
+  @SerializedName("starting_after")
+  String startingAfter;
+
+  /** Only return ReceivedDebits that have the given status: {@code succeeded} or {@code failed}. */
+  @SerializedName("status")
+  Status status;
+
+  private ReceivedDebitListParams(
+      String endingBefore,
+      List<String> expand,
+      Map<String, Object> extraParams,
+      String financialAccount,
+      Long limit,
+      String startingAfter,
+      Status status) {
+    this.endingBefore = endingBefore;
+    this.expand = expand;
+    this.extraParams = extraParams;
+    this.financialAccount = financialAccount;
+    this.limit = limit;
+    this.startingAfter = startingAfter;
+    this.status = status;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String endingBefore;
+
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    private String financialAccount;
+
+    private Long limit;
+
+    private String startingAfter;
+
+    private Status status;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public ReceivedDebitListParams build() {
+      return new ReceivedDebitListParams(
+          this.endingBefore,
+          this.expand,
+          this.extraParams,
+          this.financialAccount,
+          this.limit,
+          this.startingAfter,
+          this.status);
+    }
+
+    /**
+     * A cursor for use in pagination. {@code ending_before} is an object ID that defines your place
+     * in the list. For instance, if you make a list request and receive 100 objects, starting with
+     * {@code obj_bar}, your subsequent call can include {@code ending_before=obj_bar} in order to
+     * fetch the previous page of the list.
+     */
+    public Builder setEndingBefore(String endingBefore) {
+      this.endingBefore = endingBefore;
+      return this;
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * ReceivedDebitListParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * ReceivedDebitListParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * ReceivedDebitListParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link ReceivedDebitListParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /** The FinancialAccount that funds were pulled from. */
+    public Builder setFinancialAccount(String financialAccount) {
+      this.financialAccount = financialAccount;
+      return this;
+    }
+
+    /**
+     * A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+     * default is 10.
+     */
+    public Builder setLimit(Long limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    /**
+     * A cursor for use in pagination. {@code starting_after} is an object ID that defines your
+     * place in the list. For instance, if you make a list request and receive 100 objects, ending
+     * with {@code obj_foo}, your subsequent call can include {@code starting_after=obj_foo} in
+     * order to fetch the next page of the list.
+     */
+    public Builder setStartingAfter(String startingAfter) {
+      this.startingAfter = startingAfter;
+      return this;
+    }
+
+    /**
+     * Only return ReceivedDebits that have the given status: {@code succeeded} or {@code failed}.
+     */
+    public Builder setStatus(Status status) {
+      this.status = status;
+      return this;
+    }
+  }
+
+  public enum Status implements ApiRequestParams.EnumParam {
+    @SerializedName("failed")
+    FAILED("failed"),
+
+    @SerializedName("succeeded")
+    SUCCEEDED("succeeded");
+
+    @Getter(onMethod_ = {@Override})
+    private final String value;
+
+    Status(String value) {
+      this.value = value;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/ReceivedDebitRetrieveParams.java
+++ b/src/main/java/com/stripe/param/treasury/ReceivedDebitRetrieveParams.java
@@ -1,0 +1,98 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class ReceivedDebitRetrieveParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  private ReceivedDebitRetrieveParams(List<String> expand, Map<String, Object> extraParams) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public ReceivedDebitRetrieveParams build() {
+      return new ReceivedDebitRetrieveParams(this.expand, this.extraParams);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * ReceivedDebitRetrieveParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * ReceivedDebitRetrieveParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * ReceivedDebitRetrieveParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link ReceivedDebitRetrieveParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/TransactionEntryListParams.java
+++ b/src/main/java/com/stripe/param/treasury/TransactionEntryListParams.java
@@ -1,0 +1,489 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class TransactionEntryListParams extends ApiRequestParams {
+  @SerializedName("created")
+  Object created;
+
+  @SerializedName("effective_at")
+  Object effectiveAt;
+
+  /**
+   * A cursor for use in pagination. {@code ending_before} is an object ID that defines your place
+   * in the list. For instance, if you make a list request and receive 100 objects, starting with
+   * {@code obj_bar}, your subsequent call can include {@code ending_before=obj_bar} in order to
+   * fetch the previous page of the list.
+   */
+  @SerializedName("ending_before")
+  String endingBefore;
+
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  /** Returns objects associated with this FinancialAccount. */
+  @SerializedName("financial_account")
+  String financialAccount;
+
+  /**
+   * A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+   * default is 10.
+   */
+  @SerializedName("limit")
+  Long limit;
+
+  /**
+   * The results are in reverse chronological order by {@code created} or {@code effective_at}. The
+   * default is {@code created}.
+   */
+  @SerializedName("order_by")
+  OrderBy orderBy;
+
+  /**
+   * A cursor for use in pagination. {@code starting_after} is an object ID that defines your place
+   * in the list. For instance, if you make a list request and receive 100 objects, ending with
+   * {@code obj_foo}, your subsequent call can include {@code starting_after=obj_foo} in order to
+   * fetch the next page of the list.
+   */
+  @SerializedName("starting_after")
+  String startingAfter;
+
+  /** Only return TransactionEntries associated with this Transaction. */
+  @SerializedName("transaction")
+  String transaction;
+
+  private TransactionEntryListParams(
+      Object created,
+      Object effectiveAt,
+      String endingBefore,
+      List<String> expand,
+      Map<String, Object> extraParams,
+      String financialAccount,
+      Long limit,
+      OrderBy orderBy,
+      String startingAfter,
+      String transaction) {
+    this.created = created;
+    this.effectiveAt = effectiveAt;
+    this.endingBefore = endingBefore;
+    this.expand = expand;
+    this.extraParams = extraParams;
+    this.financialAccount = financialAccount;
+    this.limit = limit;
+    this.orderBy = orderBy;
+    this.startingAfter = startingAfter;
+    this.transaction = transaction;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Object created;
+
+    private Object effectiveAt;
+
+    private String endingBefore;
+
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    private String financialAccount;
+
+    private Long limit;
+
+    private OrderBy orderBy;
+
+    private String startingAfter;
+
+    private String transaction;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public TransactionEntryListParams build() {
+      return new TransactionEntryListParams(
+          this.created,
+          this.effectiveAt,
+          this.endingBefore,
+          this.expand,
+          this.extraParams,
+          this.financialAccount,
+          this.limit,
+          this.orderBy,
+          this.startingAfter,
+          this.transaction);
+    }
+
+    public Builder setCreated(Created created) {
+      this.created = created;
+      return this;
+    }
+
+    public Builder setCreated(Long created) {
+      this.created = created;
+      return this;
+    }
+
+    public Builder setEffectiveAt(EffectiveAt effectiveAt) {
+      this.effectiveAt = effectiveAt;
+      return this;
+    }
+
+    public Builder setEffectiveAt(Long effectiveAt) {
+      this.effectiveAt = effectiveAt;
+      return this;
+    }
+
+    /**
+     * A cursor for use in pagination. {@code ending_before} is an object ID that defines your place
+     * in the list. For instance, if you make a list request and receive 100 objects, starting with
+     * {@code obj_bar}, your subsequent call can include {@code ending_before=obj_bar} in order to
+     * fetch the previous page of the list.
+     */
+    public Builder setEndingBefore(String endingBefore) {
+      this.endingBefore = endingBefore;
+      return this;
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * TransactionEntryListParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * TransactionEntryListParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * TransactionEntryListParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link TransactionEntryListParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /** Returns objects associated with this FinancialAccount. */
+    public Builder setFinancialAccount(String financialAccount) {
+      this.financialAccount = financialAccount;
+      return this;
+    }
+
+    /**
+     * A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+     * default is 10.
+     */
+    public Builder setLimit(Long limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    /**
+     * The results are in reverse chronological order by {@code created} or {@code effective_at}.
+     * The default is {@code created}.
+     */
+    public Builder setOrderBy(OrderBy orderBy) {
+      this.orderBy = orderBy;
+      return this;
+    }
+
+    /**
+     * A cursor for use in pagination. {@code starting_after} is an object ID that defines your
+     * place in the list. For instance, if you make a list request and receive 100 objects, ending
+     * with {@code obj_foo}, your subsequent call can include {@code starting_after=obj_foo} in
+     * order to fetch the next page of the list.
+     */
+    public Builder setStartingAfter(String startingAfter) {
+      this.startingAfter = startingAfter;
+      return this;
+    }
+
+    /** Only return TransactionEntries associated with this Transaction. */
+    public Builder setTransaction(String transaction) {
+      this.transaction = transaction;
+      return this;
+    }
+  }
+
+  @Getter
+  public static class Created {
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /** Minimum value to filter by (exclusive). */
+    @SerializedName("gt")
+    Long gt;
+
+    /** Minimum value to filter by (inclusive). */
+    @SerializedName("gte")
+    Long gte;
+
+    /** Maximum value to filter by (exclusive). */
+    @SerializedName("lt")
+    Long lt;
+
+    /** Maximum value to filter by (inclusive). */
+    @SerializedName("lte")
+    Long lte;
+
+    private Created(Map<String, Object> extraParams, Long gt, Long gte, Long lt, Long lte) {
+      this.extraParams = extraParams;
+      this.gt = gt;
+      this.gte = gte;
+      this.lt = lt;
+      this.lte = lte;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Map<String, Object> extraParams;
+
+      private Long gt;
+
+      private Long gte;
+
+      private Long lt;
+
+      private Long lte;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public Created build() {
+        return new Created(this.extraParams, this.gt, this.gte, this.lt, this.lte);
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * TransactionEntryListParams.Created#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link TransactionEntryListParams.Created#extraParams} for the field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** Minimum value to filter by (exclusive). */
+      public Builder setGt(Long gt) {
+        this.gt = gt;
+        return this;
+      }
+
+      /** Minimum value to filter by (inclusive). */
+      public Builder setGte(Long gte) {
+        this.gte = gte;
+        return this;
+      }
+
+      /** Maximum value to filter by (exclusive). */
+      public Builder setLt(Long lt) {
+        this.lt = lt;
+        return this;
+      }
+
+      /** Maximum value to filter by (inclusive). */
+      public Builder setLte(Long lte) {
+        this.lte = lte;
+        return this;
+      }
+    }
+  }
+
+  @Getter
+  public static class EffectiveAt {
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /** Minimum value to filter by (exclusive). */
+    @SerializedName("gt")
+    Long gt;
+
+    /** Minimum value to filter by (inclusive). */
+    @SerializedName("gte")
+    Long gte;
+
+    /** Maximum value to filter by (exclusive). */
+    @SerializedName("lt")
+    Long lt;
+
+    /** Maximum value to filter by (inclusive). */
+    @SerializedName("lte")
+    Long lte;
+
+    private EffectiveAt(Map<String, Object> extraParams, Long gt, Long gte, Long lt, Long lte) {
+      this.extraParams = extraParams;
+      this.gt = gt;
+      this.gte = gte;
+      this.lt = lt;
+      this.lte = lte;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Map<String, Object> extraParams;
+
+      private Long gt;
+
+      private Long gte;
+
+      private Long lt;
+
+      private Long lte;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public EffectiveAt build() {
+        return new EffectiveAt(this.extraParams, this.gt, this.gte, this.lt, this.lte);
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * TransactionEntryListParams.EffectiveAt#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link TransactionEntryListParams.EffectiveAt#extraParams} for the field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** Minimum value to filter by (exclusive). */
+      public Builder setGt(Long gt) {
+        this.gt = gt;
+        return this;
+      }
+
+      /** Minimum value to filter by (inclusive). */
+      public Builder setGte(Long gte) {
+        this.gte = gte;
+        return this;
+      }
+
+      /** Maximum value to filter by (exclusive). */
+      public Builder setLt(Long lt) {
+        this.lt = lt;
+        return this;
+      }
+
+      /** Maximum value to filter by (inclusive). */
+      public Builder setLte(Long lte) {
+        this.lte = lte;
+        return this;
+      }
+    }
+  }
+
+  public enum OrderBy implements ApiRequestParams.EnumParam {
+    @SerializedName("created")
+    CREATED("created"),
+
+    @SerializedName("effective_at")
+    EFFECTIVE_AT("effective_at");
+
+    @Getter(onMethod_ = {@Override})
+    private final String value;
+
+    OrderBy(String value) {
+      this.value = value;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/TransactionEntryRetrieveParams.java
+++ b/src/main/java/com/stripe/param/treasury/TransactionEntryRetrieveParams.java
@@ -1,0 +1,98 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class TransactionEntryRetrieveParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  private TransactionEntryRetrieveParams(List<String> expand, Map<String, Object> extraParams) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public TransactionEntryRetrieveParams build() {
+      return new TransactionEntryRetrieveParams(this.expand, this.extraParams);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * TransactionEntryRetrieveParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * TransactionEntryRetrieveParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * TransactionEntryRetrieveParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link TransactionEntryRetrieveParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/TransactionListParams.java
+++ b/src/main/java/com/stripe/param/treasury/TransactionListParams.java
@@ -1,0 +1,593 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class TransactionListParams extends ApiRequestParams {
+  @SerializedName("created")
+  Object created;
+
+  /**
+   * A cursor for use in pagination. {@code ending_before} is an object ID that defines your place
+   * in the list. For instance, if you make a list request and receive 100 objects, starting with
+   * {@code obj_bar}, your subsequent call can include {@code ending_before=obj_bar} in order to
+   * fetch the previous page of the list.
+   */
+  @SerializedName("ending_before")
+  String endingBefore;
+
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  /** Returns objects associated with this FinancialAccount. */
+  @SerializedName("financial_account")
+  String financialAccount;
+
+  /**
+   * A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+   * default is 10.
+   */
+  @SerializedName("limit")
+  Long limit;
+
+  /**
+   * The results are in reverse chronological order by {@code created} or {@code posted_at}. The
+   * default is {@code created}.
+   */
+  @SerializedName("order_by")
+  OrderBy orderBy;
+
+  /**
+   * A cursor for use in pagination. {@code starting_after} is an object ID that defines your place
+   * in the list. For instance, if you make a list request and receive 100 objects, ending with
+   * {@code obj_foo}, your subsequent call can include {@code starting_after=obj_foo} in order to
+   * fetch the next page of the list.
+   */
+  @SerializedName("starting_after")
+  String startingAfter;
+
+  /**
+   * Only return Transactions that have the given status: {@code open}, {@code posted}, or {@code
+   * void}.
+   */
+  @SerializedName("status")
+  Status status;
+
+  /**
+   * A filter for the {@code status_transitions.posted_at} timestamp. When using this filter, {@code
+   * status=posted} and {@code order_by=posted_at} must also be specified.
+   */
+  @SerializedName("status_transitions")
+  StatusTransitions statusTransitions;
+
+  private TransactionListParams(
+      Object created,
+      String endingBefore,
+      List<String> expand,
+      Map<String, Object> extraParams,
+      String financialAccount,
+      Long limit,
+      OrderBy orderBy,
+      String startingAfter,
+      Status status,
+      StatusTransitions statusTransitions) {
+    this.created = created;
+    this.endingBefore = endingBefore;
+    this.expand = expand;
+    this.extraParams = extraParams;
+    this.financialAccount = financialAccount;
+    this.limit = limit;
+    this.orderBy = orderBy;
+    this.startingAfter = startingAfter;
+    this.status = status;
+    this.statusTransitions = statusTransitions;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Object created;
+
+    private String endingBefore;
+
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    private String financialAccount;
+
+    private Long limit;
+
+    private OrderBy orderBy;
+
+    private String startingAfter;
+
+    private Status status;
+
+    private StatusTransitions statusTransitions;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public TransactionListParams build() {
+      return new TransactionListParams(
+          this.created,
+          this.endingBefore,
+          this.expand,
+          this.extraParams,
+          this.financialAccount,
+          this.limit,
+          this.orderBy,
+          this.startingAfter,
+          this.status,
+          this.statusTransitions);
+    }
+
+    public Builder setCreated(Created created) {
+      this.created = created;
+      return this;
+    }
+
+    public Builder setCreated(Long created) {
+      this.created = created;
+      return this;
+    }
+
+    /**
+     * A cursor for use in pagination. {@code ending_before} is an object ID that defines your place
+     * in the list. For instance, if you make a list request and receive 100 objects, starting with
+     * {@code obj_bar}, your subsequent call can include {@code ending_before=obj_bar} in order to
+     * fetch the previous page of the list.
+     */
+    public Builder setEndingBefore(String endingBefore) {
+      this.endingBefore = endingBefore;
+      return this;
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * TransactionListParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * TransactionListParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * TransactionListParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link TransactionListParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /** Returns objects associated with this FinancialAccount. */
+    public Builder setFinancialAccount(String financialAccount) {
+      this.financialAccount = financialAccount;
+      return this;
+    }
+
+    /**
+     * A limit on the number of objects to be returned. Limit can range between 1 and 100, and the
+     * default is 10.
+     */
+    public Builder setLimit(Long limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    /**
+     * The results are in reverse chronological order by {@code created} or {@code posted_at}. The
+     * default is {@code created}.
+     */
+    public Builder setOrderBy(OrderBy orderBy) {
+      this.orderBy = orderBy;
+      return this;
+    }
+
+    /**
+     * A cursor for use in pagination. {@code starting_after} is an object ID that defines your
+     * place in the list. For instance, if you make a list request and receive 100 objects, ending
+     * with {@code obj_foo}, your subsequent call can include {@code starting_after=obj_foo} in
+     * order to fetch the next page of the list.
+     */
+    public Builder setStartingAfter(String startingAfter) {
+      this.startingAfter = startingAfter;
+      return this;
+    }
+
+    /**
+     * Only return Transactions that have the given status: {@code open}, {@code posted}, or {@code
+     * void}.
+     */
+    public Builder setStatus(Status status) {
+      this.status = status;
+      return this;
+    }
+
+    /**
+     * A filter for the {@code status_transitions.posted_at} timestamp. When using this filter,
+     * {@code status=posted} and {@code order_by=posted_at} must also be specified.
+     */
+    public Builder setStatusTransitions(StatusTransitions statusTransitions) {
+      this.statusTransitions = statusTransitions;
+      return this;
+    }
+  }
+
+  @Getter
+  public static class Created {
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /** Minimum value to filter by (exclusive). */
+    @SerializedName("gt")
+    Long gt;
+
+    /** Minimum value to filter by (inclusive). */
+    @SerializedName("gte")
+    Long gte;
+
+    /** Maximum value to filter by (exclusive). */
+    @SerializedName("lt")
+    Long lt;
+
+    /** Maximum value to filter by (inclusive). */
+    @SerializedName("lte")
+    Long lte;
+
+    private Created(Map<String, Object> extraParams, Long gt, Long gte, Long lt, Long lte) {
+      this.extraParams = extraParams;
+      this.gt = gt;
+      this.gte = gte;
+      this.lt = lt;
+      this.lte = lte;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Map<String, Object> extraParams;
+
+      private Long gt;
+
+      private Long gte;
+
+      private Long lt;
+
+      private Long lte;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public Created build() {
+        return new Created(this.extraParams, this.gt, this.gte, this.lt, this.lte);
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * TransactionListParams.Created#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link TransactionListParams.Created#extraParams} for the field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** Minimum value to filter by (exclusive). */
+      public Builder setGt(Long gt) {
+        this.gt = gt;
+        return this;
+      }
+
+      /** Minimum value to filter by (inclusive). */
+      public Builder setGte(Long gte) {
+        this.gte = gte;
+        return this;
+      }
+
+      /** Maximum value to filter by (exclusive). */
+      public Builder setLt(Long lt) {
+        this.lt = lt;
+        return this;
+      }
+
+      /** Maximum value to filter by (inclusive). */
+      public Builder setLte(Long lte) {
+        this.lte = lte;
+        return this;
+      }
+    }
+  }
+
+  @Getter
+  public static class StatusTransitions {
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /** Returns Transactions with {@code posted_at} within the specified range. */
+    @SerializedName("posted_at")
+    Object postedAt;
+
+    private StatusTransitions(Map<String, Object> extraParams, Object postedAt) {
+      this.extraParams = extraParams;
+      this.postedAt = postedAt;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Map<String, Object> extraParams;
+
+      private Object postedAt;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public StatusTransitions build() {
+        return new StatusTransitions(this.extraParams, this.postedAt);
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * TransactionListParams.StatusTransitions#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link TransactionListParams.StatusTransitions#extraParams} for the field
+       * documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** Returns Transactions with {@code posted_at} within the specified range. */
+      public Builder setPostedAt(PostedAt postedAt) {
+        this.postedAt = postedAt;
+        return this;
+      }
+
+      /** Returns Transactions with {@code posted_at} within the specified range. */
+      public Builder setPostedAt(Long postedAt) {
+        this.postedAt = postedAt;
+        return this;
+      }
+    }
+
+    @Getter
+    public static class PostedAt {
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      /** Minimum value to filter by (exclusive). */
+      @SerializedName("gt")
+      Long gt;
+
+      /** Minimum value to filter by (inclusive). */
+      @SerializedName("gte")
+      Long gte;
+
+      /** Maximum value to filter by (exclusive). */
+      @SerializedName("lt")
+      Long lt;
+
+      /** Maximum value to filter by (inclusive). */
+      @SerializedName("lte")
+      Long lte;
+
+      private PostedAt(Map<String, Object> extraParams, Long gt, Long gte, Long lt, Long lte) {
+        this.extraParams = extraParams;
+        this.gt = gt;
+        this.gte = gte;
+        this.lt = lt;
+        this.lte = lte;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Map<String, Object> extraParams;
+
+        private Long gt;
+
+        private Long gte;
+
+        private Long lt;
+
+        private Long lte;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public PostedAt build() {
+          return new PostedAt(this.extraParams, this.gt, this.gte, this.lt, this.lte);
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link TransactionListParams.StatusTransitions.PostedAt#extraParams} for the
+         * field documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link TransactionListParams.StatusTransitions.PostedAt#extraParams} for the
+         * field documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+
+        /** Minimum value to filter by (exclusive). */
+        public Builder setGt(Long gt) {
+          this.gt = gt;
+          return this;
+        }
+
+        /** Minimum value to filter by (inclusive). */
+        public Builder setGte(Long gte) {
+          this.gte = gte;
+          return this;
+        }
+
+        /** Maximum value to filter by (exclusive). */
+        public Builder setLt(Long lt) {
+          this.lt = lt;
+          return this;
+        }
+
+        /** Maximum value to filter by (inclusive). */
+        public Builder setLte(Long lte) {
+          this.lte = lte;
+          return this;
+        }
+      }
+    }
+  }
+
+  public enum OrderBy implements ApiRequestParams.EnumParam {
+    @SerializedName("created")
+    CREATED("created"),
+
+    @SerializedName("posted_at")
+    POSTED_AT("posted_at");
+
+    @Getter(onMethod_ = {@Override})
+    private final String value;
+
+    OrderBy(String value) {
+      this.value = value;
+    }
+  }
+
+  public enum Status implements ApiRequestParams.EnumParam {
+    @SerializedName("open")
+    OPEN("open"),
+
+    @SerializedName("posted")
+    POSTED("posted"),
+
+    @SerializedName("void")
+    VOID("void");
+
+    @Getter(onMethod_ = {@Override})
+    private final String value;
+
+    Status(String value) {
+      this.value = value;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/treasury/TransactionRetrieveParams.java
+++ b/src/main/java/com/stripe/param/treasury/TransactionRetrieveParams.java
@@ -1,0 +1,98 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.treasury;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class TransactionRetrieveParams extends ApiRequestParams {
+  /** Specifies which fields in the response should be expanded. */
+  @SerializedName("expand")
+  List<String> expand;
+
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  private TransactionRetrieveParams(List<String> expand, Map<String, Object> extraParams) {
+    this.expand = expand;
+    this.extraParams = extraParams;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<String> expand;
+
+    private Map<String, Object> extraParams;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public TransactionRetrieveParams build() {
+      return new TransactionRetrieveParams(this.expand, this.extraParams);
+    }
+
+    /**
+     * Add an element to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * TransactionRetrieveParams#expand} for the field documentation.
+     */
+    public Builder addExpand(String element) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.add(element);
+      return this;
+    }
+
+    /**
+     * Add all elements to `expand` list. A list is initialized for the first `add/addAll` call, and
+     * subsequent calls adds additional elements to the original list. See {@link
+     * TransactionRetrieveParams#expand} for the field documentation.
+     */
+    public Builder addAllExpand(List<String> elements) {
+      if (this.expand == null) {
+        this.expand = new ArrayList<>();
+      }
+      this.expand.addAll(elements);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * TransactionRetrieveParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link TransactionRetrieveParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+  }
+}

--- a/src/test/java/com/stripe/functional/GeneratedExamples.java
+++ b/src/test/java/com/stripe/functional/GeneratedExamples.java
@@ -13,6 +13,442 @@ import org.junit.jupiter.api.Test;
 
 class GeneratedExamples extends BaseStripeTest {
   @Test
+  public void testCustomerListPaymentMethods() throws StripeException {
+    Customer resource = Customer.retrieve("cus_xyz");
+    CustomerListPaymentMethodsParams params =
+        CustomerListPaymentMethodsParams.builder()
+            .setType(CustomerListPaymentMethodsParams.Type.CARD)
+            .build();
+
+    PaymentMethodCollection paymentMethods = resource.listPaymentMethods(params);
+    assertNotNull(paymentMethods);
+    verifyRequest(
+        ApiResource.RequestMethod.GET, "/v1/customers/cus_xyz/payment_methods", params.toMap());
+  }
+
+  @Test
+  public void testSessionExpire() throws StripeException {
+    com.stripe.model.checkout.Session resource =
+        com.stripe.model.checkout.Session.retrieve("sess_xyz");
+    com.stripe.param.checkout.SessionExpireParams params =
+        com.stripe.param.checkout.SessionExpireParams.builder().build();
+
+    com.stripe.model.checkout.Session session = resource.expire(params);
+    assertNotNull(session);
+    verifyRequest(
+        ApiResource.RequestMethod.POST, "/v1/checkout/sessions/sess_xyz/expire", params.toMap());
+  }
+
+  @Test
+  public void testShippingRateCreate() throws StripeException {
+    ShippingRateCreateParams params =
+        ShippingRateCreateParams.builder()
+            .setDisplayName("Sample Shipper")
+            .setFixedAmount(
+                ShippingRateCreateParams.FixedAmount.builder()
+                    .setCurrency("usd")
+                    .setAmount(400L)
+                    .build())
+            .setType(ShippingRateCreateParams.Type.FIXED_AMOUNT)
+            .build();
+
+    ShippingRate shippingRate = ShippingRate.create(params);
+    assertNotNull(shippingRate);
+    verifyRequest(ApiResource.RequestMethod.POST, "/v1/shipping_rates", params.toMap());
+  }
+
+  @Test
+  public void testShippingRateList() throws StripeException {
+    ShippingRateListParams params = ShippingRateListParams.builder().build();
+
+    ShippingRateCollection shippingRates = ShippingRate.list(params);
+    assertNotNull(shippingRates);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/shipping_rates", params.toMap());
+  }
+
+  @Test
+  public void testSessionCreate() throws StripeException {
+    com.stripe.param.checkout.SessionCreateParams params =
+        com.stripe.param.checkout.SessionCreateParams.builder()
+            .setSuccessUrl("https://example.com/success")
+            .setCancelUrl("https://example.com/cancel")
+            .setMode(com.stripe.param.checkout.SessionCreateParams.Mode.PAYMENT)
+            .addShippingOption(
+                com.stripe.param.checkout.SessionCreateParams.ShippingOption.builder()
+                    .setShippingRate("shr_standard")
+                    .build())
+            .addShippingOption(
+                com.stripe.param.checkout.SessionCreateParams.ShippingOption.builder()
+                    .setShippingRateData(
+                        com.stripe.param.checkout.SessionCreateParams.ShippingOption
+                            .ShippingRateData.builder()
+                            .setDisplayName("Standard")
+                            .setDeliveryEstimate(
+                                com.stripe.param.checkout.SessionCreateParams.ShippingOption
+                                    .ShippingRateData.DeliveryEstimate.builder()
+                                    .setMinimum(
+                                        com.stripe.param.checkout.SessionCreateParams.ShippingOption
+                                            .ShippingRateData.DeliveryEstimate.Minimum.builder()
+                                            .setUnit(
+                                                com.stripe.param.checkout.SessionCreateParams
+                                                    .ShippingOption.ShippingRateData
+                                                    .DeliveryEstimate.Minimum.Unit.DAY)
+                                            .setValue(5L)
+                                            .build())
+                                    .setMaximum(
+                                        com.stripe.param.checkout.SessionCreateParams.ShippingOption
+                                            .ShippingRateData.DeliveryEstimate.Maximum.builder()
+                                            .setUnit(
+                                                com.stripe.param.checkout.SessionCreateParams
+                                                    .ShippingOption.ShippingRateData
+                                                    .DeliveryEstimate.Maximum.Unit.DAY)
+                                            .setValue(7L)
+                                            .build())
+                                    .build())
+                            .build())
+                    .build())
+            .build();
+
+    com.stripe.model.checkout.Session session = com.stripe.model.checkout.Session.create(params);
+    assertNotNull(session);
+    verifyRequest(ApiResource.RequestMethod.POST, "/v1/checkout/sessions", params.toMap());
+  }
+
+  @Test
+  public void testPaymentIntentCreate() throws StripeException {
+    PaymentIntentCreateParams params =
+        PaymentIntentCreateParams.builder()
+            .setAmount(1099L)
+            .setCurrency("eur")
+            .setAutomaticPaymentMethods(
+                PaymentIntentCreateParams.AutomaticPaymentMethods.builder()
+                    .setEnabled(true)
+                    .build())
+            .build();
+
+    PaymentIntent paymentIntent = PaymentIntent.create(params);
+    assertNotNull(paymentIntent);
+    verifyRequest(ApiResource.RequestMethod.POST, "/v1/payment_intents", params.toMap());
+  }
+
+  @Test
+  public void testPaymentLinkCreate() throws StripeException {
+    PaymentLinkCreateParams params =
+        PaymentLinkCreateParams.builder()
+            .addLineItem(
+                PaymentLinkCreateParams.LineItem.builder()
+                    .setPrice("price_xxxxxxxxxxxxx")
+                    .setQuantity(1L)
+                    .build())
+            .build();
+
+    PaymentLink paymentLink = PaymentLink.create(params);
+    assertNotNull(paymentLink);
+    verifyRequest(ApiResource.RequestMethod.POST, "/v1/payment_links", params.toMap());
+  }
+
+  @Test
+  public void testPaymentLinkListLineItems() throws StripeException {
+    PaymentLink resource = PaymentLink.retrieve("pl_xyz");
+    PaymentLinkListLineItemsParams params = PaymentLinkListLineItemsParams.builder().build();
+
+    LineItemCollection lineItems = resource.listLineItems(params);
+    assertNotNull(lineItems);
+    verifyRequest(
+        ApiResource.RequestMethod.GET, "/v1/payment_links/pl_xyz/line_items", params.toMap());
+  }
+
+  @Test
+  public void testPaymentLinkRetrieve() throws StripeException {
+    PaymentLink paymentLink = PaymentLink.retrieve("pl_xyz");
+    assertNotNull(paymentLink);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/payment_links/pl_xyz");
+  }
+
+  @Test
+  public void testPaymentIntentVerifyMicrodeposits() throws StripeException {
+    PaymentIntent resource = PaymentIntent.retrieve("pi_xxxxxxxxxxxxx");
+    PaymentIntentVerifyMicrodepositsParams params =
+        PaymentIntentVerifyMicrodepositsParams.builder().build();
+
+    PaymentIntent paymentIntent = resource.verifyMicrodeposits(params);
+    assertNotNull(paymentIntent);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/payment_intents/pi_xxxxxxxxxxxxx/verify_microdeposits",
+        params.toMap());
+  }
+
+  @Test
+  public void testSetupIntentVerifyMicrodeposits() throws StripeException {
+    SetupIntent resource = SetupIntent.retrieve("seti_xxxxxxxxxxxxx");
+    SetupIntentVerifyMicrodepositsParams params =
+        SetupIntentVerifyMicrodepositsParams.builder().build();
+
+    SetupIntent setupIntent = resource.verifyMicrodeposits(params);
+    assertNotNull(setupIntent);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/setup_intents/seti_xxxxxxxxxxxxx/verify_microdeposits",
+        params.toMap());
+  }
+
+  @Test
+  public void testTestClockCreate() throws StripeException {
+    com.stripe.param.testhelpers.TestClockCreateParams params =
+        com.stripe.param.testhelpers.TestClockCreateParams.builder()
+            .setFrozenTime(123L)
+            .setName("cogsworth")
+            .build();
+
+    com.stripe.model.testhelpers.TestClock testClock =
+        com.stripe.model.testhelpers.TestClock.create(params);
+    assertNotNull(testClock);
+    verifyRequest(ApiResource.RequestMethod.POST, "/v1/test_helpers/test_clocks", params.toMap());
+  }
+
+  @Test
+  public void testTestClockRetrieve() throws StripeException {
+    com.stripe.model.testhelpers.TestClock testClock =
+        com.stripe.model.testhelpers.TestClock.retrieve("clock_xyz");
+    assertNotNull(testClock);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/test_helpers/test_clocks/clock_xyz");
+  }
+
+  @Test
+  public void testTestClockList() throws StripeException {
+    com.stripe.param.testhelpers.TestClockListParams params =
+        com.stripe.param.testhelpers.TestClockListParams.builder().build();
+
+    com.stripe.model.testhelpers.TestClockCollection testClocks =
+        com.stripe.model.testhelpers.TestClock.list(params);
+    assertNotNull(testClocks);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/test_helpers/test_clocks", params.toMap());
+  }
+
+  @Test
+  public void testTestClockDelete() throws StripeException {
+    com.stripe.model.testhelpers.TestClock resource =
+        com.stripe.model.testhelpers.TestClock.retrieve("clock_xyz");
+
+    com.stripe.model.testhelpers.TestClock testClock = resource.delete();
+    assertNotNull(testClock);
+    verifyRequest(ApiResource.RequestMethod.DELETE, "/v1/test_helpers/test_clocks/clock_xyz");
+  }
+
+  @Test
+  public void testTestClockAdvance() throws StripeException {
+    com.stripe.model.testhelpers.TestClock resource =
+        com.stripe.model.testhelpers.TestClock.retrieve("clock_xyz");
+    com.stripe.param.testhelpers.TestClockAdvanceParams params =
+        com.stripe.param.testhelpers.TestClockAdvanceParams.builder().setFrozenTime(142L).build();
+
+    com.stripe.model.testhelpers.TestClock testClock = resource.advance(params);
+    assertNotNull(testClock);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/test_clocks/clock_xyz/advance",
+        params.toMap());
+  }
+
+  @Test
+  public void testCustomerCreateFundingInstructions() throws StripeException {
+    Customer resource = Customer.retrieve("cus_123");
+    CustomerCreateFundingInstructionsParams params =
+        CustomerCreateFundingInstructionsParams.builder()
+            .setBankTransfer(
+                CustomerCreateFundingInstructionsParams.BankTransfer.builder()
+                    .addRequestedAddressType(
+                        CustomerCreateFundingInstructionsParams.BankTransfer.RequestedAddressType
+                            .ZENGIN)
+                    .setType(
+                        CustomerCreateFundingInstructionsParams.BankTransfer.Type.JP_BANK_TRANSFER)
+                    .build())
+            .setCurrency("usd")
+            .setFundingType(CustomerCreateFundingInstructionsParams.FundingType.BANK_TRANSFER)
+            .build();
+
+    FundingInstructions fundingInstructions = resource.createFundingInstructions(params);
+    assertNotNull(fundingInstructions);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/customers/cus_123/funding_instructions",
+        params.toMap());
+  }
+
+  @Test
+  public void testConfigurationList() throws StripeException {
+    com.stripe.param.terminal.ConfigurationListParams params =
+        com.stripe.param.terminal.ConfigurationListParams.builder().build();
+
+    com.stripe.model.terminal.ConfigurationCollection configurations =
+        com.stripe.model.terminal.Configuration.list(params);
+    assertNotNull(configurations);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/terminal/configurations", params.toMap());
+  }
+
+  @Test
+  public void testConfigurationRetrieve() throws StripeException {
+    com.stripe.model.terminal.Configuration configuration =
+        com.stripe.model.terminal.Configuration.retrieve("uc_123");
+    assertNotNull(configuration);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/terminal/configurations/uc_123");
+  }
+
+  @Test
+  public void testConfigurationCreate() throws StripeException {
+    com.stripe.param.terminal.ConfigurationCreateParams params =
+        com.stripe.param.terminal.ConfigurationCreateParams.builder().build();
+
+    com.stripe.model.terminal.Configuration configuration =
+        com.stripe.model.terminal.Configuration.create(params);
+    assertNotNull(configuration);
+    verifyRequest(ApiResource.RequestMethod.POST, "/v1/terminal/configurations", params.toMap());
+  }
+
+  @Test
+  public void testConfigurationUpdate() throws StripeException {
+    com.stripe.model.terminal.Configuration resource =
+        com.stripe.model.terminal.Configuration.retrieve("uc_123");
+    com.stripe.param.terminal.ConfigurationUpdateParams params =
+        com.stripe.param.terminal.ConfigurationUpdateParams.builder()
+            .setTipping(
+                com.stripe.param.terminal.ConfigurationUpdateParams.Tipping.builder()
+                    .setUsd(
+                        com.stripe.param.terminal.ConfigurationUpdateParams.Tipping.Usd.builder()
+                            .addFixedAmount(10L)
+                            .build())
+                    .build())
+            .build();
+
+    com.stripe.model.terminal.Configuration configuration = resource.update(params);
+    assertNotNull(configuration);
+    verifyRequest(
+        ApiResource.RequestMethod.POST, "/v1/terminal/configurations/uc_123", params.toMap());
+  }
+
+  @Test
+  public void testConfigurationDelete() throws StripeException {
+    com.stripe.model.terminal.Configuration resource =
+        com.stripe.model.terminal.Configuration.retrieve("uc_123");
+
+    com.stripe.model.terminal.Configuration configuration = resource.delete();
+    assertNotNull(configuration);
+    verifyRequest(ApiResource.RequestMethod.DELETE, "/v1/terminal/configurations/uc_123");
+  }
+
+  @Test
+  public void testRefundExpire() throws StripeException {
+    Refund resource = Refund.retrieve("re_123");
+    RefundExpireParams params = RefundExpireParams.builder().build();
+
+    Refund refund = resource.getTestHelpers().expire(params);
+    assertNotNull(refund);
+    verifyRequest(
+        ApiResource.RequestMethod.POST, "/v1/test_helpers/refunds/re_123/expire", params.toMap());
+  }
+
+  @Test
+  public void testAccountRetrieve() throws StripeException {
+    com.stripe.model.financialconnections.Account account =
+        com.stripe.model.financialconnections.Account.retrieve("fca_xyz");
+    assertNotNull(account);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/financial_connections/accounts/fca_xyz");
+  }
+
+  @Test
+  public void testAccountRefresh() throws StripeException {
+    com.stripe.model.financialconnections.Account resource =
+        com.stripe.model.financialconnections.Account.retrieve("fca_xyz");
+    com.stripe.param.financialconnections.AccountRefreshParams params =
+        com.stripe.param.financialconnections.AccountRefreshParams.builder()
+            .addFeature(com.stripe.param.financialconnections.AccountRefreshParams.Feature.BALANCE)
+            .build();
+
+    com.stripe.model.financialconnections.Account account = resource.refresh(params);
+    assertNotNull(account);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/financial_connections/accounts/fca_xyz/refresh",
+        params.toMap());
+  }
+
+  @Test
+  public void testAccountDisconnect() throws StripeException {
+    com.stripe.model.financialconnections.Account resource =
+        com.stripe.model.financialconnections.Account.retrieve("fca_xyz");
+    com.stripe.param.financialconnections.AccountDisconnectParams params =
+        com.stripe.param.financialconnections.AccountDisconnectParams.builder().build();
+
+    com.stripe.model.financialconnections.Account account = resource.disconnect(params);
+    assertNotNull(account);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/financial_connections/accounts/fca_xyz/disconnect",
+        params.toMap());
+  }
+
+  @Test
+  public void testSessionCreate2() throws StripeException {
+    com.stripe.param.financialconnections.SessionCreateParams params =
+        com.stripe.param.financialconnections.SessionCreateParams.builder()
+            .setAccountHolder(
+                com.stripe.param.financialconnections.SessionCreateParams.AccountHolder.builder()
+                    .setType(
+                        com.stripe.param.financialconnections.SessionCreateParams.AccountHolder.Type
+                            .CUSTOMER)
+                    .setCustomer("cus_123")
+                    .build())
+            .addPermission(
+                com.stripe.param.financialconnections.SessionCreateParams.Permission.BALANCES)
+            .build();
+
+    com.stripe.model.financialconnections.Session session =
+        com.stripe.model.financialconnections.Session.create(params);
+    assertNotNull(session);
+    verifyRequest(
+        ApiResource.RequestMethod.POST, "/v1/financial_connections/sessions", params.toMap());
+  }
+
+  @Test
+  public void testSessionRetrieve() throws StripeException {
+    com.stripe.model.financialconnections.Session session =
+        com.stripe.model.financialconnections.Session.retrieve("fcsess_xyz");
+    assertNotNull(session);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/financial_connections/sessions/fcsess_xyz");
+  }
+
+  @Test
+  public void testAccountList() throws StripeException {
+    com.stripe.param.financialconnections.AccountListParams params =
+        com.stripe.param.financialconnections.AccountListParams.builder().build();
+
+    com.stripe.model.financialconnections.AccountCollection accounts =
+        com.stripe.model.financialconnections.Account.list(params);
+    assertNotNull(accounts);
+    verifyRequest(
+        ApiResource.RequestMethod.GET, "/v1/financial_connections/accounts", params.toMap());
+  }
+
+  @Test
+  public void testAccountListOwners() throws StripeException {
+    com.stripe.model.financialconnections.Account resource =
+        com.stripe.model.financialconnections.Account.retrieve("fca_xyz");
+    com.stripe.param.financialconnections.AccountListOwnersParams params =
+        com.stripe.param.financialconnections.AccountListOwnersParams.builder()
+            .setOwnership("fcaowns_xyz")
+            .build();
+
+    com.stripe.model.financialconnections.AccountOwnerCollection accountOwners =
+        resource.listOwners(params);
+    assertNotNull(accountOwners);
+    verifyRequest(
+        ApiResource.RequestMethod.GET,
+        "/v1/financial_connections/accounts/fca_xyz/owners",
+        params.toMap());
+  }
+
+  @Test
   public void testCustomerList() throws StripeException {
     CustomerListParams params = CustomerListParams.builder().setLimit(3L).build();
 
@@ -22,20 +458,15 @@ class GeneratedExamples extends BaseStripeTest {
   }
 
   @Test
-  public void testBalanceTransactionRetrieve() throws StripeException {
-    BalanceTransaction balanceTransaction = BalanceTransaction.retrieve("txn_xxxxxxxxxxxxx");
-    assertNotNull(balanceTransaction);
-    verifyRequest(ApiResource.RequestMethod.GET, "/v1/balance_transactions/txn_xxxxxxxxxxxxx");
-  }
+  public void testCustomerSearch() throws StripeException {
+    CustomerSearchParams params =
+        CustomerSearchParams.builder()
+            .setQuery("name:'fakename' AND metadata['foo']:'bar'")
+            .build();
 
-  @Test
-  public void testBalanceTransactionList() throws StripeException {
-    BalanceTransactionListParams params =
-        BalanceTransactionListParams.builder().setLimit(3L).build();
-
-    BalanceTransactionCollection balanceTransactions = BalanceTransaction.list(params);
-    assertNotNull(balanceTransactions);
-    verifyRequest(ApiResource.RequestMethod.GET, "/v1/balance_transactions", params.toMap());
+    CustomerSearchResult customers = Customer.search(params);
+    assertNotNull(customers);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/customers/search", params.toMap());
   }
 
   @Test
@@ -92,6 +523,16 @@ class GeneratedExamples extends BaseStripeTest {
   }
 
   @Test
+  public void testChargeSearch() throws StripeException {
+    ChargeSearchParams params =
+        ChargeSearchParams.builder().setQuery("amount>999 AND metadata['order_id']:'6735'").build();
+
+    ChargeSearchResult charges = Charge.search(params);
+    assertNotNull(charges);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/charges/search", params.toMap());
+  }
+
+  @Test
   public void testCustomerCreate() throws StripeException {
     CustomerCreateParams params =
         CustomerCreateParams.builder()
@@ -138,6 +579,18 @@ class GeneratedExamples extends BaseStripeTest {
     CustomerCollection customers = Customer.list(params);
     assertNotNull(customers);
     verifyRequest(ApiResource.RequestMethod.GET, "/v1/customers", params.toMap());
+  }
+
+  @Test
+  public void testCustomerSearch2() throws StripeException {
+    CustomerSearchParams params =
+        CustomerSearchParams.builder()
+            .setQuery("name:'fakename' AND metadata['foo']:'bar'")
+            .build();
+
+    CustomerSearchResult customers = Customer.search(params);
+    assertNotNull(customers);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/customers/search", params.toMap());
   }
 
   @Test
@@ -240,7 +693,7 @@ class GeneratedExamples extends BaseStripeTest {
   }
 
   @Test
-  public void testPaymentIntentCreate() throws StripeException {
+  public void testPaymentIntentCreate2() throws StripeException {
     PaymentIntentCreateParams params =
         PaymentIntentCreateParams.builder()
             .setAmount(2000L)
@@ -322,6 +775,46 @@ class GeneratedExamples extends BaseStripeTest {
   }
 
   @Test
+  public void testPaymentIntentIncrementAuthorization() throws StripeException {
+    PaymentIntent resource = PaymentIntent.retrieve("pi_xxxxxxxxxxxxx");
+    PaymentIntentIncrementAuthorizationParams params =
+        PaymentIntentIncrementAuthorizationParams.builder().setAmount(2099L).build();
+
+    PaymentIntent paymentIntent = resource.incrementAuthorization(params);
+    assertNotNull(paymentIntent);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/payment_intents/pi_xxxxxxxxxxxxx/increment_authorization",
+        params.toMap());
+  }
+
+  @Test
+  public void testPaymentIntentSearch() throws StripeException {
+    PaymentIntentSearchParams params =
+        PaymentIntentSearchParams.builder()
+            .setQuery("status:'succeeded' AND metadata['order_id']:'6735'")
+            .build();
+
+    PaymentIntentSearchResult paymentIntents = PaymentIntent.search(params);
+    assertNotNull(paymentIntents);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/payment_intents/search", params.toMap());
+  }
+
+  @Test
+  public void testPaymentIntentApplyCustomerBalance() throws StripeException {
+    PaymentIntent resource = PaymentIntent.retrieve("pi_xxxxxxxxxxxxx");
+    PaymentIntentApplyCustomerBalanceParams params =
+        PaymentIntentApplyCustomerBalanceParams.builder().build();
+
+    PaymentIntent paymentIntent = resource.applyCustomerBalance(params);
+    assertNotNull(paymentIntent);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/payment_intents/pi_xxxxxxxxxxxxx/apply_customer_balance",
+        params.toMap());
+  }
+
+  @Test
   public void testSetupIntentCreate() throws StripeException {
     SetupIntentCreateParams params =
         SetupIntentCreateParams.builder().addPaymentMethodType("card").build();
@@ -389,7 +882,7 @@ class GeneratedExamples extends BaseStripeTest {
   @Test
   public void testSetupAttemptList() throws StripeException {
     SetupAttemptListParams params =
-        SetupAttemptListParams.builder().setSetupIntent("seti_xxxxxxxxxxxxx").setLimit(3L).build();
+        SetupAttemptListParams.builder().setLimit(3L).setSetupIntent("si_xyz").build();
 
     SetupAttemptCollection setupAttempts = SetupAttempt.list(params);
     assertNotNull(setupAttempts);
@@ -456,96 +949,6 @@ class GeneratedExamples extends BaseStripeTest {
   }
 
   @Test
-  public void testProductCreate() throws StripeException {
-    ProductCreateParams params = ProductCreateParams.builder().setName("Gold Special").build();
-
-    Product product = Product.create(params);
-    assertNotNull(product);
-    verifyRequest(ApiResource.RequestMethod.POST, "/v1/products", params.toMap());
-  }
-
-  @Test
-  public void testProductRetrieve() throws StripeException {
-    Product product = Product.retrieve("prod_xxxxxxxxxxxxx");
-    assertNotNull(product);
-    verifyRequest(ApiResource.RequestMethod.GET, "/v1/products/prod_xxxxxxxxxxxxx");
-  }
-
-  @Test
-  public void testProductUpdate() throws StripeException {
-    Product resource = Product.retrieve("prod_xxxxxxxxxxxxx");
-    ProductUpdateParams params =
-        ProductUpdateParams.builder().putMetadata("order_id", "6735").build();
-
-    Product product = resource.update(params);
-    assertNotNull(product);
-    verifyRequest(
-        ApiResource.RequestMethod.POST, "/v1/products/prod_xxxxxxxxxxxxx", params.toMap());
-  }
-
-  @Test
-  public void testProductList() throws StripeException {
-    ProductListParams params = ProductListParams.builder().setLimit(3L).build();
-
-    ProductCollection products = Product.list(params);
-    assertNotNull(products);
-    verifyRequest(ApiResource.RequestMethod.GET, "/v1/products", params.toMap());
-  }
-
-  @Test
-  public void testProductDelete() throws StripeException {
-    Product resource = Product.retrieve("prod_xxxxxxxxxxxxx");
-
-    Product product = resource.delete();
-    assertNotNull(product);
-    verifyRequest(ApiResource.RequestMethod.DELETE, "/v1/products/prod_xxxxxxxxxxxxx");
-  }
-
-  @Test
-  public void testPriceCreate() throws StripeException {
-    PriceCreateParams params =
-        PriceCreateParams.builder()
-            .setUnitAmount(2000L)
-            .setCurrency("usd")
-            .setRecurring(
-                PriceCreateParams.Recurring.builder()
-                    .setInterval(PriceCreateParams.Recurring.Interval.MONTH)
-                    .build())
-            .setProduct("prod_xxxxxxxxxxxxx")
-            .build();
-
-    Price price = Price.create(params);
-    assertNotNull(price);
-    verifyRequest(ApiResource.RequestMethod.POST, "/v1/prices", params.toMap());
-  }
-
-  @Test
-  public void testPriceRetrieve() throws StripeException {
-    Price price = Price.retrieve("price_xxxxxxxxxxxxx");
-    assertNotNull(price);
-    verifyRequest(ApiResource.RequestMethod.GET, "/v1/prices/price_xxxxxxxxxxxxx");
-  }
-
-  @Test
-  public void testPriceUpdate() throws StripeException {
-    Price resource = Price.retrieve("price_xxxxxxxxxxxxx");
-    PriceUpdateParams params = PriceUpdateParams.builder().putMetadata("order_id", "6735").build();
-
-    Price price = resource.update(params);
-    assertNotNull(price);
-    verifyRequest(ApiResource.RequestMethod.POST, "/v1/prices/price_xxxxxxxxxxxxx", params.toMap());
-  }
-
-  @Test
-  public void testPriceList() throws StripeException {
-    PriceListParams params = PriceListParams.builder().setLimit(3L).build();
-
-    PriceCollection prices = Price.list(params);
-    assertNotNull(prices);
-    verifyRequest(ApiResource.RequestMethod.GET, "/v1/prices", params.toMap());
-  }
-
-  @Test
   public void testRefundCreate() throws StripeException {
     RefundCreateParams params = RefundCreateParams.builder().setCharge("ch_xxxxxxxxxxxxx").build();
 
@@ -573,6 +976,17 @@ class GeneratedExamples extends BaseStripeTest {
   }
 
   @Test
+  public void testRefundCancel() throws StripeException {
+    Refund resource = Refund.retrieve("re_xxxxxxxxxxxxx");
+    RefundCancelParams params = RefundCancelParams.builder().build();
+
+    Refund refund = resource.cancel(params);
+    assertNotNull(refund);
+    verifyRequest(
+        ApiResource.RequestMethod.POST, "/v1/refunds/re_xxxxxxxxxxxxx/cancel", params.toMap());
+  }
+
+  @Test
   public void testRefundList() throws StripeException {
     RefundListParams params = RefundListParams.builder().setLimit(3L).build();
 
@@ -589,7 +1003,7 @@ class GeneratedExamples extends BaseStripeTest {
                 TokenCreateParams.Card.builder()
                     .setNumber("4242424242424242")
                     .setExpMonth("5")
-                    .setExpYear("2022")
+                    .setExpYear("2023")
                     .setCvc("314")
                     .build())
             .build();
@@ -722,6 +1136,22 @@ class GeneratedExamples extends BaseStripeTest {
   }
 
   @Test
+  public void testCustomerListPaymentMethods2() throws StripeException {
+    Customer resource = Customer.retrieve("cus_xxxxxxxxxxxxx");
+    CustomerListPaymentMethodsParams params =
+        CustomerListPaymentMethodsParams.builder()
+            .setType(CustomerListPaymentMethodsParams.Type.CARD)
+            .build();
+
+    PaymentMethodCollection paymentMethods = resource.listPaymentMethods(params);
+    assertNotNull(paymentMethods);
+    verifyRequest(
+        ApiResource.RequestMethod.GET,
+        "/v1/customers/cus_xxxxxxxxxxxxx/payment_methods",
+        params.toMap());
+  }
+
+  @Test
   public void testPaymentMethodAttach() throws StripeException {
     PaymentMethod resource = PaymentMethod.retrieve("pm_xxxxxxxxxxxxx");
     PaymentMethodAttachParams params =
@@ -767,13 +1197,318 @@ class GeneratedExamples extends BaseStripeTest {
   }
 
   @Test
-  public void testSessionCreate() throws StripeException {
+  public void testProductCreate() throws StripeException {
+    ProductCreateParams params = ProductCreateParams.builder().setName("Gold Special").build();
+
+    Product product = Product.create(params);
+    assertNotNull(product);
+    verifyRequest(ApiResource.RequestMethod.POST, "/v1/products", params.toMap());
+  }
+
+  @Test
+  public void testProductRetrieve() throws StripeException {
+    Product product = Product.retrieve("prod_xxxxxxxxxxxxx");
+    assertNotNull(product);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/products/prod_xxxxxxxxxxxxx");
+  }
+
+  @Test
+  public void testProductUpdate() throws StripeException {
+    Product resource = Product.retrieve("prod_xxxxxxxxxxxxx");
+    ProductUpdateParams params =
+        ProductUpdateParams.builder().putMetadata("order_id", "6735").build();
+
+    Product product = resource.update(params);
+    assertNotNull(product);
+    verifyRequest(
+        ApiResource.RequestMethod.POST, "/v1/products/prod_xxxxxxxxxxxxx", params.toMap());
+  }
+
+  @Test
+  public void testProductList() throws StripeException {
+    ProductListParams params = ProductListParams.builder().setLimit(3L).build();
+
+    ProductCollection products = Product.list(params);
+    assertNotNull(products);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/products", params.toMap());
+  }
+
+  @Test
+  public void testProductDelete() throws StripeException {
+    Product resource = Product.retrieve("prod_xxxxxxxxxxxxx");
+
+    Product product = resource.delete();
+    assertNotNull(product);
+    verifyRequest(ApiResource.RequestMethod.DELETE, "/v1/products/prod_xxxxxxxxxxxxx");
+  }
+
+  @Test
+  public void testProductSearch() throws StripeException {
+    ProductSearchParams params =
+        ProductSearchParams.builder()
+            .setQuery("active:'true' AND metadata['order_id']:'6735'")
+            .build();
+
+    ProductSearchResult products = Product.search(params);
+    assertNotNull(products);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/products/search", params.toMap());
+  }
+
+  @Test
+  public void testPriceCreate() throws StripeException {
+    PriceCreateParams params =
+        PriceCreateParams.builder()
+            .setUnitAmount(2000L)
+            .setCurrency("usd")
+            .setRecurring(
+                PriceCreateParams.Recurring.builder()
+                    .setInterval(PriceCreateParams.Recurring.Interval.MONTH)
+                    .build())
+            .setProduct("prod_xxxxxxxxxxxxx")
+            .build();
+
+    Price price = Price.create(params);
+    assertNotNull(price);
+    verifyRequest(ApiResource.RequestMethod.POST, "/v1/prices", params.toMap());
+  }
+
+  @Test
+  public void testPriceRetrieve() throws StripeException {
+    Price price = Price.retrieve("price_xxxxxxxxxxxxx");
+    assertNotNull(price);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/prices/price_xxxxxxxxxxxxx");
+  }
+
+  @Test
+  public void testPriceUpdate() throws StripeException {
+    Price resource = Price.retrieve("price_xxxxxxxxxxxxx");
+    PriceUpdateParams params = PriceUpdateParams.builder().putMetadata("order_id", "6735").build();
+
+    Price price = resource.update(params);
+    assertNotNull(price);
+    verifyRequest(ApiResource.RequestMethod.POST, "/v1/prices/price_xxxxxxxxxxxxx", params.toMap());
+  }
+
+  @Test
+  public void testPriceList() throws StripeException {
+    PriceListParams params = PriceListParams.builder().setLimit(3L).build();
+
+    PriceCollection prices = Price.list(params);
+    assertNotNull(prices);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/prices", params.toMap());
+  }
+
+  @Test
+  public void testPriceSearch() throws StripeException {
+    PriceSearchParams params =
+        PriceSearchParams.builder()
+            .setQuery("active:'true' AND metadata['order_id']:'6735'")
+            .build();
+
+    PriceSearchResult prices = Price.search(params);
+    assertNotNull(prices);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/prices/search", params.toMap());
+  }
+
+  @Test
+  public void testCouponCreate() throws StripeException {
+    CouponCreateParams params =
+        CouponCreateParams.builder()
+            .setPercentOff(new BigDecimal(25.5))
+            .setDuration(CouponCreateParams.Duration.REPEATING)
+            .setDurationInMonths(3L)
+            .build();
+
+    Coupon coupon = Coupon.create(params);
+    assertNotNull(coupon);
+    verifyRequest(ApiResource.RequestMethod.POST, "/v1/coupons", params.toMap());
+  }
+
+  @Test
+  public void testCouponRetrieve() throws StripeException {
+    Coupon coupon = Coupon.retrieve("Z4OV52SU");
+    assertNotNull(coupon);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/coupons/Z4OV52SU");
+  }
+
+  @Test
+  public void testCouponUpdate() throws StripeException {
+    Coupon resource = Coupon.retrieve("Z4OV52SU");
+    CouponUpdateParams params =
+        CouponUpdateParams.builder().putMetadata("order_id", "6735").build();
+
+    Coupon coupon = resource.update(params);
+    assertNotNull(coupon);
+    verifyRequest(ApiResource.RequestMethod.POST, "/v1/coupons/Z4OV52SU", params.toMap());
+  }
+
+  @Test
+  public void testCouponDelete() throws StripeException {
+    Coupon resource = Coupon.retrieve("Z4OV52SU");
+
+    Coupon coupon = resource.delete();
+    assertNotNull(coupon);
+    verifyRequest(ApiResource.RequestMethod.DELETE, "/v1/coupons/Z4OV52SU");
+  }
+
+  @Test
+  public void testCouponList() throws StripeException {
+    CouponListParams params = CouponListParams.builder().setLimit(3L).build();
+
+    CouponCollection coupons = Coupon.list(params);
+    assertNotNull(coupons);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/coupons", params.toMap());
+  }
+
+  @Test
+  public void testPromotionCodeCreate() throws StripeException {
+    PromotionCodeCreateParams params =
+        PromotionCodeCreateParams.builder().setCoupon("Z4OV52SU").build();
+
+    PromotionCode promotionCode = PromotionCode.create(params);
+    assertNotNull(promotionCode);
+    verifyRequest(ApiResource.RequestMethod.POST, "/v1/promotion_codes", params.toMap());
+  }
+
+  @Test
+  public void testPromotionCodeUpdate() throws StripeException {
+    PromotionCode resource = PromotionCode.retrieve("promo_xxxxxxxxxxxxx");
+    PromotionCodeUpdateParams params =
+        PromotionCodeUpdateParams.builder().putMetadata("order_id", "6735").build();
+
+    PromotionCode promotionCode = resource.update(params);
+    assertNotNull(promotionCode);
+    verifyRequest(
+        ApiResource.RequestMethod.POST, "/v1/promotion_codes/promo_xxxxxxxxxxxxx", params.toMap());
+  }
+
+  @Test
+  public void testPromotionCodeRetrieve() throws StripeException {
+    PromotionCode promotionCode = PromotionCode.retrieve("promo_xxxxxxxxxxxxx");
+    assertNotNull(promotionCode);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/promotion_codes/promo_xxxxxxxxxxxxx");
+  }
+
+  @Test
+  public void testPromotionCodeList() throws StripeException {
+    PromotionCodeListParams params = PromotionCodeListParams.builder().setLimit(3L).build();
+
+    PromotionCodeCollection promotionCodes = PromotionCode.list(params);
+    assertNotNull(promotionCodes);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/promotion_codes", params.toMap());
+  }
+
+  @Test
+  public void testTaxCodeList() throws StripeException {
+    TaxCodeListParams params = TaxCodeListParams.builder().setLimit(3L).build();
+
+    TaxCodeCollection taxCodes = TaxCode.list(params);
+    assertNotNull(taxCodes);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/tax_codes", params.toMap());
+  }
+
+  @Test
+  public void testTaxCodeRetrieve() throws StripeException {
+    TaxCode taxCode = TaxCode.retrieve("txcd_xxxxxxxxxxxxx");
+    assertNotNull(taxCode);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/tax_codes/txcd_xxxxxxxxxxxxx");
+  }
+
+  @Test
+  public void testTaxRateCreate() throws StripeException {
+    TaxRateCreateParams params =
+        TaxRateCreateParams.builder()
+            .setDisplayName("VAT")
+            .setDescription("VAT Germany")
+            .setJurisdiction("DE")
+            .setPercentage(new BigDecimal(16))
+            .setInclusive(false)
+            .build();
+
+    TaxRate taxRate = TaxRate.create(params);
+    assertNotNull(taxRate);
+    verifyRequest(ApiResource.RequestMethod.POST, "/v1/tax_rates", params.toMap());
+  }
+
+  @Test
+  public void testTaxRateRetrieve() throws StripeException {
+    TaxRate taxRate = TaxRate.retrieve("txr_xxxxxxxxxxxxx");
+    assertNotNull(taxRate);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/tax_rates/txr_xxxxxxxxxxxxx");
+  }
+
+  @Test
+  public void testTaxRateUpdate() throws StripeException {
+    TaxRate resource = TaxRate.retrieve("txr_xxxxxxxxxxxxx");
+    TaxRateUpdateParams params = TaxRateUpdateParams.builder().setActive(false).build();
+
+    TaxRate taxRate = resource.update(params);
+    assertNotNull(taxRate);
+    verifyRequest(
+        ApiResource.RequestMethod.POST, "/v1/tax_rates/txr_xxxxxxxxxxxxx", params.toMap());
+  }
+
+  @Test
+  public void testTaxRateList() throws StripeException {
+    TaxRateListParams params = TaxRateListParams.builder().setLimit(3L).build();
+
+    TaxRateCollection taxRates = TaxRate.list(params);
+    assertNotNull(taxRates);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/tax_rates", params.toMap());
+  }
+
+  @Test
+  public void testShippingRateCreate2() throws StripeException {
+    ShippingRateCreateParams params =
+        ShippingRateCreateParams.builder()
+            .setDisplayName("Ground shipping")
+            .setType(ShippingRateCreateParams.Type.FIXED_AMOUNT)
+            .setFixedAmount(
+                ShippingRateCreateParams.FixedAmount.builder()
+                    .setAmount(500L)
+                    .setCurrency("usd")
+                    .build())
+            .build();
+
+    ShippingRate shippingRate = ShippingRate.create(params);
+    assertNotNull(shippingRate);
+    verifyRequest(ApiResource.RequestMethod.POST, "/v1/shipping_rates", params.toMap());
+  }
+
+  @Test
+  public void testShippingRateRetrieve() throws StripeException {
+    ShippingRate shippingRate = ShippingRate.retrieve("shr_xxxxxxxxxxxxx");
+    assertNotNull(shippingRate);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/shipping_rates/shr_xxxxxxxxxxxxx");
+  }
+
+  @Test
+  public void testShippingRateUpdate() throws StripeException {
+    ShippingRate resource = ShippingRate.retrieve("shr_xxxxxxxxxxxxx");
+    ShippingRateUpdateParams params =
+        ShippingRateUpdateParams.builder().putMetadata("order_id", "6735").build();
+
+    ShippingRate shippingRate = resource.update(params);
+    assertNotNull(shippingRate);
+    verifyRequest(
+        ApiResource.RequestMethod.POST, "/v1/shipping_rates/shr_xxxxxxxxxxxxx", params.toMap());
+  }
+
+  @Test
+  public void testShippingRateList2() throws StripeException {
+    ShippingRateListParams params = ShippingRateListParams.builder().setLimit(3L).build();
+
+    ShippingRateCollection shippingRates = ShippingRate.list(params);
+    assertNotNull(shippingRates);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/shipping_rates", params.toMap());
+  }
+
+  @Test
+  public void testSessionCreate3() throws StripeException {
     com.stripe.param.checkout.SessionCreateParams params =
         com.stripe.param.checkout.SessionCreateParams.builder()
             .setSuccessUrl("https://example.com/success")
             .setCancelUrl("https://example.com/cancel")
-            .addPaymentMethodType(
-                com.stripe.param.checkout.SessionCreateParams.PaymentMethodType.CARD)
             .addLineItem(
                 com.stripe.param.checkout.SessionCreateParams.LineItem.builder()
                     .setPrice("price_xxxxxxxxxxxxx")
@@ -788,7 +1523,22 @@ class GeneratedExamples extends BaseStripeTest {
   }
 
   @Test
-  public void testSessionRetrieve() throws StripeException {
+  public void testSessionExpire2() throws StripeException {
+    com.stripe.model.checkout.Session resource =
+        com.stripe.model.checkout.Session.retrieve("cs_test_xxxxxxxxxxxxx");
+    com.stripe.param.checkout.SessionExpireParams params =
+        com.stripe.param.checkout.SessionExpireParams.builder().build();
+
+    com.stripe.model.checkout.Session session = resource.expire(params);
+    assertNotNull(session);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/checkout/sessions/cs_test_xxxxxxxxxxxxx/expire",
+        params.toMap());
+  }
+
+  @Test
+  public void testSessionRetrieve2() throws StripeException {
     com.stripe.model.checkout.Session session =
         com.stripe.model.checkout.Session.retrieve("cs_test_xxxxxxxxxxxxx");
     assertNotNull(session);
@@ -807,71 +1557,46 @@ class GeneratedExamples extends BaseStripeTest {
   }
 
   @Test
-  public void testCouponCreate() throws StripeException {
-    CouponCreateParams params =
-        CouponCreateParams.builder()
-            .setPercentOff(new BigDecimal(25))
-            .setDuration(CouponCreateParams.Duration.REPEATING)
-            .setDurationInMonths(3L)
-            .build();
-
-    Coupon coupon = Coupon.create(params);
-    assertNotNull(coupon);
-    verifyRequest(ApiResource.RequestMethod.POST, "/v1/coupons", params.toMap());
-  }
-
-  @Test
-  public void testCouponRetrieve() throws StripeException {
-    Coupon coupon = Coupon.retrieve("25_5OFF");
-    assertNotNull(coupon);
-    verifyRequest(ApiResource.RequestMethod.GET, "/v1/coupons/25_5OFF");
-  }
-
-  @Test
-  public void testCouponUpdate() throws StripeException {
-    Coupon resource = Coupon.retrieve("co_xxxxxxxxxxxxx");
-    CouponUpdateParams params =
-        CouponUpdateParams.builder().putMetadata("order_id", "6735").build();
-
-    Coupon coupon = resource.update(params);
-    assertNotNull(coupon);
-    verifyRequest(ApiResource.RequestMethod.POST, "/v1/coupons/co_xxxxxxxxxxxxx", params.toMap());
-  }
-
-  @Test
-  public void testCouponDelete() throws StripeException {
-    Coupon resource = Coupon.retrieve("co_xxxxxxxxxxxxx");
-
-    Coupon coupon = resource.delete();
-    assertNotNull(coupon);
-    verifyRequest(ApiResource.RequestMethod.DELETE, "/v1/coupons/co_xxxxxxxxxxxxx");
-  }
-
-  @Test
-  public void testCouponList() throws StripeException {
-    CouponListParams params = CouponListParams.builder().setLimit(3L).build();
-
-    CouponCollection coupons = Coupon.list(params);
-    assertNotNull(coupons);
-    verifyRequest(ApiResource.RequestMethod.GET, "/v1/coupons", params.toMap());
-  }
-
-  @Test
-  public void testCreditNotePreview() throws StripeException {
-    CreditNotePreviewParams params =
-        CreditNotePreviewParams.builder()
-            .setInvoice("in_xxxxxxxxxxxxx")
-            .addLine(
-                CreditNotePreviewParams.Line.builder()
-                    .setType(CreditNotePreviewParams.Line.Type.INVOICE_LINE_ITEM)
-                    .setInvoiceLineItem("il_xxxxxxxxxxxxx")
+  public void testPaymentLinkCreate2() throws StripeException {
+    PaymentLinkCreateParams params =
+        PaymentLinkCreateParams.builder()
+            .addLineItem(
+                PaymentLinkCreateParams.LineItem.builder()
+                    .setPrice("price_xxxxxxxxxxxxx")
                     .setQuantity(1L)
                     .build())
             .build();
 
-    CreditNote creditNote = CreditNote.preview(params);
-    assertNotNull(creditNote);
-    verifyRequest(ApiResource.RequestMethod.GET, "/v1/credit_notes/preview", params.toMap());
+    PaymentLink paymentLink = PaymentLink.create(params);
+    assertNotNull(paymentLink);
+    verifyRequest(ApiResource.RequestMethod.POST, "/v1/payment_links", params.toMap());
+  }
+
+  @Test
+  public void testPaymentLinkRetrieve2() throws StripeException {
+    PaymentLink paymentLink = PaymentLink.retrieve("plink_xxxxxxxxxxxxx");
+    assertNotNull(paymentLink);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/payment_links/plink_xxxxxxxxxxxxx");
+  }
+
+  @Test
+  public void testPaymentLinkUpdate() throws StripeException {
+    PaymentLink resource = PaymentLink.retrieve("plink_xxxxxxxxxxxxx");
+    PaymentLinkUpdateParams params = PaymentLinkUpdateParams.builder().setActive(false).build();
+
+    PaymentLink paymentLink = resource.update(params);
+    assertNotNull(paymentLink);
+    verifyRequest(
+        ApiResource.RequestMethod.POST, "/v1/payment_links/plink_xxxxxxxxxxxxx", params.toMap());
+  }
+
+  @Test
+  public void testPaymentLinkList() throws StripeException {
+    PaymentLinkListParams params = PaymentLinkListParams.builder().setLimit(3L).build();
+
+    PaymentLinkCollection paymentLinks = PaymentLink.list(params);
+    assertNotNull(paymentLinks);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/payment_links", params.toMap());
   }
 
   @Test
@@ -921,24 +1646,6 @@ class GeneratedExamples extends BaseStripeTest {
     assertNotNull(creditNoteLineItems);
     verifyRequest(
         ApiResource.RequestMethod.GET, "/v1/credit_notes/cn_xxxxxxxxxxxxx/lines", params.toMap());
-  }
-
-  @Test
-  public void testCreditNotePreview2() throws StripeException {
-    CreditNotePreviewParams params =
-        CreditNotePreviewParams.builder()
-            .setInvoice("in_xxxxxxxxxxxxx")
-            .addLine(
-                CreditNotePreviewParams.Line.builder()
-                    .setType(CreditNotePreviewParams.Line.Type.INVOICE_LINE_ITEM)
-                    .setInvoiceLineItem("il_xxxxxxxxxxxxx")
-                    .setQuantity(1L)
-                    .build())
-            .build();
-
-    CreditNote creditNote = CreditNote.preview(params);
-    assertNotNull(creditNote);
-    verifyRequest(ApiResource.RequestMethod.GET, "/v1/credit_notes/preview", params.toMap());
   }
 
   @Test
@@ -1008,7 +1715,7 @@ class GeneratedExamples extends BaseStripeTest {
   }
 
   @Test
-  public void testSessionCreate2() throws StripeException {
+  public void testSessionCreate4() throws StripeException {
     com.stripe.param.billingportal.SessionCreateParams params =
         com.stripe.param.billingportal.SessionCreateParams.builder()
             .setCustomer("cus_xxxxxxxxxxxxx")
@@ -1022,7 +1729,7 @@ class GeneratedExamples extends BaseStripeTest {
   }
 
   @Test
-  public void testConfigurationCreate() throws StripeException {
+  public void testConfigurationCreate2() throws StripeException {
     com.stripe.param.billingportal.ConfigurationCreateParams params =
         com.stripe.param.billingportal.ConfigurationCreateParams.builder()
             .setFeatures(
@@ -1059,7 +1766,7 @@ class GeneratedExamples extends BaseStripeTest {
   }
 
   @Test
-  public void testConfigurationUpdate() throws StripeException {
+  public void testConfigurationUpdate2() throws StripeException {
     com.stripe.model.billingportal.Configuration resource =
         com.stripe.model.billingportal.Configuration.retrieve("bpc_xxxxxxxxxxxxx");
     com.stripe.param.billingportal.ConfigurationUpdateParams params =
@@ -1080,7 +1787,7 @@ class GeneratedExamples extends BaseStripeTest {
   }
 
   @Test
-  public void testConfigurationRetrieve() throws StripeException {
+  public void testConfigurationRetrieve2() throws StripeException {
     com.stripe.model.billingportal.Configuration configuration =
         com.stripe.model.billingportal.Configuration.retrieve("bpc_xxxxxxxxxxxxx");
     assertNotNull(configuration);
@@ -1089,7 +1796,7 @@ class GeneratedExamples extends BaseStripeTest {
   }
 
   @Test
-  public void testConfigurationList() throws StripeException {
+  public void testConfigurationList2() throws StripeException {
     com.stripe.param.billingportal.ConfigurationListParams params =
         com.stripe.param.billingportal.ConfigurationListParams.builder().setLimit(3L).build();
 
@@ -1204,6 +1911,16 @@ class GeneratedExamples extends BaseStripeTest {
   }
 
   @Test
+  public void testInvoiceSearch() throws StripeException {
+    InvoiceSearchParams params =
+        InvoiceSearchParams.builder().setQuery("total>999 AND metadata['order_id']:'6735'").build();
+
+    InvoiceSearchResult invoices = Invoice.search(params);
+    assertNotNull(invoices);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/invoices/search", params.toMap());
+  }
+
+  @Test
   public void testInvoiceItemCreate() throws StripeException {
     InvoiceItemCreateParams params =
         InvoiceItemCreateParams.builder()
@@ -1304,41 +2021,79 @@ class GeneratedExamples extends BaseStripeTest {
   }
 
   @Test
-  public void testPromotionCodeCreate() throws StripeException {
-    PromotionCodeCreateParams params =
-        PromotionCodeCreateParams.builder().setCoupon("25_5OFF").build();
+  public void testQuoteCreate() throws StripeException {
+    QuoteCreateParams params =
+        QuoteCreateParams.builder()
+            .setCustomer("cus_xxxxxxxxxxxxx")
+            .addLineItem(
+                QuoteCreateParams.LineItem.builder()
+                    .setPrice("price_xxxxxxxxxxxxx")
+                    .setQuantity(2L)
+                    .build())
+            .build();
 
-    PromotionCode promotionCode = PromotionCode.create(params);
-    assertNotNull(promotionCode);
-    verifyRequest(ApiResource.RequestMethod.POST, "/v1/promotion_codes", params.toMap());
+    Quote quote = Quote.create(params);
+    assertNotNull(quote);
+    verifyRequest(ApiResource.RequestMethod.POST, "/v1/quotes", params.toMap());
   }
 
   @Test
-  public void testPromotionCodeUpdate() throws StripeException {
-    PromotionCode resource = PromotionCode.retrieve("promo_xxxxxxxxxxxxx");
-    PromotionCodeUpdateParams params =
-        PromotionCodeUpdateParams.builder().putMetadata("order_id", "6735").build();
+  public void testQuoteRetrieve() throws StripeException {
+    Quote quote = Quote.retrieve("qt_xxxxxxxxxxxxx");
+    assertNotNull(quote);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/quotes/qt_xxxxxxxxxxxxx");
+  }
 
-    PromotionCode promotionCode = resource.update(params);
-    assertNotNull(promotionCode);
+  @Test
+  public void testQuoteUpdate() throws StripeException {
+    Quote resource = Quote.retrieve("qt_xxxxxxxxxxxxx");
+    QuoteUpdateParams params = QuoteUpdateParams.builder().putMetadata("order_id", "6735").build();
+
+    Quote quote = resource.update(params);
+    assertNotNull(quote);
+    verifyRequest(ApiResource.RequestMethod.POST, "/v1/quotes/qt_xxxxxxxxxxxxx", params.toMap());
+  }
+
+  @Test
+  public void testQuoteFinalizeQuote() throws StripeException {
+    Quote resource = Quote.retrieve("qt_xxxxxxxxxxxxx");
+    QuoteFinalizeQuoteParams params = QuoteFinalizeQuoteParams.builder().build();
+
+    Quote quote = resource.finalizeQuote(params);
+    assertNotNull(quote);
     verifyRequest(
-        ApiResource.RequestMethod.POST, "/v1/promotion_codes/promo_xxxxxxxxxxxxx", params.toMap());
+        ApiResource.RequestMethod.POST, "/v1/quotes/qt_xxxxxxxxxxxxx/finalize", params.toMap());
   }
 
   @Test
-  public void testPromotionCodeRetrieve() throws StripeException {
-    PromotionCode promotionCode = PromotionCode.retrieve("promo_xxxxxxxxxxxxx");
-    assertNotNull(promotionCode);
-    verifyRequest(ApiResource.RequestMethod.GET, "/v1/promotion_codes/promo_xxxxxxxxxxxxx");
+  public void testQuoteAccept() throws StripeException {
+    Quote resource = Quote.retrieve("qt_xxxxxxxxxxxxx");
+    QuoteAcceptParams params = QuoteAcceptParams.builder().build();
+
+    Quote quote = resource.accept(params);
+    assertNotNull(quote);
+    verifyRequest(
+        ApiResource.RequestMethod.POST, "/v1/quotes/qt_xxxxxxxxxxxxx/accept", params.toMap());
   }
 
   @Test
-  public void testPromotionCodeList() throws StripeException {
-    PromotionCodeListParams params = PromotionCodeListParams.builder().setLimit(3L).build();
+  public void testQuoteCancel() throws StripeException {
+    Quote resource = Quote.retrieve("qt_xxxxxxxxxxxxx");
+    QuoteCancelParams params = QuoteCancelParams.builder().build();
 
-    PromotionCodeCollection promotionCodes = PromotionCode.list(params);
-    assertNotNull(promotionCodes);
-    verifyRequest(ApiResource.RequestMethod.GET, "/v1/promotion_codes", params.toMap());
+    Quote quote = resource.cancel(params);
+    assertNotNull(quote);
+    verifyRequest(
+        ApiResource.RequestMethod.POST, "/v1/quotes/qt_xxxxxxxxxxxxx/cancel", params.toMap());
+  }
+
+  @Test
+  public void testQuoteList() throws StripeException {
+    QuoteListParams params = QuoteListParams.builder().setLimit(3L).build();
+
+    QuoteCollection quotes = Quote.list(params);
+    assertNotNull(quotes);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/quotes", params.toMap());
   }
 
   @Test
@@ -1392,6 +2147,18 @@ class GeneratedExamples extends BaseStripeTest {
     SubscriptionCollection subscriptions = Subscription.list(params);
     assertNotNull(subscriptions);
     verifyRequest(ApiResource.RequestMethod.GET, "/v1/subscriptions", params.toMap());
+  }
+
+  @Test
+  public void testSubscriptionSearch() throws StripeException {
+    SubscriptionSearchParams params =
+        SubscriptionSearchParams.builder()
+            .setQuery("status:'active' AND metadata['order_id']:'6735'")
+            .build();
+
+    SubscriptionSearchResult subscriptions = Subscription.search(params);
+    assertNotNull(subscriptions);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/subscriptions/search", params.toMap());
   }
 
   @Test
@@ -1455,7 +2222,7 @@ class GeneratedExamples extends BaseStripeTest {
     SubscriptionScheduleCreateParams params =
         SubscriptionScheduleCreateParams.builder()
             .setCustomer("cus_xxxxxxxxxxxxx")
-            .setStartDate(1620753115L)
+            .setStartDate(1652909005L)
             .setEndBehavior(SubscriptionScheduleCreateParams.EndBehavior.RELEASE)
             .addPhase(
                 SubscriptionScheduleCreateParams.Phase.builder()
@@ -1535,46 +2302,64 @@ class GeneratedExamples extends BaseStripeTest {
   }
 
   @Test
-  public void testTaxRateCreate() throws StripeException {
-    TaxRateCreateParams params =
-        TaxRateCreateParams.builder()
-            .setDisplayName("VAT")
-            .setDescription("VAT Germany")
-            .setJurisdiction("DE")
-            .setPercentage(new BigDecimal(16))
-            .setInclusive(false)
+  public void testTestClockCreate2() throws StripeException {
+    com.stripe.param.testhelpers.TestClockCreateParams params =
+        com.stripe.param.testhelpers.TestClockCreateParams.builder()
+            .setFrozenTime(1577836800L)
             .build();
 
-    TaxRate taxRate = TaxRate.create(params);
-    assertNotNull(taxRate);
-    verifyRequest(ApiResource.RequestMethod.POST, "/v1/tax_rates", params.toMap());
+    com.stripe.model.testhelpers.TestClock testClock =
+        com.stripe.model.testhelpers.TestClock.create(params);
+    assertNotNull(testClock);
+    verifyRequest(ApiResource.RequestMethod.POST, "/v1/test_helpers/test_clocks", params.toMap());
   }
 
   @Test
-  public void testTaxRateRetrieve() throws StripeException {
-    TaxRate taxRate = TaxRate.retrieve("txr_xxxxxxxxxxxxx");
-    assertNotNull(taxRate);
-    verifyRequest(ApiResource.RequestMethod.GET, "/v1/tax_rates/txr_xxxxxxxxxxxxx");
-  }
-
-  @Test
-  public void testTaxRateUpdate() throws StripeException {
-    TaxRate resource = TaxRate.retrieve("txr_xxxxxxxxxxxxx");
-    TaxRateUpdateParams params = TaxRateUpdateParams.builder().setActive(false).build();
-
-    TaxRate taxRate = resource.update(params);
-    assertNotNull(taxRate);
+  public void testTestClockRetrieve2() throws StripeException {
+    com.stripe.model.testhelpers.TestClock testClock =
+        com.stripe.model.testhelpers.TestClock.retrieve("clock_xxxxxxxxxxxxx");
+    assertNotNull(testClock);
     verifyRequest(
-        ApiResource.RequestMethod.POST, "/v1/tax_rates/txr_xxxxxxxxxxxxx", params.toMap());
+        ApiResource.RequestMethod.GET, "/v1/test_helpers/test_clocks/clock_xxxxxxxxxxxxx");
   }
 
   @Test
-  public void testTaxRateList() throws StripeException {
-    TaxRateListParams params = TaxRateListParams.builder().setLimit(3L).build();
+  public void testTestClockDelete2() throws StripeException {
+    com.stripe.model.testhelpers.TestClock resource =
+        com.stripe.model.testhelpers.TestClock.retrieve("clock_xxxxxxxxxxxxx");
 
-    TaxRateCollection taxRates = TaxRate.list(params);
-    assertNotNull(taxRates);
-    verifyRequest(ApiResource.RequestMethod.GET, "/v1/tax_rates", params.toMap());
+    com.stripe.model.testhelpers.TestClock testClock = resource.delete();
+    assertNotNull(testClock);
+    verifyRequest(
+        ApiResource.RequestMethod.DELETE, "/v1/test_helpers/test_clocks/clock_xxxxxxxxxxxxx");
+  }
+
+  @Test
+  public void testTestClockAdvance2() throws StripeException {
+    com.stripe.model.testhelpers.TestClock resource =
+        com.stripe.model.testhelpers.TestClock.retrieve("clock_xxxxxxxxxxxxx");
+    com.stripe.param.testhelpers.TestClockAdvanceParams params =
+        com.stripe.param.testhelpers.TestClockAdvanceParams.builder()
+            .setFrozenTime(1652390605L)
+            .build();
+
+    com.stripe.model.testhelpers.TestClock testClock = resource.advance(params);
+    assertNotNull(testClock);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/test_clocks/clock_xxxxxxxxxxxxx/advance",
+        params.toMap());
+  }
+
+  @Test
+  public void testTestClockList2() throws StripeException {
+    com.stripe.param.testhelpers.TestClockListParams params =
+        com.stripe.param.testhelpers.TestClockListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.testhelpers.TestClockCollection testClocks =
+        com.stripe.model.testhelpers.TestClock.list(params);
+    assertNotNull(testClocks);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/test_helpers/test_clocks", params.toMap());
   }
 
   @Test
@@ -1603,7 +2388,7 @@ class GeneratedExamples extends BaseStripeTest {
   }
 
   @Test
-  public void testAccountRetrieve() throws StripeException {
+  public void testAccountRetrieve2() throws StripeException {
     Account account = Account.retrieve("acct_xxxxxxxxxxxxx");
     assertNotNull(account);
     verifyRequest(ApiResource.RequestMethod.GET, "/v1/accounts/acct_xxxxxxxxxxxxx");
@@ -1642,7 +2427,7 @@ class GeneratedExamples extends BaseStripeTest {
   }
 
   @Test
-  public void testAccountList() throws StripeException {
+  public void testAccountList2() throws StripeException {
     AccountListParams params = AccountListParams.builder().setLimit(3L).build();
 
     AccountCollection accounts = Account.list(params);
@@ -2515,34 +3300,32 @@ class GeneratedExamples extends BaseStripeTest {
   @Test
   public void testReaderRetrieve() throws StripeException {
     com.stripe.model.terminal.Reader reader =
-        com.stripe.model.terminal.Reader.retrieve("tmr_P400-123-456-789");
+        com.stripe.model.terminal.Reader.retrieve("tmr_xxxxxxxxxxxxx");
     assertNotNull(reader);
-    verifyRequest(ApiResource.RequestMethod.GET, "/v1/terminal/readers/tmr_P400-123-456-789");
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/terminal/readers/tmr_xxxxxxxxxxxxx");
   }
 
   @Test
   public void testReaderUpdate() throws StripeException {
     com.stripe.model.terminal.Reader resource =
-        com.stripe.model.terminal.Reader.retrieve("tmr_P400-123-456-789");
+        com.stripe.model.terminal.Reader.retrieve("tmr_xxxxxxxxxxxxx");
     com.stripe.param.terminal.ReaderUpdateParams params =
         com.stripe.param.terminal.ReaderUpdateParams.builder().setLabel("Blue Rabbit").build();
 
     com.stripe.model.terminal.Reader reader = resource.update(params);
     assertNotNull(reader);
     verifyRequest(
-        ApiResource.RequestMethod.POST,
-        "/v1/terminal/readers/tmr_P400-123-456-789",
-        params.toMap());
+        ApiResource.RequestMethod.POST, "/v1/terminal/readers/tmr_xxxxxxxxxxxxx", params.toMap());
   }
 
   @Test
   public void testReaderDelete() throws StripeException {
     com.stripe.model.terminal.Reader resource =
-        com.stripe.model.terminal.Reader.retrieve("tmr_P400-123-456-789");
+        com.stripe.model.terminal.Reader.retrieve("tmr_xxxxxxxxxxxxx");
 
     com.stripe.model.terminal.Reader reader = resource.delete();
     assertNotNull(reader);
-    verifyRequest(ApiResource.RequestMethod.DELETE, "/v1/terminal/readers/tmr_P400-123-456-789");
+    verifyRequest(ApiResource.RequestMethod.DELETE, "/v1/terminal/readers/tmr_xxxxxxxxxxxxx");
   }
 
   @Test
@@ -2554,6 +3337,536 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.model.terminal.Reader.list(params);
     assertNotNull(readers);
     verifyRequest(ApiResource.RequestMethod.GET, "/v1/terminal/readers", params.toMap());
+  }
+
+  @Test
+  public void testReaderProcessPaymentIntent() throws StripeException {
+    com.stripe.model.terminal.Reader resource =
+        com.stripe.model.terminal.Reader.retrieve("tmr_xxxxxxxxxxxxx");
+    com.stripe.param.terminal.ReaderProcessPaymentIntentParams params =
+        com.stripe.param.terminal.ReaderProcessPaymentIntentParams.builder()
+            .setPaymentIntent("pi_xxxxxxxxxxxxx")
+            .build();
+
+    com.stripe.model.terminal.Reader reader = resource.processPaymentIntent(params);
+    assertNotNull(reader);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/terminal/readers/tmr_xxxxxxxxxxxxx/process_payment_intent",
+        params.toMap());
+  }
+
+  @Test
+  public void testReaderProcessSetupIntent() throws StripeException {
+    com.stripe.model.terminal.Reader resource =
+        com.stripe.model.terminal.Reader.retrieve("tmr_xxxxxxxxxxxxx");
+    com.stripe.param.terminal.ReaderProcessSetupIntentParams params =
+        com.stripe.param.terminal.ReaderProcessSetupIntentParams.builder()
+            .setSetupIntent("seti_xxxxxxxxxxxxx")
+            .setCustomerConsentCollected(true)
+            .build();
+
+    com.stripe.model.terminal.Reader reader = resource.processSetupIntent(params);
+    assertNotNull(reader);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/terminal/readers/tmr_xxxxxxxxxxxxx/process_setup_intent",
+        params.toMap());
+  }
+
+  @Test
+  public void testReaderCancelAction() throws StripeException {
+    com.stripe.model.terminal.Reader resource =
+        com.stripe.model.terminal.Reader.retrieve("tmr_xxxxxxxxxxxxx");
+    com.stripe.param.terminal.ReaderCancelActionParams params =
+        com.stripe.param.terminal.ReaderCancelActionParams.builder().build();
+
+    com.stripe.model.terminal.Reader reader = resource.cancelAction(params);
+    assertNotNull(reader);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/terminal/readers/tmr_xxxxxxxxxxxxx/cancel_action",
+        params.toMap());
+  }
+
+  @Test
+  public void testConfigurationCreate3() throws StripeException {
+    com.stripe.param.terminal.ConfigurationCreateParams params =
+        com.stripe.param.terminal.ConfigurationCreateParams.builder()
+            .setBbposWiseposE(
+                com.stripe.param.terminal.ConfigurationCreateParams.BbposWiseposE.builder()
+                    .setSplashscreen("file_xxxxxxxxxxxxx")
+                    .build())
+            .build();
+
+    com.stripe.model.terminal.Configuration configuration =
+        com.stripe.model.terminal.Configuration.create(params);
+    assertNotNull(configuration);
+    verifyRequest(ApiResource.RequestMethod.POST, "/v1/terminal/configurations", params.toMap());
+  }
+
+  @Test
+  public void testConfigurationRetrieve3() throws StripeException {
+    com.stripe.model.terminal.Configuration configuration =
+        com.stripe.model.terminal.Configuration.retrieve("tmc_xxxxxxxxxxxxx");
+    assertNotNull(configuration);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/terminal/configurations/tmc_xxxxxxxxxxxxx");
+  }
+
+  @Test
+  public void testConfigurationUpdate3() throws StripeException {
+    com.stripe.model.terminal.Configuration resource =
+        com.stripe.model.terminal.Configuration.retrieve("tmc_xxxxxxxxxxxxx");
+    com.stripe.param.terminal.ConfigurationUpdateParams params =
+        com.stripe.param.terminal.ConfigurationUpdateParams.builder()
+            .setBbposWiseposE(
+                com.stripe.param.terminal.ConfigurationUpdateParams.BbposWiseposE.builder()
+                    .setSplashscreen("file_xxxxxxxxxxxxx")
+                    .build())
+            .build();
+
+    com.stripe.model.terminal.Configuration configuration = resource.update(params);
+    assertNotNull(configuration);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/terminal/configurations/tmc_xxxxxxxxxxxxx",
+        params.toMap());
+  }
+
+  @Test
+  public void testConfigurationDelete2() throws StripeException {
+    com.stripe.model.terminal.Configuration resource =
+        com.stripe.model.terminal.Configuration.retrieve("tmc_xxxxxxxxxxxxx");
+
+    com.stripe.model.terminal.Configuration configuration = resource.delete();
+    assertNotNull(configuration);
+    verifyRequest(
+        ApiResource.RequestMethod.DELETE, "/v1/terminal/configurations/tmc_xxxxxxxxxxxxx");
+  }
+
+  @Test
+  public void testConfigurationList3() throws StripeException {
+    com.stripe.param.terminal.ConfigurationListParams params =
+        com.stripe.param.terminal.ConfigurationListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.terminal.ConfigurationCollection configurations =
+        com.stripe.model.terminal.Configuration.list(params);
+    assertNotNull(configurations);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/terminal/configurations", params.toMap());
+  }
+
+  @Test
+  public void testFinancialAccountCreate() throws StripeException {
+    com.stripe.param.treasury.FinancialAccountCreateParams params =
+        com.stripe.param.treasury.FinancialAccountCreateParams.builder()
+            .addSupportedCurrency("usd")
+            .setFeatures(
+                com.stripe.param.treasury.FinancialAccountCreateParams.Features.builder().build())
+            .build();
+
+    com.stripe.model.treasury.FinancialAccount financialAccount =
+        com.stripe.model.treasury.FinancialAccount.create(params);
+    assertNotNull(financialAccount);
+    verifyRequest(
+        ApiResource.RequestMethod.POST, "/v1/treasury/financial_accounts", params.toMap());
+  }
+
+  @Test
+  public void testFinancialAccountUpdate() throws StripeException {
+    com.stripe.model.treasury.FinancialAccount resource =
+        com.stripe.model.treasury.FinancialAccount.retrieve("fa_xxxxxxxxxxxxx");
+    com.stripe.param.treasury.FinancialAccountUpdateParams params =
+        com.stripe.param.treasury.FinancialAccountUpdateParams.builder()
+            .putMetadata("order_id", "6735")
+            .build();
+
+    com.stripe.model.treasury.FinancialAccount financialAccount = resource.update(params);
+    assertNotNull(financialAccount);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/treasury/financial_accounts/fa_xxxxxxxxxxxxx",
+        params.toMap());
+  }
+
+  @Test
+  public void testFinancialAccountRetrieve() throws StripeException {
+    com.stripe.model.treasury.FinancialAccount financialAccount =
+        com.stripe.model.treasury.FinancialAccount.retrieve("fa_xxxxxxxxxxxxx");
+    assertNotNull(financialAccount);
+    verifyRequest(
+        ApiResource.RequestMethod.GET, "/v1/treasury/financial_accounts/fa_xxxxxxxxxxxxx");
+  }
+
+  @Test
+  public void testFinancialAccountList() throws StripeException {
+    com.stripe.param.treasury.FinancialAccountListParams params =
+        com.stripe.param.treasury.FinancialAccountListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.treasury.FinancialAccountCollection financialAccounts =
+        com.stripe.model.treasury.FinancialAccount.list(params);
+    assertNotNull(financialAccounts);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/treasury/financial_accounts", params.toMap());
+  }
+
+  @Test
+  public void testFinancialAccountUpdateFeatures() throws StripeException {
+    com.stripe.model.treasury.FinancialAccount resource =
+        com.stripe.model.treasury.FinancialAccount.retrieve("fa_xxxxxxxxxxxxx");
+    com.stripe.param.treasury.FinancialAccountUpdateFeaturesParams params =
+        com.stripe.param.treasury.FinancialAccountUpdateFeaturesParams.builder().build();
+
+    com.stripe.model.treasury.FinancialAccountFeatures financialAccountFeatures =
+        resource.updateFeatures(params);
+    assertNotNull(financialAccountFeatures);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/treasury/financial_accounts/fa_xxxxxxxxxxxxx/features",
+        params.toMap());
+  }
+
+  @Test
+  public void testFinancialAccountRetrieveFeatures() throws StripeException {
+    com.stripe.model.treasury.FinancialAccount resource =
+        com.stripe.model.treasury.FinancialAccount.retrieve("fa_xxxxxxxxxxxxx");
+    com.stripe.param.treasury.FinancialAccountRetrieveFeaturesParams params =
+        com.stripe.param.treasury.FinancialAccountRetrieveFeaturesParams.builder().build();
+
+    com.stripe.model.treasury.FinancialAccountFeatures financialAccountFeatures =
+        resource.retrieveFeatures(params);
+    assertNotNull(financialAccountFeatures);
+    verifyRequest(
+        ApiResource.RequestMethod.GET,
+        "/v1/treasury/financial_accounts/fa_xxxxxxxxxxxxx/features",
+        params.toMap());
+  }
+
+  @Test
+  public void testTransactionRetrieve2() throws StripeException {
+    com.stripe.model.treasury.Transaction transaction =
+        com.stripe.model.treasury.Transaction.retrieve("trxn_xxxxxxxxxxxxx");
+    assertNotNull(transaction);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/treasury/transactions/trxn_xxxxxxxxxxxxx");
+  }
+
+  @Test
+  public void testTransactionList2() throws StripeException {
+    com.stripe.param.treasury.TransactionListParams params =
+        com.stripe.param.treasury.TransactionListParams.builder()
+            .setFinancialAccount("fa_xxxxxxxxxxxxx")
+            .setLimit(3L)
+            .build();
+
+    com.stripe.model.treasury.TransactionCollection transactions =
+        com.stripe.model.treasury.Transaction.list(params);
+    assertNotNull(transactions);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/treasury/transactions", params.toMap());
+  }
+
+  @Test
+  public void testTransactionEntryRetrieve() throws StripeException {
+    com.stripe.model.treasury.TransactionEntry transactionEntry =
+        com.stripe.model.treasury.TransactionEntry.retrieve("trxne_xxxxxxxxxxxxx");
+    assertNotNull(transactionEntry);
+    verifyRequest(
+        ApiResource.RequestMethod.GET, "/v1/treasury/transaction_entries/trxne_xxxxxxxxxxxxx");
+  }
+
+  @Test
+  public void testTransactionEntryList() throws StripeException {
+    com.stripe.param.treasury.TransactionEntryListParams params =
+        com.stripe.param.treasury.TransactionEntryListParams.builder()
+            .setFinancialAccount("fa_xxxxxxxxxxxxx")
+            .setLimit(3L)
+            .build();
+
+    com.stripe.model.treasury.TransactionEntryCollection transactionEntries =
+        com.stripe.model.treasury.TransactionEntry.list(params);
+    assertNotNull(transactionEntries);
+    verifyRequest(
+        ApiResource.RequestMethod.GET, "/v1/treasury/transaction_entries", params.toMap());
+  }
+
+  @Test
+  public void testOutboundTransferCreate() throws StripeException {
+    com.stripe.param.treasury.OutboundTransferCreateParams params =
+        com.stripe.param.treasury.OutboundTransferCreateParams.builder()
+            .setFinancialAccount("fa_xxxxxxxxxxxxx")
+            .setDestinationPaymentMethod("pm_xxxxxxxxxxxxx")
+            .setAmount(500L)
+            .setCurrency("usd")
+            .setDescription("OutboundTransfer to my external bank account")
+            .build();
+
+    com.stripe.model.treasury.OutboundTransfer outboundTransfer =
+        com.stripe.model.treasury.OutboundTransfer.create(params);
+    assertNotNull(outboundTransfer);
+    verifyRequest(
+        ApiResource.RequestMethod.POST, "/v1/treasury/outbound_transfers", params.toMap());
+  }
+
+  @Test
+  public void testOutboundTransferCancel() throws StripeException {
+    com.stripe.model.treasury.OutboundTransfer resource =
+        com.stripe.model.treasury.OutboundTransfer.retrieve("obt_xxxxxxxxxxxxx");
+    com.stripe.param.treasury.OutboundTransferCancelParams params =
+        com.stripe.param.treasury.OutboundTransferCancelParams.builder().build();
+
+    com.stripe.model.treasury.OutboundTransfer outboundTransfer = resource.cancel(params);
+    assertNotNull(outboundTransfer);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/treasury/outbound_transfers/obt_xxxxxxxxxxxxx/cancel",
+        params.toMap());
+  }
+
+  @Test
+  public void testOutboundTransferRetrieve() throws StripeException {
+    com.stripe.model.treasury.OutboundTransfer outboundTransfer =
+        com.stripe.model.treasury.OutboundTransfer.retrieve("obt_xxxxxxxxxxxxx");
+    assertNotNull(outboundTransfer);
+    verifyRequest(
+        ApiResource.RequestMethod.GET, "/v1/treasury/outbound_transfers/obt_xxxxxxxxxxxxx");
+  }
+
+  @Test
+  public void testOutboundTransferList() throws StripeException {
+    com.stripe.param.treasury.OutboundTransferListParams params =
+        com.stripe.param.treasury.OutboundTransferListParams.builder()
+            .setFinancialAccount("fa_xxxxxxxxxxxxx")
+            .setLimit(3L)
+            .build();
+
+    com.stripe.model.treasury.OutboundTransferCollection outboundTransfers =
+        com.stripe.model.treasury.OutboundTransfer.list(params);
+    assertNotNull(outboundTransfers);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/treasury/outbound_transfers", params.toMap());
+  }
+
+  @Test
+  public void testOutboundPaymentCreate() throws StripeException {
+    com.stripe.param.treasury.OutboundPaymentCreateParams params =
+        com.stripe.param.treasury.OutboundPaymentCreateParams.builder()
+            .setFinancialAccount("fa_xxxxxxxxxxxxx")
+            .setAmount(10000L)
+            .setCurrency("usd")
+            .setCustomer("cu_xxxxxxxxxxxxx")
+            .setDestinationPaymentMethod("pm_xxxxxxxxxxxxx")
+            .setDescription("OutboundPayment to a 3rd party")
+            .build();
+
+    com.stripe.model.treasury.OutboundPayment outboundPayment =
+        com.stripe.model.treasury.OutboundPayment.create(params);
+    assertNotNull(outboundPayment);
+    verifyRequest(ApiResource.RequestMethod.POST, "/v1/treasury/outbound_payments", params.toMap());
+  }
+
+  @Test
+  public void testOutboundPaymentCancel() throws StripeException {
+    com.stripe.model.treasury.OutboundPayment resource =
+        com.stripe.model.treasury.OutboundPayment.retrieve("obp_xxxxxxxxxxxxx");
+    com.stripe.param.treasury.OutboundPaymentCancelParams params =
+        com.stripe.param.treasury.OutboundPaymentCancelParams.builder().build();
+
+    com.stripe.model.treasury.OutboundPayment outboundPayment = resource.cancel(params);
+    assertNotNull(outboundPayment);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/treasury/outbound_payments/obp_xxxxxxxxxxxxx/cancel",
+        params.toMap());
+  }
+
+  @Test
+  public void testOutboundPaymentRetrieve() throws StripeException {
+    com.stripe.model.treasury.OutboundPayment outboundPayment =
+        com.stripe.model.treasury.OutboundPayment.retrieve("obp_xxxxxxxxxxxxx");
+    assertNotNull(outboundPayment);
+    verifyRequest(
+        ApiResource.RequestMethod.GET, "/v1/treasury/outbound_payments/obp_xxxxxxxxxxxxx");
+  }
+
+  @Test
+  public void testOutboundPaymentList() throws StripeException {
+    com.stripe.param.treasury.OutboundPaymentListParams params =
+        com.stripe.param.treasury.OutboundPaymentListParams.builder()
+            .setFinancialAccount("fa_xxxxxxxxxxxxx")
+            .setLimit(3L)
+            .build();
+
+    com.stripe.model.treasury.OutboundPaymentCollection outboundPayments =
+        com.stripe.model.treasury.OutboundPayment.list(params);
+    assertNotNull(outboundPayments);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/treasury/outbound_payments", params.toMap());
+  }
+
+  @Test
+  public void testInboundTransferCreate() throws StripeException {
+    com.stripe.param.treasury.InboundTransferCreateParams params =
+        com.stripe.param.treasury.InboundTransferCreateParams.builder()
+            .setFinancialAccount("fa_xxxxxxxxxxxxx")
+            .setAmount(10000L)
+            .setCurrency("usd")
+            .setOriginPaymentMethod("pm_xxxxxxxxxxxxx")
+            .setDescription("InboundTransfer from my bank account")
+            .build();
+
+    com.stripe.model.treasury.InboundTransfer inboundTransfer =
+        com.stripe.model.treasury.InboundTransfer.create(params);
+    assertNotNull(inboundTransfer);
+    verifyRequest(ApiResource.RequestMethod.POST, "/v1/treasury/inbound_transfers", params.toMap());
+  }
+
+  @Test
+  public void testInboundTransferRetrieve() throws StripeException {
+    com.stripe.model.treasury.InboundTransfer inboundTransfer =
+        com.stripe.model.treasury.InboundTransfer.retrieve("ibt_xxxxxxxxxxxxx");
+    assertNotNull(inboundTransfer);
+    verifyRequest(
+        ApiResource.RequestMethod.GET, "/v1/treasury/inbound_transfers/ibt_xxxxxxxxxxxxx");
+  }
+
+  @Test
+  public void testInboundTransferList() throws StripeException {
+    com.stripe.param.treasury.InboundTransferListParams params =
+        com.stripe.param.treasury.InboundTransferListParams.builder()
+            .setFinancialAccount("fa_xxxxxxxxxxxxx")
+            .setLimit(3L)
+            .build();
+
+    com.stripe.model.treasury.InboundTransferCollection inboundTransfers =
+        com.stripe.model.treasury.InboundTransfer.list(params);
+    assertNotNull(inboundTransfers);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/treasury/inbound_transfers", params.toMap());
+  }
+
+  @Test
+  public void testInboundTransferCancel() throws StripeException {
+    com.stripe.model.treasury.InboundTransfer resource =
+        com.stripe.model.treasury.InboundTransfer.retrieve("ibt_xxxxxxxxxxxxx");
+    com.stripe.param.treasury.InboundTransferCancelParams params =
+        com.stripe.param.treasury.InboundTransferCancelParams.builder().build();
+
+    com.stripe.model.treasury.InboundTransfer inboundTransfer = resource.cancel(params);
+    assertNotNull(inboundTransfer);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/treasury/inbound_transfers/ibt_xxxxxxxxxxxxx/cancel",
+        params.toMap());
+  }
+
+  @Test
+  public void testReceivedCreditRetrieve() throws StripeException {
+    com.stripe.model.treasury.ReceivedCredit receivedCredit =
+        com.stripe.model.treasury.ReceivedCredit.retrieve("rc_xxxxxxxxxxxxx");
+    assertNotNull(receivedCredit);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/treasury/received_credits/rc_xxxxxxxxxxxxx");
+  }
+
+  @Test
+  public void testReceivedCreditList() throws StripeException {
+    com.stripe.param.treasury.ReceivedCreditListParams params =
+        com.stripe.param.treasury.ReceivedCreditListParams.builder()
+            .setFinancialAccount("fa_xxxxxxxxxxxxx")
+            .setLimit(3L)
+            .build();
+
+    com.stripe.model.treasury.ReceivedCreditCollection receivedCredits =
+        com.stripe.model.treasury.ReceivedCredit.list(params);
+    assertNotNull(receivedCredits);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/treasury/received_credits", params.toMap());
+  }
+
+  @Test
+  public void testReceivedDebitRetrieve() throws StripeException {
+    com.stripe.model.treasury.ReceivedDebit receivedDebit =
+        com.stripe.model.treasury.ReceivedDebit.retrieve("rd_xxxxxxxxxxxxx");
+    assertNotNull(receivedDebit);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/treasury/received_debits/rd_xxxxxxxxxxxxx");
+  }
+
+  @Test
+  public void testReceivedDebitList() throws StripeException {
+    com.stripe.param.treasury.ReceivedDebitListParams params =
+        com.stripe.param.treasury.ReceivedDebitListParams.builder()
+            .setFinancialAccount("fa_xxxxxxxxxxxxx")
+            .setLimit(3L)
+            .build();
+
+    com.stripe.model.treasury.ReceivedDebitCollection receivedDebits =
+        com.stripe.model.treasury.ReceivedDebit.list(params);
+    assertNotNull(receivedDebits);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/treasury/received_debits", params.toMap());
+  }
+
+  @Test
+  public void testCreditReversalCreate() throws StripeException {
+    com.stripe.param.treasury.CreditReversalCreateParams params =
+        com.stripe.param.treasury.CreditReversalCreateParams.builder()
+            .setReceivedCredit("rc_xxxxxxxxxxxxx")
+            .build();
+
+    com.stripe.model.treasury.CreditReversal creditReversal =
+        com.stripe.model.treasury.CreditReversal.create(params);
+    assertNotNull(creditReversal);
+    verifyRequest(ApiResource.RequestMethod.POST, "/v1/treasury/credit_reversals", params.toMap());
+  }
+
+  @Test
+  public void testCreditReversalRetrieve() throws StripeException {
+    com.stripe.model.treasury.CreditReversal creditReversal =
+        com.stripe.model.treasury.CreditReversal.retrieve("credrev_xxxxxxxxxxxxx");
+    assertNotNull(creditReversal);
+    verifyRequest(
+        ApiResource.RequestMethod.GET, "/v1/treasury/credit_reversals/credrev_xxxxxxxxxxxxx");
+  }
+
+  @Test
+  public void testCreditReversalList() throws StripeException {
+    com.stripe.param.treasury.CreditReversalListParams params =
+        com.stripe.param.treasury.CreditReversalListParams.builder()
+            .setFinancialAccount("fa_xxxxxxxxxxxxx")
+            .setLimit(3L)
+            .build();
+
+    com.stripe.model.treasury.CreditReversalCollection creditReversals =
+        com.stripe.model.treasury.CreditReversal.list(params);
+    assertNotNull(creditReversals);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/treasury/credit_reversals", params.toMap());
+  }
+
+  @Test
+  public void testDebitReversalCreate() throws StripeException {
+    com.stripe.param.treasury.DebitReversalCreateParams params =
+        com.stripe.param.treasury.DebitReversalCreateParams.builder()
+            .setReceivedDebit("rd_xxxxxxxxxxxxx")
+            .build();
+
+    com.stripe.model.treasury.DebitReversal debitReversal =
+        com.stripe.model.treasury.DebitReversal.create(params);
+    assertNotNull(debitReversal);
+    verifyRequest(ApiResource.RequestMethod.POST, "/v1/treasury/debit_reversals", params.toMap());
+  }
+
+  @Test
+  public void testDebitReversalRetrieve() throws StripeException {
+    com.stripe.model.treasury.DebitReversal debitReversal =
+        com.stripe.model.treasury.DebitReversal.retrieve("debrev_xxxxxxxxxxxxx");
+    assertNotNull(debitReversal);
+    verifyRequest(
+        ApiResource.RequestMethod.GET, "/v1/treasury/debit_reversals/debrev_xxxxxxxxxxxxx");
+  }
+
+  @Test
+  public void testDebitReversalList() throws StripeException {
+    com.stripe.param.treasury.DebitReversalListParams params =
+        com.stripe.param.treasury.DebitReversalListParams.builder()
+            .setFinancialAccount("fa_xxxxxxxxxxxxx")
+            .setLimit(3L)
+            .build();
+
+    com.stripe.model.treasury.DebitReversalCollection debitReversals =
+        com.stripe.model.treasury.DebitReversal.list(params);
+    assertNotNull(debitReversals);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/treasury/debit_reversals", params.toMap());
   }
 
   @Test
@@ -2689,6 +4002,198 @@ class GeneratedExamples extends BaseStripeTest {
   }
 
   @Test
+  public void testAccountRetrieve3() throws StripeException {
+    com.stripe.model.financialconnections.Account account =
+        com.stripe.model.financialconnections.Account.retrieve("fca_xxxxxxxxxxxxx");
+    assertNotNull(account);
+    verifyRequest(
+        ApiResource.RequestMethod.GET, "/v1/financial_connections/accounts/fca_xxxxxxxxxxxxx");
+  }
+
+  @Test
+  public void testAccountList3() throws StripeException {
+    com.stripe.param.financialconnections.AccountListParams params =
+        com.stripe.param.financialconnections.AccountListParams.builder()
+            .setAccountHolder(
+                com.stripe.param.financialconnections.AccountListParams.AccountHolder.builder()
+                    .setCustomer("cus_xxxxxxxxxxxxx")
+                    .build())
+            .build();
+
+    com.stripe.model.financialconnections.AccountCollection accounts =
+        com.stripe.model.financialconnections.Account.list(params);
+    assertNotNull(accounts);
+    verifyRequest(
+        ApiResource.RequestMethod.GET, "/v1/financial_connections/accounts", params.toMap());
+  }
+
+  @Test
+  public void testAccountListOwners2() throws StripeException {
+    com.stripe.model.financialconnections.Account resource =
+        com.stripe.model.financialconnections.Account.retrieve("fca_xxxxxxxxxxxxx");
+    com.stripe.param.financialconnections.AccountListOwnersParams params =
+        com.stripe.param.financialconnections.AccountListOwnersParams.builder()
+            .setLimit(3L)
+            .setOwnership("fcaowns_xxxxxxxxxxxxx")
+            .build();
+
+    com.stripe.model.financialconnections.AccountOwnerCollection accountOwners =
+        resource.listOwners(params);
+    assertNotNull(accountOwners);
+    verifyRequest(
+        ApiResource.RequestMethod.GET,
+        "/v1/financial_connections/accounts/fca_xxxxxxxxxxxxx/owners",
+        params.toMap());
+  }
+
+  @Test
+  public void testSessionCreate5() throws StripeException {
+    com.stripe.param.financialconnections.SessionCreateParams params =
+        com.stripe.param.financialconnections.SessionCreateParams.builder()
+            .setAccountHolder(
+                com.stripe.param.financialconnections.SessionCreateParams.AccountHolder.builder()
+                    .setType(
+                        com.stripe.param.financialconnections.SessionCreateParams.AccountHolder.Type
+                            .CUSTOMER)
+                    .setCustomer("cus_xxxxxxxxxxxxx")
+                    .build())
+            .addPermission(
+                com.stripe.param.financialconnections.SessionCreateParams.Permission.PAYMENT_METHOD)
+            .addPermission(
+                com.stripe.param.financialconnections.SessionCreateParams.Permission.BALANCES)
+            .setFilters(
+                com.stripe.param.financialconnections.SessionCreateParams.Filters.builder()
+                    .addCountry("US")
+                    .build())
+            .build();
+
+    com.stripe.model.financialconnections.Session session =
+        com.stripe.model.financialconnections.Session.create(params);
+    assertNotNull(session);
+    verifyRequest(
+        ApiResource.RequestMethod.POST, "/v1/financial_connections/sessions", params.toMap());
+  }
+
+  @Test
+  public void testSessionRetrieve3() throws StripeException {
+    com.stripe.model.financialconnections.Session session =
+        com.stripe.model.financialconnections.Session.retrieve("fcsess_xxxxxxxxxxxxx");
+    assertNotNull(session);
+    verifyRequest(
+        ApiResource.RequestMethod.GET, "/v1/financial_connections/sessions/fcsess_xxxxxxxxxxxxx");
+  }
+
+  @Test
+  public void testSourceRetrieve2() throws StripeException {
+    Source source = Source.retrieve("src_xxxxxxxxxxxxx");
+    assertNotNull(source);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/sources/src_xxxxxxxxxxxxx");
+  }
+
+  @Test
+  public void testVerificationSessionCreate() throws StripeException {
+    com.stripe.param.identity.VerificationSessionCreateParams params =
+        com.stripe.param.identity.VerificationSessionCreateParams.builder()
+            .setType(com.stripe.param.identity.VerificationSessionCreateParams.Type.DOCUMENT)
+            .build();
+
+    com.stripe.model.identity.VerificationSession verificationSession =
+        com.stripe.model.identity.VerificationSession.create(params);
+    assertNotNull(verificationSession);
+    verifyRequest(
+        ApiResource.RequestMethod.POST, "/v1/identity/verification_sessions", params.toMap());
+  }
+
+  @Test
+  public void testVerificationSessionList() throws StripeException {
+    com.stripe.param.identity.VerificationSessionListParams params =
+        com.stripe.param.identity.VerificationSessionListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.identity.VerificationSessionCollection verificationSessions =
+        com.stripe.model.identity.VerificationSession.list(params);
+    assertNotNull(verificationSessions);
+    verifyRequest(
+        ApiResource.RequestMethod.GET, "/v1/identity/verification_sessions", params.toMap());
+  }
+
+  @Test
+  public void testVerificationSessionRetrieve() throws StripeException {
+    com.stripe.model.identity.VerificationSession verificationSession =
+        com.stripe.model.identity.VerificationSession.retrieve("vs_xxxxxxxxxxxxx");
+    assertNotNull(verificationSession);
+    verifyRequest(
+        ApiResource.RequestMethod.GET, "/v1/identity/verification_sessions/vs_xxxxxxxxxxxxx");
+  }
+
+  @Test
+  public void testVerificationSessionUpdate() throws StripeException {
+    com.stripe.model.identity.VerificationSession resource =
+        com.stripe.model.identity.VerificationSession.retrieve("vs_xxxxxxxxxxxxx");
+    com.stripe.param.identity.VerificationSessionUpdateParams params =
+        com.stripe.param.identity.VerificationSessionUpdateParams.builder()
+            .setType(com.stripe.param.identity.VerificationSessionUpdateParams.Type.ID_NUMBER)
+            .build();
+
+    com.stripe.model.identity.VerificationSession verificationSession = resource.update(params);
+    assertNotNull(verificationSession);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/identity/verification_sessions/vs_xxxxxxxxxxxxx",
+        params.toMap());
+  }
+
+  @Test
+  public void testVerificationSessionCancel() throws StripeException {
+    com.stripe.model.identity.VerificationSession resource =
+        com.stripe.model.identity.VerificationSession.retrieve("vs_xxxxxxxxxxxxx");
+    com.stripe.param.identity.VerificationSessionCancelParams params =
+        com.stripe.param.identity.VerificationSessionCancelParams.builder().build();
+
+    com.stripe.model.identity.VerificationSession verificationSession = resource.cancel(params);
+    assertNotNull(verificationSession);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/identity/verification_sessions/vs_xxxxxxxxxxxxx/cancel",
+        params.toMap());
+  }
+
+  @Test
+  public void testVerificationSessionRedact() throws StripeException {
+    com.stripe.model.identity.VerificationSession resource =
+        com.stripe.model.identity.VerificationSession.retrieve("vs_xxxxxxxxxxxxx");
+    com.stripe.param.identity.VerificationSessionRedactParams params =
+        com.stripe.param.identity.VerificationSessionRedactParams.builder().build();
+
+    com.stripe.model.identity.VerificationSession verificationSession = resource.redact(params);
+    assertNotNull(verificationSession);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/identity/verification_sessions/vs_xxxxxxxxxxxxx/redact",
+        params.toMap());
+  }
+
+  @Test
+  public void testVerificationReportRetrieve() throws StripeException {
+    com.stripe.model.identity.VerificationReport verificationReport =
+        com.stripe.model.identity.VerificationReport.retrieve("vr_xxxxxxxxxxxxx");
+    assertNotNull(verificationReport);
+    verifyRequest(
+        ApiResource.RequestMethod.GET, "/v1/identity/verification_reports/vr_xxxxxxxxxxxxx");
+  }
+
+  @Test
+  public void testVerificationReportList() throws StripeException {
+    com.stripe.param.identity.VerificationReportListParams params =
+        com.stripe.param.identity.VerificationReportListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.identity.VerificationReportCollection verificationReports =
+        com.stripe.model.identity.VerificationReport.list(params);
+    assertNotNull(verificationReports);
+    verifyRequest(
+        ApiResource.RequestMethod.GET, "/v1/identity/verification_reports", params.toMap());
+  }
+
+  @Test
   public void testWebhookEndpointCreate() throws StripeException {
     WebhookEndpointCreateParams params =
         WebhookEndpointCreateParams.builder()
@@ -2737,411 +4242,5 @@ class GeneratedExamples extends BaseStripeTest {
     WebhookEndpoint webhookEndpoint = resource.delete();
     assertNotNull(webhookEndpoint);
     verifyRequest(ApiResource.RequestMethod.DELETE, "/v1/webhook_endpoints/we_xxxxxxxxxxxxx");
-  }
-
-  @Test
-  public void testCustomerListPaymentMethods() throws StripeException {
-    Customer resource = Customer.retrieve("cus_xyz");
-    CustomerListPaymentMethodsParams params =
-        CustomerListPaymentMethodsParams.builder()
-            .setType(CustomerListPaymentMethodsParams.Type.CARD)
-            .build();
-
-    PaymentMethodCollection paymentMethods = resource.listPaymentMethods(params);
-    assertNotNull(paymentMethods);
-    verifyRequest(
-        ApiResource.RequestMethod.GET, "/v1/customers/cus_xyz/payment_methods", params.toMap());
-  }
-
-  @Test
-  public void testSessionExpire() throws StripeException {
-    com.stripe.model.checkout.Session resource =
-        com.stripe.model.checkout.Session.retrieve("sess_xyz");
-    com.stripe.param.checkout.SessionExpireParams params =
-        com.stripe.param.checkout.SessionExpireParams.builder().build();
-
-    com.stripe.model.checkout.Session session = resource.expire(params);
-    assertNotNull(session);
-    verifyRequest(
-        ApiResource.RequestMethod.POST, "/v1/checkout/sessions/sess_xyz/expire", params.toMap());
-  }
-
-  @Test
-  public void testShippingRateCreate() throws StripeException {
-    ShippingRateCreateParams params =
-        ShippingRateCreateParams.builder()
-            .setDisplayName("Sample Shipper")
-            .setFixedAmount(
-                ShippingRateCreateParams.FixedAmount.builder()
-                    .setCurrency("usd")
-                    .setAmount(400L)
-                    .build())
-            .setType(ShippingRateCreateParams.Type.FIXED_AMOUNT)
-            .build();
-
-    ShippingRate shippingRate = ShippingRate.create(params);
-    assertNotNull(shippingRate);
-    verifyRequest(ApiResource.RequestMethod.POST, "/v1/shipping_rates", params.toMap());
-  }
-
-  @Test
-  public void testShippingRateList() throws StripeException {
-    ShippingRateListParams params = ShippingRateListParams.builder().build();
-
-    ShippingRateCollection shippingRates = ShippingRate.list(params);
-    assertNotNull(shippingRates);
-    verifyRequest(ApiResource.RequestMethod.GET, "/v1/shipping_rates", params.toMap());
-  }
-
-  @Test
-  public void testSessionCreate3() throws StripeException {
-    com.stripe.param.checkout.SessionCreateParams params =
-        com.stripe.param.checkout.SessionCreateParams.builder()
-            .setSuccessUrl("https://example.com/success")
-            .setCancelUrl("https://example.com/cancel")
-            .setMode(com.stripe.param.checkout.SessionCreateParams.Mode.PAYMENT)
-            .addShippingOption(
-                com.stripe.param.checkout.SessionCreateParams.ShippingOption.builder()
-                    .setShippingRate("shr_standard")
-                    .build())
-            .addShippingOption(
-                com.stripe.param.checkout.SessionCreateParams.ShippingOption.builder()
-                    .setShippingRateData(
-                        com.stripe.param.checkout.SessionCreateParams.ShippingOption
-                            .ShippingRateData.builder()
-                            .setDisplayName("Standard")
-                            .setDeliveryEstimate(
-                                com.stripe.param.checkout.SessionCreateParams.ShippingOption
-                                    .ShippingRateData.DeliveryEstimate.builder()
-                                    .setMinimum(
-                                        com.stripe.param.checkout.SessionCreateParams.ShippingOption
-                                            .ShippingRateData.DeliveryEstimate.Minimum.builder()
-                                            .setUnit(
-                                                com.stripe.param.checkout.SessionCreateParams
-                                                    .ShippingOption.ShippingRateData
-                                                    .DeliveryEstimate.Minimum.Unit.DAY)
-                                            .setValue(5L)
-                                            .build())
-                                    .setMaximum(
-                                        com.stripe.param.checkout.SessionCreateParams.ShippingOption
-                                            .ShippingRateData.DeliveryEstimate.Maximum.builder()
-                                            .setUnit(
-                                                com.stripe.param.checkout.SessionCreateParams
-                                                    .ShippingOption.ShippingRateData
-                                                    .DeliveryEstimate.Maximum.Unit.DAY)
-                                            .setValue(7L)
-                                            .build())
-                                    .build())
-                            .build())
-                    .build())
-            .build();
-
-    com.stripe.model.checkout.Session session = com.stripe.model.checkout.Session.create(params);
-    assertNotNull(session);
-    verifyRequest(ApiResource.RequestMethod.POST, "/v1/checkout/sessions", params.toMap());
-  }
-
-  @Test
-  public void testPaymentIntentCreate2() throws StripeException {
-    PaymentIntentCreateParams params =
-        PaymentIntentCreateParams.builder()
-            .setAmount(1099L)
-            .setCurrency("eur")
-            .setAutomaticPaymentMethods(
-                PaymentIntentCreateParams.AutomaticPaymentMethods.builder()
-                    .setEnabled(true)
-                    .build())
-            .build();
-
-    PaymentIntent paymentIntent = PaymentIntent.create(params);
-    assertNotNull(paymentIntent);
-    verifyRequest(ApiResource.RequestMethod.POST, "/v1/payment_intents", params.toMap());
-  }
-
-  @Test
-  public void testPaymentLinkCreate() throws StripeException {
-    PaymentLinkCreateParams params =
-        PaymentLinkCreateParams.builder()
-            .addLineItem(
-                PaymentLinkCreateParams.LineItem.builder()
-                    .setPrice("price_xxxxxxxxxxxxx")
-                    .setQuantity(1L)
-                    .build())
-            .build();
-
-    PaymentLink paymentLink = PaymentLink.create(params);
-    assertNotNull(paymentLink);
-    verifyRequest(ApiResource.RequestMethod.POST, "/v1/payment_links", params.toMap());
-  }
-
-  @Test
-  public void testPaymentLinkListLineItems() throws StripeException {
-    PaymentLink resource = PaymentLink.retrieve("pl_xyz");
-    PaymentLinkListLineItemsParams params = PaymentLinkListLineItemsParams.builder().build();
-
-    LineItemCollection lineItems = resource.listLineItems(params);
-    assertNotNull(lineItems);
-    verifyRequest(
-        ApiResource.RequestMethod.GET, "/v1/payment_links/pl_xyz/line_items", params.toMap());
-  }
-
-  @Test
-  public void testPaymentLinkRetrieve() throws StripeException {
-    PaymentLink paymentLink = PaymentLink.retrieve("pl_xyz");
-    assertNotNull(paymentLink);
-    verifyRequest(ApiResource.RequestMethod.GET, "/v1/payment_links/pl_xyz");
-  }
-
-  @Test
-  public void testPaymentIntentVerifyMicrodeposits() throws StripeException {
-    PaymentIntent resource = PaymentIntent.retrieve("pi_xxxxxxxxxxxxx");
-    PaymentIntentVerifyMicrodepositsParams params =
-        PaymentIntentVerifyMicrodepositsParams.builder().build();
-
-    PaymentIntent paymentIntent = resource.verifyMicrodeposits(params);
-    assertNotNull(paymentIntent);
-    verifyRequest(
-        ApiResource.RequestMethod.POST,
-        "/v1/payment_intents/pi_xxxxxxxxxxxxx/verify_microdeposits",
-        params.toMap());
-  }
-
-  @Test
-  public void testSetupIntentVerifyMicrodeposits() throws StripeException {
-    SetupIntent resource = SetupIntent.retrieve("seti_xxxxxxxxxxxxx");
-    SetupIntentVerifyMicrodepositsParams params =
-        SetupIntentVerifyMicrodepositsParams.builder().build();
-
-    SetupIntent setupIntent = resource.verifyMicrodeposits(params);
-    assertNotNull(setupIntent);
-    verifyRequest(
-        ApiResource.RequestMethod.POST,
-        "/v1/setup_intents/seti_xxxxxxxxxxxxx/verify_microdeposits",
-        params.toMap());
-  }
-
-  @Test
-  public void testTestClockCreate() throws StripeException {
-    com.stripe.param.testhelpers.TestClockCreateParams params =
-        com.stripe.param.testhelpers.TestClockCreateParams.builder()
-            .setFrozenTime(123L)
-            .setName("cogsworth")
-            .build();
-
-    com.stripe.model.testhelpers.TestClock testClock =
-        com.stripe.model.testhelpers.TestClock.create(params);
-    assertNotNull(testClock);
-    verifyRequest(ApiResource.RequestMethod.POST, "/v1/test_helpers/test_clocks", params.toMap());
-  }
-
-  @Test
-  public void testTestClockRetrieve() throws StripeException {
-    com.stripe.model.testhelpers.TestClock testClock =
-        com.stripe.model.testhelpers.TestClock.retrieve("clock_xyz");
-    assertNotNull(testClock);
-    verifyRequest(ApiResource.RequestMethod.GET, "/v1/test_helpers/test_clocks/clock_xyz");
-  }
-
-  @Test
-  public void testTestClockList() throws StripeException {
-    com.stripe.param.testhelpers.TestClockListParams params =
-        com.stripe.param.testhelpers.TestClockListParams.builder().build();
-
-    com.stripe.model.testhelpers.TestClockCollection testClocks =
-        com.stripe.model.testhelpers.TestClock.list(params);
-    assertNotNull(testClocks);
-    verifyRequest(ApiResource.RequestMethod.GET, "/v1/test_helpers/test_clocks", params.toMap());
-  }
-
-  @Test
-  public void testTestClockDelete() throws StripeException {
-    com.stripe.model.testhelpers.TestClock resource =
-        com.stripe.model.testhelpers.TestClock.retrieve("clock_xyz");
-
-    com.stripe.model.testhelpers.TestClock testClock = resource.delete();
-    assertNotNull(testClock);
-    verifyRequest(ApiResource.RequestMethod.DELETE, "/v1/test_helpers/test_clocks/clock_xyz");
-  }
-
-  @Test
-  public void testTestClockAdvance() throws StripeException {
-    com.stripe.model.testhelpers.TestClock resource =
-        com.stripe.model.testhelpers.TestClock.retrieve("clock_xyz");
-    com.stripe.param.testhelpers.TestClockAdvanceParams params =
-        com.stripe.param.testhelpers.TestClockAdvanceParams.builder().setFrozenTime(142L).build();
-
-    com.stripe.model.testhelpers.TestClock testClock = resource.advance(params);
-    assertNotNull(testClock);
-    verifyRequest(
-        ApiResource.RequestMethod.POST,
-        "/v1/test_helpers/test_clocks/clock_xyz/advance",
-        params.toMap());
-  }
-
-  @Test
-  public void testCustomerCreateFundingInstructions() throws StripeException {
-    Customer resource = Customer.retrieve("cus_123");
-    CustomerCreateFundingInstructionsParams params =
-        CustomerCreateFundingInstructionsParams.builder()
-            .setBankTransfer(
-                CustomerCreateFundingInstructionsParams.BankTransfer.builder()
-                    .addRequestedAddressType(
-                        CustomerCreateFundingInstructionsParams.BankTransfer.RequestedAddressType
-                            .ZENGIN)
-                    .setType(
-                        CustomerCreateFundingInstructionsParams.BankTransfer.Type.JP_BANK_TRANSFER)
-                    .build())
-            .setCurrency("usd")
-            .setFundingType(CustomerCreateFundingInstructionsParams.FundingType.BANK_TRANSFER)
-            .build();
-
-    FundingInstructions fundingInstructions = resource.createFundingInstructions(params);
-    assertNotNull(fundingInstructions);
-    verifyRequest(
-        ApiResource.RequestMethod.POST,
-        "/v1/customers/cus_123/funding_instructions",
-        params.toMap());
-  }
-
-  @Test
-  public void testConfigurationList2() throws StripeException {
-    com.stripe.param.terminal.ConfigurationListParams params =
-        com.stripe.param.terminal.ConfigurationListParams.builder().build();
-
-    com.stripe.model.terminal.ConfigurationCollection configurations =
-        com.stripe.model.terminal.Configuration.list(params);
-    assertNotNull(configurations);
-    verifyRequest(ApiResource.RequestMethod.GET, "/v1/terminal/configurations", params.toMap());
-  }
-
-  @Test
-  public void testConfigurationRetrieve2() throws StripeException {
-    com.stripe.model.terminal.Configuration configuration =
-        com.stripe.model.terminal.Configuration.retrieve("uc_123");
-    assertNotNull(configuration);
-    verifyRequest(ApiResource.RequestMethod.GET, "/v1/terminal/configurations/uc_123");
-  }
-
-  @Test
-  public void testConfigurationCreate2() throws StripeException {
-    com.stripe.param.terminal.ConfigurationCreateParams params =
-        com.stripe.param.terminal.ConfigurationCreateParams.builder().build();
-
-    com.stripe.model.terminal.Configuration configuration =
-        com.stripe.model.terminal.Configuration.create(params);
-    assertNotNull(configuration);
-    verifyRequest(ApiResource.RequestMethod.POST, "/v1/terminal/configurations", params.toMap());
-  }
-
-  @Test
-  public void testConfigurationUpdate2() throws StripeException {
-    com.stripe.model.terminal.Configuration resource =
-        com.stripe.model.terminal.Configuration.retrieve("uc_123");
-    com.stripe.param.terminal.ConfigurationUpdateParams params =
-        com.stripe.param.terminal.ConfigurationUpdateParams.builder()
-            .setTipping(
-                com.stripe.param.terminal.ConfigurationUpdateParams.Tipping.builder()
-                    .setUsd(
-                        com.stripe.param.terminal.ConfigurationUpdateParams.Tipping.Usd.builder()
-                            .addFixedAmount(10L)
-                            .build())
-                    .build())
-            .build();
-
-    com.stripe.model.terminal.Configuration configuration = resource.update(params);
-    assertNotNull(configuration);
-    verifyRequest(
-        ApiResource.RequestMethod.POST, "/v1/terminal/configurations/uc_123", params.toMap());
-  }
-
-  @Test
-  public void testConfigurationDelete() throws StripeException {
-    com.stripe.model.terminal.Configuration resource =
-        com.stripe.model.terminal.Configuration.retrieve("uc_123");
-
-    com.stripe.model.terminal.Configuration configuration = resource.delete();
-    assertNotNull(configuration);
-    verifyRequest(ApiResource.RequestMethod.DELETE, "/v1/terminal/configurations/uc_123");
-  }
-
-  @Test
-  public void testRefundExpire() throws StripeException {
-    Refund resource = Refund.retrieve("re_123");
-    RefundExpireParams params = RefundExpireParams.builder().build();
-
-    Refund refund = resource.getTestHelpers().expire(params);
-    assertNotNull(refund);
-    verifyRequest(
-        ApiResource.RequestMethod.POST, "/v1/test_helpers/refunds/re_123/expire", params.toMap());
-  }
-
-  @Test
-  public void testAccountRetrieve2() throws StripeException {
-    com.stripe.model.financialconnections.Account account =
-        com.stripe.model.financialconnections.Account.retrieve("fca_xyz");
-    assertNotNull(account);
-    verifyRequest(ApiResource.RequestMethod.GET, "/v1/financial_connections/accounts/fca_xyz");
-  }
-
-  @Test
-  public void testAccountRefresh() throws StripeException {
-    com.stripe.param.financialconnections.AccountRefreshParams params =
-        com.stripe.param.financialconnections.AccountRefreshParams.builder()
-            .addFeature(com.stripe.param.financialconnections.AccountRefreshParams.Feature.BALANCE)
-            .build();
-
-    com.stripe.net.RequestOptions opts = com.stripe.net.RequestOptions.builder().build();
-    com.stripe.model.financialconnections.Account account =
-        com.stripe.model.financialconnections.Account.refresh("fca_xyz", params, opts);
-    assertNotNull(account);
-    verifyRequest(
-        ApiResource.RequestMethod.POST,
-        "/v1/financial_connections/accounts/fca_xyz/refresh",
-        params.toMap());
-  }
-
-  @Test
-  public void testAccountDisconnect() throws StripeException {
-    com.stripe.param.financialconnections.AccountDisconnectParams params =
-        com.stripe.param.financialconnections.AccountDisconnectParams.builder().build();
-
-    com.stripe.net.RequestOptions opts = com.stripe.net.RequestOptions.builder().build();
-    com.stripe.model.financialconnections.Account account =
-        com.stripe.model.financialconnections.Account.disconnect("fca_xyz", params, opts);
-    assertNotNull(account);
-    verifyRequest(
-        ApiResource.RequestMethod.POST,
-        "/v1/financial_connections/accounts/fca_xyz/disconnect",
-        params.toMap());
-  }
-
-  @Test
-  public void testSessionCreate4() throws StripeException {
-    com.stripe.param.financialconnections.SessionCreateParams params =
-        com.stripe.param.financialconnections.SessionCreateParams.builder()
-            .setAccountHolder(
-                com.stripe.param.financialconnections.SessionCreateParams.AccountHolder.builder()
-                    .setType(
-                        com.stripe.param.financialconnections.SessionCreateParams.AccountHolder.Type
-                            .CUSTOMER)
-                    .setCustomer("cus_123")
-                    .build())
-            .addPermission(
-                com.stripe.param.financialconnections.SessionCreateParams.Permission.BALANCES)
-            .build();
-
-    com.stripe.model.financialconnections.Session session =
-        com.stripe.model.financialconnections.Session.create(params);
-    assertNotNull(session);
-    verifyRequest(
-        ApiResource.RequestMethod.POST, "/v1/financial_connections/sessions", params.toMap());
-  }
-
-  @Test
-  public void testSessionRetrieve2() throws StripeException {
-    com.stripe.model.financialconnections.Session session =
-        com.stripe.model.financialconnections.Session.retrieve("fcsess_xyz");
-    assertNotNull(session);
-    verifyRequest(ApiResource.RequestMethod.GET, "/v1/financial_connections/sessions/fcsess_xyz");
   }
 }

--- a/src/test/java/com/stripe/functional/GeneratedExamples.java
+++ b/src/test/java/com/stripe/functional/GeneratedExamples.java
@@ -560,44 +560,6 @@ class GeneratedExamples extends BaseStripeTest {
   }
 
   @Test
-  public void testReceivedCreditCreate() throws StripeException {
-    com.stripe.param.treasury.ReceivedCreditCreateParams params =
-        com.stripe.param.treasury.ReceivedCreditCreateParams.builder()
-            .setFinancialAccount("fa_123")
-            .setNetwork(com.stripe.param.treasury.ReceivedCreditCreateParams.Network.ACH)
-            .setAmount(1234L)
-            .setCurrency("usd")
-            .build();
-
-    com.stripe.model.treasury.ReceivedCredit receivedCredit =
-        com.stripe.model.treasury.ReceivedCredit.create(params);
-    assertNotNull(receivedCredit);
-    verifyRequest(
-        ApiResource.RequestMethod.POST,
-        "/v1/test_helpers/treasury/received_credits",
-        params.toMap());
-  }
-
-  @Test
-  public void testReceivedDebitCreate() throws StripeException {
-    com.stripe.param.treasury.ReceivedDebitCreateParams params =
-        com.stripe.param.treasury.ReceivedDebitCreateParams.builder()
-            .setFinancialAccount("fa_123")
-            .setNetwork(com.stripe.param.treasury.ReceivedDebitCreateParams.Network.ACH)
-            .setAmount(1234L)
-            .setCurrency("usd")
-            .build();
-
-    com.stripe.model.treasury.ReceivedDebit receivedDebit =
-        com.stripe.model.treasury.ReceivedDebit.create(params);
-    assertNotNull(receivedDebit);
-    verifyRequest(
-        ApiResource.RequestMethod.POST,
-        "/v1/test_helpers/treasury/received_debits",
-        params.toMap());
-  }
-
-  @Test
   public void testCustomerList() throws StripeException {
     CustomerListParams params = CustomerListParams.builder().setLimit(3L).build();
 

--- a/src/test/java/com/stripe/functional/GeneratedExamples.java
+++ b/src/test/java/com/stripe/functional/GeneratedExamples.java
@@ -449,6 +449,155 @@ class GeneratedExamples extends BaseStripeTest {
   }
 
   @Test
+  public void testInboundTransferFail() throws StripeException {
+    com.stripe.model.treasury.InboundTransfer resource =
+        com.stripe.model.treasury.InboundTransfer.retrieve("ibt_123");
+    com.stripe.param.treasury.InboundTransferFailParams params =
+        com.stripe.param.treasury.InboundTransferFailParams.builder()
+            .setFailureDetails(
+                com.stripe.param.treasury.InboundTransferFailParams.FailureDetails.builder()
+                    .setCode(
+                        com.stripe.param.treasury.InboundTransferFailParams.FailureDetails.Code
+                            .ACCOUNT_CLOSED)
+                    .build())
+            .build();
+
+    com.stripe.model.treasury.InboundTransfer inboundTransfer =
+        resource.getTestHelpers().fail(params);
+    assertNotNull(inboundTransfer);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/treasury/inbound_transfers/ibt_123/fail",
+        params.toMap());
+  }
+
+  @Test
+  public void testInboundTransferReturnInboundTransfer() throws StripeException {
+    com.stripe.model.treasury.InboundTransfer resource =
+        com.stripe.model.treasury.InboundTransfer.retrieve("ibt_123");
+    com.stripe.param.treasury.InboundTransferReturnInboundTransferParams params =
+        com.stripe.param.treasury.InboundTransferReturnInboundTransferParams.builder().build();
+
+    com.stripe.model.treasury.InboundTransfer inboundTransfer =
+        resource.getTestHelpers().returnInboundTransfer(params);
+    assertNotNull(inboundTransfer);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/treasury/inbound_transfers/ibt_123/return",
+        params.toMap());
+  }
+
+  @Test
+  public void testInboundTransferSucceed() throws StripeException {
+    com.stripe.model.treasury.InboundTransfer resource =
+        com.stripe.model.treasury.InboundTransfer.retrieve("ibt_123");
+    com.stripe.param.treasury.InboundTransferSucceedParams params =
+        com.stripe.param.treasury.InboundTransferSucceedParams.builder().build();
+
+    com.stripe.model.treasury.InboundTransfer inboundTransfer =
+        resource.getTestHelpers().succeed(params);
+    assertNotNull(inboundTransfer);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/treasury/inbound_transfers/ibt_123/succeed",
+        params.toMap());
+  }
+
+  @Test
+  public void testOutboundTransferPost() throws StripeException {
+    com.stripe.model.treasury.OutboundTransfer resource =
+        com.stripe.model.treasury.OutboundTransfer.retrieve("obt_123");
+    com.stripe.param.treasury.OutboundTransferPostParams params =
+        com.stripe.param.treasury.OutboundTransferPostParams.builder().build();
+
+    com.stripe.model.treasury.OutboundTransfer outboundTransfer =
+        resource.getTestHelpers().post(params);
+    assertNotNull(outboundTransfer);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/treasury/outbound_transfers/obt_123/post",
+        params.toMap());
+  }
+
+  @Test
+  public void testOutboundTransferFail() throws StripeException {
+    com.stripe.model.treasury.OutboundTransfer resource =
+        com.stripe.model.treasury.OutboundTransfer.retrieve("obt_123");
+    com.stripe.param.treasury.OutboundTransferFailParams params =
+        com.stripe.param.treasury.OutboundTransferFailParams.builder().build();
+
+    com.stripe.model.treasury.OutboundTransfer outboundTransfer =
+        resource.getTestHelpers().fail(params);
+    assertNotNull(outboundTransfer);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/treasury/outbound_transfers/obt_123/fail",
+        params.toMap());
+  }
+
+  @Test
+  public void testOutboundTransferReturnOutboundTransfer() throws StripeException {
+    com.stripe.model.treasury.OutboundTransfer resource =
+        com.stripe.model.treasury.OutboundTransfer.retrieve("obt_123");
+    com.stripe.param.treasury.OutboundTransferReturnOutboundTransferParams params =
+        com.stripe.param.treasury.OutboundTransferReturnOutboundTransferParams.builder()
+            .setReturnedDetails(
+                com.stripe.param.treasury.OutboundTransferReturnOutboundTransferParams
+                    .ReturnedDetails.builder()
+                    .setCode(
+                        com.stripe.param.treasury.OutboundTransferReturnOutboundTransferParams
+                            .ReturnedDetails.Code.ACCOUNT_CLOSED)
+                    .build())
+            .build();
+
+    com.stripe.model.treasury.OutboundTransfer outboundTransfer =
+        resource.getTestHelpers().returnOutboundTransfer(params);
+    assertNotNull(outboundTransfer);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/treasury/outbound_transfers/obt_123/return",
+        params.toMap());
+  }
+
+  @Test
+  public void testReceivedCreditCreate() throws StripeException {
+    com.stripe.param.treasury.ReceivedCreditCreateParams params =
+        com.stripe.param.treasury.ReceivedCreditCreateParams.builder()
+            .setFinancialAccount("fa_123")
+            .setNetwork(com.stripe.param.treasury.ReceivedCreditCreateParams.Network.ACH)
+            .setAmount(1234L)
+            .setCurrency("usd")
+            .build();
+
+    com.stripe.model.treasury.ReceivedCredit receivedCredit =
+        com.stripe.model.treasury.ReceivedCredit.create(params);
+    assertNotNull(receivedCredit);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/treasury/received_credits",
+        params.toMap());
+  }
+
+  @Test
+  public void testReceivedDebitCreate() throws StripeException {
+    com.stripe.param.treasury.ReceivedDebitCreateParams params =
+        com.stripe.param.treasury.ReceivedDebitCreateParams.builder()
+            .setFinancialAccount("fa_123")
+            .setNetwork(com.stripe.param.treasury.ReceivedDebitCreateParams.Network.ACH)
+            .setAmount(1234L)
+            .setCurrency("usd")
+            .build();
+
+    com.stripe.model.treasury.ReceivedDebit receivedDebit =
+        com.stripe.model.treasury.ReceivedDebit.create(params);
+    assertNotNull(receivedDebit);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/treasury/received_debits",
+        params.toMap());
+  }
+
+  @Test
   public void testCustomerList() throws StripeException {
     CustomerListParams params = CustomerListParams.builder().setLimit(3L).build();
 

--- a/src/test/java/com/stripe/model/StandardizationTest.java
+++ b/src/test/java/com/stripe/model/StandardizationTest.java
@@ -83,7 +83,7 @@ public class StandardizationTest {
         // Skip `public static Foo retrieve(String id) {...` helper methods
         if (String.class.equals(finalParamType)
             && parameters.size() == 1
-            && "retrieve".equals(method.getName())) {
+            && method.getName().startsWith("retrieve")) {
           continue;
         }
 


### PR DESCRIPTION
Codegen for openapi 056745c.
r? @dcr-stripe
cc @stripe/api-libraries

## Changelog

* Add support for new resources `Treasury.CreditReversal`, `Treasury.DebitReversal`, `Treasury.FinancialAccountFeatures`, `Treasury.FinancialAccount`, `Treasury.FlowDetails`, `Treasury.InboundTransfer`, `Treasury.OutboundPayment`, `Treasury.OutboundTransfer`, `Treasury.ReceivedCredit`, `Treasury.ReceivedDebit`, `Treasury.TransactionEntry`, and `Treasury.Transaction`
* Add support for `retrieve_payment_method` method on resource `Customer`
* Add support for `list_owners` and `list` methods on resource `FinancialConnections.Account`
* Change `BillingPortalConfigurationCreateParams.features.customer_update.allowed_updates` to be optional
* Add support for `afterpay_clearpay`, `au_becs_debit`, `bacs_debit`, `eps`, `fpx`, `giropay`, `grabpay`, `klarna`, `paynow`, and `sepa_debit` on `Checkout.Session.payment_method_options`
* Add support for `treasury` on `Issuing.Authorization`, `Issuing.Dispute`, `Issuing.Transaction`, and `IssuingDisputeCreateParams`
* Add support for `financial_account` on `Issuing.Card` and `IssuingCardCreateParams`
* Add support for `client_secret` on `Order`
* Add support for `networks` on `PaymentIntentConfirmParams.payment_method_options.us_bank_account`, `PaymentIntentCreateParams.payment_method_options.us_bank_account`, `PaymentIntentUpdateParams.payment_method_options.us_bank_account`, `PaymentMethod.us_bank_account`, `SetupIntentConfirmParams.payment_method_options.us_bank_account`, `SetupIntentCreateParams.payment_method_options.us_bank_account`, and `SetupIntentUpdateParams.payment_method_options.us_bank_account`
* Add support for `attach_to_self` and `flow_directions` on `SetupIntent`
* Add support for `save_default_payment_method` on `Subscription.payment_settings`, `SubscriptionCreateParams.payment_settings`, and `SubscriptionUpdateParams.payment_settings`
* Add support for `czk` on `Terminal.Configuration.tipping`, `TerminalConfigurationCreateParams.tipping`, and `TerminalConfigurationUpdateParams.tipping`
* Add support for new values `treasury.credit_reversal.created`, `treasury.credit_reversal.posted`, `treasury.debit_reversal.completed`, `treasury.debit_reversal.created`, `treasury.debit_reversal.initial_credit_granted`, `treasury.financial_account.closed`, `treasury.financial_account.created`, `treasury.financial_account.features_status_updated`, `treasury.inbound_transfer.canceled`, `treasury.inbound_transfer.created`, `treasury.inbound_transfer.failed`, `treasury.inbound_transfer.succeeded`, `treasury.outbound_payment.canceled`, `treasury.outbound_payment.created`, `treasury.outbound_payment.expected_arrival_date_updated`, `treasury.outbound_payment.failed`, `treasury.outbound_payment.posted`, `treasury.outbound_payment.returned`, `treasury.outbound_transfer.canceled`, `treasury.outbound_transfer.created`, `treasury.outbound_transfer.expected_arrival_date_updated`, `treasury.outbound_transfer.failed`, `treasury.outbound_transfer.posted`, `treasury.outbound_transfer.returned`, `treasury.received_credit.created`, `treasury.received_credit.failed`, `treasury.received_credit.reversed`, `treasury.received_credit.succeeded`, and `treasury.received_debit.created` on enums `WebhookEndpointCreateParams.enabled_events[]` and `WebhookEndpointUpdateParams.enabled_events[]`
