### PR TITLE
Use github.actor as GRGIT_USER

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,7 @@ jobs:
 
       - name: Publish Javadoc
         run: |
-          ./gradlew gitPublishPush --stacktrace --info -Dorg.ajoberstar.grgit.auth.username=$GRGIT_USER
+          ./gradlew gitPublishPush --stacktrace --info
         env:
-          GRGIT_USER: ${{ secrets.GITHUB_TOKEN }}
+          GRGIT_USER: ${{ github.actor }}
+          GRGIT_PASS: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Attempt to fix docs publishing error. 

We were using GITHUB_TOKEN as GRGIT_USER but I think we need to have both the username and the password.