### PR TITLE
Use the generated API version

### DIFF
--- a/src/main/java/com/stripe/ApiVersion.java
+++ b/src/main/java/com/stripe/ApiVersion.java
@@ -1,0 +1,6 @@
+// File generated from our OpenAPI spec
+package com.stripe;
+
+final class ApiVersion {
+  public static final String CURRENT = "2020-08-27";
+}

--- a/src/main/java/com/stripe/Stripe.java
+++ b/src/main/java/com/stripe/Stripe.java
@@ -9,7 +9,7 @@ public abstract class Stripe {
   public static final int DEFAULT_CONNECT_TIMEOUT = 30 * 1000;
   public static final int DEFAULT_READ_TIMEOUT = 80 * 1000;
 
-  public static final String API_VERSION = "2020-08-27";
+  public static final String API_VERSION = ApiVersion.CURRENT;
   public static final String CONNECT_API_BASE = "https://connect.stripe.com";
   public static final String LIVE_API_BASE = "https://api.stripe.com";
   public static final String UPLOAD_API_BASE = "https://files.stripe.com";


### PR DESCRIPTION
To support generating beta header values, use the generated ApiVersion value instead of the hardcoded one.

r? @dcr-stripe 