### PR TITLE
API Version 2022-11-09

### DIFF
--- a/src/main/java/com/stripe/ApiVersion.java
+++ b/src/main/java/com/stripe/ApiVersion.java
@@ -2,5 +2,5 @@
 package com.stripe;
 
 final class ApiVersion {
-  public static final String CURRENT = "2022-08-01";
+  public static final String CURRENT = "2022-11-09";
 }

--- a/src/main/java/com/stripe/model/PaymentIntent.java
+++ b/src/main/java/com/stripe/model/PaymentIntent.java
@@ -113,10 +113,6 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
   @SerializedName("capture_method")
   String captureMethod;
 
-  /** Charges that were created by this PaymentIntent, if any. */
-  @SerializedName("charges")
-  ChargeCollection charges;
-
   /**
    * The client secret of this PaymentIntent. Used for client-side retrieval using a publishable
    * key.
@@ -182,6 +178,12 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
    */
   @SerializedName("last_payment_error")
   StripeError lastPaymentError;
+
+  /** The latest charge created by this payment intent. */
+  @SerializedName("latest_charge")
+  @Getter(lombok.AccessLevel.NONE)
+  @Setter(lombok.AccessLevel.NONE)
+  ExpandableField<Charge> latestCharge;
 
   /**
    * Has the value {@code true} if the object exists in live mode or the value {@code false} if the
@@ -381,6 +383,24 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
 
   public void setInvoiceObject(Invoice expandableObject) {
     this.invoice = new ExpandableField<Invoice>(expandableObject.getId(), expandableObject);
+  }
+
+  /** Get ID of expandable {@code latestCharge} object. */
+  public String getLatestCharge() {
+    return (this.latestCharge != null) ? this.latestCharge.getId() : null;
+  }
+
+  public void setLatestCharge(String id) {
+    this.latestCharge = ApiResource.setExpandableFieldId(id, this.latestCharge);
+  }
+
+  /** Get expanded {@code latestCharge}. */
+  public Charge getLatestChargeObject() {
+    return (this.latestCharge != null) ? this.latestCharge.getExpanded() : null;
+  }
+
+  public void setLatestChargeObject(Charge expandableObject) {
+    this.latestCharge = new ExpandableField<Charge>(expandableObject.getId(), expandableObject);
   }
 
   /** Get ID of expandable {@code onBehalfOf} object. */

--- a/src/main/java/com/stripe/model/issuing/Authorization.java
+++ b/src/main/java/com/stripe/model/issuing/Authorization.java
@@ -692,11 +692,18 @@ public class Authorization extends ApiResource
      * <p>One of {@code account_disabled}, {@code card_active}, {@code card_inactive}, {@code
      * cardholder_inactive}, {@code cardholder_verification_required}, {@code insufficient_funds},
      * {@code not_allowed}, {@code spending_controls}, {@code suspected_fraud}, {@code
-     * verification_failed}, {@code webhook_approved}, {@code webhook_declined}, or {@code
-     * webhook_timeout}.
+     * verification_failed}, {@code webhook_approved}, {@code webhook_declined}, {@code
+     * webhook_error}, or {@code webhook_timeout}.
      */
     @SerializedName("reason")
     String reason;
+
+    /**
+     * If approve/decline decision is directly responsed to the webhook with json payload and if the
+     * response is invalid (e.g., parsing errors), we surface the detailed message via this field.
+     */
+    @SerializedName("reason_message")
+    String reasonMessage;
 
     @Getter
     @Setter

--- a/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
+++ b/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
@@ -565,7 +565,10 @@ public class WebhookEndpointCreateParams extends ApiRequestParams {
     VERSION_2020_08_27("2020-08-27"),
 
     @SerializedName("2022-08-01")
-    VERSION_2022_08_01("2022-08-01");
+    VERSION_2022_08_01("2022-08-01"),
+
+    @SerializedName("2022-11-09")
+    VERSION_2022_11_09("2022-11-09");
 
     @Getter(onMethod_ = {@Override})
     private final String value;

--- a/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
+++ b/src/main/java/com/stripe/param/checkout/SessionCreateParams.java
@@ -1553,26 +1553,6 @@ public class SessionCreateParams extends ApiRequestParams {
     AdjustableQuantity adjustableQuantity;
 
     /**
-     * [Deprecated] The amount to be collected per unit of the line item. If specified, must also
-     * pass {@code currency} and {@code name}.
-     */
-    @SerializedName("amount")
-    Long amount;
-
-    /**
-     * [Deprecated] Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO
-     * currency code</a>, in lowercase. Must be a <a
-     * href="https://stripe.com/docs/currencies">supported currency</a>. Required if {@code amount}
-     * is passed.
-     */
-    @SerializedName("currency")
-    String currency;
-
-    /** [Deprecated] The description for the line item, to be displayed on the Checkout page. */
-    @SerializedName("description")
-    String description;
-
-    /**
      * The <a href="https://stripe.com/docs/api/tax_rates">tax rates</a> that will be applied to
      * this line item depending on the customer's billing/shipping address. We currently support the
      * following countries: US, GB, AU, and all countries in the EU.
@@ -1588,21 +1568,6 @@ public class SessionCreateParams extends ApiRequestParams {
      */
     @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
     Map<String, Object> extraParams;
-
-    /**
-     * [Deprecated] A list of image URLs representing this line item. Each image can be up to 5 MB
-     * in size. If passing {@code price} or {@code price_data}, specify images on the associated
-     * product instead.
-     */
-    @SerializedName("images")
-    List<String> images;
-
-    /**
-     * [Deprecated] The name for the item to be displayed on the Checkout page. Required if {@code
-     * amount} is passed.
-     */
-    @SerializedName("name")
-    String name;
 
     /**
      * The ID of the <a href="https://stripe.com/docs/api/prices">Price</a> or <a
@@ -1635,25 +1600,15 @@ public class SessionCreateParams extends ApiRequestParams {
 
     private LineItem(
         AdjustableQuantity adjustableQuantity,
-        Long amount,
-        String currency,
-        String description,
         List<String> dynamicTaxRates,
         Map<String, Object> extraParams,
-        List<String> images,
-        String name,
         String price,
         PriceData priceData,
         Long quantity,
         List<String> taxRates) {
       this.adjustableQuantity = adjustableQuantity;
-      this.amount = amount;
-      this.currency = currency;
-      this.description = description;
       this.dynamicTaxRates = dynamicTaxRates;
       this.extraParams = extraParams;
-      this.images = images;
-      this.name = name;
       this.price = price;
       this.priceData = priceData;
       this.quantity = quantity;
@@ -1667,19 +1622,9 @@ public class SessionCreateParams extends ApiRequestParams {
     public static class Builder {
       private AdjustableQuantity adjustableQuantity;
 
-      private Long amount;
-
-      private String currency;
-
-      private String description;
-
       private List<String> dynamicTaxRates;
 
       private Map<String, Object> extraParams;
-
-      private List<String> images;
-
-      private String name;
 
       private String price;
 
@@ -1693,13 +1638,8 @@ public class SessionCreateParams extends ApiRequestParams {
       public SessionCreateParams.LineItem build() {
         return new SessionCreateParams.LineItem(
             this.adjustableQuantity,
-            this.amount,
-            this.currency,
-            this.description,
             this.dynamicTaxRates,
             this.extraParams,
-            this.images,
-            this.name,
             this.price,
             this.priceData,
             this.quantity,
@@ -1713,32 +1653,6 @@ public class SessionCreateParams extends ApiRequestParams {
       public Builder setAdjustableQuantity(
           SessionCreateParams.LineItem.AdjustableQuantity adjustableQuantity) {
         this.adjustableQuantity = adjustableQuantity;
-        return this;
-      }
-
-      /**
-       * [Deprecated] The amount to be collected per unit of the line item. If specified, must also
-       * pass {@code currency} and {@code name}.
-       */
-      public Builder setAmount(Long amount) {
-        this.amount = amount;
-        return this;
-      }
-
-      /**
-       * [Deprecated] Three-letter <a href="https://www.iso.org/iso-4217-currency-codes.html">ISO
-       * currency code</a>, in lowercase. Must be a <a
-       * href="https://stripe.com/docs/currencies">supported currency</a>. Required if {@code
-       * amount} is passed.
-       */
-      public Builder setCurrency(String currency) {
-        this.currency = currency;
-        return this;
-      }
-
-      /** [Deprecated] The description for the line item, to be displayed on the Checkout page. */
-      public Builder setDescription(String description) {
-        this.description = description;
         return this;
       }
 
@@ -1791,41 +1705,6 @@ public class SessionCreateParams extends ApiRequestParams {
           this.extraParams = new HashMap<>();
         }
         this.extraParams.putAll(map);
-        return this;
-      }
-
-      /**
-       * Add an element to `images` list. A list is initialized for the first `add/addAll` call, and
-       * subsequent calls adds additional elements to the original list. See {@link
-       * SessionCreateParams.LineItem#images} for the field documentation.
-       */
-      public Builder addImage(String element) {
-        if (this.images == null) {
-          this.images = new ArrayList<>();
-        }
-        this.images.add(element);
-        return this;
-      }
-
-      /**
-       * Add all elements to `images` list. A list is initialized for the first `add/addAll` call,
-       * and subsequent calls adds additional elements to the original list. See {@link
-       * SessionCreateParams.LineItem#images} for the field documentation.
-       */
-      public Builder addAllImage(List<String> elements) {
-        if (this.images == null) {
-          this.images = new ArrayList<>();
-        }
-        this.images.addAll(elements);
-        return this;
-      }
-
-      /**
-       * [Deprecated] The name for the item to be displayed on the Checkout page. Required if {@code
-       * amount} is passed.
-       */
-      public Builder setName(String name) {
-        this.name = name;
         return this;
       }
 
@@ -6902,17 +6781,9 @@ public class SessionCreateParams extends ApiRequestParams {
       @SerializedName("setup_future_usage")
       SetupFutureUsage setupFutureUsage;
 
-      /** Confirm that the payer has accepted the P24 terms and conditions. */
-      @SerializedName("tos_shown_and_accepted")
-      Boolean tosShownAndAccepted;
-
-      private Paynow(
-          Map<String, Object> extraParams,
-          SetupFutureUsage setupFutureUsage,
-          Boolean tosShownAndAccepted) {
+      private Paynow(Map<String, Object> extraParams, SetupFutureUsage setupFutureUsage) {
         this.extraParams = extraParams;
         this.setupFutureUsage = setupFutureUsage;
-        this.tosShownAndAccepted = tosShownAndAccepted;
       }
 
       public static Builder builder() {
@@ -6924,12 +6795,10 @@ public class SessionCreateParams extends ApiRequestParams {
 
         private SetupFutureUsage setupFutureUsage;
 
-        private Boolean tosShownAndAccepted;
-
         /** Finalize and obtain parameter instance from this builder. */
         public SessionCreateParams.PaymentMethodOptions.Paynow build() {
           return new SessionCreateParams.PaymentMethodOptions.Paynow(
-              this.extraParams, this.setupFutureUsage, this.tosShownAndAccepted);
+              this.extraParams, this.setupFutureUsage);
         }
 
         /**
@@ -6979,12 +6848,6 @@ public class SessionCreateParams extends ApiRequestParams {
         public Builder setSetupFutureUsage(
             SessionCreateParams.PaymentMethodOptions.Paynow.SetupFutureUsage setupFutureUsage) {
           this.setupFutureUsage = setupFutureUsage;
-          return this;
-        }
-
-        /** Confirm that the payer has accepted the P24 terms and conditions. */
-        public Builder setTosShownAndAccepted(Boolean tosShownAndAccepted) {
-          this.tosShownAndAccepted = tosShownAndAccepted;
           return this;
         }
       }


### PR DESCRIPTION
## Changelog
* Remove support for `charges` on `PaymentIntent` (breaking)
* Add support for `latest_charge` on `PaymentIntent`
* Add support for `reason_message` on `issuing.Authorization`
* Remove support for `amount`, `currency`, `description`, `images` and `name` from `line_items` on `checkout.SessionCreateParams` (breaking)
* Remove support for `PayNow.tos_shown_and_accepted` from `checkout.SessionCreateParams` (breaking)