### PR TITLE
Make verifyRequest aware of requestStream

### DIFF
--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
+import org.mockito.exceptions.base.MockitoAssertionError;
 
 public class BaseStripeTest {
   private static final String MOCK_MINIMUM_VERSION = "0.109.0";
@@ -179,17 +180,30 @@ public class BaseStripeTest {
       url = path;
     }
 
-    Mockito.verify(networkSpy)
-        .request(
-            Mockito.eq(method),
-            Mockito.eq(url),
-            (params != null)
-                ? Mockito.argThat(new ParamMapMatcher(params))
-                : Mockito.<Map<String, Object>>any(),
-            Mockito.<Class<T>>any(),
-            (options != null)
-                ? Mockito.argThat(new RequestOptionsMatcher(options))
-                : Mockito.<RequestOptions>any());
+    try {
+      Mockito.verify(networkSpy)
+          .requestStream(
+              Mockito.eq(method),
+              Mockito.eq(url),
+              (params != null)
+                  ? Mockito.argThat(new ParamMapMatcher(params))
+                  : Mockito.<Map<String, Object>>any(),
+              (options != null)
+                  ? Mockito.argThat(new RequestOptionsMatcher(options))
+                  : Mockito.<RequestOptions>any());
+    } catch (MockitoAssertionError e) {
+      Mockito.verify(networkSpy)
+          .request(
+              Mockito.eq(method),
+              Mockito.eq(url),
+              (params != null)
+                  ? Mockito.argThat(new ParamMapMatcher(params))
+                  : Mockito.<Map<String, Object>>any(),
+              Mockito.<Class<T>>any(),
+              (options != null)
+                  ? Mockito.argThat(new RequestOptionsMatcher(options))
+                  : Mockito.<RequestOptions>any());
+    }
   }
 
   /** Verifies that no request was made. */

--- a/src/test/java/com/stripe/functional/GeneratedExamples.java
+++ b/src/test/java/com/stripe/functional/GeneratedExamples.java
@@ -4870,4 +4870,15 @@ class GeneratedExamples extends BaseStripeTest {
     assertNotNull(calculation);
     verifyRequest(ApiResource.RequestMethod.POST, "/v1/tax/calculations", params.toMap());
   }
+
+  @Test
+  public void testQuotePdf() throws StripeException {
+    Quote resource = Quote.retrieve("qt_xxxxxxxxxxxxx");
+
+    QuotePdfParams params = QuotePdfParams.builder().build();
+
+    java.io.InputStream file = resource.pdf(params);
+    assertNotNull(file);
+    verifyRequest(ApiResource.RequestMethod.GET, "/v1/quotes/qt_xxxxxxxxxxxxx/pdf", params.toMap());
+  }
 }


### PR DESCRIPTION
Allows us to test file-returning methods.