### PR TITLE
Update README badge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: update-version codegen-format
 update-version:
 	@echo "$(VERSION)" > VERSION
+	@perl -pi -e 's|badge/maven--central-v[.\d\-\w]+-blue|badge/maven--central-v$(VERSION)-blue|' README.md
 	@perl -pi -e 's|https:\/\/search\.maven\.org\/remotecontent\?filepath=com\/stripe\/stripe-java\/[.\d\-\w]+\/stripe-java-[.\d\-\w]+.jar|https://search.maven.org/remotecontent?filepath=com/stripe/stripe-java/$(VERSION)/stripe-java-$(VERSION).jar|' README.md
 	@perl -pi -e 's|implementation "com\.stripe:stripe-java:[.\d\-\w]+"|implementation "com.stripe:stripe-java:$(VERSION)"|' README.md
 	@perl -pi -e 's|<version>[.\d\-\w]+<\/version>|<version>$(VERSION)</version>|' README.md

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stripe Java client library
 
-[![Maven Central](https://img.shields.io/maven-central/v/com.stripe/stripe-java)](https://mvnrepository.com/artifact/com.stripe/stripe-java)
+[![Maven Central](https://img.shields.io/badge/maven--central-v21.4.0-blue)](https://mvnrepository.com/artifact/com.stripe/stripe-java)
 [![JavaDoc](http://img.shields.io/badge/javadoc-reference-blue.svg)](https://stripe.dev/stripe-java)
 [![Build Status](https://github.com/stripe/stripe-java/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/stripe/stripe-java/actions?query=branch%3Amaster)
 [![Coverage Status](https://coveralls.io/repos/github/stripe/stripe-java/badge.svg?branch=master)](https://coveralls.io/github/stripe/stripe-java?branch=master)
@@ -253,7 +253,7 @@ We highly recommend keeping an eye on when the beta feature you are interested i
 If your beta feature requires a `Stripe-Version` header to be sent, use the `Stripe.stripeVersion` field to set it:
 
 > **Note**
-> The `stripeVersion` can only be set in beta versions of the library. 
+> The `stripeVersion` can only be set in beta versions of the library.
 
 ```java
 Stripe.stripeVersion += "; feature_beta=v3";

--- a/src/test/java/com/stripe/DocumentationTest.java
+++ b/src/test/java/com/stripe/DocumentationTest.java
@@ -90,7 +90,7 @@ public class DocumentationTest {
     try (final BufferedReader reader =
         new BufferedReader(
             new InputStreamReader(new FileInputStream(readmeFile), StandardCharsets.UTF_8))) {
-      final int expectedMentionsOfVersion = 3;
+      final int expectedMentionsOfVersion = 4;
       // Currently three places mention the Stripe version: the latest Maven JAR hyperlink, the
       // sample pom, and gradle files.
       final List<String> mentioningLines = new ArrayList<String>();


### PR DESCRIPTION
### Summary
Update Maven Central badge to a static display that gets updated via the `make update-version` command.

### Motivation
This change is to prevent the badge from displaying a beta version of Stripe Java from Maven.

### Testing
Validated that `make update-version VERSION=21.4.1` edits and displays the next version correctly in the README.

Before:
<img width="696" alt="Screen Shot 2022-08-29 at 3 05 35 PM" src="https://user-images.githubusercontent.com/97691964/187307276-e9902bd3-ff06-4562-85a3-4aab9f8d931f.png">

After:
<img width="696" alt="Screen Shot 2022-08-29 at 3 05 29 PM" src="https://user-images.githubusercontent.com/97691964/187307267-73424391-0a48-4a25-a30c-a2440dd51d63.png">
