### PR TITLE
Temporary allow triggering docs push from master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
   publish-docs:
     if: >-
       ((github.event_name == 'workflow_dispatch') || (github.event_name == 'push')) &&
-      startsWith(github.ref, 'refs/tags/v') &&
+      (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master') &&
       endsWith(github.actor, '-stripe')
     needs: [build, test]
     runs-on: ubuntu-latest


### PR DESCRIPTION
When we re-run tags the workflow that gets used is from the same tag without new fixes. 