### PR TITLE
Bump Gson to 2.10.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ repositories {
 dependencies {
     errorprone group: "com.google.errorprone", name: "error_prone_core", version: "2.10.0"
     errorproneJavac group: "com.google.errorprone", name: "javac", version:"9+181-r4173-1"
-    implementation group: "com.google.code.gson", name: "gson", version:"2.9.1"
+    implementation group: "com.google.code.gson", name: "gson", version:"2.10.1"
     testImplementation group: "com.google.guava", name: "guava", version:"31.0.1-jre"
     testImplementation group: "com.squareup.okhttp3", name: "mockwebserver", version: "4.9.1"
     testImplementation group: "org.mockito", name: "mockito-core", version:"4.1.0"


### PR DESCRIPTION
## Notify
r? @stripe/api-library-reviewers 

## Summary
Gson recently merged https://github.com/google/gson/pull/1832 released in [Gson 2.10.1](https://github.com/google/gson/releases/tag/gson-parent-2.10.1) which to fixes a thread-safeness bug that was causing #1213, stripe-java users experiencing (confusing) deserialization errors when trying to deserialize multiple Stripe responses concurrently.

This PR bumps the version of Gson so that new users installing stripe-java will (by default) get the newest version and avoid experiencing this bug. The library is still compatible with Gson >= 2.9.1, though.