### PR TITLE
Make response getter on the client public

### DIFF
--- a/src/main/java/com/stripe/StripeClient.java
+++ b/src/main/java/com/stripe/StripeClient.java
@@ -32,7 +32,7 @@ public class StripeClient {
     this.responseGetter = responseGetter;
   }
 
-  protected StripeResponseGetter getResponseGetter() {
+  public StripeResponseGetter getResponseGetter() {
     return responseGetter;
   }
 


### PR DESCRIPTION
It's useful as a replacement for `request**` methods we are removing from `ApiResource`.