### PR TITLE
Ephemeral key accepts Stripe-Version through params, not opts (next major)

### DIFF
--- a/src/main/java/com/stripe/model/EphemeralKey.java
+++ b/src/main/java/com/stripe/model/EphemeralKey.java
@@ -4,6 +4,7 @@ import com.google.gson.annotations.SerializedName;
 import com.stripe.exception.StripeException;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
+import com.stripe.net.RequestOptions.RequestOptionsBuilder;
 import com.stripe.param.EphemeralKeyCreateParams;
 import java.util.HashMap;
 import java.util.List;
@@ -123,7 +124,9 @@ public class EphemeralKey extends ApiResource implements HasId {
     // Take "stripe-version" from params and plug it into RequestOptions
     // so it will be sent in the Stripe-Version header
     final RequestOptions overriddenOptions =
-        options.toBuilderFullCopy()._setStripeVersionOverride(versionOverride).build();
+        RequestOptionsBuilder.unsafeSetStripeVersionOverride(
+                options.toBuilderFullCopy(), versionOverride)
+            .build();
 
     // Remove "stripe-version" from params so that it is not sent in the
     // request body.

--- a/src/main/java/com/stripe/net/RequestOptions.java
+++ b/src/main/java/com/stripe/net/RequestOptions.java
@@ -291,7 +291,7 @@ public class RequestOptions {
     }
 
     /** For internal use only. */
-    public String _getStripeVersionOverride() {
+   String getStripeVersionOverride() {
       return this.stripeVersionOverride;
     }
 

--- a/src/main/java/com/stripe/net/RequestOptions.java
+++ b/src/main/java/com/stripe/net/RequestOptions.java
@@ -84,8 +84,8 @@ public class RequestOptions {
     return stripeVersion;
   }
 
-  public String getStripeVersionOverride() {
-    return stripeVersionOverride;
+  public static String unsafeGetStripeVersionOverride(RequestOptions options) {
+    return options.stripeVersionOverride;
   }
 
   public int getReadTimeout() {
@@ -130,17 +130,18 @@ public class RequestOptions {
    * @return option builder.
    */
   public RequestOptionsBuilder toBuilderFullCopy() {
-    return new RequestOptionsBuilder()
-        .setApiKey(this.apiKey)
-        .setClientId(this.clientId)
-        .setIdempotencyKey(this.idempotencyKey)
-        .setStripeAccount(this.stripeAccount)
-        ._setStripeVersionOverride(this.stripeVersionOverride)
-        .setConnectTimeout(this.connectTimeout)
-        .setReadTimeout(this.readTimeout)
-        .setMaxNetworkRetries(this.maxNetworkRetries)
-        .setConnectionProxy(this.connectionProxy)
-        .setProxyCredential(this.proxyCredential);
+    return RequestOptionsBuilder.unsafeSetStripeVersionOverride(
+        new RequestOptionsBuilder()
+            .setApiKey(this.apiKey)
+            .setClientId(this.clientId)
+            .setIdempotencyKey(this.idempotencyKey)
+            .setStripeAccount(this.stripeAccount)
+            .setConnectTimeout(this.connectTimeout)
+            .setReadTimeout(this.readTimeout)
+            .setMaxNetworkRetries(this.maxNetworkRetries)
+            .setConnectionProxy(this.connectionProxy)
+            .setProxyCredential(this.proxyCredential),
+        stripeVersionOverride);
   }
 
   public static final class RequestOptionsBuilder {
@@ -300,11 +301,14 @@ public class RequestOptions {
      * request and this library's types, which can result in missing data and deserialization
      * errors.
      *
+     * <p>Static, so that it doesn't appear in IDE auto-completion alongside the other setters.
+     *
      * @return option builder
      */
-    public RequestOptionsBuilder _setStripeVersionOverride(String stripeVersionOverride) {
-      this.stripeVersionOverride = normalizeStripeVersion(stripeVersionOverride);
-      return this;
+    public static RequestOptionsBuilder unsafeSetStripeVersionOverride(
+        RequestOptionsBuilder builder, String stripeVersionOverride) {
+      builder.stripeVersionOverride = normalizeStripeVersion(stripeVersionOverride);
+      return builder;
     }
 
     /** Constructs a {@link RequestOptions} with the specified values. */

--- a/src/main/java/com/stripe/net/RequestOptions.java
+++ b/src/main/java/com/stripe/net/RequestOptions.java
@@ -115,10 +115,32 @@ public class RequestOptions {
   /**
    * Convert request options to builder, retaining invariant values for the integration.
    *
+   * @deprecated prefer {@link toBuilderFullCopy} which fully copies the request options instead of
+   *     a subset of its options.
    * @return option builder.
    */
+  @Deprecated
   public RequestOptionsBuilder toBuilder() {
     return new RequestOptionsBuilder().setApiKey(this.apiKey).setStripeAccount(this.stripeAccount);
+  }
+
+  /**
+   * Convert request options to builder, copying all options.
+   *
+   * @return option builder.
+   */
+  public RequestOptionsBuilder toBuilderFullCopy() {
+    return new RequestOptionsBuilder()
+        .setApiKey(this.apiKey)
+        .setClientId(this.clientId)
+        .setIdempotencyKey(this.idempotencyKey)
+        .setStripeAccount(this.stripeAccount)
+        ._setStripeVersionOverride(this.stripeVersionOverride)
+        .setConnectTimeout(this.connectTimeout)
+        .setReadTimeout(this.readTimeout)
+        .setMaxNetworkRetries(this.maxNetworkRetries)
+        .setConnectionProxy(this.connectionProxy)
+        .setProxyCredential(this.proxyCredential);
   }
 
   public static final class RequestOptionsBuilder {
@@ -267,29 +289,22 @@ public class RequestOptions {
       return setStripeAccount(null);
     }
 
-    public String getStripeVersionOverride() {
+    /** For internal use only. */
+    public String _getStripeVersionOverride() {
       return this.stripeVersionOverride;
     }
 
     /**
-     * Do not use this except for in API where JSON response is not fully deserialized into explicit
-     * Stripe classes, but only passed to other clients as raw data -- essentially making request on
-     * behalf of others with their API version. One example is in {@link
-     * com.stripe.model.EphemeralKey#create(Map, RequestOptions)}. Setting this value in a typical
-     * scenario will result in deserialization error as the model classes have schema according to
-     * the pinned {@link Stripe#API_VERSION} and not the {@code stripeVersionOverride}
+     * This is for internal use only. See {@link com.stripe.model.EphemeralKey#create(Map,
+     * RequestOptions)}. Setting this yourself will result in a version mismatch between your
+     * request and this library's types, which can result in missing data and deserialization
+     * errors.
      *
-     * @param stripeVersionOverride stripe version override which belongs to the client to make
-     *     request on behalf of.
      * @return option builder
      */
-    public RequestOptionsBuilder setStripeVersionOverride(String stripeVersionOverride) {
+    public RequestOptionsBuilder _setStripeVersionOverride(String stripeVersionOverride) {
       this.stripeVersionOverride = normalizeStripeVersion(stripeVersionOverride);
       return this;
-    }
-
-    public RequestOptionsBuilder clearStripeVersionOverride() {
-      return setStripeVersionOverride(null);
     }
 
     /** Constructs a {@link RequestOptions} with the specified values. */

--- a/src/main/java/com/stripe/net/RequestOptions.java
+++ b/src/main/java/com/stripe/net/RequestOptions.java
@@ -291,7 +291,7 @@ public class RequestOptions {
     }
 
     /** For internal use only. */
-   String getStripeVersionOverride() {
+    String getStripeVersionOverride() {
       return this.stripeVersionOverride;
     }
 

--- a/src/main/java/com/stripe/net/StripeRequest.java
+++ b/src/main/java/com/stripe/net/StripeRequest.java
@@ -180,8 +180,9 @@ public class StripeRequest {
     headerMap.put("Authorization", Arrays.asList(String.format("Bearer %s", apiKey)));
 
     // Stripe-Version
-    if (options.getStripeVersionOverride() != null) {
-      headerMap.put("Stripe-Version", Arrays.asList(options.getStripeVersionOverride()));
+    if (RequestOptions.unsafeGetStripeVersionOverride(options) != null) {
+      headerMap.put(
+          "Stripe-Version", Arrays.asList(RequestOptions.unsafeGetStripeVersionOverride(options)));
     } else if (options.getStripeVersion() != null) {
       headerMap.put("Stripe-Version", Arrays.asList(options.getStripeVersion()));
     } else {

--- a/src/main/java/com/stripe/param/EphemeralKeyCreateParams.java
+++ b/src/main/java/com/stripe/param/EphemeralKeyCreateParams.java
@@ -29,12 +29,20 @@ public class EphemeralKeyCreateParams extends ApiRequestParams {
   @SerializedName("issuing_card")
   String issuingCard;
 
+  @SerializedName("stripe-version")
+  String stripeVersion;
+
   private EphemeralKeyCreateParams(
-      String customer, List<String> expand, Map<String, Object> extraParams, String issuingCard) {
+      String customer,
+      List<String> expand,
+      Map<String, Object> extraParams,
+      String issuingCard,
+      String stripeVersion) {
     this.customer = customer;
     this.expand = expand;
     this.extraParams = extraParams;
     this.issuingCard = issuingCard;
+    this.stripeVersion = stripeVersion;
   }
 
   public static Builder builder() {
@@ -50,10 +58,12 @@ public class EphemeralKeyCreateParams extends ApiRequestParams {
 
     private String issuingCard;
 
+    private String stripeVersion;
+
     /** Finalize and obtain parameter instance from this builder. */
     public EphemeralKeyCreateParams build() {
       return new EphemeralKeyCreateParams(
-          this.customer, this.expand, this.extraParams, this.issuingCard);
+          this.customer, this.expand, this.extraParams, this.issuingCard, this.stripeVersion);
     }
 
     /** The ID of the Customer you'd like to modify using the resulting ephemeral key. */
@@ -117,6 +127,12 @@ public class EphemeralKeyCreateParams extends ApiRequestParams {
     /** The ID of the Issuing Card you'd like to access using the resulting ephemeral key. */
     public Builder setIssuingCard(String issuingCard) {
       this.issuingCard = issuingCard;
+      return this;
+    }
+
+    /** The ID of the Issuing Card you'd like to access using the resulting ephemeral key. */
+    public Builder setStripeVersion(String stripeVersion) {
+      this.stripeVersion = stripeVersion;
       return this;
     }
   }

--- a/src/test/java/com/stripe/functional/EphemeralKeyTest.java
+++ b/src/test/java/com/stripe/functional/EphemeralKeyTest.java
@@ -10,6 +10,7 @@ import com.stripe.exception.StripeException;
 import com.stripe.model.EphemeralKey;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
+import com.stripe.net.RequestOptions.RequestOptionsBuilder;
 import com.stripe.param.EphemeralKeyCreateParams;
 import java.io.IOException;
 import java.util.HashMap;
@@ -34,7 +35,8 @@ public class EphemeralKeyTest extends BaseStripeTest {
         ApiResource.RequestMethod.POST,
         "/v1/ephemeral_keys",
         expectedParams,
-        RequestOptions.builder().unsafeStripeVersionOverride("foobar").build());
+        RequestOptionsBuilder.unsafeSetStripeVersionOverride(RequestOptions.builder(), "foobar")
+            .build());
   }
 
   @Test
@@ -55,7 +57,8 @@ public class EphemeralKeyTest extends BaseStripeTest {
         ApiResource.RequestMethod.POST,
         "/v1/ephemeral_keys",
         expectedParams,
-        RequestOptions.builder().unsafeStripeVersionOverride("foobar").build());
+        RequestOptionsBuilder.unsafeSetStripeVersionOverride(RequestOptions.builder(), "foobar")
+            .build());
   }
 
   @Test

--- a/src/test/java/com/stripe/functional/EphemeralKeyTest.java
+++ b/src/test/java/com/stripe/functional/EphemeralKeyTest.java
@@ -34,7 +34,7 @@ public class EphemeralKeyTest extends BaseStripeTest {
         ApiResource.RequestMethod.POST,
         "/v1/ephemeral_keys",
         expectedParams,
-        RequestOptions.builder()._setStripeVersionOverride("foobar").build());
+        RequestOptions.builder().unsafeStripeVersionOverride("foobar").build());
   }
 
   @Test
@@ -55,7 +55,7 @@ public class EphemeralKeyTest extends BaseStripeTest {
         ApiResource.RequestMethod.POST,
         "/v1/ephemeral_keys",
         expectedParams,
-        RequestOptions.builder()._setStripeVersionOverride("foobar").build());
+        RequestOptions.builder().unsafeStripeVersionOverride("foobar").build());
   }
 
   @Test

--- a/src/test/java/com/stripe/functional/RequestOptionsTest.java
+++ b/src/test/java/com/stripe/functional/RequestOptionsTest.java
@@ -17,7 +17,7 @@ public class RequestOptionsTest extends BaseStripeTest {
   public void testApiVersion() throws StripeException {
     final RequestOptions options = RequestOptions.builder().build();
     assertEquals(Stripe.API_VERSION, options.getStripeVersion());
-    assertNull(options.getStripeVersionOverride());
+    assertNull(RequestOptions.unsafeGetStripeVersionOverride(options));
 
     final Balance balance = Balance.retrieve(options);
     final StripeResponse response = balance.getLastResponse();

--- a/src/test/java/com/stripe/net/RequestOptionsTest.java
+++ b/src/test/java/com/stripe/net/RequestOptionsTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.stripe.Stripe;
+import com.stripe.net.RequestOptions.RequestOptionsBuilder;
 import java.net.InetSocketAddress;
 import java.net.PasswordAuthentication;
 import java.net.Proxy;
@@ -14,17 +15,19 @@ public class RequestOptionsTest {
   @Test
   public void testPersistentValuesInToBuilder() {
     RequestOptions opts =
-        RequestOptions.builder()
-            .setApiKey("sk_foo")
-            .setClientId("123")
-            .setIdempotencyKey("123")
-            .setStripeAccount("acct_bar")
-            .unsafeStripeVersionOverride("2015-05-05")
-            .setConnectTimeout(100)
-            .setReadTimeout(100)
-            .setConnectionProxy(
-                new Proxy(Proxy.Type.HTTP, new InetSocketAddress("localhost", 1234)))
-            .setProxyCredential(new PasswordAuthentication("username", "password".toCharArray()))
+        RequestOptionsBuilder.unsafeSetStripeVersionOverride(
+                RequestOptions.builder()
+                    .setApiKey("sk_foo")
+                    .setClientId("123")
+                    .setIdempotencyKey("123")
+                    .setStripeAccount("acct_bar")
+                    .setConnectTimeout(100)
+                    .setReadTimeout(100)
+                    .setConnectionProxy(
+                        new Proxy(Proxy.Type.HTTP, new InetSocketAddress("localhost", 1234)))
+                    .setProxyCredential(
+                        new PasswordAuthentication("username", "password".toCharArray())),
+                "2015-05-05")
             .build();
 
     @SuppressWarnings("deprecation")
@@ -37,7 +40,7 @@ public class RequestOptionsTest {
 
     assertNull(optsRebuilt.getClientId());
     assertNull(optsRebuilt.getIdempotencyKey());
-    assertNull(optsRebuilt.getStripeVersionOverride());
+    assertNull(RequestOptions.unsafeGetStripeVersionOverride(optsRebuilt));
     assertEquals(Stripe.DEFAULT_CONNECT_TIMEOUT, optsRebuilt.getConnectTimeout());
     assertEquals(Stripe.DEFAULT_READ_TIMEOUT, optsRebuilt.getReadTimeout());
     assertEquals(Stripe.getConnectionProxy(), optsRebuilt.getConnectionProxy());
@@ -47,17 +50,19 @@ public class RequestOptionsTest {
   @Test
   public void testToBuilderFullCopy() {
     RequestOptions opts =
-        RequestOptions.builder()
-            .setApiKey("sk_foo")
-            .setClientId("123")
-            .setIdempotencyKey("123")
-            .setStripeAccount("acct_bar")
-            .unsafeStripeVersionOverride("2015-05-05")
-            .setConnectTimeout(100)
-            .setReadTimeout(100)
-            .setConnectionProxy(
-                new Proxy(Proxy.Type.HTTP, new InetSocketAddress("localhost", 1234)))
-            .setProxyCredential(new PasswordAuthentication("username", "password".toCharArray()))
+        RequestOptionsBuilder.unsafeSetStripeVersionOverride(
+                RequestOptions.builder()
+                    .setApiKey("sk_foo")
+                    .setClientId("123")
+                    .setIdempotencyKey("123")
+                    .setStripeAccount("acct_bar")
+                    .setConnectTimeout(100)
+                    .setReadTimeout(100)
+                    .setConnectionProxy(
+                        new Proxy(Proxy.Type.HTTP, new InetSocketAddress("localhost", 1234)))
+                    .setProxyCredential(
+                        new PasswordAuthentication("username", "password".toCharArray())),
+                "2015-05-05")
             .build();
 
     RequestOptions optsRebuilt = opts.toBuilderFullCopy().build();
@@ -70,7 +75,8 @@ public class RequestOptionsTest {
     String stripeVersionOverride = "2015-05-05";
 
     RequestOptions.RequestOptionsBuilder builder =
-        RequestOptions.builder().unsafeStripeVersionOverride(stripeVersionOverride);
+        RequestOptionsBuilder.unsafeSetStripeVersionOverride(
+            RequestOptions.builder(), stripeVersionOverride);
 
     assertEquals(stripeVersionOverride, builder._getStripeVersionOverride());
   }
@@ -82,29 +88,31 @@ public class RequestOptionsTest {
         new PasswordAuthentication("username", "password".toCharArray());
 
     RequestOptions opts1 =
-        RequestOptions.builder()
-            .setApiKey("sk_foo")
-            .setClientId("123")
-            .setIdempotencyKey("123")
-            .setStripeAccount("acct_bar")
-            .unsafeStripeVersionOverride("2015-05-05")
-            .setConnectTimeout(100)
-            .setReadTimeout(200)
-            .setConnectionProxy(connectionProxy)
-            .setProxyCredential(proxyCredential)
+        RequestOptionsBuilder.unsafeSetStripeVersionOverride(
+                RequestOptions.builder()
+                    .setApiKey("sk_foo")
+                    .setClientId("123")
+                    .setIdempotencyKey("123")
+                    .setStripeAccount("acct_bar")
+                    .setConnectTimeout(100)
+                    .setReadTimeout(200)
+                    .setConnectionProxy(connectionProxy)
+                    .setProxyCredential(proxyCredential),
+                "2015-05-05")
             .build();
 
     RequestOptions opts2 =
-        RequestOptions.builder()
-            .setApiKey("sk_foo")
-            .setClientId("123")
-            .setIdempotencyKey("123")
-            .setStripeAccount("acct_bar")
-            .unsafeStripeVersionOverride("2015-05-05")
-            .setConnectTimeout(100)
-            .setReadTimeout(200)
-            .setConnectionProxy(connectionProxy)
-            .setProxyCredential(proxyCredential)
+        RequestOptionsBuilder.unsafeSetStripeVersionOverride(
+                RequestOptions.builder()
+                    .setApiKey("sk_foo")
+                    .setClientId("123")
+                    .setIdempotencyKey("123")
+                    .setStripeAccount("acct_bar")
+                    .setConnectTimeout(100)
+                    .setReadTimeout(200)
+                    .setConnectionProxy(connectionProxy)
+                    .setProxyCredential(proxyCredential),
+                "2015-05-05")
             .build();
 
     assertEquals(opts1, opts2);

--- a/src/test/java/com/stripe/net/RequestOptionsTest.java
+++ b/src/test/java/com/stripe/net/RequestOptionsTest.java
@@ -19,7 +19,7 @@ public class RequestOptionsTest {
             .setClientId("123")
             .setIdempotencyKey("123")
             .setStripeAccount("acct_bar")
-            .setStripeVersionOverride("2015-05-05")
+            ._setStripeVersionOverride("2015-05-05")
             .setConnectTimeout(100)
             .setReadTimeout(100)
             .setConnectionProxy(
@@ -27,6 +27,7 @@ public class RequestOptionsTest {
             .setProxyCredential(new PasswordAuthentication("username", "password".toCharArray()))
             .build();
 
+    @SuppressWarnings("deprecation")
     RequestOptions optsRebuilt = opts.toBuilder().build();
 
     // only api keys and account should persist
@@ -44,16 +45,34 @@ public class RequestOptionsTest {
   }
 
   @Test
+  public void testToBuilderFullCopy() {
+    RequestOptions opts =
+        RequestOptions.builder()
+            .setApiKey("sk_foo")
+            .setClientId("123")
+            .setIdempotencyKey("123")
+            .setStripeAccount("acct_bar")
+            ._setStripeVersionOverride("2015-05-05")
+            .setConnectTimeout(100)
+            .setReadTimeout(100)
+            .setConnectionProxy(
+                new Proxy(Proxy.Type.HTTP, new InetSocketAddress("localhost", 1234)))
+            .setProxyCredential(new PasswordAuthentication("username", "password".toCharArray()))
+            .build();
+
+    RequestOptions optsRebuilt = opts.toBuilderFullCopy().build();
+
+    assertEquals(opts, optsRebuilt);
+  }
+
+  @Test
   public void testStripeVersionOverride() {
     String stripeVersionOverride = "2015-05-05";
 
     RequestOptions.RequestOptionsBuilder builder =
-        RequestOptions.builder().setStripeVersionOverride(stripeVersionOverride);
+        RequestOptions.builder()._setStripeVersionOverride(stripeVersionOverride);
 
-    assertEquals(stripeVersionOverride, builder.getStripeVersionOverride());
-
-    builder.clearStripeVersionOverride();
-    assertNull(builder.getStripeVersionOverride());
+    assertEquals(stripeVersionOverride, builder._getStripeVersionOverride());
   }
 
   @Test
@@ -68,7 +87,7 @@ public class RequestOptionsTest {
             .setClientId("123")
             .setIdempotencyKey("123")
             .setStripeAccount("acct_bar")
-            .setStripeVersionOverride("2015-05-05")
+            ._setStripeVersionOverride("2015-05-05")
             .setConnectTimeout(100)
             .setReadTimeout(200)
             .setConnectionProxy(connectionProxy)
@@ -81,7 +100,7 @@ public class RequestOptionsTest {
             .setClientId("123")
             .setIdempotencyKey("123")
             .setStripeAccount("acct_bar")
-            .setStripeVersionOverride("2015-05-05")
+            ._setStripeVersionOverride("2015-05-05")
             .setConnectTimeout(100)
             .setReadTimeout(200)
             .setConnectionProxy(connectionProxy)

--- a/src/test/java/com/stripe/net/RequestOptionsTest.java
+++ b/src/test/java/com/stripe/net/RequestOptionsTest.java
@@ -19,7 +19,7 @@ public class RequestOptionsTest {
             .setClientId("123")
             .setIdempotencyKey("123")
             .setStripeAccount("acct_bar")
-            ._setStripeVersionOverride("2015-05-05")
+            .unsafeStripeVersionOverride("2015-05-05")
             .setConnectTimeout(100)
             .setReadTimeout(100)
             .setConnectionProxy(
@@ -52,7 +52,7 @@ public class RequestOptionsTest {
             .setClientId("123")
             .setIdempotencyKey("123")
             .setStripeAccount("acct_bar")
-            ._setStripeVersionOverride("2015-05-05")
+            .unsafeStripeVersionOverride("2015-05-05")
             .setConnectTimeout(100)
             .setReadTimeout(100)
             .setConnectionProxy(
@@ -70,7 +70,7 @@ public class RequestOptionsTest {
     String stripeVersionOverride = "2015-05-05";
 
     RequestOptions.RequestOptionsBuilder builder =
-        RequestOptions.builder()._setStripeVersionOverride(stripeVersionOverride);
+        RequestOptions.builder().unsafeStripeVersionOverride(stripeVersionOverride);
 
     assertEquals(stripeVersionOverride, builder._getStripeVersionOverride());
   }
@@ -87,7 +87,7 @@ public class RequestOptionsTest {
             .setClientId("123")
             .setIdempotencyKey("123")
             .setStripeAccount("acct_bar")
-            ._setStripeVersionOverride("2015-05-05")
+            .unsafeStripeVersionOverride("2015-05-05")
             .setConnectTimeout(100)
             .setReadTimeout(200)
             .setConnectionProxy(connectionProxy)
@@ -100,7 +100,7 @@ public class RequestOptionsTest {
             .setClientId("123")
             .setIdempotencyKey("123")
             .setStripeAccount("acct_bar")
-            ._setStripeVersionOverride("2015-05-05")
+            .unsafeStripeVersionOverride("2015-05-05")
             .setConnectTimeout(100)
             .setReadTimeout(200)
             .setConnectionProxy(connectionProxy)

--- a/src/test/java/com/stripe/net/StripeRequestTest.java
+++ b/src/test/java/com/stripe/net/StripeRequestTest.java
@@ -103,7 +103,7 @@ public class StripeRequestTest extends BaseStripeTest {
             .setApiKey("sk_override")
             .setIdempotencyKey("idempotency_key")
             .setStripeAccount("acct_456")
-            ._setStripeVersionOverride("2012-12-21")
+            .unsafeStripeVersionOverride("2012-12-21")
             .build();
     StripeRequest request =
         new StripeRequest(ApiResource.RequestMethod.GET, "http://example.com/get", null, options);

--- a/src/test/java/com/stripe/net/StripeRequestTest.java
+++ b/src/test/java/com/stripe/net/StripeRequestTest.java
@@ -12,6 +12,7 @@ import com.stripe.BaseStripeTest;
 import com.stripe.Stripe;
 import com.stripe.exception.AuthenticationException;
 import com.stripe.exception.StripeException;
+import com.stripe.net.RequestOptions.RequestOptionsBuilder;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 
@@ -99,11 +100,12 @@ public class StripeRequestTest extends BaseStripeTest {
   @Test
   public void testCtorRequestOptions() throws StripeException {
     RequestOptions options =
-        RequestOptions.builder()
-            .setApiKey("sk_override")
-            .setIdempotencyKey("idempotency_key")
-            .setStripeAccount("acct_456")
-            .unsafeStripeVersionOverride("2012-12-21")
+        RequestOptionsBuilder.unsafeSetStripeVersionOverride(
+                RequestOptions.builder()
+                    .setApiKey("sk_override")
+                    .setIdempotencyKey("idempotency_key")
+                    .setStripeAccount("acct_456"),
+                "2012-12-21")
             .build();
     StripeRequest request =
         new StripeRequest(ApiResource.RequestMethod.GET, "http://example.com/get", null, options);

--- a/src/test/java/com/stripe/net/StripeRequestTest.java
+++ b/src/test/java/com/stripe/net/StripeRequestTest.java
@@ -103,7 +103,7 @@ public class StripeRequestTest extends BaseStripeTest {
             .setApiKey("sk_override")
             .setIdempotencyKey("idempotency_key")
             .setStripeAccount("acct_456")
-            .setStripeVersionOverride("2012-12-21")
+            ._setStripeVersionOverride("2012-12-21")
             .build();
     StripeRequest request =
         new StripeRequest(ApiResource.RequestMethod.GET, "http://example.com/get", null, options);


### PR DESCRIPTION
## Notify
cc @stripe/api-library-reviewers 

## Summary

This turns `RequestOptions.setStripeVersionOverride` into something completely internal, something that users should never use. There was only one supported use case for `setStripeVersionOverride`, for `EphemeralKey.create`. Now, users should

```java
EphemeralKeyCreateParams params = EphemeralKeyCreateParams.builder()
  .setStripeVersion("XXXX-YY-ZZ")
  .build();
```

to set the `Stripe-Version` header appropriately.

Unfortunately, because `com.stripe.model` and `com.stripe.net` are different packages, we can't actually change the visibility of `RequestOptions.setStripeVersionOverride`. Instead, we rename it to confront upgrading users with the fact that it is now internal-only and they should not use it.

## Changelog
* Add support for `StripeVersion` as a required value on `EphemeralKeyCreateParams`.
* Add support for `EphemeralKey.create` without specifying `RequestOptions`.
* `RequestOptions.setStripeVersionOverride` is renamed to `_setStripeVersionOverride` to confront upgrading users with the fact that this is now internal-only and should not be used. The docs now indicate it is internal-only, instead of outlining circumstances it might be appropriate.
* `RequestOptions.getStripeVersionOverride` is similarly changed to `_getStripeVersionOverride`.
* `RequestOptions.clearStripeVersionOverride` is removed entirely. There is no reason to use this.
* `RequestOptions.toBuilder` is now marked as deprecated, in favor of `toBuilderFullCopy`, which has clearer semantics.

