### PR TITLE
chore: Update gradle lombok plugin.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
     id "maven-publish"
     id "signing"
     id "jacoco"
-    id "io.freefair.lombok" version "6.3.0"
+    id "io.freefair.lombok" version "6.5.0.3"
     id "com.diffplug.spotless" version "6.4.0"
     id "net.ltgt.errorprone" version "2.0.2"
     id "com.github.kt3k.coveralls" version "2.12.0"


### PR DESCRIPTION
Updates the lombok plugin to get the most recent Lombok stable in an attempt to fix https://github.com/stripe/stripe-java/issues/1371#issuecomment-1168977414. This will include some Lombok changes which fix delombok output not matching.

Note that this is only rolling this out in the beta SDKs until we've confirmed the fix.