### PR TITLE
chore: Update gson version in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Add this dependency to your project's POM:
 You'll need to manually install the following JARs:
 
 - [The Stripe JAR](https://search.maven.org/remote_content?g=com.stripe&a=stripe-java&v=LATEST)
-- [Google Gson][gson] from <https://repo1.maven.org/maven2/com/google/code/gson/gson/2.8.9/gson-2.8.9.jar>.
+- [Google Gson][gson] from <https://repo1.maven.org/maven2/com/google/code/gson/gson/2.9.0/gson-2.9.0.jar>.
 
 ### [ProGuard][proguard]
 


### PR DESCRIPTION
r? @stripe/api-library-reviewers 

## Summary

Updates the gson jar version mentioned in the README to line up with the version in build.gradle: https://github.com/stripe/stripe-java/blob/5b4e2ff6/build.gradle#L85