### PR TITLE
Update Changelog to indicate removal of associatedObjects field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,7 @@ Breaking changes that arose during code generation of the library that we postpo
 - ⚠️ Removed deprecated `Amount`, `Currency`, `Description`, `Images`, `Name` properties from `SessionCreateParams.LineItem` (#1473)
 - ⚠️ Remove support for `tos_shown_and_accepted` on `CheckoutSessionCreateParams.payment_method_options.paynow` (#1473)
 - ⚠️ Removed deprecated `Sku` resource (#1459)
+- ⚠️ Removed deprecated `EphemeralKey.associatedObjects` field. ([#1470](https://github.com/stripe/stripe-java/pull/1470))
 - ⚠️ Removed `RequestOptions.getStripeVersionOverride`, `RequestOptions.setStripeVersionOverride`,  and `RequestOptions.clearStripeVersionOverride` (#1464)
 
 Use of `setStripeVersionOverride` is discouraged and can lead to unexpected errors during service calls because Java SDK class shapes are not guaranteed to match API responses on arbitrary versions.


### PR DESCRIPTION
Will follow up by updating the [v22 migration guide](https://github.com/stripe/stripe-java/wiki/Migration-guide-for-v22) and [v22.0.0 version tag](https://github.com/stripe/stripe-java/releases/tag/v22.0.0).

I'm using the same wording as in the [stripe-go v74.0.0 Changelog](https://github.com/stripe/stripe-go/blob/master/CHANGELOG.md#7400---2022-11-15), which includes the same change.