### PR TITLE
Do not run Coveralls if secret token is not available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Send code coverage report to coveralls.io
         run: ./gradlew jacocoTestReport coveralls
-        if: matrix.java-version == '17'
+        if: env.COVERALLS_REPO_TOKEN && matrix.java-version == '17'
         env:
           CI_NAME: github-actions
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}


### PR DESCRIPTION
## Summary
Do not run Coveralls step if the secret token does not exist (for pushes triggered by outside collaborators).

## Motivation
https://github.com/stripe/stripe-php/pull/1379- make this change consistent across all languages