### PR TITLE
Add fix for per-request ApiBase

### DIFF
--- a/src/main/java/com/stripe/model/File.java
+++ b/src/main/java/com/stripe/model/File.java
@@ -92,7 +92,7 @@ public class File extends ApiResource implements HasId {
    */
   public static File create(FileCreateParams params, RequestOptions options)
       throws StripeException {
-    checkNullTypedParams(String.format("%s/v1/files", Stripe.getUploadBase()), params);
+    checkNullTypedParams(ApiResource.fullUrl(Stripe.getUploadBase(), options, "/v1/files"), params);
     return create(params.toMap(), options);
   }
 
@@ -105,7 +105,8 @@ public class File extends ApiResource implements HasId {
       throws StripeException {
     return request(
         RequestMethod.POST,
-        String.format("%s/v1/files", Stripe.getUploadBase()),
+        ApiResource.fullUrl(
+        Stripe.getUploadBase(), options, "/v1/files"),
         params,
         File.class,
         options);

--- a/src/main/java/com/stripe/model/File.java
+++ b/src/main/java/com/stripe/model/File.java
@@ -105,8 +105,7 @@ public class File extends ApiResource implements HasId {
       throws StripeException {
     return request(
         RequestMethod.POST,
-        ApiResource.fullUrl(
-        Stripe.getUploadBase(), options, "/v1/files"),
+        ApiResource.fullUrl(Stripe.getUploadBase(), options, "/v1/files"),
         params,
         File.class,
         options);

--- a/src/main/java/com/stripe/net/OAuth.java
+++ b/src/main/java/com/stripe/net/OAuth.java
@@ -46,7 +46,7 @@ public final class OAuth {
    */
   public static TokenResponse token(Map<String, Object> params, RequestOptions options)
       throws StripeException {
-    String url = ApiResource.fullUrl(Stripe.getConnectBase(), options,"/oauth/token");
+    String url = ApiResource.fullUrl(Stripe.getConnectBase(), options, "/oauth/token");
     return OAuth.stripeResponseGetter.oauthRequest(
         ApiResource.RequestMethod.POST, url, params, TokenResponse.class, options);
   }

--- a/src/main/java/com/stripe/net/OAuth.java
+++ b/src/main/java/com/stripe/net/OAuth.java
@@ -46,7 +46,7 @@ public final class OAuth {
    */
   public static TokenResponse token(Map<String, Object> params, RequestOptions options)
       throws StripeException {
-    String url = Stripe.getConnectBase() + "/oauth/token";
+    String url = ApiResource.fullUrl(Stripe.getConnectBase(), options,"/oauth/token");
     return OAuth.stripeResponseGetter.oauthRequest(
         ApiResource.RequestMethod.POST, url, params, TokenResponse.class, options);
   }
@@ -63,7 +63,7 @@ public final class OAuth {
     Map<String, Object> paramsCopy = new HashMap<>();
     paramsCopy.putAll(params);
 
-    String url = Stripe.getConnectBase() + "/oauth/deauthorize";
+    String url = ApiResource.fullUrl(Stripe.getConnectBase(), options, "/oauth/deauthorize");
     paramsCopy.put("client_id", getClientId(paramsCopy, options));
     return OAuth.stripeResponseGetter.oauthRequest(
         ApiResource.RequestMethod.POST, url, paramsCopy, DeauthorizedAccount.class, options);

--- a/src/main/java/com/stripe/net/RequestOptions.java
+++ b/src/main/java/com/stripe/net/RequestOptions.java
@@ -141,6 +141,7 @@ public class RequestOptions {
     return RequestOptionsBuilder.unsafeSetStripeVersionOverride(
         new RequestOptionsBuilder()
             .setApiKey(this.apiKey)
+            .setBaseUrl(this.baseUrl)
             .setClientId(this.clientId)
             .setIdempotencyKey(this.idempotencyKey)
             .setStripeAccount(this.stripeAccount)
@@ -177,7 +178,6 @@ public class RequestOptions {
       this.maxNetworkRetries = Stripe.getMaxNetworkRetries();
       this.connectionProxy = Stripe.getConnectionProxy();
       this.proxyCredential = Stripe.getProxyCredential();
-      this.baseUrl = Stripe.getApiBase();
     }
 
     public String getApiKey() {

--- a/src/test/java/com/stripe/functional/RequestOptionsTest.java
+++ b/src/test/java/com/stripe/functional/RequestOptionsTest.java
@@ -4,9 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import com.google.gson.annotations.SerializedName;
 import com.stripe.BaseStripeTest;
 import com.stripe.Stripe;
@@ -15,11 +12,12 @@ import com.stripe.model.Balance;
 import com.stripe.net.ApiResource;
 import com.stripe.net.RequestOptions;
 import com.stripe.net.StripeResponse;
-import org.junit.jupiter.api.Test;
-
+import java.util.HashMap;
+import java.util.Map;
 import lombok.Cleanup;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.Test;
 
 public class RequestOptionsTest extends BaseStripeTest {
   @Test
@@ -53,17 +51,13 @@ public class RequestOptionsTest extends BaseStripeTest {
   static class MyResource extends ApiResource {
     @SerializedName("id")
     String id;
-    public static MyResource myMethod(Map<String, Object> params, RequestOptions options) throws StripeException {
-      String url = ApiResource.fullUrl(
-          Stripe.getUploadBase(),
-          options,
-          String.format("/v1/foo/bar"));
+
+    public static MyResource myMethod(Map<String, Object> params, RequestOptions options)
+        throws StripeException {
+      String url =
+          ApiResource.fullUrl(Stripe.getUploadBase(), options, String.format("/v1/foo/bar"));
       return ApiResource.request(
-          ApiResource.RequestMethod.POST,
-          url,
-          params,
-          MyResource.class,
-          options);
+          ApiResource.RequestMethod.POST, url, params, MyResource.class, options);
     }
   }
 
@@ -82,10 +76,12 @@ public class RequestOptionsTest extends BaseStripeTest {
     @Cleanup MockWebServer serverOverride = new MockWebServer();
     serverOverride.enqueue(new MockResponse().setBody("{\"id\": \"override\"}"));
     serverOverride.start();
-    MyResource r2 = MyResource.myMethod(new HashMap<>(), RequestOptions.builder().setBaseUrl(serverOverride.url("").toString()).build());
+    MyResource r2 =
+        MyResource.myMethod(
+            new HashMap<>(),
+            RequestOptions.builder().setBaseUrl(serverOverride.url("").toString()).build());
     serverOverride.takeRequest();
     assertEquals("override", r2.id);
     serverOverride.shutdown();
   }
-  
 }

--- a/src/test/java/com/stripe/net/ApiResourceTest.java
+++ b/src/test/java/com/stripe/net/ApiResourceTest.java
@@ -27,6 +27,12 @@ class ApiResourceTest {
         });
   }
 
+  @Test
+  public void testFullUrl() {
+    assertEquals("http://example.com/override/foo", ApiResource.fullUrl("http://example.com", RequestOptions.builder().setBaseUrl("http://example.com/override").build(), "/foo"));
+    assertEquals("http://example.com/foo", ApiResource.fullUrl("http://example.com", RequestOptions.builder().build(), "/foo"));
+  }
+
   static class MyClass extends ApiResource {
     public Proxy proxy;
   }

--- a/src/test/java/com/stripe/net/ApiResourceTest.java
+++ b/src/test/java/com/stripe/net/ApiResourceTest.java
@@ -29,8 +29,15 @@ class ApiResourceTest {
 
   @Test
   public void testFullUrl() {
-    assertEquals("http://example.com/override/foo", ApiResource.fullUrl("http://example.com", RequestOptions.builder().setBaseUrl("http://example.com/override").build(), "/foo"));
-    assertEquals("http://example.com/foo", ApiResource.fullUrl("http://example.com", RequestOptions.builder().build(), "/foo"));
+    assertEquals(
+        "http://example.com/override/foo",
+        ApiResource.fullUrl(
+            "http://example.com",
+            RequestOptions.builder().setBaseUrl("http://example.com/override").build(),
+            "/foo"));
+    assertEquals(
+        "http://example.com/foo",
+        ApiResource.fullUrl("http://example.com", RequestOptions.builder().build(), "/foo"));
   }
 
   static class MyClass extends ApiResource {

--- a/src/test/java/com/stripe/net/RequestOptionsTest.java
+++ b/src/test/java/com/stripe/net/RequestOptionsTest.java
@@ -45,6 +45,7 @@ public class RequestOptionsTest {
     assertEquals(Stripe.DEFAULT_READ_TIMEOUT, optsRebuilt.getReadTimeout());
     assertEquals(Stripe.getConnectionProxy(), optsRebuilt.getConnectionProxy());
     assertEquals(Stripe.getProxyCredential(), optsRebuilt.getProxyCredential());
+    assertEquals(null, optsRebuilt.getBaseUrl());
   }
 
   @Test
@@ -53,6 +54,7 @@ public class RequestOptionsTest {
         RequestOptionsBuilder.unsafeSetStripeVersionOverride(
                 RequestOptions.builder()
                     .setApiKey("sk_foo")
+                    .setBaseUrl("http://example.com")
                     .setClientId("123")
                     .setIdempotencyKey("123")
                     .setStripeAccount("acct_bar")


### PR DESCRIPTION
## Notify
r? @pakrym-stripe 
## Summary
Add tests for the feature introduced in #1476 and fixes two bugs (these bugs did not get released!)

* One bug broke `.toBuilderFullCopy()`. It didn't copy over the new field `baseUrl`.
* The other bug was that `new RequestOptions()` defaulted to `baseUrl = Stripe.getApiBase()` when really it should have defaulted to `null`. This means that code like in `Quote.java`

```java
  public InputStream pdf(Map<String, Object> params, RequestOptions options)
      throws StripeException {
    String url =
        ApiResource.fullUrl(
            Stripe.getUploadBase(),
            options,
            String.format("/v1/quotes/%s/pdf", ApiResource.urlEncodeId(this.getId())));
    return ApiResource.requestStream(ApiResource.RequestMethod.GET, url, params, options);
  }
```
would have regressed and been sending requests to api.stripe.com instead of files.stripe.com as intended.