### PR TITLE
Check for API key in autoPagingIterable

### DIFF
--- a/src/main/java/com/stripe/exception/ApiKeyMissingException.java
+++ b/src/main/java/com/stripe/exception/ApiKeyMissingException.java
@@ -8,11 +8,6 @@ package com.stripe.exception;
 public class ApiKeyMissingException extends RuntimeException {
   private static final long serialVersionUID = 1L;
 
-  /** Initializes a new instance of the {@link ApiKeyMissingException}. */
-  public ApiKeyMissingException() {
-    super();
-  }
-
   /** Initializes a new instance of the {@link ApiKeyMissingException} with a message. */
   public ApiKeyMissingException(String message) {
     super(message);

--- a/src/main/java/com/stripe/exception/ApiKeyMissingException.java
+++ b/src/main/java/com/stripe/exception/ApiKeyMissingException.java
@@ -1,0 +1,20 @@
+package com.stripe.exception;
+
+/**
+ * {@link ApiKeyMissingException} is thrown when the API key is not set for a request. The API key
+ * for a request may be set either globally through {@link com.stripe.Stripe#apiKey} or through
+ * {@link com.stripe.net.RequestOptions}.
+ */
+public class ApiKeyMissingException extends RuntimeException {
+  private static final long serialVersionUID = 1L;
+
+  /** Initializes a new instance of the {@link ApiKeyMissingException}. */
+  public ApiKeyMissingException() {
+    super();
+  }
+
+  /** Initializes a new instance of the {@link ApiKeyMissingException} with a message. */
+  public ApiKeyMissingException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/stripe/model/StripeCollection.java
+++ b/src/main/java/com/stripe/model/StripeCollection.java
@@ -1,7 +1,7 @@
 package com.stripe.model;
 
 import com.stripe.Stripe;
-import com.stripe.exception.AuthenticationException;
+import com.stripe.exception.ApiKeyMissingException;
 import com.stripe.net.RequestOptions;
 import java.util.List;
 import java.util.Map;
@@ -58,16 +58,16 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject
   @Setter(onMethod = @__({@Override}))
   private Map<String, Object> requestParams;
 
-  public Iterable<T> autoPagingIterable() throws AuthenticationException {
+  public Iterable<T> autoPagingIterable() {
     if (Stripe.apiKey == null) {
-      throw new AuthenticationException("No API key provided.", null, null, 0);
+      throw new ApiKeyMissingException();
     }
     return new PagingIterable<>(this);
   }
 
-  public Iterable<T> autoPagingIterable(Map<String, Object> params) throws AuthenticationException {
+  public Iterable<T> autoPagingIterable(Map<String, Object> params) {
     if (Stripe.apiKey == null) {
-      throw new AuthenticationException("No API key provided.", null, null, 0);
+      throw new ApiKeyMissingException();
     }
 
     this.setRequestParams(params);
@@ -82,11 +82,10 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject
    * @param params request parameters (will override the parameters from the initial list request)
    * @param options request options (will override the options from the initial list request)
    */
-  public Iterable<T> autoPagingIterable(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException {
+  public Iterable<T> autoPagingIterable(Map<String, Object> params, RequestOptions options) {
     String apiKey = options.getApiKey();
     if (apiKey == null) {
-      throw new AuthenticationException("No API key provided.", null, null, 0);
+      throw new ApiKeyMissingException();
     }
     this.setRequestOptions(options);
     this.setRequestParams(params);

--- a/src/main/java/com/stripe/model/StripeCollection.java
+++ b/src/main/java/com/stripe/model/StripeCollection.java
@@ -60,22 +60,14 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject
 
   public Iterable<T> autoPagingIterable() {
     if (Stripe.apiKey == null) {
-      throw new AuthenticationException(
-          "No API key provided.",
-          null,
-          null,
-          0);
+      throw new AuthenticationException("No API key provided.", null, null, 0);
     }
     return new PagingIterable<>(this);
   }
 
   public Iterable<T> autoPagingIterable(Map<String, Object> params) {
     if (Stripe.apiKey == null) {
-      throw new AuthenticationException(
-          "No API key provided.",
-          null,
-          null,
-          0);
+      throw new AuthenticationException("No API key provided.", null, null, 0);
     }
 
     this.setRequestParams(params);
@@ -93,11 +85,7 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject
   public Iterable<T> autoPagingIterable(Map<String, Object> params, RequestOptions options) {
     String apiKey = options.getApiKey();
     if (apiKey == null) {
-      throw new AuthenticationException(
-          "No API key provided.",
-          null,
-          null,
-          0);
+      throw new AuthenticationException("No API key provided.", null, null, 0);
     }
     this.setRequestOptions(options);
     this.setRequestParams(params);

--- a/src/main/java/com/stripe/model/StripeCollection.java
+++ b/src/main/java/com/stripe/model/StripeCollection.java
@@ -60,14 +60,16 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject
 
   public Iterable<T> autoPagingIterable() {
     if (Stripe.apiKey == null) {
-      throw new ApiKeyMissingException();
+      throw new ApiKeyMissingException(
+          "API key is not set for autoPagingIterable. You can set the API key globally using Stripe.ApiKey, or through RequestOptions in with autoPagingIterable(params, options).");
     }
     return new PagingIterable<>(this);
   }
 
   public Iterable<T> autoPagingIterable(Map<String, Object> params) {
     if (Stripe.apiKey == null) {
-      throw new ApiKeyMissingException();
+      throw new ApiKeyMissingException(
+          "API key is not set for autoPagingIterable. You can set the API key globally using Stripe.ApiKey, or through RequestOptions in with autoPagingIterable(params, options).");
     }
 
     this.setRequestParams(params);
@@ -84,8 +86,9 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject
    */
   public Iterable<T> autoPagingIterable(Map<String, Object> params, RequestOptions options) {
     String apiKey = options.getApiKey();
-    if (apiKey == null) {
-      throw new ApiKeyMissingException();
+    if (Stripe.apiKey == null && apiKey == null) {
+      throw new ApiKeyMissingException(
+          "API key is not set for autoPagingIterable. You can set the API key globally using Stripe.ApiKey, or through RequestOptions in with autoPagingIterable(params, options).");
     }
     this.setRequestOptions(options);
     this.setRequestParams(params);

--- a/src/main/java/com/stripe/model/StripeCollection.java
+++ b/src/main/java/com/stripe/model/StripeCollection.java
@@ -61,7 +61,7 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject
   public Iterable<T> autoPagingIterable() {
     if (Stripe.apiKey == null) {
       throw new ApiKeyMissingException(
-          "API key is not set for autoPagingIterable. You can set the API key globally using Stripe.ApiKey, or through RequestOptions in with autoPagingIterable(params, options).");
+          "API key is not set for autoPagingIterable. You can set the API key globally using Stripe.ApiKey, or through RequestOptions with autoPagingIterable(params, options).");
     }
     return new PagingIterable<>(this);
   }
@@ -69,7 +69,7 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject
   public Iterable<T> autoPagingIterable(Map<String, Object> params) {
     if (Stripe.apiKey == null) {
       throw new ApiKeyMissingException(
-          "API key is not set for autoPagingIterable. You can set the API key globally using Stripe.ApiKey, or through RequestOptions in with autoPagingIterable(params, options).");
+          "API key is not set for autoPagingIterable. You can set the API key globally using Stripe.ApiKey, or through RequestOptions with autoPagingIterable(params, options).");
     }
 
     this.setRequestParams(params);
@@ -88,7 +88,7 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject
     String apiKey = options.getApiKey();
     if (Stripe.apiKey == null && apiKey == null) {
       throw new ApiKeyMissingException(
-          "API key is not set for autoPagingIterable. You can set the API key globally using Stripe.ApiKey, or through RequestOptions in with autoPagingIterable(params, options).");
+          "API key is not set for autoPagingIterable. You can set the API key globally using Stripe.ApiKey, or through RequestOptions with autoPagingIterable(params, options).");
     }
     this.setRequestOptions(options);
     this.setRequestParams(params);

--- a/src/main/java/com/stripe/model/StripeCollection.java
+++ b/src/main/java/com/stripe/model/StripeCollection.java
@@ -1,5 +1,7 @@
 package com.stripe.model;
 
+import com.stripe.Stripe;
+import com.stripe.exception.AuthenticationException;
 import com.stripe.net.RequestOptions;
 import java.util.List;
 import java.util.Map;
@@ -57,10 +59,25 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject
   private Map<String, Object> requestParams;
 
   public Iterable<T> autoPagingIterable() {
+    if (Stripe.apiKey == null) {
+      throw new AuthenticationException(
+          "No API key provided.",
+          null,
+          null,
+          0);
+    }
     return new PagingIterable<>(this);
   }
 
   public Iterable<T> autoPagingIterable(Map<String, Object> params) {
+    if (Stripe.apiKey == null) {
+      throw new AuthenticationException(
+          "No API key provided.",
+          null,
+          null,
+          0);
+    }
+
     this.setRequestParams(params);
     return new PagingIterable<>(this);
   }
@@ -74,6 +91,14 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject
    * @param options request options (will override the options from the initial list request)
    */
   public Iterable<T> autoPagingIterable(Map<String, Object> params, RequestOptions options) {
+    String apiKey = options.getApiKey();
+    if (apiKey == null) {
+      throw new AuthenticationException(
+          "No API key provided.",
+          null,
+          null,
+          0);
+    }
     this.setRequestOptions(options);
     this.setRequestParams(params);
     return new PagingIterable<>(this);

--- a/src/main/java/com/stripe/model/StripeCollection.java
+++ b/src/main/java/com/stripe/model/StripeCollection.java
@@ -58,14 +58,14 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject
   @Setter(onMethod = @__({@Override}))
   private Map<String, Object> requestParams;
 
-  public Iterable<T> autoPagingIterable() {
+  public Iterable<T> autoPagingIterable() throws AuthenticationException {
     if (Stripe.apiKey == null) {
       throw new AuthenticationException("No API key provided.", null, null, 0);
     }
     return new PagingIterable<>(this);
   }
 
-  public Iterable<T> autoPagingIterable(Map<String, Object> params) {
+  public Iterable<T> autoPagingIterable(Map<String, Object> params) throws AuthenticationException {
     if (Stripe.apiKey == null) {
       throw new AuthenticationException("No API key provided.", null, null, 0);
     }
@@ -82,7 +82,8 @@ public abstract class StripeCollection<T extends HasId> extends StripeObject
    * @param params request parameters (will override the parameters from the initial list request)
    * @param options request options (will override the options from the initial list request)
    */
-  public Iterable<T> autoPagingIterable(Map<String, Object> params, RequestOptions options) {
+  public Iterable<T> autoPagingIterable(Map<String, Object> params, RequestOptions options)
+      throws AuthenticationException {
     String apiKey = options.getApiKey();
     if (apiKey == null) {
       throw new AuthenticationException("No API key provided.", null, null, 0);

--- a/src/main/java/com/stripe/model/StripeSearchResult.java
+++ b/src/main/java/com/stripe/model/StripeSearchResult.java
@@ -1,7 +1,7 @@
 package com.stripe.model;
 
 import com.stripe.Stripe;
-import com.stripe.exception.AuthenticationException;
+import com.stripe.exception.ApiKeyMissingException;
 import com.stripe.net.RequestOptions;
 import java.util.List;
 import java.util.Map;
@@ -44,16 +44,16 @@ public abstract class StripeSearchResult<T> extends StripeObject
   @Setter(onMethod = @__({@Override}))
   private Map<String, Object> requestParams;
 
-  public Iterable<T> autoPagingIterable() throws AuthenticationException {
+  public Iterable<T> autoPagingIterable() {
     if (Stripe.apiKey == null) {
-      throw new AuthenticationException("No API key provided.", null, null, 0);
+      throw new ApiKeyMissingException();
     }
     return new SearchPagingIterable<>(this);
   }
 
-  public Iterable<T> autoPagingIterable(Map<String, Object> params) throws AuthenticationException {
+  public Iterable<T> autoPagingIterable(Map<String, Object> params) {
     if (Stripe.apiKey == null) {
-      throw new AuthenticationException("No API key provided.", null, null, 0);
+      throw new ApiKeyMissingException();
     }
     this.setRequestParams(params);
     return new SearchPagingIterable<>(this);
@@ -67,11 +67,10 @@ public abstract class StripeSearchResult<T> extends StripeObject
    * @param params request parameters (will override the parameters from the initial list request)
    * @param options request options (will override the options from the initial list request)
    */
-  public Iterable<T> autoPagingIterable(Map<String, Object> params, RequestOptions options)
-      throws AuthenticationException {
+  public Iterable<T> autoPagingIterable(Map<String, Object> params, RequestOptions options) {
     String apiKey = options.getApiKey();
     if (apiKey == null) {
-      throw new AuthenticationException("No API key provided.", null, null, 0);
+      throw new ApiKeyMissingException();
     }
     this.setRequestOptions(options);
     this.setRequestParams(params);

--- a/src/main/java/com/stripe/model/StripeSearchResult.java
+++ b/src/main/java/com/stripe/model/StripeSearchResult.java
@@ -44,14 +44,14 @@ public abstract class StripeSearchResult<T> extends StripeObject
   @Setter(onMethod = @__({@Override}))
   private Map<String, Object> requestParams;
 
-  public Iterable<T> autoPagingIterable() {
+  public Iterable<T> autoPagingIterable() throws AuthenticationException {
     if (Stripe.apiKey == null) {
       throw new AuthenticationException("No API key provided.", null, null, 0);
     }
     return new SearchPagingIterable<>(this);
   }
 
-  public Iterable<T> autoPagingIterable(Map<String, Object> params) {
+  public Iterable<T> autoPagingIterable(Map<String, Object> params) throws AuthenticationException {
     if (Stripe.apiKey == null) {
       throw new AuthenticationException("No API key provided.", null, null, 0);
     }
@@ -67,7 +67,8 @@ public abstract class StripeSearchResult<T> extends StripeObject
    * @param params request parameters (will override the parameters from the initial list request)
    * @param options request options (will override the options from the initial list request)
    */
-  public Iterable<T> autoPagingIterable(Map<String, Object> params, RequestOptions options) {
+  public Iterable<T> autoPagingIterable(Map<String, Object> params, RequestOptions options)
+      throws AuthenticationException {
     String apiKey = options.getApiKey();
     if (apiKey == null) {
       throw new AuthenticationException("No API key provided.", null, null, 0);

--- a/src/main/java/com/stripe/model/StripeSearchResult.java
+++ b/src/main/java/com/stripe/model/StripeSearchResult.java
@@ -46,22 +46,14 @@ public abstract class StripeSearchResult<T> extends StripeObject
 
   public Iterable<T> autoPagingIterable() {
     if (Stripe.apiKey == null) {
-      throw new AuthenticationException(
-          "No API key provided.",
-          null,
-          null,
-          0);
+      throw new AuthenticationException("No API key provided.", null, null, 0);
     }
     return new SearchPagingIterable<>(this);
   }
 
   public Iterable<T> autoPagingIterable(Map<String, Object> params) {
     if (Stripe.apiKey == null) {
-      throw new AuthenticationException(
-          "No API key provided.",
-          null,
-          null,
-          0);
+      throw new AuthenticationException("No API key provided.", null, null, 0);
     }
     this.setRequestParams(params);
     return new SearchPagingIterable<>(this);
@@ -78,11 +70,7 @@ public abstract class StripeSearchResult<T> extends StripeObject
   public Iterable<T> autoPagingIterable(Map<String, Object> params, RequestOptions options) {
     String apiKey = options.getApiKey();
     if (apiKey == null) {
-      throw new AuthenticationException(
-          "No API key provided.",
-          null,
-          null,
-          0);
+      throw new AuthenticationException("No API key provided.", null, null, 0);
     }
     this.setRequestOptions(options);
     this.setRequestParams(params);

--- a/src/main/java/com/stripe/model/StripeSearchResult.java
+++ b/src/main/java/com/stripe/model/StripeSearchResult.java
@@ -1,5 +1,7 @@
 package com.stripe.model;
 
+import com.stripe.Stripe;
+import com.stripe.exception.AuthenticationException;
 import com.stripe.net.RequestOptions;
 import java.util.List;
 import java.util.Map;
@@ -43,10 +45,24 @@ public abstract class StripeSearchResult<T> extends StripeObject
   private Map<String, Object> requestParams;
 
   public Iterable<T> autoPagingIterable() {
+    if (Stripe.apiKey == null) {
+      throw new AuthenticationException(
+          "No API key provided.",
+          null,
+          null,
+          0);
+    }
     return new SearchPagingIterable<>(this);
   }
 
   public Iterable<T> autoPagingIterable(Map<String, Object> params) {
+    if (Stripe.apiKey == null) {
+      throw new AuthenticationException(
+          "No API key provided.",
+          null,
+          null,
+          0);
+    }
     this.setRequestParams(params);
     return new SearchPagingIterable<>(this);
   }
@@ -60,6 +76,14 @@ public abstract class StripeSearchResult<T> extends StripeObject
    * @param options request options (will override the options from the initial list request)
    */
   public Iterable<T> autoPagingIterable(Map<String, Object> params, RequestOptions options) {
+    String apiKey = options.getApiKey();
+    if (apiKey == null) {
+      throw new AuthenticationException(
+          "No API key provided.",
+          null,
+          null,
+          0);
+    }
     this.setRequestOptions(options);
     this.setRequestParams(params);
     return new SearchPagingIterable<>(this);

--- a/src/main/java/com/stripe/model/StripeSearchResult.java
+++ b/src/main/java/com/stripe/model/StripeSearchResult.java
@@ -47,7 +47,7 @@ public abstract class StripeSearchResult<T> extends StripeObject
   public Iterable<T> autoPagingIterable() {
     if (Stripe.apiKey == null) {
       throw new ApiKeyMissingException(
-          "API key is not set for autoPagingIterable. You can set the API key globally using Stripe.ApiKey, or through RequestOptions in with autoPagingIterable(params, options).");
+          "API key is not set for autoPagingIterable. You can set the API key globally using Stripe.ApiKey, or through RequestOptions with autoPagingIterable(params, options).");
     }
     return new SearchPagingIterable<>(this);
   }
@@ -55,7 +55,7 @@ public abstract class StripeSearchResult<T> extends StripeObject
   public Iterable<T> autoPagingIterable(Map<String, Object> params) {
     if (Stripe.apiKey == null) {
       throw new ApiKeyMissingException(
-          "API key is not set for autoPagingIterable. You can set the API key globally using Stripe.ApiKey, or through RequestOptions in with autoPagingIterable(params, options).");
+          "API key is not set for autoPagingIterable. You can set the API key globally using Stripe.ApiKey, or through RequestOptions with autoPagingIterable(params, options).");
     }
     this.setRequestParams(params);
     return new SearchPagingIterable<>(this);
@@ -73,7 +73,7 @@ public abstract class StripeSearchResult<T> extends StripeObject
     String apiKey = options.getApiKey();
     if (Stripe.apiKey == null && apiKey == null) {
       throw new ApiKeyMissingException(
-          "API key is not set for autoPagingIterable. You can set the API key globally using Stripe.ApiKey, or through RequestOptions in with autoPagingIterable(params, options).");
+          "API key is not set for autoPagingIterable. You can set the API key globally using Stripe.ApiKey, or through RequestOptions with autoPagingIterable(params, options).");
     }
     this.setRequestOptions(options);
     this.setRequestParams(params);

--- a/src/main/java/com/stripe/model/StripeSearchResult.java
+++ b/src/main/java/com/stripe/model/StripeSearchResult.java
@@ -46,14 +46,16 @@ public abstract class StripeSearchResult<T> extends StripeObject
 
   public Iterable<T> autoPagingIterable() {
     if (Stripe.apiKey == null) {
-      throw new ApiKeyMissingException();
+      throw new ApiKeyMissingException(
+          "API key is not set for autoPagingIterable. You can set the API key globally using Stripe.ApiKey, or through RequestOptions in with autoPagingIterable(params, options).");
     }
     return new SearchPagingIterable<>(this);
   }
 
   public Iterable<T> autoPagingIterable(Map<String, Object> params) {
     if (Stripe.apiKey == null) {
-      throw new ApiKeyMissingException();
+      throw new ApiKeyMissingException(
+          "API key is not set for autoPagingIterable. You can set the API key globally using Stripe.ApiKey, or through RequestOptions in with autoPagingIterable(params, options).");
     }
     this.setRequestParams(params);
     return new SearchPagingIterable<>(this);
@@ -69,8 +71,9 @@ public abstract class StripeSearchResult<T> extends StripeObject
    */
   public Iterable<T> autoPagingIterable(Map<String, Object> params, RequestOptions options) {
     String apiKey = options.getApiKey();
-    if (apiKey == null) {
-      throw new ApiKeyMissingException();
+    if (Stripe.apiKey == null && apiKey == null) {
+      throw new ApiKeyMissingException(
+          "API key is not set for autoPagingIterable. You can set the API key globally using Stripe.ApiKey, or through RequestOptions in with autoPagingIterable(params, options).");
     }
     this.setRequestOptions(options);
     this.setRequestParams(params);

--- a/src/test/java/com/stripe/model/PagingIteratorTest.java
+++ b/src/test/java/com/stripe/model/PagingIteratorTest.java
@@ -1,9 +1,12 @@
 package com.stripe.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.stripe.BaseStripeTest;
+import com.stripe.Stripe;
+import com.stripe.exception.ApiKeyMissingException;
 import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
@@ -147,5 +150,22 @@ public class PagingIteratorTest extends BaseStripeTest {
     verifyRequest(ApiResource.RequestMethod.GET, "/v1/pageable_models", page1Params, options);
     verifyRequest(ApiResource.RequestMethod.GET, "/v1/pageable_models", page2Params, options);
     verifyNoMoreInteractions(networkSpy);
+  }
+
+  @Test
+  void testAutoPaginationWithoutApiKey() throws StripeException {
+    // set some arbitrary parameters so that we can verify that they're
+    // used for requests on ALL pages
+    final Map<String, Object> page0Params = new HashMap<>();
+    page0Params.put("foo", "bar");
+
+    final PageableModelCollection collection = PageableModel.list(page0Params, null);
+
+    Stripe.apiKey = null;
+    assertThrows(
+        ApiKeyMissingException.class,
+        () -> {
+          collection.autoPagingIterable();
+        });
   }
 }

--- a/src/test/java/com/stripe/model/SearchPagingIteratorTest.java
+++ b/src/test/java/com/stripe/model/SearchPagingIteratorTest.java
@@ -1,9 +1,12 @@
 package com.stripe.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.stripe.BaseStripeTest;
+import com.stripe.Stripe;
+import com.stripe.exception.ApiKeyMissingException;
 import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
@@ -145,5 +148,23 @@ public class SearchPagingIteratorTest extends BaseStripeTest {
     verifyRequest(ApiResource.RequestMethod.GET, "/v1/searchable_models", page1Params, options);
     verifyRequest(ApiResource.RequestMethod.GET, "/v1/searchable_models", page2Params, options);
     verifyNoMoreInteractions(networkSpy);
+  }
+
+  @Test
+  public void testAutoPaginationWithoutApiKey() throws StripeException {
+
+    final Map<String, Object> page0Params = new HashMap<>();
+    page0Params.put("query", "query 1");
+
+    final SearchableModelCollection collection = SearchableModel.search(page0Params, null);
+
+    final List<SearchableModel> models = new ArrayList<>();
+
+    Stripe.apiKey = null;
+    assertThrows(
+        ApiKeyMissingException.class,
+        () -> {
+          collection.autoPagingIterable();
+        });
   }
 }


### PR DESCRIPTION
r? @dcr-stripe @kamil-stripe 

## Summary
Check that `apiKey` is set (either globally or via request options) in `StripeCollection.autoPagingIterable` and `StripeSearchResult.autoPagingIterable`, and throw an exception if it is not.