### PR TITLE
Update coveralls to only run for one java version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,7 @@ jobs:
 
       - name: Send code coverage report to coveralls.io
         run: ./gradlew jacocoTestReport coveralls
+        if: matrix.java-version == '18'
         env:
           CI_NAME: github-actions
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}


### PR DESCRIPTION
### Summary
r? @dcr-stripe 

Update coveralls CI step to run for one Java version like in other client libraries.

See related discussion thread: https://github.com/stripe/stripe-php/pull/1360#discussion_r955290668