### PR TITLE
Support serializing nested objects in map

### DIFF
--- a/src/main/java/com/stripe/net/ApiRequestParamsConverter.java
+++ b/src/main/java/com/stripe/net/ApiRequestParamsConverter.java
@@ -88,15 +88,12 @@ class ApiRequestParamsConverter {
   }
 
   private static class NullValuesInMapsTypeAdapterFactory implements TypeAdapterFactory {
-    TypeAdapter<?> getValueAdapter(Gson gson, TypeToken<?> type)
-    {
+    TypeAdapter<?> getValueAdapter(Gson gson, TypeToken<?> type) {
       Type valueType;
       if (type.getType() instanceof ParameterizedType) {
         ParameterizedType mapParameterizedType = (ParameterizedType) type.getType();
         valueType = mapParameterizedType.getActualTypeArguments()[1];
-      }
-      else
-      {
+      } else {
         valueType = Object.class;
       }
 
@@ -118,16 +115,15 @@ class ApiRequestParamsConverter {
     }
   }
 
-  private static class MapAdapter<V> extends TypeAdapter<Map<String, V>>
-  {
+  private static class MapAdapter<V> extends TypeAdapter<Map<String, V>> {
     private TypeAdapter<V> valueTypeAdapter;
     private TypeAdapter<Map<String, V>> mapTypeAdapter;
 
-    public MapAdapter(TypeAdapter<V> valueTypeAdapter, TypeAdapter<Map<String, V>> mapTypeAdapter)
-    {
+    public MapAdapter(TypeAdapter<V> valueTypeAdapter, TypeAdapter<Map<String, V>> mapTypeAdapter) {
       this.valueTypeAdapter = valueTypeAdapter;
       this.mapTypeAdapter = mapTypeAdapter;
     }
+
     @Override
     public void write(JsonWriter out, Map<String, V> value) throws IOException {
       if (value == null) {
@@ -139,18 +135,15 @@ class ApiRequestParamsConverter {
       for (Map.Entry<String, V> entry : value.entrySet()) {
         out.name(entry.getKey());
         V entryValue = entry.getValue();
-        if (entryValue == null)
-        {
+        if (entryValue == null) {
           boolean oldSerializeNullsValue = out.getSerializeNulls();
           try {
             out.setSerializeNulls(true);
             out.nullValue();
-          }
-          finally {
+          } finally {
             out.setSerializeNulls(oldSerializeNullsValue);
           }
-        }
-        else {
+        } else {
           valueTypeAdapter.write(out, entryValue);
         }
       }
@@ -158,7 +151,7 @@ class ApiRequestParamsConverter {
     }
 
     @Override
-    public Map<String,V> read(JsonReader in) throws IOException {
+    public Map<String, V> read(JsonReader in) throws IOException {
       return mapTypeAdapter.read(in);
     }
   }

--- a/src/test/java/com/stripe/functional/GeneratedExamples.java
+++ b/src/test/java/com/stripe/functional/GeneratedExamples.java
@@ -178,34 +178,6 @@ class GeneratedExamples extends BaseStripeTest {
   }
 
   @Test
-  public void testPriceCreate() throws StripeException {
-    PriceCreateParams params =
-        PriceCreateParams.builder()
-            .setUnitAmount(2000L)
-            .setCurrency("usd")
-            .putCurrencyOption(
-                "uah",
-                PriceCreateParams.CurrencyOption.builder()
-                    .setTaxBehavior(PriceCreateParams.CurrencyOption.TaxBehavior.INCLUSIVE)
-                    .build())
-            .putCurrencyOption(
-                "usd",
-                PriceCreateParams.CurrencyOption.builder()
-                    .setTaxBehavior(PriceCreateParams.CurrencyOption.TaxBehavior.EXCLUSIVE)
-                    .build())
-            .setRecurring(
-                PriceCreateParams.Recurring.builder()
-                    .setInterval(PriceCreateParams.Recurring.Interval.MONTH)
-                    .build())
-            .setProduct("prod_xxxxxxxxxxxxx")
-            .build();
-
-    Price price = Price.create(params);
-    assertNotNull(price);
-    verifyRequest(ApiResource.RequestMethod.POST, "/v1/prices", params.toMap());
-  }
-
-  @Test
   public void testAccountList() throws StripeException {
     com.stripe.param.financialconnections.AccountListParams params =
         com.stripe.param.financialconnections.AccountListParams.builder().build();
@@ -371,16 +343,6 @@ class GeneratedExamples extends BaseStripeTest {
   }
 
   @Test
-  public void testSetupAttemptList() throws StripeException {
-    SetupAttemptListParams params =
-        SetupAttemptListParams.builder().setLimit(3L).setSetupIntent("si_xyz").build();
-
-    SetupAttemptCollection setupAttempts = SetupAttempt.list(params);
-    assertNotNull(setupAttempts);
-    verifyRequest(ApiResource.RequestMethod.GET, "/v1/setup_attempts", params.toMap());
-  }
-
-  @Test
   public void testSetupIntentVerifyMicrodeposits() throws StripeException {
     SetupIntent resource = SetupIntent.retrieve("seti_xxxxxxxxxxxxx");
     SetupIntentVerifyMicrodepositsParams params =
@@ -494,62 +456,6 @@ class GeneratedExamples extends BaseStripeTest {
     verifyRequest(
         ApiResource.RequestMethod.POST,
         "/v1/test_helpers/customers/cus_123/fund_cash_balance",
-        params.toMap());
-  }
-
-  @Test
-  public void testCardDeliverCard() throws StripeException {
-    com.stripe.model.issuing.Card resource = com.stripe.model.issuing.Card.retrieve("card_123");
-    com.stripe.param.issuing.CardDeliverCardParams params =
-        com.stripe.param.issuing.CardDeliverCardParams.builder().build();
-
-    com.stripe.model.issuing.Card card = resource.getTestHelpers().deliverCard(params);
-    assertNotNull(card);
-    verifyRequest(
-        ApiResource.RequestMethod.POST,
-        "/v1/test_helpers/issuing/cards/card_123/shipping/deliver",
-        params.toMap());
-  }
-
-  @Test
-  public void testCardFailCard() throws StripeException {
-    com.stripe.model.issuing.Card resource = com.stripe.model.issuing.Card.retrieve("card_123");
-    com.stripe.param.issuing.CardFailCardParams params =
-        com.stripe.param.issuing.CardFailCardParams.builder().build();
-
-    com.stripe.model.issuing.Card card = resource.getTestHelpers().failCard(params);
-    assertNotNull(card);
-    verifyRequest(
-        ApiResource.RequestMethod.POST,
-        "/v1/test_helpers/issuing/cards/card_123/shipping/fail",
-        params.toMap());
-  }
-
-  @Test
-  public void testCardReturnCard() throws StripeException {
-    com.stripe.model.issuing.Card resource = com.stripe.model.issuing.Card.retrieve("card_123");
-    com.stripe.param.issuing.CardReturnCardParams params =
-        com.stripe.param.issuing.CardReturnCardParams.builder().build();
-
-    com.stripe.model.issuing.Card card = resource.getTestHelpers().returnCard(params);
-    assertNotNull(card);
-    verifyRequest(
-        ApiResource.RequestMethod.POST,
-        "/v1/test_helpers/issuing/cards/card_123/shipping/return",
-        params.toMap());
-  }
-
-  @Test
-  public void testCardShipCard() throws StripeException {
-    com.stripe.model.issuing.Card resource = com.stripe.model.issuing.Card.retrieve("card_123");
-    com.stripe.param.issuing.CardShipCardParams params =
-        com.stripe.param.issuing.CardShipCardParams.builder().build();
-
-    com.stripe.model.issuing.Card card = resource.getTestHelpers().shipCard(params);
-    assertNotNull(card);
-    verifyRequest(
-        ApiResource.RequestMethod.POST,
-        "/v1/test_helpers/issuing/cards/card_123/shipping/ship",
         params.toMap());
   }
 
@@ -787,6 +693,72 @@ class GeneratedExamples extends BaseStripeTest {
     Token token = Token.create(params);
     assertNotNull(token);
     verifyRequest(ApiResource.RequestMethod.POST, "/v1/tokens", params.toMap());
+  }
+
+  @Test
+  public void testSetupAttemptList() throws StripeException {
+    SetupAttemptListParams params =
+        SetupAttemptListParams.builder().setLimit(3L).setSetupIntent("si_xyz").build();
+
+    SetupAttemptCollection setupAttempts = SetupAttempt.list(params);
+    assertNotNull(setupAttempts);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/setup_attempts", params.toMap());
+  }
+
+  @Test
+  public void testCardDeliverCard() throws StripeException {
+    com.stripe.model.issuing.Card resource = com.stripe.model.issuing.Card.retrieve("card_123");
+    com.stripe.param.issuing.CardDeliverCardParams params =
+        com.stripe.param.issuing.CardDeliverCardParams.builder().build();
+
+    com.stripe.model.issuing.Card card = resource.getTestHelpers().deliverCard(params);
+    assertNotNull(card);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/issuing/cards/card_123/shipping/deliver",
+        params.toMap());
+  }
+
+  @Test
+  public void testCardFailCard() throws StripeException {
+    com.stripe.model.issuing.Card resource = com.stripe.model.issuing.Card.retrieve("card_123");
+    com.stripe.param.issuing.CardFailCardParams params =
+        com.stripe.param.issuing.CardFailCardParams.builder().build();
+
+    com.stripe.model.issuing.Card card = resource.getTestHelpers().failCard(params);
+    assertNotNull(card);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/issuing/cards/card_123/shipping/fail",
+        params.toMap());
+  }
+
+  @Test
+  public void testCardReturnCard() throws StripeException {
+    com.stripe.model.issuing.Card resource = com.stripe.model.issuing.Card.retrieve("card_123");
+    com.stripe.param.issuing.CardReturnCardParams params =
+        com.stripe.param.issuing.CardReturnCardParams.builder().build();
+
+    com.stripe.model.issuing.Card card = resource.getTestHelpers().returnCard(params);
+    assertNotNull(card);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/issuing/cards/card_123/shipping/return",
+        params.toMap());
+  }
+
+  @Test
+  public void testCardShipCard() throws StripeException {
+    com.stripe.model.issuing.Card resource = com.stripe.model.issuing.Card.retrieve("card_123");
+    com.stripe.param.issuing.CardShipCardParams params =
+        com.stripe.param.issuing.CardShipCardParams.builder().build();
+
+    com.stripe.model.issuing.Card card = resource.getTestHelpers().shipCard(params);
+    assertNotNull(card);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/issuing/cards/card_123/shipping/ship",
+        params.toMap());
   }
 
   @Test
@@ -2607,7 +2579,7 @@ class GeneratedExamples extends BaseStripeTest {
   }
 
   @Test
-  public void testPriceCreate2() throws StripeException {
+  public void testPriceCreate() throws StripeException {
     PriceCreateParams params =
         PriceCreateParams.builder()
             .setUnitAmount(2000L)

--- a/src/test/java/com/stripe/functional/GeneratedExamples.java
+++ b/src/test/java/com/stripe/functional/GeneratedExamples.java
@@ -178,6 +178,34 @@ class GeneratedExamples extends BaseStripeTest {
   }
 
   @Test
+  public void testPriceCreate() throws StripeException {
+    PriceCreateParams params =
+        PriceCreateParams.builder()
+            .setUnitAmount(2000L)
+            .setCurrency("usd")
+            .putCurrencyOption(
+                "uah",
+                PriceCreateParams.CurrencyOption.builder()
+                    .setTaxBehavior(PriceCreateParams.CurrencyOption.TaxBehavior.INCLUSIVE)
+                    .build())
+            .putCurrencyOption(
+                "usd",
+                PriceCreateParams.CurrencyOption.builder()
+                    .setTaxBehavior(PriceCreateParams.CurrencyOption.TaxBehavior.EXCLUSIVE)
+                    .build())
+            .setRecurring(
+                PriceCreateParams.Recurring.builder()
+                    .setInterval(PriceCreateParams.Recurring.Interval.MONTH)
+                    .build())
+            .setProduct("prod_xxxxxxxxxxxxx")
+            .build();
+
+    Price price = Price.create(params);
+    assertNotNull(price);
+    verifyRequest(ApiResource.RequestMethod.POST, "/v1/prices", params.toMap());
+  }
+
+  @Test
   public void testAccountList() throws StripeException {
     com.stripe.param.financialconnections.AccountListParams params =
         com.stripe.param.financialconnections.AccountListParams.builder().build();
@@ -343,6 +371,16 @@ class GeneratedExamples extends BaseStripeTest {
   }
 
   @Test
+  public void testSetupAttemptList() throws StripeException {
+    SetupAttemptListParams params =
+        SetupAttemptListParams.builder().setLimit(3L).setSetupIntent("si_xyz").build();
+
+    SetupAttemptCollection setupAttempts = SetupAttempt.list(params);
+    assertNotNull(setupAttempts);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/setup_attempts", params.toMap());
+  }
+
+  @Test
   public void testSetupIntentVerifyMicrodeposits() throws StripeException {
     SetupIntent resource = SetupIntent.retrieve("seti_xxxxxxxxxxxxx");
     SetupIntentVerifyMicrodepositsParams params =
@@ -456,6 +494,62 @@ class GeneratedExamples extends BaseStripeTest {
     verifyRequest(
         ApiResource.RequestMethod.POST,
         "/v1/test_helpers/customers/cus_123/fund_cash_balance",
+        params.toMap());
+  }
+
+  @Test
+  public void testCardDeliverCard() throws StripeException {
+    com.stripe.model.issuing.Card resource = com.stripe.model.issuing.Card.retrieve("card_123");
+    com.stripe.param.issuing.CardDeliverCardParams params =
+        com.stripe.param.issuing.CardDeliverCardParams.builder().build();
+
+    com.stripe.model.issuing.Card card = resource.getTestHelpers().deliverCard(params);
+    assertNotNull(card);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/issuing/cards/card_123/shipping/deliver",
+        params.toMap());
+  }
+
+  @Test
+  public void testCardFailCard() throws StripeException {
+    com.stripe.model.issuing.Card resource = com.stripe.model.issuing.Card.retrieve("card_123");
+    com.stripe.param.issuing.CardFailCardParams params =
+        com.stripe.param.issuing.CardFailCardParams.builder().build();
+
+    com.stripe.model.issuing.Card card = resource.getTestHelpers().failCard(params);
+    assertNotNull(card);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/issuing/cards/card_123/shipping/fail",
+        params.toMap());
+  }
+
+  @Test
+  public void testCardReturnCard() throws StripeException {
+    com.stripe.model.issuing.Card resource = com.stripe.model.issuing.Card.retrieve("card_123");
+    com.stripe.param.issuing.CardReturnCardParams params =
+        com.stripe.param.issuing.CardReturnCardParams.builder().build();
+
+    com.stripe.model.issuing.Card card = resource.getTestHelpers().returnCard(params);
+    assertNotNull(card);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/issuing/cards/card_123/shipping/return",
+        params.toMap());
+  }
+
+  @Test
+  public void testCardShipCard() throws StripeException {
+    com.stripe.model.issuing.Card resource = com.stripe.model.issuing.Card.retrieve("card_123");
+    com.stripe.param.issuing.CardShipCardParams params =
+        com.stripe.param.issuing.CardShipCardParams.builder().build();
+
+    com.stripe.model.issuing.Card card = resource.getTestHelpers().shipCard(params);
+    assertNotNull(card);
+    verifyRequest(
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/issuing/cards/card_123/shipping/ship",
         params.toMap());
   }
 
@@ -693,72 +787,6 @@ class GeneratedExamples extends BaseStripeTest {
     Token token = Token.create(params);
     assertNotNull(token);
     verifyRequest(ApiResource.RequestMethod.POST, "/v1/tokens", params.toMap());
-  }
-
-  @Test
-  public void testSetupAttemptList() throws StripeException {
-    SetupAttemptListParams params =
-        SetupAttemptListParams.builder().setLimit(3L).setSetupIntent("si_xyz").build();
-
-    SetupAttemptCollection setupAttempts = SetupAttempt.list(params);
-    assertNotNull(setupAttempts);
-    verifyRequest(ApiResource.RequestMethod.GET, "/v1/setup_attempts", params.toMap());
-  }
-
-  @Test
-  public void testCardDeliverCard() throws StripeException {
-    com.stripe.model.issuing.Card resource = com.stripe.model.issuing.Card.retrieve("card_123");
-    com.stripe.param.issuing.CardDeliverCardParams params =
-        com.stripe.param.issuing.CardDeliverCardParams.builder().build();
-
-    com.stripe.model.issuing.Card card = resource.getTestHelpers().deliverCard(params);
-    assertNotNull(card);
-    verifyRequest(
-        ApiResource.RequestMethod.POST,
-        "/v1/test_helpers/issuing/cards/card_123/shipping/deliver",
-        params.toMap());
-  }
-
-  @Test
-  public void testCardFailCard() throws StripeException {
-    com.stripe.model.issuing.Card resource = com.stripe.model.issuing.Card.retrieve("card_123");
-    com.stripe.param.issuing.CardFailCardParams params =
-        com.stripe.param.issuing.CardFailCardParams.builder().build();
-
-    com.stripe.model.issuing.Card card = resource.getTestHelpers().failCard(params);
-    assertNotNull(card);
-    verifyRequest(
-        ApiResource.RequestMethod.POST,
-        "/v1/test_helpers/issuing/cards/card_123/shipping/fail",
-        params.toMap());
-  }
-
-  @Test
-  public void testCardReturnCard() throws StripeException {
-    com.stripe.model.issuing.Card resource = com.stripe.model.issuing.Card.retrieve("card_123");
-    com.stripe.param.issuing.CardReturnCardParams params =
-        com.stripe.param.issuing.CardReturnCardParams.builder().build();
-
-    com.stripe.model.issuing.Card card = resource.getTestHelpers().returnCard(params);
-    assertNotNull(card);
-    verifyRequest(
-        ApiResource.RequestMethod.POST,
-        "/v1/test_helpers/issuing/cards/card_123/shipping/return",
-        params.toMap());
-  }
-
-  @Test
-  public void testCardShipCard() throws StripeException {
-    com.stripe.model.issuing.Card resource = com.stripe.model.issuing.Card.retrieve("card_123");
-    com.stripe.param.issuing.CardShipCardParams params =
-        com.stripe.param.issuing.CardShipCardParams.builder().build();
-
-    com.stripe.model.issuing.Card card = resource.getTestHelpers().shipCard(params);
-    assertNotNull(card);
-    verifyRequest(
-        ApiResource.RequestMethod.POST,
-        "/v1/test_helpers/issuing/cards/card_123/shipping/ship",
-        params.toMap());
   }
 
   @Test
@@ -2579,7 +2607,7 @@ class GeneratedExamples extends BaseStripeTest {
   }
 
   @Test
-  public void testPriceCreate() throws StripeException {
+  public void testPriceCreate2() throws StripeException {
     PriceCreateParams params =
         PriceCreateParams.builder()
             .setUnitAmount(2000L)

--- a/src/test/java/com/stripe/net/ApiRequestParamsConverterTest.java
+++ b/src/test/java/com/stripe/net/ApiRequestParamsConverterTest.java
@@ -267,8 +267,8 @@ public class ApiRequestParamsConverterTest {
     Map<String, Object> untypedParams = toMap(params);
     Map<String, Object> metadata = (Map<String, Object>) untypedParams.get("object_map");
     assertEquals(metadata.size(), 2);
-    Map<String, Object> objFoo = (Map<String, Object>)metadata.get("foo");
-    Map<String, Object> objBar = (Map<String, Object>)metadata.get("bar");
+    Map<String, Object> objFoo = (Map<String, Object>) metadata.get("foo");
+    Map<String, Object> objBar = (Map<String, Object>) metadata.get("bar");
     assertEquals(objFoo.size(), 3);
     assertEquals(objBar.size(), 3);
 

--- a/src/test/java/com/stripe/net/ApiRequestParamsConverterTest.java
+++ b/src/test/java/com/stripe/net/ApiRequestParamsConverterTest.java
@@ -100,6 +100,9 @@ public class ApiRequestParamsConverterTest {
 
     @SerializedName("feature_map")
     Map<String, Long> featureMap;
+
+    @SerializedName("object_map")
+    Map<String, ModelHasExtraParams> objectMap;
   }
 
   private static class ModelHasExtraParamsWithWrongSerializedName extends ApiRequestParams {
@@ -251,6 +254,31 @@ public class ApiRequestParamsConverterTest {
     assertEquals(featureMap.size(), 2);
     assertEquals(featureMap.get("fooLong"), 123L);
     assertEquals(featureMap.get("barLong"), null);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testObjectMaps() {
+    HasMetadataParams params = new HasMetadataParams();
+    params.objectMap = new HashMap<>();
+    params.objectMap.put("foo", new ModelHasExtraParams(ParamCode.ENUM_FOO));
+    params.objectMap.put("bar", new ModelHasExtraParams(ParamCode.ENUM_BAR));
+
+    Map<String, Object> untypedParams = toMap(params);
+    Map<String, Object> metadata = (Map<String, Object>) untypedParams.get("object_map");
+    assertEquals(metadata.size(), 2);
+    Map<String, Object> objFoo = (Map<String, Object>)metadata.get("foo");
+    Map<String, Object> objBar = (Map<String, Object>)metadata.get("bar");
+    assertEquals(objFoo.size(), 3);
+    assertEquals(objBar.size(), 3);
+
+    assertEquals(objFoo.get("enum_value"), "enum_foo");
+    assertEquals(objFoo.get("string_value"), "foo");
+    assertEquals(objFoo.get("hello"), "world");
+
+    assertEquals(objBar.get("enum_value"), "enum_bar");
+    assertEquals(objBar.get("string_value"), "foo");
+    assertEquals(objBar.get("hello"), "world");
   }
 
   private Map<String, Object> toMap(ApiRequestParams params) {


### PR DESCRIPTION
r? @kamil-stripe 

Currently we call `out.setSerializeNulls(true);` before serializing `Map`s. This worked well when values were strings but causes unexpected issues now that values can have full Params classes. One of the issues is that `extraParams` dictionary gets serialized with null value.

This PR changes our custom serializer to manually serialize items and enable writing null only when explicitly serializing a null map value.