### PR TITLE
Revert master trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
   publish-docs:
     if: >-
       ((github.event_name == 'workflow_dispatch') || (github.event_name == 'push')) &&
-      (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master') &&
+      startsWith(github.ref, 'refs/tags/v') &&
       endsWith(github.actor, '-stripe')
     needs: [build, test]
     runs-on: ubuntu-latest


### PR DESCRIPTION
The latest fix worked: https://github.com/stripe/stripe-java/commits/gh-pages

Reverting trigger on master.