### PR TITLE
Fix naming of array builder helper methods

### DIFF
--- a/src/main/java/com/stripe/param/AccountCreateParams.java
+++ b/src/main/java/com/stripe/param/AccountCreateParams.java
@@ -6890,7 +6890,7 @@ public class AccountCreateParams extends ApiRequestParams {
        * AccountCreateParams.Individual#fullNameAliases} for the field documentation.
        */
       @SuppressWarnings("unchecked")
-      public Builder addFullNameAliase(String element) {
+      public Builder addFullNameAlias(String element) {
         if (this.fullNameAliases == null || this.fullNameAliases instanceof EmptyParam) {
           this.fullNameAliases = new ArrayList<String>();
         }
@@ -6904,7 +6904,7 @@ public class AccountCreateParams extends ApiRequestParams {
        * {@link AccountCreateParams.Individual#fullNameAliases} for the field documentation.
        */
       @SuppressWarnings("unchecked")
-      public Builder addAllFullNameAliase(List<String> elements) {
+      public Builder addAllFullNameAlias(List<String> elements) {
         if (this.fullNameAliases == null || this.fullNameAliases instanceof EmptyParam) {
           this.fullNameAliases = new ArrayList<String>();
         }

--- a/src/main/java/com/stripe/param/AccountUpdateParams.java
+++ b/src/main/java/com/stripe/param/AccountUpdateParams.java
@@ -7240,7 +7240,7 @@ public class AccountUpdateParams extends ApiRequestParams {
        * AccountUpdateParams.Individual#fullNameAliases} for the field documentation.
        */
       @SuppressWarnings("unchecked")
-      public Builder addFullNameAliase(String element) {
+      public Builder addFullNameAlias(String element) {
         if (this.fullNameAliases == null || this.fullNameAliases instanceof EmptyParam) {
           this.fullNameAliases = new ArrayList<String>();
         }
@@ -7254,7 +7254,7 @@ public class AccountUpdateParams extends ApiRequestParams {
        * {@link AccountUpdateParams.Individual#fullNameAliases} for the field documentation.
        */
       @SuppressWarnings("unchecked")
-      public Builder addAllFullNameAliase(List<String> elements) {
+      public Builder addAllFullNameAlias(List<String> elements) {
         if (this.fullNameAliases == null || this.fullNameAliases instanceof EmptyParam) {
           this.fullNameAliases = new ArrayList<String>();
         }

--- a/src/main/java/com/stripe/param/PersonCollectionCreateParams.java
+++ b/src/main/java/com/stripe/param/PersonCollectionCreateParams.java
@@ -431,7 +431,7 @@ public class PersonCollectionCreateParams extends ApiRequestParams {
      * PersonCollectionCreateParams#fullNameAliases} for the field documentation.
      */
     @SuppressWarnings("unchecked")
-    public Builder addFullNameAliase(String element) {
+    public Builder addFullNameAlias(String element) {
       if (this.fullNameAliases == null || this.fullNameAliases instanceof EmptyParam) {
         this.fullNameAliases = new ArrayList<String>();
       }
@@ -445,7 +445,7 @@ public class PersonCollectionCreateParams extends ApiRequestParams {
      * PersonCollectionCreateParams#fullNameAliases} for the field documentation.
      */
     @SuppressWarnings("unchecked")
-    public Builder addAllFullNameAliase(List<String> elements) {
+    public Builder addAllFullNameAlias(List<String> elements) {
       if (this.fullNameAliases == null || this.fullNameAliases instanceof EmptyParam) {
         this.fullNameAliases = new ArrayList<String>();
       }

--- a/src/main/java/com/stripe/param/PersonUpdateParams.java
+++ b/src/main/java/com/stripe/param/PersonUpdateParams.java
@@ -455,7 +455,7 @@ public class PersonUpdateParams extends ApiRequestParams {
      * PersonUpdateParams#fullNameAliases} for the field documentation.
      */
     @SuppressWarnings("unchecked")
-    public Builder addFullNameAliase(String element) {
+    public Builder addFullNameAlias(String element) {
       if (this.fullNameAliases == null || this.fullNameAliases instanceof EmptyParam) {
         this.fullNameAliases = new ArrayList<String>();
       }
@@ -469,7 +469,7 @@ public class PersonUpdateParams extends ApiRequestParams {
      * PersonUpdateParams#fullNameAliases} for the field documentation.
      */
     @SuppressWarnings("unchecked")
-    public Builder addAllFullNameAliase(List<String> elements) {
+    public Builder addAllFullNameAlias(List<String> elements) {
       if (this.fullNameAliases == null || this.fullNameAliases instanceof EmptyParam) {
         this.fullNameAliases = new ArrayList<String>();
       }

--- a/src/main/java/com/stripe/param/PriceListParams.java
+++ b/src/main/java/com/stripe/param/PriceListParams.java
@@ -268,7 +268,7 @@ public class PriceListParams extends ApiRequestParams {
      * and subsequent calls adds additional elements to the original list. See {@link
      * PriceListParams#lookupKeys} for the field documentation.
      */
-    public Builder addLookupKeys(String element) {
+    public Builder addLookupKey(String element) {
       if (this.lookupKeys == null) {
         this.lookupKeys = new ArrayList<>();
       }
@@ -281,7 +281,7 @@ public class PriceListParams extends ApiRequestParams {
      * and subsequent calls adds additional elements to the original list. See {@link
      * PriceListParams#lookupKeys} for the field documentation.
      */
-    public Builder addAllLookupKeys(List<String> elements) {
+    public Builder addAllLookupKey(List<String> elements) {
       if (this.lookupKeys == null) {
         this.lookupKeys = new ArrayList<>();
       }

--- a/src/main/java/com/stripe/param/TokenCreateParams.java
+++ b/src/main/java/com/stripe/param/TokenCreateParams.java
@@ -1995,7 +1995,7 @@ public class TokenCreateParams extends ApiRequestParams {
          * documentation.
          */
         @SuppressWarnings("unchecked")
-        public Builder addFullNameAliase(String element) {
+        public Builder addFullNameAlias(String element) {
           if (this.fullNameAliases == null || this.fullNameAliases instanceof EmptyParam) {
             this.fullNameAliases = new ArrayList<String>();
           }
@@ -2010,7 +2010,7 @@ public class TokenCreateParams extends ApiRequestParams {
          * documentation.
          */
         @SuppressWarnings("unchecked")
-        public Builder addAllFullNameAliase(List<String> elements) {
+        public Builder addAllFullNameAlias(List<String> elements) {
           if (this.fullNameAliases == null || this.fullNameAliases instanceof EmptyParam) {
             this.fullNameAliases = new ArrayList<String>();
           }
@@ -4182,7 +4182,7 @@ public class TokenCreateParams extends ApiRequestParams {
        * TokenCreateParams.Person#fullNameAliases} for the field documentation.
        */
       @SuppressWarnings("unchecked")
-      public Builder addFullNameAliase(String element) {
+      public Builder addFullNameAlias(String element) {
         if (this.fullNameAliases == null || this.fullNameAliases instanceof EmptyParam) {
           this.fullNameAliases = new ArrayList<String>();
         }
@@ -4196,7 +4196,7 @@ public class TokenCreateParams extends ApiRequestParams {
        * {@link TokenCreateParams.Person#fullNameAliases} for the field documentation.
        */
       @SuppressWarnings("unchecked")
-      public Builder addAllFullNameAliase(List<String> elements) {
+      public Builder addAllFullNameAlias(List<String> elements) {
         if (this.fullNameAliases == null || this.fullNameAliases instanceof EmptyParam) {
           this.fullNameAliases = new ArrayList<String>();
         }


### PR DESCRIPTION
## Changelog
- `addFullNameAliase` renamed to `addFullNameAlias` in `AccountCreateParams`, `AccountUpdateParams`, `PersonCollectionCreateParams`, `TokenCreateParams`, `PersonCollectionCreateParams`, `PersonUpdateParams`.

- `addLookupKeys` renamed to `addLookupKey` in `PriceListParams`