### PR TITLE
Allow setting Stripe API Version on global configuration.

### DIFF
--- a/src/main/java/com/stripe/Stripe.java
+++ b/src/main/java/com/stripe/Stripe.java
@@ -20,6 +20,15 @@ public abstract class Stripe {
   public static volatile boolean enableTelemetry = true;
   public static volatile String partnerId;
 
+  /**
+   * Stripe API version which is sent by default on requests. This can be updated to include beta
+   * headers.
+   *
+   * <p>Pointing to different API versions than {@code API_VERSION} can lead to deserialziation
+   * errors and should be avoided.
+   */
+  public static volatile String stripeVersion = API_VERSION;
+
   // Note that URLConnection reserves the value of 0 to mean "infinite
   // timeout", so we use -1 here to represent an unset value which should
   // fall back to a default.

--- a/src/main/java/com/stripe/model/EventDataObjectDeserializer.java
+++ b/src/main/java/com/stripe/model/EventDataObjectDeserializer.java
@@ -155,10 +155,7 @@ public class EventDataObjectDeserializer {
                     + "consider transforming the raw JSON data object to be compatible with this "
                     + "current model class schemas using `deserializeUnsafeWith`. "
                     + "Original error message: %s",
-                Stripe.stripeVersion,
-                this.apiVersion,
-                Stripe.stripeVersion,
-                e.getMessage());
+                Stripe.stripeVersion, this.apiVersion, Stripe.stripeVersion, e.getMessage());
       } else {
         errorMessage =
             String.format(

--- a/src/main/java/com/stripe/model/EventDataObjectDeserializer.java
+++ b/src/main/java/com/stripe/model/EventDataObjectDeserializer.java
@@ -183,7 +183,6 @@ public class EventDataObjectDeserializer {
         transformer.transform(rawJsonObject.deepCopy(), apiVersion, eventType));
   }
 
-  @SuppressWarnings("StringSplitter")
   private boolean apiVersionMatch() {
     // Trim the locally configured API version to not include beta headers, since the payload won't
     // have any.

--- a/src/main/java/com/stripe/model/EventDataObjectDeserializer.java
+++ b/src/main/java/com/stripe/model/EventDataObjectDeserializer.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.stripe.Stripe;
 import com.stripe.exception.EventDataObjectDeserializationException;
+import com.stripe.util.StringUtils;
 import java.util.Map;
 import java.util.Optional;
 import lombok.EqualsAndHashCode;
@@ -184,12 +185,10 @@ public class EventDataObjectDeserializer {
 
   @SuppressWarnings("StringSplitter")
   private boolean apiVersionMatch() {
-    // Test that only the actual API version component of the version strings match. The integration
-    // API version might have beta headers that are not present in the event payload.
-    String integrationApiVersionStableComponent = Stripe.stripeVersion.split(";")[0];
-    String payloadApiVersionStableComponent = this.apiVersion.split(";")[0];
-
-    return integrationApiVersionStableComponent.equals(payloadApiVersionStableComponent);
+    // Trim the locally configured API version to not include beta headers, since the payload won't
+    // have any.
+    String localApiVersion = StringUtils.trimApiVersion(Stripe.stripeVersion);
+    return localApiVersion.equals(this.apiVersion);
   }
 
   /**

--- a/src/main/java/com/stripe/model/EventDataObjectDeserializer.java
+++ b/src/main/java/com/stripe/model/EventDataObjectDeserializer.java
@@ -155,9 +155,9 @@ public class EventDataObjectDeserializer {
                     + "consider transforming the raw JSON data object to be compatible with this "
                     + "current model class schemas using `deserializeUnsafeWith`. "
                     + "Original error message: %s",
-                getIntegrationApiVersion(),
+                Stripe.stripeVersion,
                 this.apiVersion,
-                getIntegrationApiVersion(),
+                Stripe.stripeVersion,
                 e.getMessage());
       } else {
         errorMessage =
@@ -185,13 +185,14 @@ public class EventDataObjectDeserializer {
         transformer.transform(rawJsonObject.deepCopy(), apiVersion, eventType));
   }
 
+  @SuppressWarnings("StringSplitter")
   private boolean apiVersionMatch() {
-    return getIntegrationApiVersion().equals(this.apiVersion);
-  }
+    // Test that only the actual API version component of the version strings match. The integration
+    // API version might have beta headers that are not present in the event payload.
+    String integrationApiVersionStableComponent = Stripe.stripeVersion.split(";")[0];
+    String payloadApiVersionStableComponent = this.apiVersion.split(";")[0];
 
-  /** Internal method to allow for testing with different Stripe version. */
-  String getIntegrationApiVersion() {
-    return Stripe.API_VERSION;
+    return integrationApiVersionStableComponent.equals(payloadApiVersionStableComponent);
   }
 
   /**

--- a/src/main/java/com/stripe/net/RequestOptions.java
+++ b/src/main/java/com/stripe/net/RequestOptions.java
@@ -12,8 +12,10 @@ public class RequestOptions {
   private final String clientId;
   private final String idempotencyKey;
   private final String stripeAccount;
-  /** Stripe version always set at {@link Stripe#API_VERSION}. */
-  private final String stripeVersion = Stripe.API_VERSION;
+
+  /** Uses the globally set version by defaeult, unless an override is provided. */
+  private final String stripeVersion = Stripe.stripeVersion;
+
   /**
    * Stripe version override when made on behalf of others. This can be used when the returned
    * response will not be deserialized into the current classes pinned to {@link Stripe#VERSION}.
@@ -333,7 +335,7 @@ public class RequestOptions {
   }
 
   private static String normalizeStripeVersion(String stripeVersion) {
-    // null stripeVersions are considered "valid" and use Stripe.apiVersion
+    // null stripeVersions are considered "valid" and use Stripe.stripeVersion
     if (stripeVersion == null) {
       return null;
     }

--- a/src/main/java/com/stripe/util/StringUtils.java
+++ b/src/main/java/com/stripe/util/StringUtils.java
@@ -47,4 +47,20 @@ public final class StringUtils {
         .replaceAll("([a-z0-9])([A-Z])", "$1_$2")
         .toLowerCase();
   }
+
+  /**
+   * Trims the beta header part of an API Version string. For example, "2022-12-22; orders_beta=v3"
+   * is converted to "2022-12-22".
+   *
+   * @param apiVersion The API Version to trim. For example, "2022-12-22; orders_beta=v3".
+   */
+  public static String trimApiVersion(String apiVersion) {
+    int indexOfSemicolon = apiVersion.indexOf(";");
+
+    if (indexOfSemicolon != -1) {
+      return apiVersion.substring(0, indexOfSemicolon);
+    }
+
+    return apiVersion;
+  }
 }

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -42,6 +42,7 @@ public class BaseStripeTest {
   private String origApiKey;
   private String origClientId;
   private String origUploadBase;
+  private String origStripeVersion;
 
   static {
     // To only stop stripe-mock process after all the test classes.
@@ -111,6 +112,7 @@ public class BaseStripeTest {
     this.origUploadBase = Stripe.getUploadBase();
     this.origApiKey = Stripe.apiKey;
     this.origClientId = Stripe.clientId;
+    this.origStripeVersion = Stripe.stripeVersion;
 
     Stripe.overrideApiBase("http://localhost:" + port);
     Stripe.overrideUploadBase("http://localhost:" + port);
@@ -135,6 +137,7 @@ public class BaseStripeTest {
     Stripe.overrideUploadBase(this.origUploadBase);
     Stripe.apiKey = this.origApiKey;
     Stripe.clientId = this.origClientId;
+    Stripe.stripeVersion = this.origStripeVersion;
   }
 
   /**

--- a/src/test/java/com/stripe/functional/EventTest.java
+++ b/src/test/java/com/stripe/functional/EventTest.java
@@ -2,6 +2,7 @@ package com.stripe.functional;
 
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.google.common.collect.ImmutableMap;
@@ -13,6 +14,8 @@ import com.stripe.model.EventCollection;
 import com.stripe.model.StripeObject;
 import com.stripe.net.ApiResource;
 import com.stripe.param.EventListParams;
+import com.stripe.util.StringUtils;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -55,10 +58,11 @@ public class EventTest extends BaseStripeTest {
   }
 
   @Test
-  public void tesGetDataObjectWithSameApiVersion() throws StripeException {
+  public void testGetDataObjectWithSameApiVersion() throws StripeException {
     final Event event = Event.retrieve(EVENT_ID);
-    // Suppose event has the same API version as the library's pinned version
-    event.setApiVersion(Stripe.API_VERSION);
+    // Suppose event has the same API version as the library's pinned version. Note that beta
+    // payloads don't return beta headeres, so we trim.
+    event.setApiVersion(StringUtils.trimApiVersion(Stripe.API_VERSION));
 
     Optional<StripeObject> stripeObject = event.getDataObjectDeserializer().getObject();
 
@@ -66,7 +70,7 @@ public class EventTest extends BaseStripeTest {
   }
 
   @Test
-  public void tesGetDataObjectWithDifferentApiVersion() throws StripeException {
+  public void testGetDataObjectWithDifferentApiVersion() throws StripeException {
     final Event event = Event.retrieve(EVENT_ID);
     // Suppose event has different API version from the library's pinned version
     event.setApiVersion("2017-05-25");

--- a/src/test/java/com/stripe/functional/EventTest.java
+++ b/src/test/java/com/stripe/functional/EventTest.java
@@ -2,7 +2,6 @@ package com.stripe.functional;
 
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.google.common.collect.ImmutableMap;
@@ -15,7 +14,6 @@ import com.stripe.model.StripeObject;
 import com.stripe.net.ApiResource;
 import com.stripe.param.EventListParams;
 import com.stripe.util.StringUtils;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;

--- a/src/test/java/com/stripe/net/RequestOptionsTest.java
+++ b/src/test/java/com/stripe/net/RequestOptionsTest.java
@@ -3,16 +3,19 @@ package com.stripe.net;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import com.stripe.BaseStripeTest;
 import com.stripe.Stripe;
 import java.net.InetSocketAddress;
 import java.net.PasswordAuthentication;
 import java.net.Proxy;
 import org.junit.jupiter.api.Test;
 
-public class RequestOptionsTest {
+public class RequestOptionsTest extends BaseStripeTest {
 
   @Test
   public void testPersistentValuesInToBuilder() {
+    Stripe.clientId = "other value";
+
     RequestOptions opts =
         RequestOptions.builder()
             .setApiKey("sk_foo")
@@ -34,13 +37,31 @@ public class RequestOptionsTest {
     assertEquals("sk_foo", optsRebuilt.getApiKey());
     assertEquals("acct_bar", optsRebuilt.getStripeAccount());
 
-    assertNull(optsRebuilt.getClientId());
     assertNull(optsRebuilt.getIdempotencyKey());
     assertNull(optsRebuilt.getStripeVersionOverride());
+    assertEquals("other value", optsRebuilt.getClientId());
     assertEquals(Stripe.DEFAULT_CONNECT_TIMEOUT, optsRebuilt.getConnectTimeout());
     assertEquals(Stripe.DEFAULT_READ_TIMEOUT, optsRebuilt.getReadTimeout());
     assertEquals(Stripe.getConnectionProxy(), optsRebuilt.getConnectionProxy());
     assertEquals(Stripe.getProxyCredential(), optsRebuilt.getProxyCredential());
+  }
+
+  @Test
+  public void testUsesGlobalStripeVersionWithDefault() {
+    String originalVersion = Stripe.stripeVersion;
+    assertEquals(originalVersion, RequestOptions.getDefault().getStripeVersion());
+
+    Stripe.stripeVersion = "2022-08-19";
+    assertEquals("2022-08-19", RequestOptions.getDefault().getStripeVersion());
+  }
+
+  @Test
+  public void testUsesGlobalStripeVersionWithBuilder() {
+    String originalVersion = Stripe.stripeVersion;
+    assertEquals(originalVersion, RequestOptions.builder().build().getStripeVersion());
+
+    Stripe.stripeVersion = "2022-08-19";
+    assertEquals("2022-08-19", RequestOptions.builder().build().getStripeVersion());
   }
 
   @Test

--- a/src/test/java/com/stripe/net/StripeRequestTest.java
+++ b/src/test/java/com/stripe/net/StripeRequestTest.java
@@ -121,6 +121,20 @@ public class StripeRequestTest extends BaseStripeTest {
   }
 
   @Test
+  public void testUsesGlobalStripeVersion() throws StripeException {
+
+    String originalVersion = Stripe.stripeVersion;
+    StripeRequest request =
+        new StripeRequest(ApiResource.RequestMethod.GET, "http://example.com/get", null, null);
+    assertEquals(originalVersion, request.headers().firstValue("Stripe-Version").get());
+
+    Stripe.stripeVersion = "2022-08-19";
+    request =
+        new StripeRequest(ApiResource.RequestMethod.GET, "http://example.com/get", null, null);
+    assertEquals("2022-08-19", request.headers().firstValue("Stripe-Version").get());
+  }
+
+  @Test
   public void testCtorThrowsOnNullApiKey() throws StripeException {
     String origApiKey = Stripe.apiKey;
 

--- a/src/test/java/com/stripe/util/StringUtilsTest.java
+++ b/src/test/java/com/stripe/util/StringUtilsTest.java
@@ -107,4 +107,15 @@ public class StringUtilsTest {
       assertEquals(testCase.getWant(), StringUtils.toSnakeCase(testCase.getData()));
     }
   }
+
+  @Test
+  public void testTrimApiVersionNoBeta() {
+    assertEquals("2022-08-19", StringUtils.trimApiVersion("2022-08-19"));
+  }
+
+  @Test
+  public void testTrimApiVersionWithBetaHeaders() {
+    assertEquals(
+        "2022-08-19", StringUtils.trimApiVersion("2022-08-19; some_beta=v2; some_other_beta=v1"));
+  }
 }


### PR DESCRIPTION
r? @pakrym-stripe 

## Summary

Allows configuring `Stripe.stripeVersion` on a global-basis to specify beta headers.

For per-requests, `setStripeVersionOverride` can be used.

This also tweaks webhook version checking to ignore beta headers.

## Note 

I tried to stick to the nomenclature used within stripe-java + pre-existing methods rather than making breaking changes to name this apiVersion across the board. WDYT?