### PR TITLE
Fix incorrect javadoc references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         run: ./gradlew spotlessCheck
 
       - name: Build artifacts
-        run: ./gradlew assemble
+        run: ./gradlew assemble javadoc
 
   test:
     name: Test

--- a/src/main/java/com/stripe/model/EventDataDeserializer.java
+++ b/src/main/java/com/stripe/model/EventDataDeserializer.java
@@ -17,7 +17,7 @@ public class EventDataDeserializer implements JsonDeserializer<Event.Data> {
 
   /**
    * Deserializes the JSON payload contained in an event's {@code data} attribute into an {@link
-   * Event.Data} instance.
+   * EventData} instance.
    */
   @Override
   public Event.Data deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)

--- a/src/main/java/com/stripe/model/EventDataDeserializer.java
+++ b/src/main/java/com/stripe/model/EventDataDeserializer.java
@@ -17,7 +17,7 @@ public class EventDataDeserializer implements JsonDeserializer<Event.Data> {
 
   /**
    * Deserializes the JSON payload contained in an event's {@code data} attribute into an {@link
-   * EventData} instance.
+   * Event.Data} instance.
    */
   @Override
   public Event.Data deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)

--- a/src/main/java/com/stripe/model/EventDataObjectDeserializer.java
+++ b/src/main/java/com/stripe/model/EventDataObjectDeserializer.java
@@ -65,12 +65,11 @@ public class EventDataObjectDeserializer {
   }
 
   /**
-   * Gets an {@code Optional} of data event object, in favor of the deprecated {@link
-   * EventData#getObject()}. When the optional is present, the deserialized {@code StripeObject}
-   * preserves high data integrity because of correspondence between schema of the API response and
-   * the model class (the underlying concrete class for abstract {@code StripeObject}) schema. This
-   * is when {@link Event#getApiVersion()} matches {@link Stripe#API_VERSION}. Otherwise, the
-   * optional is empty.
+   * Gets an {@code Optional} of data event object. When the optional is present, the deserialized
+   * {@code StripeObject} preserves high data integrity because of correspondence between schema of
+   * the PI response and the model class (the underlying concrete class for abstract {@code
+   * StripeObject}) schema. This is when {@link Event#getApiVersion()} matches {@link
+   * Stripe#API_VERSION}. Otherwise, the optional is empty.
    *
    * @return {@code Optional} of stripe object when deserialization is safe.
    */

--- a/src/main/java/com/stripe/model/EventDataObjectDeserializer.java
+++ b/src/main/java/com/stripe/model/EventDataObjectDeserializer.java
@@ -65,11 +65,12 @@ public class EventDataObjectDeserializer {
   }
 
   /**
-   * Gets an {@code Optional} of data event object. When the optional is present, the deserialized
-   * {@code StripeObject} preserves high data integrity because of correspondence between schema of
-   * the PI response and the model class (the underlying concrete class for abstract {@code
-   * StripeObject}) schema. This is when {@link Event#getApiVersion()} matches {@link
-   * Stripe#API_VERSION}. Otherwise, the optional is empty.
+   * Gets an {@code Optional} of data event object, in favor of the deprecated {@link
+   * EventData#getObject()}. When the optional is present, the deserialized {@code StripeObject}
+   * preserves high data integrity because of correspondence between schema of the API response and
+   * the model class (the underlying concrete class for abstract {@code StripeObject}) schema. This
+   * is when {@link Event#getApiVersion()} matches {@link Stripe#API_VERSION}. Otherwise, the
+   * optional is empty.
    *
    * @return {@code Optional} of stripe object when deserialization is safe.
    */


### PR DESCRIPTION
## Changelog
  * Fixes Javadoc references to EventData, which was moved to `Event.Data`.
  * Adds :javadoc to the CI "build" job, to catch these errors in CI.