### PR TITLE
Deprecate ApiResource.classUrl, etc.

### DIFF
--- a/src/main/java/com/stripe/model/File.java
+++ b/src/main/java/com/stripe/model/File.java
@@ -92,7 +92,7 @@ public class File extends ApiResource implements HasId {
    */
   public static File create(FileCreateParams params, RequestOptions options)
       throws StripeException {
-    checkNullTypedParams(classUrl(File.class, Stripe.getUploadBase()), params);
+    checkNullTypedParams(String.format("%s/v1/files", Stripe.getUploadBase()), params);
     return create(params.toMap(), options);
   }
 
@@ -105,7 +105,7 @@ public class File extends ApiResource implements HasId {
       throws StripeException {
     return request(
         RequestMethod.POST,
-        classUrl(File.class, Stripe.getUploadBase()),
+        String.format("%s/v1/files", Stripe.getUploadBase()),
         params,
         File.class,
         options);
@@ -125,7 +125,8 @@ public class File extends ApiResource implements HasId {
    */
   public static FileCollection list(Map<String, Object> params, RequestOptions options)
       throws StripeException {
-    return requestCollection(classUrl(File.class), params, FileCollection.class, options);
+    return requestCollection(
+        String.format("%s/v1/files", Stripe.getApiBase()), params, FileCollection.class, options);
   }
 
   /**
@@ -142,7 +143,8 @@ public class File extends ApiResource implements HasId {
    */
   public static FileCollection list(FileListParams params, RequestOptions options)
       throws StripeException {
-    return requestCollection(classUrl(File.class), params, FileCollection.class, options);
+    return requestCollection(
+        String.format("%s/v1/files", Stripe.getApiBase()), params, FileCollection.class, options);
   }
 
   /**
@@ -167,6 +169,11 @@ public class File extends ApiResource implements HasId {
    */
   public static File retrieve(String id, Map<String, Object> params, RequestOptions options)
       throws StripeException {
-    return request(RequestMethod.GET, instanceUrl(File.class, id), params, File.class, options);
+    return request(
+        RequestMethod.GET,
+        String.format("%s/v1/files/%s", Stripe.getApiBase(), id),
+        params,
+        File.class,
+        options);
   }
 }

--- a/src/main/java/com/stripe/net/ApiResource.java
+++ b/src/main/java/com/stripe/net/ApiResource.java
@@ -55,6 +55,7 @@ public abstract class ApiResource extends StripeObject {
     return builder.create();
   }
 
+  @Deprecated
   private static String className(Class<?> clazz) {
     // Convert CamelCase to snake_case
     String className = StringUtils.toSnakeCase(clazz.getSimpleName());
@@ -79,36 +80,44 @@ public abstract class ApiResource extends StripeObject {
     }
   }
 
+  @Deprecated
   protected static String singleClassUrl(Class<?> clazz) {
     return singleClassUrl(clazz, Stripe.getApiBase());
   }
 
+  @Deprecated
   protected static String singleClassUrl(Class<?> clazz, String apiBase) {
     return String.format("%s/v1/%s", apiBase, className(clazz));
   }
 
+  @Deprecated
   protected static String classUrl(Class<?> clazz) {
     return classUrl(clazz, Stripe.getApiBase());
   }
 
+  @Deprecated
   protected static String classUrl(Class<?> clazz, String apiBase) {
     return String.format("%ss", singleClassUrl(clazz, apiBase));
   }
 
+  @Deprecated
   protected static String instanceUrl(Class<?> clazz, String id) throws InvalidRequestException {
     return instanceUrl(clazz, id, Stripe.getApiBase());
   }
 
+  @Deprecated
   protected static String instanceUrl(Class<?> clazz, String id, String apiBase)
       throws InvalidRequestException {
     return String.format("%s/%s", classUrl(clazz, apiBase), urlEncode(id));
   }
 
+  @Deprecated
   protected static String subresourceUrl(Class<?> clazz, String id, Class<?> subClazz)
       throws InvalidRequestException {
     return subresourceUrl(clazz, id, subClazz, Stripe.getApiBase());
   }
 
+  @Deprecated
   private static String subresourceUrl(Class<?> clazz, String id, Class<?> subClazz, String apiBase)
       throws InvalidRequestException {
     return String.format("%s/%s/%ss", classUrl(clazz, apiBase), urlEncode(id), className(subClazz));

--- a/src/test/java/com/stripe/model/PagingIteratorTest.java
+++ b/src/test/java/com/stripe/model/PagingIteratorTest.java
@@ -34,7 +34,10 @@ public class PagingIteratorTest extends BaseStripeTest {
     public static PageableModelCollection list(Map<String, Object> params, RequestOptions options)
         throws StripeException {
       return requestCollection(
-          classUrl(PageableModel.class), params, PageableModelCollection.class, options);
+          String.format("%s/v1/pageable_models", Stripe.getApiBase()),
+          params,
+          PageableModelCollection.class,
+          options);
     }
 
     @Override
@@ -60,7 +63,7 @@ public class PagingIteratorTest extends BaseStripeTest {
     public static ReferencesPageableModel retrieve(RequestOptions options) throws StripeException {
       return request(
           ApiResource.RequestMethod.GET,
-          classUrl(ReferencesPageableModel.class),
+          String.format("%s/v1/references_pageable_models", Stripe.getApiBase()),
           new HashMap<String, Object>(),
           ReferencesPageableModel.class,
           options);

--- a/src/test/java/com/stripe/model/SearchPagingIteratorTest.java
+++ b/src/test/java/com/stripe/model/SearchPagingIteratorTest.java
@@ -29,7 +29,10 @@ public class SearchPagingIteratorTest extends BaseStripeTest {
     public static SearchableModelCollection search(
         Map<String, Object> params, RequestOptions options) throws StripeException {
       return requestSearchResult(
-          classUrl(SearchableModel.class), params, SearchableModelCollection.class, options);
+          String.format("%s/v1/searchable_models", Stripe.getApiBase()),
+          params,
+          SearchableModelCollection.class,
+          options);
     }
 
     @Override


### PR DESCRIPTION
## Notify
r? @stripe/api-library-reviewers 
## Summary
Deprecates several url calculation methods in ApiResource that were unused, or used only in File.java.

## Changelog
* Mark `ApiResource.className`, `ApiResource.singleClassUrl`, `ApiResource.classUrl`, `ApiResource.instanceUrl`, and `ApiResource.subresourceUrl` as deprecated
