### PR TITLE
Add treasury test helpers

### DIFF
--- a/src/main/java/com/stripe/model/Refund.java
+++ b/src/main/java/com/stripe/model/Refund.java
@@ -519,10 +519,20 @@ public class Refund extends ApiResource implements MetadataStore<Refund>, Balanc
   }
 
   public TestHelpers getTestHelpers() {
-    return new TestHelpers();
+    return new TestHelpers(this);
   }
 
   public class TestHelpers {
+    private final Refund resource;
+
+    public TestHelpers() {
+      this.resource = Refund.this;
+    }
+
+    private TestHelpers(Refund resource) {
+      this.resource = resource;
+    }
+
     /** Expire a refund with a status of <code>requires_action</code>. */
     public Refund expire() throws StripeException {
       return expire((Map<String, Object>) null, (RequestOptions) null);
@@ -547,7 +557,7 @@ public class Refund extends ApiResource implements MetadataStore<Refund>, Balanc
               Stripe.getApiBase(),
               String.format(
                   "/v1/test_helpers/refunds/%s/expire",
-                  ApiResource.urlEncodeId(Refund.this.getId())));
+                  ApiResource.urlEncodeId(this.resource.getId())));
       return ApiResource.request(
           ApiResource.RequestMethod.POST, url, params, Refund.class, options);
     }
@@ -565,7 +575,7 @@ public class Refund extends ApiResource implements MetadataStore<Refund>, Balanc
               Stripe.getApiBase(),
               String.format(
                   "/v1/test_helpers/refunds/%s/expire",
-                  ApiResource.urlEncodeId(Refund.this.getId())));
+                  ApiResource.urlEncodeId(this.resource.getId())));
       return ApiResource.request(
           ApiResource.RequestMethod.POST, url, params, Refund.class, options);
     }

--- a/src/main/java/com/stripe/model/Refund.java
+++ b/src/main/java/com/stripe/model/Refund.java
@@ -525,6 +525,7 @@ public class Refund extends ApiResource implements MetadataStore<Refund>, Balanc
   public class TestHelpers {
     private final Refund resource;
 
+    @Deprecated
     public TestHelpers() {
       this.resource = Refund.this;
     }

--- a/src/main/java/com/stripe/model/terminal/Reader.java
+++ b/src/main/java/com/stripe/model/terminal/Reader.java
@@ -602,6 +602,7 @@ public class Reader extends ApiResource implements HasId, MetadataStore<Reader> 
   public class TestHelpers {
     private final Reader resource;
 
+    @Deprecated
     public TestHelpers() {
       this.resource = Reader.this;
     }

--- a/src/main/java/com/stripe/model/terminal/Reader.java
+++ b/src/main/java/com/stripe/model/terminal/Reader.java
@@ -596,10 +596,20 @@ public class Reader extends ApiResource implements HasId, MetadataStore<Reader> 
   }
 
   public TestHelpers getTestHelpers() {
-    return new TestHelpers();
+    return new TestHelpers(this);
   }
 
   public class TestHelpers {
+    private final Reader resource;
+
+    public TestHelpers() {
+      this.resource = Reader.this;
+    }
+
+    private TestHelpers(Reader resource) {
+      this.resource = resource;
+    }
+
     /**
      * Presents a payment method on a simulated reader. Can be used to simulate accepting a payment,
      * saving a card or refunding a transaction.
@@ -636,7 +646,7 @@ public class Reader extends ApiResource implements HasId, MetadataStore<Reader> 
               Stripe.getApiBase(),
               String.format(
                   "/v1/test_helpers/terminal/readers/%s/present_payment_method",
-                  ApiResource.urlEncodeId(Reader.this.getId())));
+                  ApiResource.urlEncodeId(this.resource.getId())));
       return ApiResource.request(
           ApiResource.RequestMethod.POST, url, params, Reader.class, options);
     }
@@ -662,7 +672,7 @@ public class Reader extends ApiResource implements HasId, MetadataStore<Reader> 
               Stripe.getApiBase(),
               String.format(
                   "/v1/test_helpers/terminal/readers/%s/present_payment_method",
-                  ApiResource.urlEncodeId(Reader.this.getId())));
+                  ApiResource.urlEncodeId(this.resource.getId())));
       return ApiResource.request(
           ApiResource.RequestMethod.POST, url, params, Reader.class, options);
     }

--- a/src/main/java/com/stripe/model/treasury/InboundTransfer.java
+++ b/src/main/java/com/stripe/model/treasury/InboundTransfer.java
@@ -417,10 +417,20 @@ public class InboundTransfer extends ApiResource implements HasId {
   }
 
   public TestHelpers getTestHelpers() {
-    return new TestHelpers();
+    return new TestHelpers(this);
   }
 
   public class TestHelpers {
+    private final InboundTransfer resource;
+
+    public TestHelpers() {
+      this.resource = InboundTransfer.this;
+    }
+
+    private TestHelpers(InboundTransfer resource) {
+      this.resource = resource;
+    }
+
     /**
      * Transitions a test mode created InboundTransfer to the <code>succeeded</code> status. The
      * InboundTransfer must already be in the <code>processing</code> state.
@@ -457,7 +467,7 @@ public class InboundTransfer extends ApiResource implements HasId {
               Stripe.getApiBase(),
               String.format(
                   "/v1/test_helpers/treasury/inbound_transfers/%s/succeed",
-                  ApiResource.urlEncodeId(InboundTransfer.this.getId())));
+                  ApiResource.urlEncodeId(this.resource.getId())));
       return ApiResource.request(
           ApiResource.RequestMethod.POST, url, params, InboundTransfer.class, options);
     }
@@ -482,7 +492,7 @@ public class InboundTransfer extends ApiResource implements HasId {
               Stripe.getApiBase(),
               String.format(
                   "/v1/test_helpers/treasury/inbound_transfers/%s/succeed",
-                  ApiResource.urlEncodeId(InboundTransfer.this.getId())));
+                  ApiResource.urlEncodeId(this.resource.getId())));
       return ApiResource.request(
           ApiResource.RequestMethod.POST, url, params, InboundTransfer.class, options);
     }
@@ -523,7 +533,7 @@ public class InboundTransfer extends ApiResource implements HasId {
               Stripe.getApiBase(),
               String.format(
                   "/v1/test_helpers/treasury/inbound_transfers/%s/fail",
-                  ApiResource.urlEncodeId(InboundTransfer.this.getId())));
+                  ApiResource.urlEncodeId(this.resource.getId())));
       return ApiResource.request(
           ApiResource.RequestMethod.POST, url, params, InboundTransfer.class, options);
     }
@@ -548,7 +558,7 @@ public class InboundTransfer extends ApiResource implements HasId {
               Stripe.getApiBase(),
               String.format(
                   "/v1/test_helpers/treasury/inbound_transfers/%s/fail",
-                  ApiResource.urlEncodeId(InboundTransfer.this.getId())));
+                  ApiResource.urlEncodeId(this.resource.getId())));
       return ApiResource.request(
           ApiResource.RequestMethod.POST, url, params, InboundTransfer.class, options);
     }
@@ -590,7 +600,7 @@ public class InboundTransfer extends ApiResource implements HasId {
               Stripe.getApiBase(),
               String.format(
                   "/v1/test_helpers/treasury/inbound_transfers/%s/return",
-                  ApiResource.urlEncodeId(InboundTransfer.this.getId())));
+                  ApiResource.urlEncodeId(this.resource.getId())));
       return ApiResource.request(
           ApiResource.RequestMethod.POST, url, params, InboundTransfer.class, options);
     }
@@ -617,7 +627,7 @@ public class InboundTransfer extends ApiResource implements HasId {
               Stripe.getApiBase(),
               String.format(
                   "/v1/test_helpers/treasury/inbound_transfers/%s/return",
-                  ApiResource.urlEncodeId(InboundTransfer.this.getId())));
+                  ApiResource.urlEncodeId(this.resource.getId())));
       return ApiResource.request(
           ApiResource.RequestMethod.POST, url, params, InboundTransfer.class, options);
     }

--- a/src/main/java/com/stripe/model/treasury/InboundTransfer.java
+++ b/src/main/java/com/stripe/model/treasury/InboundTransfer.java
@@ -423,6 +423,7 @@ public class InboundTransfer extends ApiResource implements HasId {
   public class TestHelpers {
     private final InboundTransfer resource;
 
+    @Deprecated
     public TestHelpers() {
       this.resource = InboundTransfer.this;
     }

--- a/src/main/java/com/stripe/model/treasury/OutboundPayment.java
+++ b/src/main/java/com/stripe/model/treasury/OutboundPayment.java
@@ -500,6 +500,7 @@ public class OutboundPayment extends ApiResource implements HasId {
   public class TestHelpers {
     private final OutboundPayment resource;
 
+    @Deprecated
     public TestHelpers() {
       this.resource = OutboundPayment.this;
     }

--- a/src/main/java/com/stripe/model/treasury/OutboundPayment.java
+++ b/src/main/java/com/stripe/model/treasury/OutboundPayment.java
@@ -494,10 +494,20 @@ public class OutboundPayment extends ApiResource implements HasId {
   }
 
   public TestHelpers getTestHelpers() {
-    return new TestHelpers();
+    return new TestHelpers(this);
   }
 
   public class TestHelpers {
+    private final OutboundPayment resource;
+
+    public TestHelpers() {
+      this.resource = OutboundPayment.this;
+    }
+
+    private TestHelpers(OutboundPayment resource) {
+      this.resource = resource;
+    }
+
     /**
      * Transitions a test mode created OutboundPayment to the <code>failed</code> status. The
      * OutboundPayment must already be in the <code>processing</code> state.
@@ -534,7 +544,7 @@ public class OutboundPayment extends ApiResource implements HasId {
               Stripe.getApiBase(),
               String.format(
                   "/v1/test_helpers/treasury/outbound_payments/%s/fail",
-                  ApiResource.urlEncodeId(OutboundPayment.this.getId())));
+                  ApiResource.urlEncodeId(this.resource.getId())));
       return ApiResource.request(
           ApiResource.RequestMethod.POST, url, params, OutboundPayment.class, options);
     }
@@ -559,7 +569,7 @@ public class OutboundPayment extends ApiResource implements HasId {
               Stripe.getApiBase(),
               String.format(
                   "/v1/test_helpers/treasury/outbound_payments/%s/fail",
-                  ApiResource.urlEncodeId(OutboundPayment.this.getId())));
+                  ApiResource.urlEncodeId(this.resource.getId())));
       return ApiResource.request(
           ApiResource.RequestMethod.POST, url, params, OutboundPayment.class, options);
     }
@@ -600,7 +610,7 @@ public class OutboundPayment extends ApiResource implements HasId {
               Stripe.getApiBase(),
               String.format(
                   "/v1/test_helpers/treasury/outbound_payments/%s/post",
-                  ApiResource.urlEncodeId(OutboundPayment.this.getId())));
+                  ApiResource.urlEncodeId(this.resource.getId())));
       return ApiResource.request(
           ApiResource.RequestMethod.POST, url, params, OutboundPayment.class, options);
     }
@@ -625,7 +635,7 @@ public class OutboundPayment extends ApiResource implements HasId {
               Stripe.getApiBase(),
               String.format(
                   "/v1/test_helpers/treasury/outbound_payments/%s/post",
-                  ApiResource.urlEncodeId(OutboundPayment.this.getId())));
+                  ApiResource.urlEncodeId(this.resource.getId())));
       return ApiResource.request(
           ApiResource.RequestMethod.POST, url, params, OutboundPayment.class, options);
     }
@@ -667,7 +677,7 @@ public class OutboundPayment extends ApiResource implements HasId {
               Stripe.getApiBase(),
               String.format(
                   "/v1/test_helpers/treasury/outbound_payments/%s/return",
-                  ApiResource.urlEncodeId(OutboundPayment.this.getId())));
+                  ApiResource.urlEncodeId(this.resource.getId())));
       return ApiResource.request(
           ApiResource.RequestMethod.POST, url, params, OutboundPayment.class, options);
     }
@@ -694,7 +704,7 @@ public class OutboundPayment extends ApiResource implements HasId {
               Stripe.getApiBase(),
               String.format(
                   "/v1/test_helpers/treasury/outbound_payments/%s/return",
-                  ApiResource.urlEncodeId(OutboundPayment.this.getId())));
+                  ApiResource.urlEncodeId(this.resource.getId())));
       return ApiResource.request(
           ApiResource.RequestMethod.POST, url, params, OutboundPayment.class, options);
     }

--- a/src/main/java/com/stripe/model/treasury/OutboundTransfer.java
+++ b/src/main/java/com/stripe/model/treasury/OutboundTransfer.java
@@ -445,10 +445,20 @@ public class OutboundTransfer extends ApiResource implements HasId {
   }
 
   public TestHelpers getTestHelpers() {
-    return new TestHelpers();
+    return new TestHelpers(this);
   }
 
   public class TestHelpers {
+    private final OutboundTransfer resource;
+
+    public TestHelpers() {
+      this.resource = OutboundTransfer.this;
+    }
+
+    private TestHelpers(OutboundTransfer resource) {
+      this.resource = resource;
+    }
+
     /**
      * Transitions a test mode created OutboundTransfer to the <code>failed</code> status. The
      * OutboundTransfer must already be in the <code>processing</code> state.
@@ -485,7 +495,7 @@ public class OutboundTransfer extends ApiResource implements HasId {
               Stripe.getApiBase(),
               String.format(
                   "/v1/test_helpers/treasury/outbound_transfers/%s/fail",
-                  ApiResource.urlEncodeId(OutboundTransfer.this.getId())));
+                  ApiResource.urlEncodeId(this.resource.getId())));
       return ApiResource.request(
           ApiResource.RequestMethod.POST, url, params, OutboundTransfer.class, options);
     }
@@ -510,7 +520,7 @@ public class OutboundTransfer extends ApiResource implements HasId {
               Stripe.getApiBase(),
               String.format(
                   "/v1/test_helpers/treasury/outbound_transfers/%s/fail",
-                  ApiResource.urlEncodeId(OutboundTransfer.this.getId())));
+                  ApiResource.urlEncodeId(this.resource.getId())));
       return ApiResource.request(
           ApiResource.RequestMethod.POST, url, params, OutboundTransfer.class, options);
     }
@@ -551,7 +561,7 @@ public class OutboundTransfer extends ApiResource implements HasId {
               Stripe.getApiBase(),
               String.format(
                   "/v1/test_helpers/treasury/outbound_transfers/%s/post",
-                  ApiResource.urlEncodeId(OutboundTransfer.this.getId())));
+                  ApiResource.urlEncodeId(this.resource.getId())));
       return ApiResource.request(
           ApiResource.RequestMethod.POST, url, params, OutboundTransfer.class, options);
     }
@@ -576,7 +586,7 @@ public class OutboundTransfer extends ApiResource implements HasId {
               Stripe.getApiBase(),
               String.format(
                   "/v1/test_helpers/treasury/outbound_transfers/%s/post",
-                  ApiResource.urlEncodeId(OutboundTransfer.this.getId())));
+                  ApiResource.urlEncodeId(this.resource.getId())));
       return ApiResource.request(
           ApiResource.RequestMethod.POST, url, params, OutboundTransfer.class, options);
     }
@@ -618,7 +628,7 @@ public class OutboundTransfer extends ApiResource implements HasId {
               Stripe.getApiBase(),
               String.format(
                   "/v1/test_helpers/treasury/outbound_transfers/%s/return",
-                  ApiResource.urlEncodeId(OutboundTransfer.this.getId())));
+                  ApiResource.urlEncodeId(this.resource.getId())));
       return ApiResource.request(
           ApiResource.RequestMethod.POST, url, params, OutboundTransfer.class, options);
     }
@@ -645,7 +655,7 @@ public class OutboundTransfer extends ApiResource implements HasId {
               Stripe.getApiBase(),
               String.format(
                   "/v1/test_helpers/treasury/outbound_transfers/%s/return",
-                  ApiResource.urlEncodeId(OutboundTransfer.this.getId())));
+                  ApiResource.urlEncodeId(this.resource.getId())));
       return ApiResource.request(
           ApiResource.RequestMethod.POST, url, params, OutboundTransfer.class, options);
     }

--- a/src/main/java/com/stripe/model/treasury/OutboundTransfer.java
+++ b/src/main/java/com/stripe/model/treasury/OutboundTransfer.java
@@ -451,6 +451,7 @@ public class OutboundTransfer extends ApiResource implements HasId {
   public class TestHelpers {
     private final OutboundTransfer resource;
 
+    @Deprecated
     public TestHelpers() {
       this.resource = OutboundTransfer.this;
     }

--- a/src/main/java/com/stripe/model/treasury/ReceivedCredit.java
+++ b/src/main/java/com/stripe/model/treasury/ReceivedCredit.java
@@ -11,6 +11,7 @@ import com.stripe.model.Payout;
 import com.stripe.model.StripeObject;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
+import com.stripe.param.treasury.ReceivedCreditCreateParams;
 import com.stripe.param.treasury.ReceivedCreditListParams;
 import com.stripe.param.treasury.ReceivedCreditRetrieveParams;
 import java.util.Map;
@@ -382,5 +383,49 @@ public class ReceivedCredit extends ApiResource implements HasId {
     /** Timestamp describing when the CreditReversal changed status to {@code posted}. */
     @SerializedName("posted_at")
     Long postedAt;
+  }
+
+  public static class TestHelpers {
+    private TestHelpers() {}
+
+    /**
+     * Use this endpoint to simulate a test mode ReceivedCredit initiated by a third party. In live
+     * mode, you can’t directly create ReceivedCredits initiated by third parties.
+     */
+    public static ReceivedCredit create(Map<String, Object> params) throws StripeException {
+      return create(params, (RequestOptions) null);
+    }
+
+    /**
+     * Use this endpoint to simulate a test mode ReceivedCredit initiated by a third party. In live
+     * mode, you can’t directly create ReceivedCredits initiated by third parties.
+     */
+    public static ReceivedCredit create(Map<String, Object> params, RequestOptions options)
+        throws StripeException {
+      String url =
+          String.format("%s%s", Stripe.getApiBase(), "/v1/test_helpers/treasury/received_credits");
+      return ApiResource.request(
+          ApiResource.RequestMethod.POST, url, params, ReceivedCredit.class, options);
+    }
+
+    /**
+     * Use this endpoint to simulate a test mode ReceivedCredit initiated by a third party. In live
+     * mode, you can’t directly create ReceivedCredits initiated by third parties.
+     */
+    public static ReceivedCredit create(ReceivedCreditCreateParams params) throws StripeException {
+      return create(params, (RequestOptions) null);
+    }
+
+    /**
+     * Use this endpoint to simulate a test mode ReceivedCredit initiated by a third party. In live
+     * mode, you can’t directly create ReceivedCredits initiated by third parties.
+     */
+    public static ReceivedCredit create(ReceivedCreditCreateParams params, RequestOptions options)
+        throws StripeException {
+      String url =
+          String.format("%s%s", Stripe.getApiBase(), "/v1/test_helpers/treasury/received_credits");
+      return ApiResource.request(
+          ApiResource.RequestMethod.POST, url, params, ReceivedCredit.class, options);
+    }
   }
 }

--- a/src/main/java/com/stripe/model/treasury/ReceivedDebit.java
+++ b/src/main/java/com/stripe/model/treasury/ReceivedDebit.java
@@ -10,6 +10,7 @@ import com.stripe.model.HasId;
 import com.stripe.model.StripeObject;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
+import com.stripe.param.treasury.ReceivedDebitCreateParams;
 import com.stripe.param.treasury.ReceivedDebitListParams;
 import com.stripe.param.treasury.ReceivedDebitRetrieveParams;
 import java.util.Map;
@@ -315,5 +316,49 @@ public class ReceivedDebit extends ApiResource implements HasId {
     /** Timestamp describing when the DebitReversal changed status to {@code completed}. */
     @SerializedName("completed_at")
     Long completedAt;
+  }
+
+  public static class TestHelpers {
+    private TestHelpers() {}
+
+    /**
+     * Use this endpoint to simulate a test mode ReceivedDebit initiated by a third party. In live
+     * mode, you can’t directly create ReceivedDebits initiated by third parties.
+     */
+    public static ReceivedDebit create(Map<String, Object> params) throws StripeException {
+      return create(params, (RequestOptions) null);
+    }
+
+    /**
+     * Use this endpoint to simulate a test mode ReceivedDebit initiated by a third party. In live
+     * mode, you can’t directly create ReceivedDebits initiated by third parties.
+     */
+    public static ReceivedDebit create(Map<String, Object> params, RequestOptions options)
+        throws StripeException {
+      String url =
+          String.format("%s%s", Stripe.getApiBase(), "/v1/test_helpers/treasury/received_debits");
+      return ApiResource.request(
+          ApiResource.RequestMethod.POST, url, params, ReceivedDebit.class, options);
+    }
+
+    /**
+     * Use this endpoint to simulate a test mode ReceivedDebit initiated by a third party. In live
+     * mode, you can’t directly create ReceivedDebits initiated by third parties.
+     */
+    public static ReceivedDebit create(ReceivedDebitCreateParams params) throws StripeException {
+      return create(params, (RequestOptions) null);
+    }
+
+    /**
+     * Use this endpoint to simulate a test mode ReceivedDebit initiated by a third party. In live
+     * mode, you can’t directly create ReceivedDebits initiated by third parties.
+     */
+    public static ReceivedDebit create(ReceivedDebitCreateParams params, RequestOptions options)
+        throws StripeException {
+      String url =
+          String.format("%s%s", Stripe.getApiBase(), "/v1/test_helpers/treasury/received_debits");
+      return ApiResource.request(
+          ApiResource.RequestMethod.POST, url, params, ReceivedDebit.class, options);
+    }
   }
 }

--- a/src/test/java/com/stripe/functional/GeneratedExamples.java
+++ b/src/test/java/com/stripe/functional/GeneratedExamples.java
@@ -560,6 +560,44 @@ class GeneratedExamples extends BaseStripeTest {
   }
 
   @Test
+  public void testReceivedCreditCreate() throws StripeException {
+    com.stripe.param.treasury.ReceivedCreditCreateParams params =
+        com.stripe.param.treasury.ReceivedCreditCreateParams.builder()
+            .setFinancialAccount("fa_123")
+            .setNetwork(com.stripe.param.treasury.ReceivedCreditCreateParams.Network.ACH)
+            .setAmount(1234L)
+            .setCurrency("usd")
+            .build();
+
+    com.stripe.model.treasury.ReceivedCredit receivedCredit =
+        com.stripe.model.treasury.ReceivedCredit.TestHelpers.create(params);
+    assertNotNull(receivedCredit);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/treasury/received_credits",
+        params.toMap());
+  }
+
+  @Test
+  public void testReceivedDebitCreate() throws StripeException {
+    com.stripe.param.treasury.ReceivedDebitCreateParams params =
+        com.stripe.param.treasury.ReceivedDebitCreateParams.builder()
+            .setFinancialAccount("fa_123")
+            .setNetwork(com.stripe.param.treasury.ReceivedDebitCreateParams.Network.ACH)
+            .setAmount(1234L)
+            .setCurrency("usd")
+            .build();
+
+    com.stripe.model.treasury.ReceivedDebit receivedDebit =
+        com.stripe.model.treasury.ReceivedDebit.TestHelpers.create(params);
+    assertNotNull(receivedDebit);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/treasury/received_debits",
+        params.toMap());
+  }
+
+  @Test
   public void testSecretCreate() throws StripeException {
     com.stripe.param.apps.SecretCreateParams params =
         com.stripe.param.apps.SecretCreateParams.builder()


### PR DESCRIPTION
Fixes: https://github.com/stripe/stripe-java/issues/1364


## Changelog
* Add support for `create` test helper on `ReceivedCredit`.
* Add support for `create` test helper on `ReceivedDebit`.
* Deprecates the ability to directly create instances of inner `TestHelper` classes.