### PR TITLE
CI: Drop testing for 9, 10, 12-16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,16 +52,12 @@ jobs:
       matrix:
         java-version:
           - "1.8"
-          - "9"
-          - "10"
           - "11"
-          - "12"
-          - "13"
-          - "14"
-          - "15"
-          - "16"
           - "17"
           - "18"
+          - "19"
+          - "20"
+          - "21"
 
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
Java 10 in particular has been pretty flaky. We get little value from testing intermediate versions.