### PR TITLE
Determine exception type by error type first

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,7 +86,7 @@ dependencies {
     testImplementation group: "com.google.guava", name: "guava", version:"31.0.1-jre"
     testImplementation group: "com.squareup.okhttp3", name: "mockwebserver", version: "4.9.1"
     testImplementation group: "org.mockito", name: "mockito-core", version:"4.1.0"
-    testImplementation group: "org.junit.jupiter", name: "junit-jupiter-api", version: "5.8.2"
+    testImplementation group: "org.junit.jupiter", name: "junit-jupiter", version: "5.8.2"
     testRuntimeOnly group: "org.junit.jupiter", name: "junit-jupiter-engine", version: "5.8.2"
     testRuntimeOnly group: "org.slf4j", name: "slf4j-api", version: "1.7.32"
 }

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -177,62 +177,84 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 
     error.setLastResponse(response);
 
-    switch (response.code()) {
-      case 400:
-      case 404:
-        if ("idempotency_error".equals(error.getType())) {
-          exception =
-              new IdempotencyException(
-                  error.getMessage(), response.requestId(), error.getCode(), response.code());
-        } else {
-          exception =
-              new InvalidRequestException(
-                  error.getMessage(),
-                  error.getParam(),
-                  response.requestId(),
-                  error.getCode(),
-                  response.code(),
-                  null);
-        }
-        break;
-      case 401:
-        exception =
-            new AuthenticationException(
-                error.getMessage(), response.requestId(), error.getCode(), response.code());
-        break;
-      case 402:
-        exception =
-            new CardException(
-                error.getMessage(),
-                response.requestId(),
-                error.getCode(),
-                error.getParam(),
-                error.getDeclineCode(),
-                error.getCharge(),
-                response.code(),
-                null);
-        break;
-      case 403:
-        exception =
-            new PermissionException(
-                error.getMessage(), response.requestId(), error.getCode(), response.code());
-        break;
-      case 429:
-        exception =
-            new RateLimitException(
-                error.getMessage(),
-                error.getParam(),
-                response.requestId(),
-                error.getCode(),
-                response.code(),
-                null);
-        break;
-      default:
-        exception =
-            new ApiException(
-                error.getMessage(), response.requestId(), error.getCode(), response.code(), null);
-        break;
+    String errorType = error.getType();
+    if ("invalid_request_error".equals(errorType)) {
+      exception = new InvalidRequestException(
+        error.getMessage(),
+        error.getParam(),
+        response.requestId(),
+        error.getCode(),
+        response.code(),
+        null);
+    } else if ("idempotency_error".equals(errorType)) {
+      exception =
+        new IdempotencyException(
+          error.getMessage(), response.requestId(), error.getCode(), response.code());
+    } else if ("card_error".equals(errorType)) {
+      exception =
+        new CardException(
+          error.getMessage(),
+          response.requestId(),
+          error.getCode(),
+          error.getParam(),
+          error.getDeclineCode(),
+          error.getCharge(),
+          response.code(),
+          null);
     }
+    else {
+      switch (response.code()) {
+        case 400:
+        case 404:
+          exception =
+            new InvalidRequestException(
+              error.getMessage(),
+              error.getParam(),
+              response.requestId(),
+              error.getCode(),
+              response.code(),
+              null);
+          break;
+        case 401:
+          exception =
+            new AuthenticationException(
+              error.getMessage(), response.requestId(), error.getCode(), response.code());
+          break;
+        case 402:
+          exception =
+            new CardException(
+              error.getMessage(),
+              response.requestId(),
+              error.getCode(),
+              error.getParam(),
+              error.getDeclineCode(),
+              error.getCharge(),
+              response.code(),
+              null);
+          break;
+        case 403:
+          exception =
+            new PermissionException(
+              error.getMessage(), response.requestId(), error.getCode(), response.code());
+          break;
+        case 429:
+          exception =
+            new RateLimitException(
+              error.getMessage(),
+              error.getParam(),
+              response.requestId(),
+              error.getCode(),
+              response.code(),
+              null);
+          break;
+        default:
+          exception =
+            new ApiException(
+              error.getMessage(), response.requestId(), error.getCode(), response.code(), null);
+          break;
+      }
+    }
+
 
     exception.setStripeError(error);
 

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -179,50 +179,21 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 
     String errorType = error.getType();
     if ("invalid_request_error".equals(errorType)) {
-      exception = new InvalidRequestException(
-        error.getMessage(),
-        error.getParam(),
-        response.requestId(),
-        error.getCode(),
-        response.code(),
-        null);
-    } else if ("idempotency_error".equals(errorType)) {
       exception =
-        new IdempotencyException(
-          error.getMessage(), response.requestId(), error.getCode(), response.code());
-    } else if ("card_error".equals(errorType)) {
-      exception =
-        new CardException(
-          error.getMessage(),
-          response.requestId(),
-          error.getCode(),
-          error.getParam(),
-          error.getDeclineCode(),
-          error.getCharge(),
-          response.code(),
-          null);
-    }
-    else {
-      switch (response.code()) {
-        case 400:
-        case 404:
-          exception =
-            new InvalidRequestException(
+          new InvalidRequestException(
               error.getMessage(),
               error.getParam(),
               response.requestId(),
               error.getCode(),
               response.code(),
               null);
-          break;
-        case 401:
-          exception =
-            new AuthenticationException(
+    } else if ("idempotency_error".equals(errorType)) {
+      exception =
+          new IdempotencyException(
               error.getMessage(), response.requestId(), error.getCode(), response.code());
-          break;
-        case 402:
-          exception =
-            new CardException(
+    } else if ("card_error".equals(errorType)) {
+      exception =
+          new CardException(
               error.getMessage(),
               response.requestId(),
               error.getCode(),
@@ -231,30 +202,58 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
               error.getCharge(),
               response.code(),
               null);
+    } else {
+      switch (response.code()) {
+        case 400:
+        case 404:
+          exception =
+              new InvalidRequestException(
+                  error.getMessage(),
+                  error.getParam(),
+                  response.requestId(),
+                  error.getCode(),
+                  response.code(),
+                  null);
+          break;
+        case 401:
+          exception =
+              new AuthenticationException(
+                  error.getMessage(), response.requestId(), error.getCode(), response.code());
+          break;
+        case 402:
+          exception =
+              new CardException(
+                  error.getMessage(),
+                  response.requestId(),
+                  error.getCode(),
+                  error.getParam(),
+                  error.getDeclineCode(),
+                  error.getCharge(),
+                  response.code(),
+                  null);
           break;
         case 403:
           exception =
-            new PermissionException(
-              error.getMessage(), response.requestId(), error.getCode(), response.code());
+              new PermissionException(
+                  error.getMessage(), response.requestId(), error.getCode(), response.code());
           break;
         case 429:
           exception =
-            new RateLimitException(
-              error.getMessage(),
-              error.getParam(),
-              response.requestId(),
-              error.getCode(),
-              response.code(),
-              null);
+              new RateLimitException(
+                  error.getMessage(),
+                  error.getParam(),
+                  response.requestId(),
+                  error.getCode(),
+                  response.code(),
+                  null);
           break;
         default:
           exception =
-            new ApiException(
-              error.getMessage(), response.requestId(), error.getCode(), response.code(), null);
+              new ApiException(
+                  error.getMessage(), response.requestId(), error.getCode(), response.code(), null);
           break;
       }
     }
-
 
     exception.setStripeError(error);
 

--- a/src/test/java/com/stripe/functional/LiveStripeResponseGetterTest.java
+++ b/src/test/java/com/stripe/functional/LiveStripeResponseGetterTest.java
@@ -29,71 +29,77 @@ public class LiveStripeResponseGetterTest extends BaseStripeTest {
     StripeResponseGetter srg = new LiveStripeResponseGetter(spy);
     ApiResource.setStripeResponseGetter(srg);
     StripeResponse response =
-      new StripeResponse(200, HttpHeaders.of(Collections.emptyMap()), "invalid JSON");
+        new StripeResponse(200, HttpHeaders.of(Collections.emptyMap()), "invalid JSON");
     Mockito.doReturn(response).when(spy).requestWithRetries(Mockito.<StripeRequest>any());
     Exception exception =
-      assertThrows(
-        ApiException.class,
-        () -> {
-          Subscription.retrieve("sub_123");
-        });
+        assertThrows(
+            ApiException.class,
+            () -> {
+              Subscription.retrieve("sub_123");
+            });
     assertThat(
-      exception.getMessage(), CoreMatchers.containsString("Invalid response object from API"));
+        exception.getMessage(), CoreMatchers.containsString("Invalid response object from API"));
     assertNotNull(exception.getCause());
     assertThat(exception.getCause(), CoreMatchers.instanceOf(JsonSyntaxException.class));
   }
 
   public static Object[][] responseExceptionsByType() {
     return new Object[][] {
-      { "card_error", CardException.class },
-      { "invalid_request_error", InvalidRequestException.class },
-      { "idempotency_error", IdempotencyException.class }
+      {"card_error", CardException.class},
+      {"invalid_request_error", InvalidRequestException.class},
+      {"idempotency_error", IdempotencyException.class}
     };
   }
 
   @ParameterizedTest(name = "{0}")
   @MethodSource(value = "responseExceptionsByType")
-  public void testCreatesCorrectExceptionFromType(String type, Class<? extends Exception> exceptionClass) throws StripeException {
+  public void testCreatesCorrectExceptionFromType(
+      String type, Class<? extends Exception> exceptionClass) throws StripeException {
     HttpClient spy = Mockito.spy(new HttpURLConnectionClient());
     StripeResponseGetter srg = new LiveStripeResponseGetter(spy);
     ApiResource.setStripeResponseGetter(srg);
     StripeResponse response =
-      new StripeResponse(432, HttpHeaders.of(Collections.emptyMap()), "{\"error\":{ \"type\":\""+ type + "\" }}");
+        new StripeResponse(
+            432,
+            HttpHeaders.of(Collections.emptyMap()),
+            "{\"error\":{ \"type\":\"" + type + "\" }}");
     Mockito.doReturn(response).when(spy).requestWithRetries(Mockito.<StripeRequest>any());
 
     assertThrows(
-      exceptionClass,
-      () -> {
-        Subscription.retrieve("sub_123");
-      });
+        exceptionClass,
+        () -> {
+          Subscription.retrieve("sub_123");
+        });
   }
 
   public static Object[][] responseExceptionsByStatus() {
     return new Object[][] {
-      { 402, CardException.class },
-      { 400, InvalidRequestException.class },
-      { 404, InvalidRequestException.class },
-      { 401, AuthenticationException.class },
-      { 403, PermissionException.class },
-      { 429, RateLimitException.class },
-      { 499, ApiException.class },
+      {402, CardException.class},
+      {400, InvalidRequestException.class},
+      {404, InvalidRequestException.class},
+      {401, AuthenticationException.class},
+      {403, PermissionException.class},
+      {429, RateLimitException.class},
+      {499, ApiException.class},
     };
   }
 
   @ParameterizedTest(name = "{0}")
   @MethodSource(value = "responseExceptionsByStatus")
-  public void testCreatesCorrectExceptionFromStatus(Integer status, Class<? extends Exception> exceptionClass) throws StripeException {
+  public void testCreatesCorrectExceptionFromStatus(
+      Integer status, Class<? extends Exception> exceptionClass) throws StripeException {
     HttpClient spy = Mockito.spy(new HttpURLConnectionClient());
     StripeResponseGetter srg = new LiveStripeResponseGetter(spy);
     ApiResource.setStripeResponseGetter(srg);
     StripeResponse response =
-      new StripeResponse(status, HttpHeaders.of(Collections.emptyMap()), "{\"error\":{ \"type\":\"???\" }}");
+        new StripeResponse(
+            status, HttpHeaders.of(Collections.emptyMap()), "{\"error\":{ \"type\":\"???\" }}");
     Mockito.doReturn(response).when(spy).requestWithRetries(Mockito.<StripeRequest>any());
 
     assertThrows(
-      exceptionClass,
-      () -> {
-        Subscription.retrieve("sub_123");
-      });
+        exceptionClass,
+        () -> {
+          Subscription.retrieve("sub_123");
+        });
   }
 }

--- a/src/test/java/com/stripe/functional/LiveStripeResponseGetterTest.java
+++ b/src/test/java/com/stripe/functional/LiveStripeResponseGetterTest.java
@@ -4,8 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.gson.JsonSyntaxException;
 import com.stripe.BaseStripeTest;
-import com.stripe.exception.ApiException;
-import com.stripe.exception.StripeException;
+import com.stripe.exception.*;
 import com.stripe.model.Subscription;
 import com.stripe.net.ApiResource;
 import com.stripe.net.HttpClient;
@@ -18,6 +17,9 @@ import com.stripe.net.StripeResponseGetter;
 import java.util.Collections;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
 public class LiveStripeResponseGetterTest extends BaseStripeTest {
@@ -28,17 +30,44 @@ public class LiveStripeResponseGetterTest extends BaseStripeTest {
     StripeResponseGetter srg = new LiveStripeResponseGetter(spy);
     ApiResource.setStripeResponseGetter(srg);
     StripeResponse response =
-        new StripeResponse(200, HttpHeaders.of(Collections.emptyMap()), "invalid JSON");
+      new StripeResponse(200, HttpHeaders.of(Collections.emptyMap()), "invalid JSON");
     Mockito.doReturn(response).when(spy).requestWithRetries(Mockito.<StripeRequest>any());
     Exception exception =
-        assertThrows(
-            ApiException.class,
-            () -> {
-              Subscription.retrieve("sub_123");
-            });
+      assertThrows(
+        ApiException.class,
+        () -> {
+          Subscription.retrieve("sub_123");
+        });
     assertThat(
-        exception.getMessage(), CoreMatchers.containsString("Invalid response object from API"));
+      exception.getMessage(), CoreMatchers.containsString("Invalid response object from API"));
     assertNotNull(exception.getCause());
     assertThat(exception.getCause(), CoreMatchers.instanceOf(JsonSyntaxException.class));
   }
+
+  public static Object[][] responseExceptions() {
+    return new Object[][] {
+      { "card_error", CardException.class },
+      { "invalid_request_error", InvalidRequestException.class },
+      { "idempotency_error", IdempotencyException.class }
+    };
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource(value = "responseExceptions")
+  public void testCreatesCorrectException(String type, Class<? extends Exception> exceptionClass) throws StripeException {
+    HttpClient spy = Mockito.spy(new HttpURLConnectionClient());
+    StripeResponseGetter srg = new LiveStripeResponseGetter(spy);
+    ApiResource.setStripeResponseGetter(srg);
+    StripeResponse response =
+      new StripeResponse(432, HttpHeaders.of(Collections.emptyMap()), "{\"error\":{ \"type\":\""+ type + "\" }}");
+    Mockito.doReturn(response).when(spy).requestWithRetries(Mockito.<StripeRequest>any());
+
+    assertThrows(
+      exceptionClass,
+      () -> {
+        Subscription.retrieve("sub_123");
+      });
+  }
+
+
 }


### PR DESCRIPTION
Right now we are using status codes to determine the exception type which causes issues like https://github.com/stripe/stripe-java/issues/1358 where `invalid_request_error` was returned with `402` status code.


Change the error-handling logic to look at the error type first but keep the old status code-based logic as a fallback.

Add a bunch of tests.

Fixes: https://github.com/stripe/stripe-java/issues/1358