### PR TITLE
Report usage of `stripe_client`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,10 @@ tasks.withType(JavaCompile) {
       // com.stripe.param.AccountUpdateParams.Individual.Address] within this file.)
       // We should fix this by having autogen use the fully-qualified class to eliminate ambiguity.
       check("SameNameButDifferent", net.ltgt.gradle.errorprone.CheckSeverity.OFF)
+
+      // InlineMe (https://errorprone.info/docs/inlineme) seems neat, but in order to add these annotations
+      // we would be imposing another dependency on `errorprone` to our users, not worth it.
+      check("InlineMeSuggester", net.ltgt.gradle.errorprone.CheckSeverity.OFF)
     }
 }
 

--- a/src/main/java/com/stripe/net/ApiRequest.java
+++ b/src/main/java/com/stripe/net/ApiRequest.java
@@ -42,6 +42,7 @@ public class ApiRequest extends BaseApiRequest {
         this.getPath(),
         this.getOptions(),
         this.getApiMode(),
-        newUsage, this.getParams());
+        newUsage,
+        this.getParams());
   }
 }

--- a/src/main/java/com/stripe/net/ApiRequest.java
+++ b/src/main/java/com/stripe/net/ApiRequest.java
@@ -31,7 +31,7 @@ public class ApiRequest extends BaseApiRequest {
     this(baseAddress, method, path, options, apiMode, null, params);
   }
 
-  public ApiRequest withAddedUsage(String usage) {
+  public ApiRequest addUsage(String usage) {
     List<String> newUsage = new ArrayList<>();
     if (this.getUsage() != null) {
       newUsage.addAll(this.getUsage());

--- a/src/main/java/com/stripe/net/ApiRequest.java
+++ b/src/main/java/com/stripe/net/ApiRequest.java
@@ -1,11 +1,25 @@
 package com.stripe.net;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import lombok.Getter;
 
 @Getter
 public class ApiRequest extends BaseApiRequest {
   private Map<String, Object> params;
+
+  private ApiRequest(
+      BaseAddress baseAddress,
+      ApiResource.RequestMethod method,
+      String path,
+      RequestOptions options,
+      ApiMode apiMode,
+      List<String> usage,
+      Map<String, Object> params) {
+    super(baseAddress, method, path, options, apiMode, usage);
+    this.params = params;
+  }
 
   public ApiRequest(
       BaseAddress baseAddress,
@@ -14,7 +28,20 @@ public class ApiRequest extends BaseApiRequest {
       Map<String, Object> params,
       RequestOptions options,
       ApiMode apiMode) {
-    super(baseAddress, method, path, options, apiMode);
-    this.params = params;
+    this(baseAddress, method, path, options, apiMode, null, params);
+  }
+
+  public ApiRequest withAddedUsage(String usage) {
+    List<String> newUsage = new ArrayList<>();
+    if (this.getUsage() != null) {
+      newUsage.addAll(this.getUsage());
+    }
+    return new ApiRequest(
+        this.getBaseAddress(),
+        this.getMethod(),
+        this.getPath(),
+        this.getOptions(),
+        this.getApiMode(),
+        newUsage, this.getParams());
   }
 }

--- a/src/main/java/com/stripe/net/ApiRequest.java
+++ b/src/main/java/com/stripe/net/ApiRequest.java
@@ -36,6 +36,7 @@ public class ApiRequest extends BaseApiRequest {
     if (this.getUsage() != null) {
       newUsage.addAll(this.getUsage());
     }
+    newUsage.add(usage);
     return new ApiRequest(
         this.getBaseAddress(),
         this.getMethod(),

--- a/src/main/java/com/stripe/net/BaseApiRequest.java
+++ b/src/main/java/com/stripe/net/BaseApiRequest.java
@@ -1,8 +1,6 @@
 package com.stripe.net;
 
-import java.util.ArrayList;
 import java.util.List;
-
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/stripe/net/BaseApiRequest.java
+++ b/src/main/java/com/stripe/net/BaseApiRequest.java
@@ -14,6 +14,11 @@ class BaseApiRequest {
 
   @Setter private List<String> usage;
 
+  /** Internal method. Adds a record of a tracked behavior identified by "used" to the request. */
+  public void addUsage(String used) {
+    this.usage.add(used);
+  }
+
   public BaseApiRequest(
       BaseAddress baseAddress,
       ApiResource.RequestMethod method,

--- a/src/main/java/com/stripe/net/BaseApiRequest.java
+++ b/src/main/java/com/stripe/net/BaseApiRequest.java
@@ -2,37 +2,18 @@ package com.stripe.net;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 class BaseApiRequest {
-  private BaseAddress baseAddress;
-  private ApiResource.RequestMethod method;
-  private String path;
-  private RequestOptions options;
-  private ApiMode apiMode;
-
-  @Setter private List<String> usage;
-
-  /** Internal method. Adds a record of a tracked behavior identified by "used" to the request. */
-  public void addUsage(String used) {
-    if (this.usage == null) {
-      this.usage = new ArrayList<>();
-    }
-    this.usage.add(used);
-  }
-
-  public BaseApiRequest(
-      BaseAddress baseAddress,
-      ApiResource.RequestMethod method,
-      String path,
-      RequestOptions options,
-      ApiMode apiMode) {
-    this.baseAddress = baseAddress;
-    this.method = method;
-    this.path = path;
-    this.options = options;
-    this.apiMode = apiMode;
-  }
+  private final BaseAddress baseAddress;
+  private final ApiResource.RequestMethod method;
+  private final String path;
+  private final RequestOptions options;
+  private final ApiMode apiMode;
+  private final List<String> usage;
 }

--- a/src/main/java/com/stripe/net/BaseApiRequest.java
+++ b/src/main/java/com/stripe/net/BaseApiRequest.java
@@ -17,7 +17,7 @@ class BaseApiRequest {
   // TODO (major): Remove setter and make final
   private List<String> usage;
 
-  /** @deprecated Use {@link com.stripe.net.ApiRequest#withAddedUsage(String)} instead. */
+  /** @deprecated Use {@link com.stripe.net.ApiRequest#addUsage(String)} instead. */
   @Deprecated
   public void setUsage(List<String> usage) {
     this.usage = usage;

--- a/src/main/java/com/stripe/net/BaseApiRequest.java
+++ b/src/main/java/com/stripe/net/BaseApiRequest.java
@@ -13,5 +13,15 @@ class BaseApiRequest {
   private final String path;
   private final RequestOptions options;
   private final ApiMode apiMode;
-  private final List<String> usage;
+
+  // TODO (major): Remove setter and make final
+  private List<String> usage;
+
+  /**
+   * @deprecated Use {@link com.stripe.net.ApiRequest#withAddedUsage(String)} instead.
+   */
+  @Deprecated
+  public void setUsage(List<String> usage) {
+    this.usage = usage;
+  }
 }

--- a/src/main/java/com/stripe/net/BaseApiRequest.java
+++ b/src/main/java/com/stripe/net/BaseApiRequest.java
@@ -17,9 +17,7 @@ class BaseApiRequest {
   // TODO (major): Remove setter and make final
   private List<String> usage;
 
-  /**
-   * @deprecated Use {@link com.stripe.net.ApiRequest#withAddedUsage(String)} instead.
-   */
+  /** @deprecated Use {@link com.stripe.net.ApiRequest#withAddedUsage(String)} instead. */
   @Deprecated
   public void setUsage(List<String> usage) {
     this.usage = usage;

--- a/src/main/java/com/stripe/net/BaseApiRequest.java
+++ b/src/main/java/com/stripe/net/BaseApiRequest.java
@@ -1,5 +1,6 @@
 package com.stripe.net;
 
+import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
@@ -16,6 +17,9 @@ class BaseApiRequest {
 
   /** Internal method. Adds a record of a tracked behavior identified by "used" to the request. */
   public void addUsage(String used) {
+    if (this.usage == null) {
+      this.usage = new ArrayList<>();
+    }
     this.usage.add(used);
   }
 

--- a/src/main/java/com/stripe/net/HttpClient.java
+++ b/src/main/java/com/stripe/net/HttpClient.java
@@ -67,7 +67,7 @@ public abstract class HttpClient {
 
     stopwatch.stop();
 
-    requestTelemetry.maybeEnqueueMetrics(response, stopwatch.getElapsed());
+    requestTelemetry.maybeEnqueueMetrics(response, stopwatch.getElapsed(), request.usage());
 
     return response;
   }

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -50,7 +50,8 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
         apiRequest.getMethod(),
         fullUrl,
         apiRequest.getParams(),
-        RequestOptions.merge(this.options, apiRequest.getOptions()));
+        RequestOptions.merge(this.options, apiRequest.getOptions()),
+        apiRequest.getUsage());
   }
 
   @Override

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -77,8 +77,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
             apiRequest.getMethod(),
             fullUrl,
             apiRequest.getParams(),
-            RequestOptions.merge(this.options, apiRequest.getOptions()),
-            apiRequest.getUsage());
+            RequestOptions.merge(this.options, apiRequest.getOptions()));
     if (telemetryHeaderValue.isPresent()) {
       request =
           request.withAdditionalHeader(RequestTelemetry.HEADER_NAME, telemetryHeaderValue.get());

--- a/src/main/java/com/stripe/net/RequestTelemetry.java
+++ b/src/main/java/com/stripe/net/RequestTelemetry.java
@@ -78,7 +78,7 @@ class RequestTelemetry {
       return;
     }
 
-    if (usage.size() == 0) {
+    if (usage != null && usage.size() == 0) {
       usage = null;
     }
 

--- a/src/main/java/com/stripe/net/StripeRequest.java
+++ b/src/main/java/com/stripe/net/StripeRequest.java
@@ -15,7 +15,6 @@ import java.util.Map;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Getter;
 import lombok.Value;
 import lombok.experimental.Accessors;
 
@@ -52,10 +51,6 @@ public class StripeRequest {
   /** The special modifiers of the request. */
   RequestOptions options;
 
-  /** List of tracked behaviors associated with this request. */
-  @Getter(AccessLevel.PACKAGE)
-  List<String> usage;
-
   /**
    * Initializes a new instance of the {@link StripeRequest} class.
    *
@@ -63,15 +58,13 @@ public class StripeRequest {
    * @param url the URL of the request
    * @param params the parameters of the request
    * @param options the special modifiers of the request
-   * @param usage list of tracked behaviors associated with this request
    * @throws StripeException if the request cannot be initialized for any reason
    */
   public StripeRequest(
       ApiResource.RequestMethod method,
       String url,
       Map<String, Object> params,
-      RequestOptions options,
-      List<String> usage)
+      RequestOptions options)
       throws StripeException {
     try {
       this.params = (params != null) ? Collections.unmodifiableMap(params) : null;
@@ -80,7 +73,6 @@ public class StripeRequest {
       this.url = buildURL(method, url, params);
       this.content = buildContent(method, params);
       this.headers = buildHeaders(method, this.options);
-      this.usage = usage;
     } catch (IOException e) {
       throw new ApiConnectionException(
           String.format(
@@ -91,15 +83,6 @@ public class StripeRequest {
               Stripe.getApiBase(), e.getMessage()),
           e);
     }
-  }
-
-  public StripeRequest(
-      ApiResource.RequestMethod method,
-      String url,
-      Map<String, Object> params,
-      RequestOptions options)
-      throws StripeException {
-    this(method, url, params, options, Collections.emptyList());
   }
 
   /**
@@ -116,8 +99,7 @@ public class StripeRequest {
         this.content,
         this.headers.withAdditionalHeader(name, value),
         this.params,
-        this.options,
-        this.usage);
+        this.options);
   }
 
   private static URL buildURL(

--- a/src/main/java/com/stripe/net/StripeRequest.java
+++ b/src/main/java/com/stripe/net/StripeRequest.java
@@ -7,7 +7,6 @@ import com.stripe.exception.StripeException;
 import com.stripe.util.StringUtils;
 import java.io.IOException;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -98,7 +97,7 @@ public class StripeRequest {
       Map<String, Object> params,
       RequestOptions options)
       throws StripeException {
-    this(method, url, params, options, new ArrayList<String>());
+    this(method, url, params, options, Collections.emptyList());
   }
 
   /**

--- a/src/main/java/com/stripe/net/StripeRequest.java
+++ b/src/main/java/com/stripe/net/StripeRequest.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.Value;
 import lombok.experimental.Accessors;
 
@@ -52,6 +53,7 @@ public class StripeRequest {
   RequestOptions options;
 
   /** List of tracked behaviors associated with this request. */
+  @Getter(AccessLevel.PACKAGE)
   List<String> usage;
 
   /**

--- a/src/main/java/com/stripe/net/StripeRequest.java
+++ b/src/main/java/com/stripe/net/StripeRequest.java
@@ -7,6 +7,7 @@ import com.stripe.exception.StripeException;
 import com.stripe.util.StringUtils;
 import java.io.IOException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -51,6 +52,9 @@ public class StripeRequest {
   /** The special modifiers of the request. */
   RequestOptions options;
 
+  /** List of tracked behaviors associated with this request. */
+  List<String> usage;
+
   /**
    * Initializes a new instance of the {@link StripeRequest} class.
    *
@@ -58,13 +62,15 @@ public class StripeRequest {
    * @param url the URL of the request
    * @param params the parameters of the request
    * @param options the special modifiers of the request
+   * @param usage list of tracked behaviors associated with this request
    * @throws StripeException if the request cannot be initialized for any reason
    */
   public StripeRequest(
       ApiResource.RequestMethod method,
       String url,
       Map<String, Object> params,
-      RequestOptions options)
+      RequestOptions options,
+      List<String> usage)
       throws StripeException {
     try {
       this.params = (params != null) ? Collections.unmodifiableMap(params) : null;
@@ -73,6 +79,7 @@ public class StripeRequest {
       this.url = buildURL(method, url, params);
       this.content = buildContent(method, params);
       this.headers = buildHeaders(method, this.options);
+      this.usage = usage;
     } catch (IOException e) {
       throw new ApiConnectionException(
           String.format(
@@ -83,6 +90,15 @@ public class StripeRequest {
               Stripe.getApiBase(), e.getMessage()),
           e);
     }
+  }
+
+  public StripeRequest(
+      ApiResource.RequestMethod method,
+      String url,
+      Map<String, Object> params,
+      RequestOptions options)
+      throws StripeException {
+    this(method, url, params, options, new ArrayList<String>());
   }
 
   /**
@@ -99,7 +115,8 @@ public class StripeRequest {
         this.content,
         this.headers.withAdditionalHeader(name, value),
         this.params,
-        this.options);
+        this.options,
+        this.usage);
   }
 
   private static URL buildURL(

--- a/src/main/java/com/stripe/net/StripeResponseGetterOptions.java
+++ b/src/main/java/com/stripe/net/StripeResponseGetterOptions.java
@@ -5,8 +5,7 @@ import java.net.Proxy;
 
 /** Controls how the request is sent by {@link StripeResponseGetter} */
 public abstract class StripeResponseGetterOptions {
-
-  // When adding setting here keep them in sync with settings in RequestOptions and
+  // When adding settings here keep them in sync with settings in RequestOptions and
   // in the RequestOptions.merge method
   public abstract String getApiKey();
 

--- a/src/main/java/com/stripe/service/AccountLinkService.java
+++ b/src/main/java/com/stripe/service/AccountLinkService.java
@@ -40,6 +40,7 @@ public final class AccountLinkService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, AccountLink.class);
   }
 }

--- a/src/main/java/com/stripe/service/AccountLinkService.java
+++ b/src/main/java/com/stripe/service/AccountLinkService.java
@@ -40,7 +40,7 @@ public final class AccountLinkService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, AccountLink.class);
   }
 }

--- a/src/main/java/com/stripe/service/AccountLinkService.java
+++ b/src/main/java/com/stripe/service/AccountLinkService.java
@@ -40,7 +40,7 @@ public final class AccountLinkService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, AccountLink.class);
   }
 }

--- a/src/main/java/com/stripe/service/AccountService.java
+++ b/src/main/java/com/stripe/service/AccountService.java
@@ -55,6 +55,7 @@ public final class AccountService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Account.class);
   }
   /** Retrieves the details of an account. */
@@ -81,6 +82,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Account.class);
   }
   /**
@@ -163,6 +165,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Account.class);
   }
   /** Retrieves the details of an account. */
@@ -189,6 +192,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Account.class);
   }
   /**
@@ -231,6 +235,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Account>>() {}.getType());
   }
@@ -293,6 +298,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Account.class);
   }
   /**
@@ -323,6 +329,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Account.class);
   }
 

--- a/src/main/java/com/stripe/service/AccountService.java
+++ b/src/main/java/com/stripe/service/AccountService.java
@@ -55,7 +55,7 @@ public final class AccountService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Account.class);
   }
   /** Retrieves the details of an account. */
@@ -82,7 +82,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Account.class);
   }
   /**
@@ -165,7 +165,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Account.class);
   }
   /** Retrieves the details of an account. */
@@ -192,7 +192,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Account.class);
   }
   /**
@@ -235,7 +235,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Account>>() {}.getType());
   }
@@ -298,7 +298,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Account.class);
   }
   /**
@@ -329,7 +329,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Account.class);
   }
 

--- a/src/main/java/com/stripe/service/AccountService.java
+++ b/src/main/java/com/stripe/service/AccountService.java
@@ -55,7 +55,7 @@ public final class AccountService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Account.class);
   }
   /** Retrieves the details of an account. */
@@ -82,7 +82,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Account.class);
   }
   /**
@@ -165,7 +165,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Account.class);
   }
   /** Retrieves the details of an account. */
@@ -192,7 +192,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Account.class);
   }
   /**
@@ -235,7 +235,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Account>>() {}.getType());
   }
@@ -298,7 +298,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Account.class);
   }
   /**
@@ -329,7 +329,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Account.class);
   }
 

--- a/src/main/java/com/stripe/service/AccountSessionService.java
+++ b/src/main/java/com/stripe/service/AccountSessionService.java
@@ -40,7 +40,7 @@ public final class AccountSessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, AccountSession.class);
   }
 }

--- a/src/main/java/com/stripe/service/AccountSessionService.java
+++ b/src/main/java/com/stripe/service/AccountSessionService.java
@@ -40,7 +40,7 @@ public final class AccountSessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, AccountSession.class);
   }
 }

--- a/src/main/java/com/stripe/service/AccountSessionService.java
+++ b/src/main/java/com/stripe/service/AccountSessionService.java
@@ -40,6 +40,7 @@ public final class AccountSessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, AccountSession.class);
   }
 }

--- a/src/main/java/com/stripe/service/ApplePayDomainService.java
+++ b/src/main/java/com/stripe/service/ApplePayDomainService.java
@@ -32,7 +32,7 @@ public final class ApplePayDomainService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, ApplePayDomain.class);
   }
   /** Retrieve an apple pay domain. */
@@ -61,7 +61,7 @@ public final class ApplePayDomainService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, ApplePayDomain.class);
   }
   /** List apple pay domains. */
@@ -89,7 +89,7 @@ public final class ApplePayDomainService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ApplePayDomain>>() {}.getType());
   }
@@ -109,7 +109,7 @@ public final class ApplePayDomainService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, ApplePayDomain.class);
   }
 }

--- a/src/main/java/com/stripe/service/ApplePayDomainService.java
+++ b/src/main/java/com/stripe/service/ApplePayDomainService.java
@@ -32,7 +32,7 @@ public final class ApplePayDomainService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, ApplePayDomain.class);
   }
   /** Retrieve an apple pay domain. */
@@ -61,7 +61,7 @@ public final class ApplePayDomainService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, ApplePayDomain.class);
   }
   /** List apple pay domains. */
@@ -89,7 +89,7 @@ public final class ApplePayDomainService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ApplePayDomain>>() {}.getType());
   }
@@ -109,7 +109,7 @@ public final class ApplePayDomainService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, ApplePayDomain.class);
   }
 }

--- a/src/main/java/com/stripe/service/ApplePayDomainService.java
+++ b/src/main/java/com/stripe/service/ApplePayDomainService.java
@@ -32,6 +32,7 @@ public final class ApplePayDomainService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, ApplePayDomain.class);
   }
   /** Retrieve an apple pay domain. */
@@ -60,6 +61,7 @@ public final class ApplePayDomainService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, ApplePayDomain.class);
   }
   /** List apple pay domains. */
@@ -87,6 +89,7 @@ public final class ApplePayDomainService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ApplePayDomain>>() {}.getType());
   }
@@ -106,6 +109,7 @@ public final class ApplePayDomainService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, ApplePayDomain.class);
   }
 }

--- a/src/main/java/com/stripe/service/ApplicationFeeService.java
+++ b/src/main/java/com/stripe/service/ApplicationFeeService.java
@@ -58,7 +58,7 @@ public final class ApplicationFeeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ApplicationFee>>() {}.getType());
   }
@@ -100,7 +100,7 @@ public final class ApplicationFeeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, ApplicationFee.class);
   }
 

--- a/src/main/java/com/stripe/service/ApplicationFeeService.java
+++ b/src/main/java/com/stripe/service/ApplicationFeeService.java
@@ -58,7 +58,7 @@ public final class ApplicationFeeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ApplicationFee>>() {}.getType());
   }
@@ -100,7 +100,7 @@ public final class ApplicationFeeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, ApplicationFee.class);
   }
 

--- a/src/main/java/com/stripe/service/ApplicationFeeService.java
+++ b/src/main/java/com/stripe/service/ApplicationFeeService.java
@@ -58,6 +58,7 @@ public final class ApplicationFeeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ApplicationFee>>() {}.getType());
   }
@@ -99,6 +100,7 @@ public final class ApplicationFeeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, ApplicationFee.class);
   }
 

--- a/src/main/java/com/stripe/service/BalanceService.java
+++ b/src/main/java/com/stripe/service/BalanceService.java
@@ -62,7 +62,7 @@ public final class BalanceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Balance.class);
   }
 }

--- a/src/main/java/com/stripe/service/BalanceService.java
+++ b/src/main/java/com/stripe/service/BalanceService.java
@@ -62,6 +62,7 @@ public final class BalanceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Balance.class);
   }
 }

--- a/src/main/java/com/stripe/service/BalanceService.java
+++ b/src/main/java/com/stripe/service/BalanceService.java
@@ -62,7 +62,7 @@ public final class BalanceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Balance.class);
   }
 }

--- a/src/main/java/com/stripe/service/BalanceTransactionService.java
+++ b/src/main/java/com/stripe/service/BalanceTransactionService.java
@@ -74,7 +74,7 @@ public final class BalanceTransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<BalanceTransaction>>() {}.getType());
   }
@@ -120,7 +120,7 @@ public final class BalanceTransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, BalanceTransaction.class);
   }
 }

--- a/src/main/java/com/stripe/service/BalanceTransactionService.java
+++ b/src/main/java/com/stripe/service/BalanceTransactionService.java
@@ -74,6 +74,7 @@ public final class BalanceTransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<BalanceTransaction>>() {}.getType());
   }
@@ -119,6 +120,7 @@ public final class BalanceTransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, BalanceTransaction.class);
   }
 }

--- a/src/main/java/com/stripe/service/BalanceTransactionService.java
+++ b/src/main/java/com/stripe/service/BalanceTransactionService.java
@@ -74,7 +74,7 @@ public final class BalanceTransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<BalanceTransaction>>() {}.getType());
   }
@@ -120,7 +120,7 @@ public final class BalanceTransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, BalanceTransaction.class);
   }
 }

--- a/src/main/java/com/stripe/service/BankAccountService.java
+++ b/src/main/java/com/stripe/service/BankAccountService.java
@@ -48,7 +48,7 @@ public final class BankAccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, BankAccount.class);
   }
 }

--- a/src/main/java/com/stripe/service/BankAccountService.java
+++ b/src/main/java/com/stripe/service/BankAccountService.java
@@ -48,7 +48,7 @@ public final class BankAccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, BankAccount.class);
   }
 }

--- a/src/main/java/com/stripe/service/BankAccountService.java
+++ b/src/main/java/com/stripe/service/BankAccountService.java
@@ -48,6 +48,7 @@ public final class BankAccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, BankAccount.class);
   }
 }

--- a/src/main/java/com/stripe/service/CapabilityService.java
+++ b/src/main/java/com/stripe/service/CapabilityService.java
@@ -60,7 +60,7 @@ public final class CapabilityService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Capability>>() {}.getType());
   }
@@ -94,7 +94,7 @@ public final class CapabilityService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Capability.class);
   }
   /**
@@ -139,7 +139,7 @@ public final class CapabilityService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Capability.class);
   }
 }

--- a/src/main/java/com/stripe/service/CapabilityService.java
+++ b/src/main/java/com/stripe/service/CapabilityService.java
@@ -60,7 +60,7 @@ public final class CapabilityService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Capability>>() {}.getType());
   }
@@ -94,7 +94,7 @@ public final class CapabilityService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Capability.class);
   }
   /**
@@ -139,7 +139,7 @@ public final class CapabilityService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Capability.class);
   }
 }

--- a/src/main/java/com/stripe/service/CapabilityService.java
+++ b/src/main/java/com/stripe/service/CapabilityService.java
@@ -60,6 +60,7 @@ public final class CapabilityService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Capability>>() {}.getType());
   }
@@ -93,6 +94,7 @@ public final class CapabilityService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Capability.class);
   }
   /**
@@ -137,6 +139,7 @@ public final class CapabilityService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Capability.class);
   }
 }

--- a/src/main/java/com/stripe/service/CashBalanceService.java
+++ b/src/main/java/com/stripe/service/CashBalanceService.java
@@ -45,7 +45,7 @@ public final class CashBalanceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, CashBalance.class);
   }
   /** Changes the settings on a customer’s cash balance. */
@@ -73,7 +73,7 @@ public final class CashBalanceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, CashBalance.class);
   }
 }

--- a/src/main/java/com/stripe/service/CashBalanceService.java
+++ b/src/main/java/com/stripe/service/CashBalanceService.java
@@ -45,7 +45,7 @@ public final class CashBalanceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, CashBalance.class);
   }
   /** Changes the settings on a customer’s cash balance. */
@@ -73,7 +73,7 @@ public final class CashBalanceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, CashBalance.class);
   }
 }

--- a/src/main/java/com/stripe/service/CashBalanceService.java
+++ b/src/main/java/com/stripe/service/CashBalanceService.java
@@ -45,6 +45,7 @@ public final class CashBalanceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, CashBalance.class);
   }
   /** Changes the settings on a customer’s cash balance. */
@@ -72,6 +73,7 @@ public final class CashBalanceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, CashBalance.class);
   }
 }

--- a/src/main/java/com/stripe/service/ChargeService.java
+++ b/src/main/java/com/stripe/service/ChargeService.java
@@ -62,6 +62,7 @@ public final class ChargeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Charge>>() {}.getType());
   }
@@ -108,6 +109,7 @@ public final class ChargeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Charge.class);
   }
   /**
@@ -150,6 +152,7 @@ public final class ChargeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Charge.class);
   }
   /**
@@ -188,6 +191,7 @@ public final class ChargeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Charge.class);
   }
   /**
@@ -220,6 +224,7 @@ public final class ChargeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeSearchResult<Charge>>() {}.getType());
   }
@@ -287,6 +292,7 @@ public final class ChargeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Charge.class);
   }
 }

--- a/src/main/java/com/stripe/service/ChargeService.java
+++ b/src/main/java/com/stripe/service/ChargeService.java
@@ -62,7 +62,7 @@ public final class ChargeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Charge>>() {}.getType());
   }
@@ -109,7 +109,7 @@ public final class ChargeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Charge.class);
   }
   /**
@@ -152,7 +152,7 @@ public final class ChargeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Charge.class);
   }
   /**
@@ -191,7 +191,7 @@ public final class ChargeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Charge.class);
   }
   /**
@@ -224,7 +224,7 @@ public final class ChargeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeSearchResult<Charge>>() {}.getType());
   }
@@ -292,7 +292,7 @@ public final class ChargeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Charge.class);
   }
 }

--- a/src/main/java/com/stripe/service/ChargeService.java
+++ b/src/main/java/com/stripe/service/ChargeService.java
@@ -62,7 +62,7 @@ public final class ChargeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Charge>>() {}.getType());
   }
@@ -109,7 +109,7 @@ public final class ChargeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Charge.class);
   }
   /**
@@ -152,7 +152,7 @@ public final class ChargeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Charge.class);
   }
   /**
@@ -191,7 +191,7 @@ public final class ChargeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Charge.class);
   }
   /**
@@ -224,7 +224,7 @@ public final class ChargeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeSearchResult<Charge>>() {}.getType());
   }
@@ -292,7 +292,7 @@ public final class ChargeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Charge.class);
   }
 }

--- a/src/main/java/com/stripe/service/CountrySpecService.java
+++ b/src/main/java/com/stripe/service/CountrySpecService.java
@@ -45,7 +45,7 @@ public final class CountrySpecService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<CountrySpec>>() {}.getType());
   }
@@ -75,7 +75,7 @@ public final class CountrySpecService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, CountrySpec.class);
   }
 }

--- a/src/main/java/com/stripe/service/CountrySpecService.java
+++ b/src/main/java/com/stripe/service/CountrySpecService.java
@@ -45,7 +45,7 @@ public final class CountrySpecService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<CountrySpec>>() {}.getType());
   }
@@ -75,7 +75,7 @@ public final class CountrySpecService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, CountrySpec.class);
   }
 }

--- a/src/main/java/com/stripe/service/CountrySpecService.java
+++ b/src/main/java/com/stripe/service/CountrySpecService.java
@@ -45,6 +45,7 @@ public final class CountrySpecService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<CountrySpec>>() {}.getType());
   }
@@ -74,6 +75,7 @@ public final class CountrySpecService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, CountrySpec.class);
   }
 }

--- a/src/main/java/com/stripe/service/CouponService.java
+++ b/src/main/java/com/stripe/service/CouponService.java
@@ -43,7 +43,7 @@ public final class CouponService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Coupon.class);
   }
   /** Retrieves the coupon with the given ID. */
@@ -70,7 +70,7 @@ public final class CouponService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Coupon.class);
   }
   /**
@@ -109,7 +109,7 @@ public final class CouponService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Coupon.class);
   }
   /** Returns a list of your coupons. */
@@ -136,7 +136,7 @@ public final class CouponService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Coupon>>() {}.getType());
   }
@@ -203,7 +203,7 @@ public final class CouponService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Coupon.class);
   }
 }

--- a/src/main/java/com/stripe/service/CouponService.java
+++ b/src/main/java/com/stripe/service/CouponService.java
@@ -43,7 +43,7 @@ public final class CouponService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Coupon.class);
   }
   /** Retrieves the coupon with the given ID. */
@@ -70,7 +70,7 @@ public final class CouponService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Coupon.class);
   }
   /**
@@ -109,7 +109,7 @@ public final class CouponService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Coupon.class);
   }
   /** Returns a list of your coupons. */
@@ -136,7 +136,7 @@ public final class CouponService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Coupon>>() {}.getType());
   }
@@ -203,7 +203,7 @@ public final class CouponService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Coupon.class);
   }
 }

--- a/src/main/java/com/stripe/service/CouponService.java
+++ b/src/main/java/com/stripe/service/CouponService.java
@@ -43,6 +43,7 @@ public final class CouponService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Coupon.class);
   }
   /** Retrieves the coupon with the given ID. */
@@ -69,6 +70,7 @@ public final class CouponService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Coupon.class);
   }
   /**
@@ -107,6 +109,7 @@ public final class CouponService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Coupon.class);
   }
   /** Returns a list of your coupons. */
@@ -133,6 +136,7 @@ public final class CouponService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Coupon>>() {}.getType());
   }
@@ -199,6 +203,7 @@ public final class CouponService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Coupon.class);
   }
 }

--- a/src/main/java/com/stripe/service/CreditNoteLineItemService.java
+++ b/src/main/java/com/stripe/service/CreditNoteLineItemService.java
@@ -63,7 +63,7 @@ public final class CreditNoteLineItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<CreditNoteLineItem>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/CreditNoteLineItemService.java
+++ b/src/main/java/com/stripe/service/CreditNoteLineItemService.java
@@ -63,7 +63,7 @@ public final class CreditNoteLineItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<CreditNoteLineItem>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/CreditNoteLineItemService.java
+++ b/src/main/java/com/stripe/service/CreditNoteLineItemService.java
@@ -63,6 +63,7 @@ public final class CreditNoteLineItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<CreditNoteLineItem>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/CreditNotePreviewLinesService.java
+++ b/src/main/java/com/stripe/service/CreditNotePreviewLinesService.java
@@ -45,7 +45,7 @@ public final class CreditNotePreviewLinesService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<CreditNoteLineItem>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/CreditNotePreviewLinesService.java
+++ b/src/main/java/com/stripe/service/CreditNotePreviewLinesService.java
@@ -45,6 +45,7 @@ public final class CreditNotePreviewLinesService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<CreditNoteLineItem>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/CreditNotePreviewLinesService.java
+++ b/src/main/java/com/stripe/service/CreditNotePreviewLinesService.java
@@ -45,7 +45,7 @@ public final class CreditNotePreviewLinesService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<CreditNoteLineItem>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/CreditNoteService.java
+++ b/src/main/java/com/stripe/service/CreditNoteService.java
@@ -49,7 +49,7 @@ public final class CreditNoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<CreditNote>>() {}.getType());
   }
@@ -115,7 +115,7 @@ public final class CreditNoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, CreditNote.class);
   }
   /** Retrieves the credit note object with the given identifier. */
@@ -142,7 +142,7 @@ public final class CreditNoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, CreditNote.class);
   }
   /** Updates an existing credit note. */
@@ -169,7 +169,7 @@ public final class CreditNoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, CreditNote.class);
   }
   /** Get a preview of a credit note without creating it. */
@@ -188,7 +188,7 @@ public final class CreditNoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, CreditNote.class);
   }
   /**
@@ -229,7 +229,7 @@ public final class CreditNoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, CreditNote.class);
   }
 

--- a/src/main/java/com/stripe/service/CreditNoteService.java
+++ b/src/main/java/com/stripe/service/CreditNoteService.java
@@ -49,7 +49,7 @@ public final class CreditNoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<CreditNote>>() {}.getType());
   }
@@ -115,7 +115,7 @@ public final class CreditNoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, CreditNote.class);
   }
   /** Retrieves the credit note object with the given identifier. */
@@ -142,7 +142,7 @@ public final class CreditNoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, CreditNote.class);
   }
   /** Updates an existing credit note. */
@@ -169,7 +169,7 @@ public final class CreditNoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, CreditNote.class);
   }
   /** Get a preview of a credit note without creating it. */
@@ -188,7 +188,7 @@ public final class CreditNoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, CreditNote.class);
   }
   /**
@@ -229,7 +229,7 @@ public final class CreditNoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, CreditNote.class);
   }
 

--- a/src/main/java/com/stripe/service/CreditNoteService.java
+++ b/src/main/java/com/stripe/service/CreditNoteService.java
@@ -49,6 +49,7 @@ public final class CreditNoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<CreditNote>>() {}.getType());
   }
@@ -114,6 +115,7 @@ public final class CreditNoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, CreditNote.class);
   }
   /** Retrieves the credit note object with the given identifier. */
@@ -140,6 +142,7 @@ public final class CreditNoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, CreditNote.class);
   }
   /** Updates an existing credit note. */
@@ -166,6 +169,7 @@ public final class CreditNoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, CreditNote.class);
   }
   /** Get a preview of a credit note without creating it. */
@@ -184,6 +188,7 @@ public final class CreditNoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, CreditNote.class);
   }
   /**
@@ -224,6 +229,7 @@ public final class CreditNoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, CreditNote.class);
   }
 

--- a/src/main/java/com/stripe/service/CustomerBalanceTransactionService.java
+++ b/src/main/java/com/stripe/service/CustomerBalanceTransactionService.java
@@ -63,7 +63,7 @@ public final class CustomerBalanceTransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(
             request, new TypeToken<StripeCollection<CustomerBalanceTransaction>>() {}.getType());
@@ -93,7 +93,7 @@ public final class CustomerBalanceTransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, CustomerBalanceTransaction.class);
   }
   /**
@@ -148,7 +148,7 @@ public final class CustomerBalanceTransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, CustomerBalanceTransaction.class);
   }
   /**
@@ -202,7 +202,7 @@ public final class CustomerBalanceTransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, CustomerBalanceTransaction.class);
   }
 }

--- a/src/main/java/com/stripe/service/CustomerBalanceTransactionService.java
+++ b/src/main/java/com/stripe/service/CustomerBalanceTransactionService.java
@@ -63,7 +63,7 @@ public final class CustomerBalanceTransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(
             request, new TypeToken<StripeCollection<CustomerBalanceTransaction>>() {}.getType());
@@ -93,7 +93,7 @@ public final class CustomerBalanceTransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, CustomerBalanceTransaction.class);
   }
   /**
@@ -148,7 +148,7 @@ public final class CustomerBalanceTransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, CustomerBalanceTransaction.class);
   }
   /**
@@ -202,7 +202,7 @@ public final class CustomerBalanceTransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, CustomerBalanceTransaction.class);
   }
 }

--- a/src/main/java/com/stripe/service/CustomerBalanceTransactionService.java
+++ b/src/main/java/com/stripe/service/CustomerBalanceTransactionService.java
@@ -63,6 +63,7 @@ public final class CustomerBalanceTransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(
             request, new TypeToken<StripeCollection<CustomerBalanceTransaction>>() {}.getType());
@@ -92,6 +93,7 @@ public final class CustomerBalanceTransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, CustomerBalanceTransaction.class);
   }
   /**
@@ -146,6 +148,7 @@ public final class CustomerBalanceTransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, CustomerBalanceTransaction.class);
   }
   /**
@@ -199,6 +202,7 @@ public final class CustomerBalanceTransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, CustomerBalanceTransaction.class);
   }
 }

--- a/src/main/java/com/stripe/service/CustomerCashBalanceTransactionService.java
+++ b/src/main/java/com/stripe/service/CustomerCashBalanceTransactionService.java
@@ -63,6 +63,7 @@ public final class CustomerCashBalanceTransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(
             request,
@@ -120,6 +121,7 @@ public final class CustomerCashBalanceTransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, CustomerCashBalanceTransaction.class);
   }
 }

--- a/src/main/java/com/stripe/service/CustomerCashBalanceTransactionService.java
+++ b/src/main/java/com/stripe/service/CustomerCashBalanceTransactionService.java
@@ -63,7 +63,7 @@ public final class CustomerCashBalanceTransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(
             request,
@@ -121,7 +121,7 @@ public final class CustomerCashBalanceTransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, CustomerCashBalanceTransaction.class);
   }
 }

--- a/src/main/java/com/stripe/service/CustomerCashBalanceTransactionService.java
+++ b/src/main/java/com/stripe/service/CustomerCashBalanceTransactionService.java
@@ -63,7 +63,7 @@ public final class CustomerCashBalanceTransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(
             request,
@@ -121,7 +121,7 @@ public final class CustomerCashBalanceTransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, CustomerCashBalanceTransaction.class);
   }
 }

--- a/src/main/java/com/stripe/service/CustomerFundingInstructionsService.java
+++ b/src/main/java/com/stripe/service/CustomerFundingInstructionsService.java
@@ -47,7 +47,7 @@ public final class CustomerFundingInstructionsService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, FundingInstructions.class);
   }
 }

--- a/src/main/java/com/stripe/service/CustomerFundingInstructionsService.java
+++ b/src/main/java/com/stripe/service/CustomerFundingInstructionsService.java
@@ -47,6 +47,7 @@ public final class CustomerFundingInstructionsService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, FundingInstructions.class);
   }
 }

--- a/src/main/java/com/stripe/service/CustomerFundingInstructionsService.java
+++ b/src/main/java/com/stripe/service/CustomerFundingInstructionsService.java
@@ -47,7 +47,7 @@ public final class CustomerFundingInstructionsService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, FundingInstructions.class);
   }
 }

--- a/src/main/java/com/stripe/service/CustomerPaymentMethodService.java
+++ b/src/main/java/com/stripe/service/CustomerPaymentMethodService.java
@@ -49,7 +49,7 @@ public final class CustomerPaymentMethodService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<PaymentMethod>>() {}.getType());
   }
@@ -88,7 +88,7 @@ public final class CustomerPaymentMethodService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethod.class);
   }
 }

--- a/src/main/java/com/stripe/service/CustomerPaymentMethodService.java
+++ b/src/main/java/com/stripe/service/CustomerPaymentMethodService.java
@@ -49,7 +49,7 @@ public final class CustomerPaymentMethodService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<PaymentMethod>>() {}.getType());
   }
@@ -88,7 +88,7 @@ public final class CustomerPaymentMethodService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethod.class);
   }
 }

--- a/src/main/java/com/stripe/service/CustomerPaymentMethodService.java
+++ b/src/main/java/com/stripe/service/CustomerPaymentMethodService.java
@@ -49,6 +49,7 @@ public final class CustomerPaymentMethodService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<PaymentMethod>>() {}.getType());
   }
@@ -87,6 +88,7 @@ public final class CustomerPaymentMethodService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethod.class);
   }
 }

--- a/src/main/java/com/stripe/service/CustomerService.java
+++ b/src/main/java/com/stripe/service/CustomerService.java
@@ -42,6 +42,7 @@ public final class CustomerService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Customer.class);
   }
   /** Retrieves a Customer object. */
@@ -68,6 +69,7 @@ public final class CustomerService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Customer.class);
   }
   /**
@@ -146,6 +148,7 @@ public final class CustomerService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Customer.class);
   }
   /** Removes the currently applied discount on a customer. */
@@ -158,6 +161,7 @@ public final class CustomerService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Discount.class);
   }
   /**
@@ -196,6 +200,7 @@ public final class CustomerService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Customer>>() {}.getType());
   }
@@ -223,6 +228,7 @@ public final class CustomerService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Customer.class);
   }
   /**
@@ -255,6 +261,7 @@ public final class CustomerService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeSearchResult<Customer>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/CustomerService.java
+++ b/src/main/java/com/stripe/service/CustomerService.java
@@ -42,7 +42,7 @@ public final class CustomerService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Customer.class);
   }
   /** Retrieves a Customer object. */
@@ -69,7 +69,7 @@ public final class CustomerService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Customer.class);
   }
   /**
@@ -148,7 +148,7 @@ public final class CustomerService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Customer.class);
   }
   /** Removes the currently applied discount on a customer. */
@@ -161,7 +161,7 @@ public final class CustomerService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Discount.class);
   }
   /**
@@ -200,7 +200,7 @@ public final class CustomerService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Customer>>() {}.getType());
   }
@@ -228,7 +228,7 @@ public final class CustomerService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Customer.class);
   }
   /**
@@ -261,7 +261,7 @@ public final class CustomerService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeSearchResult<Customer>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/CustomerService.java
+++ b/src/main/java/com/stripe/service/CustomerService.java
@@ -42,7 +42,7 @@ public final class CustomerService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Customer.class);
   }
   /** Retrieves a Customer object. */
@@ -69,7 +69,7 @@ public final class CustomerService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Customer.class);
   }
   /**
@@ -148,7 +148,7 @@ public final class CustomerService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Customer.class);
   }
   /** Removes the currently applied discount on a customer. */
@@ -161,7 +161,7 @@ public final class CustomerService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Discount.class);
   }
   /**
@@ -200,7 +200,7 @@ public final class CustomerService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Customer>>() {}.getType());
   }
@@ -228,7 +228,7 @@ public final class CustomerService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Customer.class);
   }
   /**
@@ -261,7 +261,7 @@ public final class CustomerService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeSearchResult<Customer>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/CustomerSessionService.java
+++ b/src/main/java/com/stripe/service/CustomerSessionService.java
@@ -40,7 +40,7 @@ public final class CustomerSessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, CustomerSession.class);
   }
 }

--- a/src/main/java/com/stripe/service/CustomerSessionService.java
+++ b/src/main/java/com/stripe/service/CustomerSessionService.java
@@ -40,7 +40,7 @@ public final class CustomerSessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, CustomerSession.class);
   }
 }

--- a/src/main/java/com/stripe/service/CustomerSessionService.java
+++ b/src/main/java/com/stripe/service/CustomerSessionService.java
@@ -40,6 +40,7 @@ public final class CustomerSessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, CustomerSession.class);
   }
 }

--- a/src/main/java/com/stripe/service/DisputeService.java
+++ b/src/main/java/com/stripe/service/DisputeService.java
@@ -47,7 +47,7 @@ public final class DisputeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Dispute>>() {}.getType());
   }
@@ -75,7 +75,7 @@ public final class DisputeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Dispute.class);
   }
   /**
@@ -138,7 +138,7 @@ public final class DisputeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Dispute.class);
   }
   /**
@@ -189,7 +189,7 @@ public final class DisputeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Dispute.class);
   }
 }

--- a/src/main/java/com/stripe/service/DisputeService.java
+++ b/src/main/java/com/stripe/service/DisputeService.java
@@ -47,7 +47,7 @@ public final class DisputeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Dispute>>() {}.getType());
   }
@@ -75,7 +75,7 @@ public final class DisputeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Dispute.class);
   }
   /**
@@ -138,7 +138,7 @@ public final class DisputeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Dispute.class);
   }
   /**
@@ -189,7 +189,7 @@ public final class DisputeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Dispute.class);
   }
 }

--- a/src/main/java/com/stripe/service/DisputeService.java
+++ b/src/main/java/com/stripe/service/DisputeService.java
@@ -47,6 +47,7 @@ public final class DisputeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Dispute>>() {}.getType());
   }
@@ -74,6 +75,7 @@ public final class DisputeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Dispute.class);
   }
   /**
@@ -136,6 +138,7 @@ public final class DisputeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Dispute.class);
   }
   /**
@@ -186,6 +189,7 @@ public final class DisputeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Dispute.class);
   }
 }

--- a/src/main/java/com/stripe/service/EphemeralKeyService.java
+++ b/src/main/java/com/stripe/service/EphemeralKeyService.java
@@ -43,6 +43,7 @@ public final class EphemeralKeyService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, EphemeralKey.class);
   }
   /** Creates a short-lived API key for a given resource. */

--- a/src/main/java/com/stripe/service/EphemeralKeyService.java
+++ b/src/main/java/com/stripe/service/EphemeralKeyService.java
@@ -43,7 +43,7 @@ public final class EphemeralKeyService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, EphemeralKey.class);
   }
   /** Creates a short-lived API key for a given resource. */

--- a/src/main/java/com/stripe/service/EphemeralKeyService.java
+++ b/src/main/java/com/stripe/service/EphemeralKeyService.java
@@ -43,7 +43,7 @@ public final class EphemeralKeyService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, EphemeralKey.class);
   }
   /** Creates a short-lived API key for a given resource. */

--- a/src/main/java/com/stripe/service/EventService.java
+++ b/src/main/java/com/stripe/service/EventService.java
@@ -65,6 +65,7 @@ public final class EventService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Event>>() {}.getType());
   }
@@ -104,6 +105,7 @@ public final class EventService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Event.class);
   }
 }

--- a/src/main/java/com/stripe/service/EventService.java
+++ b/src/main/java/com/stripe/service/EventService.java
@@ -65,7 +65,7 @@ public final class EventService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Event>>() {}.getType());
   }
@@ -105,7 +105,7 @@ public final class EventService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Event.class);
   }
 }

--- a/src/main/java/com/stripe/service/EventService.java
+++ b/src/main/java/com/stripe/service/EventService.java
@@ -65,7 +65,7 @@ public final class EventService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Event>>() {}.getType());
   }
@@ -105,7 +105,7 @@ public final class EventService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Event.class);
   }
 }

--- a/src/main/java/com/stripe/service/ExchangeRateService.java
+++ b/src/main/java/com/stripe/service/ExchangeRateService.java
@@ -57,7 +57,7 @@ public final class ExchangeRateService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ExchangeRate>>() {}.getType());
   }
@@ -87,7 +87,7 @@ public final class ExchangeRateService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, ExchangeRate.class);
   }
 }

--- a/src/main/java/com/stripe/service/ExchangeRateService.java
+++ b/src/main/java/com/stripe/service/ExchangeRateService.java
@@ -57,7 +57,7 @@ public final class ExchangeRateService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ExchangeRate>>() {}.getType());
   }
@@ -87,7 +87,7 @@ public final class ExchangeRateService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, ExchangeRate.class);
   }
 }

--- a/src/main/java/com/stripe/service/ExchangeRateService.java
+++ b/src/main/java/com/stripe/service/ExchangeRateService.java
@@ -57,6 +57,7 @@ public final class ExchangeRateService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ExchangeRate>>() {}.getType());
   }
@@ -86,6 +87,7 @@ public final class ExchangeRateService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, ExchangeRate.class);
   }
 }

--- a/src/main/java/com/stripe/service/ExternalAccountService.java
+++ b/src/main/java/com/stripe/service/ExternalAccountService.java
@@ -37,6 +37,7 @@ public final class ExternalAccountService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, ExternalAccount.class);
   }
   /** Retrieve a specified external account for a given account. */
@@ -69,6 +70,7 @@ public final class ExternalAccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, ExternalAccount.class);
   }
   /**
@@ -129,6 +131,7 @@ public final class ExternalAccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, ExternalAccount.class);
   }
   /** List external accounts for an account. */
@@ -159,6 +162,7 @@ public final class ExternalAccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ExternalAccount>>() {}.getType());
   }
@@ -181,6 +185,7 @@ public final class ExternalAccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, ExternalAccount.class);
   }
 }

--- a/src/main/java/com/stripe/service/ExternalAccountService.java
+++ b/src/main/java/com/stripe/service/ExternalAccountService.java
@@ -37,7 +37,7 @@ public final class ExternalAccountService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, ExternalAccount.class);
   }
   /** Retrieve a specified external account for a given account. */
@@ -70,7 +70,7 @@ public final class ExternalAccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, ExternalAccount.class);
   }
   /**
@@ -131,7 +131,7 @@ public final class ExternalAccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, ExternalAccount.class);
   }
   /** List external accounts for an account. */
@@ -162,7 +162,7 @@ public final class ExternalAccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ExternalAccount>>() {}.getType());
   }
@@ -185,7 +185,7 @@ public final class ExternalAccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, ExternalAccount.class);
   }
 }

--- a/src/main/java/com/stripe/service/ExternalAccountService.java
+++ b/src/main/java/com/stripe/service/ExternalAccountService.java
@@ -37,7 +37,7 @@ public final class ExternalAccountService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, ExternalAccount.class);
   }
   /** Retrieve a specified external account for a given account. */
@@ -70,7 +70,7 @@ public final class ExternalAccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, ExternalAccount.class);
   }
   /**
@@ -131,7 +131,7 @@ public final class ExternalAccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, ExternalAccount.class);
   }
   /** List external accounts for an account. */
@@ -162,7 +162,7 @@ public final class ExternalAccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ExternalAccount>>() {}.getType());
   }
@@ -185,7 +185,7 @@ public final class ExternalAccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, ExternalAccount.class);
   }
 }

--- a/src/main/java/com/stripe/service/FeeRefundService.java
+++ b/src/main/java/com/stripe/service/FeeRefundService.java
@@ -68,7 +68,7 @@ public final class FeeRefundService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, FeeRefund.class);
   }
   /**
@@ -120,7 +120,7 @@ public final class FeeRefundService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, FeeRefund.class);
   }
   /**
@@ -169,7 +169,7 @@ public final class FeeRefundService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<FeeRefund>>() {}.getType());
   }
@@ -237,7 +237,7 @@ public final class FeeRefundService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, FeeRefund.class);
   }
 }

--- a/src/main/java/com/stripe/service/FeeRefundService.java
+++ b/src/main/java/com/stripe/service/FeeRefundService.java
@@ -68,6 +68,7 @@ public final class FeeRefundService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, FeeRefund.class);
   }
   /**
@@ -119,6 +120,7 @@ public final class FeeRefundService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, FeeRefund.class);
   }
   /**
@@ -167,6 +169,7 @@ public final class FeeRefundService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<FeeRefund>>() {}.getType());
   }
@@ -234,6 +237,7 @@ public final class FeeRefundService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, FeeRefund.class);
   }
 }

--- a/src/main/java/com/stripe/service/FeeRefundService.java
+++ b/src/main/java/com/stripe/service/FeeRefundService.java
@@ -68,7 +68,7 @@ public final class FeeRefundService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, FeeRefund.class);
   }
   /**
@@ -120,7 +120,7 @@ public final class FeeRefundService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, FeeRefund.class);
   }
   /**
@@ -169,7 +169,7 @@ public final class FeeRefundService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<FeeRefund>>() {}.getType());
   }
@@ -237,7 +237,7 @@ public final class FeeRefundService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, FeeRefund.class);
   }
 }

--- a/src/main/java/com/stripe/service/FileLinkService.java
+++ b/src/main/java/com/stripe/service/FileLinkService.java
@@ -47,7 +47,7 @@ public final class FileLinkService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<FileLink>>() {}.getType());
   }
@@ -67,7 +67,7 @@ public final class FileLinkService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, FileLink.class);
   }
   /** Retrieves the file link with the given ID. */
@@ -94,7 +94,7 @@ public final class FileLinkService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, FileLink.class);
   }
   /** Updates an existing file link object. Expired links can no longer be updated. */
@@ -121,7 +121,7 @@ public final class FileLinkService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, FileLink.class);
   }
 }

--- a/src/main/java/com/stripe/service/FileLinkService.java
+++ b/src/main/java/com/stripe/service/FileLinkService.java
@@ -47,6 +47,7 @@ public final class FileLinkService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<FileLink>>() {}.getType());
   }
@@ -66,6 +67,7 @@ public final class FileLinkService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, FileLink.class);
   }
   /** Retrieves the file link with the given ID. */
@@ -92,6 +94,7 @@ public final class FileLinkService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, FileLink.class);
   }
   /** Updates an existing file link object. Expired links can no longer be updated. */
@@ -118,6 +121,7 @@ public final class FileLinkService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, FileLink.class);
   }
 }

--- a/src/main/java/com/stripe/service/FileLinkService.java
+++ b/src/main/java/com/stripe/service/FileLinkService.java
@@ -47,7 +47,7 @@ public final class FileLinkService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<FileLink>>() {}.getType());
   }
@@ -67,7 +67,7 @@ public final class FileLinkService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, FileLink.class);
   }
   /** Retrieves the file link with the given ID. */
@@ -94,7 +94,7 @@ public final class FileLinkService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, FileLink.class);
   }
   /** Updates an existing file link object. Expired links can no longer be updated. */
@@ -121,7 +121,7 @@ public final class FileLinkService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, FileLink.class);
   }
 }

--- a/src/main/java/com/stripe/service/FileService.java
+++ b/src/main/java/com/stripe/service/FileService.java
@@ -58,6 +58,7 @@ public final class FileService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<File>>() {}.getType());
   }
@@ -88,6 +89,7 @@ public final class FileService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, File.class);
   }
   /**
@@ -130,6 +132,7 @@ public final class FileService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, File.class);
   }
 }

--- a/src/main/java/com/stripe/service/FileService.java
+++ b/src/main/java/com/stripe/service/FileService.java
@@ -58,7 +58,7 @@ public final class FileService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<File>>() {}.getType());
   }
@@ -89,7 +89,7 @@ public final class FileService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, File.class);
   }
   /**
@@ -132,7 +132,7 @@ public final class FileService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, File.class);
   }
 }

--- a/src/main/java/com/stripe/service/FileService.java
+++ b/src/main/java/com/stripe/service/FileService.java
@@ -58,7 +58,7 @@ public final class FileService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<File>>() {}.getType());
   }
@@ -89,7 +89,7 @@ public final class FileService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, File.class);
   }
   /**
@@ -132,7 +132,7 @@ public final class FileService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, File.class);
   }
 }

--- a/src/main/java/com/stripe/service/InvoiceItemService.java
+++ b/src/main/java/com/stripe/service/InvoiceItemService.java
@@ -39,7 +39,7 @@ public final class InvoiceItemService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, InvoiceItem.class);
   }
   /** Retrieves the invoice item with the given ID. */
@@ -68,7 +68,7 @@ public final class InvoiceItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, InvoiceItem.class);
   }
   /**
@@ -109,7 +109,7 @@ public final class InvoiceItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, InvoiceItem.class);
   }
   /**
@@ -148,7 +148,7 @@ public final class InvoiceItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<InvoiceItem>>() {}.getType());
   }
@@ -174,7 +174,7 @@ public final class InvoiceItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, InvoiceItem.class);
   }
 }

--- a/src/main/java/com/stripe/service/InvoiceItemService.java
+++ b/src/main/java/com/stripe/service/InvoiceItemService.java
@@ -39,7 +39,7 @@ public final class InvoiceItemService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, InvoiceItem.class);
   }
   /** Retrieves the invoice item with the given ID. */
@@ -68,7 +68,7 @@ public final class InvoiceItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, InvoiceItem.class);
   }
   /**
@@ -109,7 +109,7 @@ public final class InvoiceItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, InvoiceItem.class);
   }
   /**
@@ -148,7 +148,7 @@ public final class InvoiceItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<InvoiceItem>>() {}.getType());
   }
@@ -174,7 +174,7 @@ public final class InvoiceItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, InvoiceItem.class);
   }
 }

--- a/src/main/java/com/stripe/service/InvoiceItemService.java
+++ b/src/main/java/com/stripe/service/InvoiceItemService.java
@@ -39,6 +39,7 @@ public final class InvoiceItemService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, InvoiceItem.class);
   }
   /** Retrieves the invoice item with the given ID. */
@@ -67,6 +68,7 @@ public final class InvoiceItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, InvoiceItem.class);
   }
   /**
@@ -107,6 +109,7 @@ public final class InvoiceItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, InvoiceItem.class);
   }
   /**
@@ -145,6 +148,7 @@ public final class InvoiceItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<InvoiceItem>>() {}.getType());
   }
@@ -170,6 +174,7 @@ public final class InvoiceItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, InvoiceItem.class);
   }
 }

--- a/src/main/java/com/stripe/service/InvoiceLineItemService.java
+++ b/src/main/java/com/stripe/service/InvoiceLineItemService.java
@@ -63,7 +63,7 @@ public final class InvoiceLineItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<InvoiceLineItem>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/InvoiceLineItemService.java
+++ b/src/main/java/com/stripe/service/InvoiceLineItemService.java
@@ -63,6 +63,7 @@ public final class InvoiceLineItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<InvoiceLineItem>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/InvoiceLineItemService.java
+++ b/src/main/java/com/stripe/service/InvoiceLineItemService.java
@@ -63,7 +63,7 @@ public final class InvoiceLineItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<InvoiceLineItem>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/InvoiceService.java
+++ b/src/main/java/com/stripe/service/InvoiceService.java
@@ -51,6 +51,7 @@ public final class InvoiceService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Invoice.class);
   }
   /** Retrieves the invoice with the given ID. */
@@ -77,6 +78,7 @@ public final class InvoiceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Invoice.class);
   }
   /**
@@ -139,6 +141,7 @@ public final class InvoiceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Invoice.class);
   }
   /**
@@ -177,6 +180,7 @@ public final class InvoiceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Invoice>>() {}.getType());
   }
@@ -223,6 +227,7 @@ public final class InvoiceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Invoice.class);
   }
   /**
@@ -255,6 +260,7 @@ public final class InvoiceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeSearchResult<Invoice>>() {}.getType());
   }
@@ -358,6 +364,7 @@ public final class InvoiceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Invoice.class);
   }
   /**
@@ -398,6 +405,7 @@ public final class InvoiceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Invoice.class);
   }
   /**
@@ -439,6 +447,7 @@ public final class InvoiceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Invoice.class);
   }
   /**
@@ -489,6 +498,7 @@ public final class InvoiceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Invoice.class);
   }
   /**
@@ -553,6 +563,7 @@ public final class InvoiceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Invoice.class);
   }
   /**
@@ -597,6 +608,7 @@ public final class InvoiceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Invoice.class);
   }
 

--- a/src/main/java/com/stripe/service/InvoiceService.java
+++ b/src/main/java/com/stripe/service/InvoiceService.java
@@ -51,7 +51,7 @@ public final class InvoiceService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Invoice.class);
   }
   /** Retrieves the invoice with the given ID. */
@@ -78,7 +78,7 @@ public final class InvoiceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Invoice.class);
   }
   /**
@@ -141,7 +141,7 @@ public final class InvoiceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Invoice.class);
   }
   /**
@@ -180,7 +180,7 @@ public final class InvoiceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Invoice>>() {}.getType());
   }
@@ -227,7 +227,7 @@ public final class InvoiceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Invoice.class);
   }
   /**
@@ -260,7 +260,7 @@ public final class InvoiceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeSearchResult<Invoice>>() {}.getType());
   }
@@ -364,7 +364,7 @@ public final class InvoiceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Invoice.class);
   }
   /**
@@ -405,7 +405,7 @@ public final class InvoiceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Invoice.class);
   }
   /**
@@ -447,7 +447,7 @@ public final class InvoiceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Invoice.class);
   }
   /**
@@ -498,7 +498,7 @@ public final class InvoiceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Invoice.class);
   }
   /**
@@ -563,7 +563,7 @@ public final class InvoiceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Invoice.class);
   }
   /**
@@ -608,7 +608,7 @@ public final class InvoiceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Invoice.class);
   }
 

--- a/src/main/java/com/stripe/service/InvoiceService.java
+++ b/src/main/java/com/stripe/service/InvoiceService.java
@@ -51,7 +51,7 @@ public final class InvoiceService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Invoice.class);
   }
   /** Retrieves the invoice with the given ID. */
@@ -78,7 +78,7 @@ public final class InvoiceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Invoice.class);
   }
   /**
@@ -141,7 +141,7 @@ public final class InvoiceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Invoice.class);
   }
   /**
@@ -180,7 +180,7 @@ public final class InvoiceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Invoice>>() {}.getType());
   }
@@ -227,7 +227,7 @@ public final class InvoiceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Invoice.class);
   }
   /**
@@ -260,7 +260,7 @@ public final class InvoiceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeSearchResult<Invoice>>() {}.getType());
   }
@@ -364,7 +364,7 @@ public final class InvoiceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Invoice.class);
   }
   /**
@@ -405,7 +405,7 @@ public final class InvoiceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Invoice.class);
   }
   /**
@@ -447,7 +447,7 @@ public final class InvoiceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Invoice.class);
   }
   /**
@@ -498,7 +498,7 @@ public final class InvoiceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Invoice.class);
   }
   /**
@@ -563,7 +563,7 @@ public final class InvoiceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Invoice.class);
   }
   /**
@@ -608,7 +608,7 @@ public final class InvoiceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Invoice.class);
   }
 

--- a/src/main/java/com/stripe/service/InvoiceUpcomingLinesService.java
+++ b/src/main/java/com/stripe/service/InvoiceUpcomingLinesService.java
@@ -61,7 +61,7 @@ public final class InvoiceUpcomingLinesService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<InvoiceLineItem>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/InvoiceUpcomingLinesService.java
+++ b/src/main/java/com/stripe/service/InvoiceUpcomingLinesService.java
@@ -61,7 +61,7 @@ public final class InvoiceUpcomingLinesService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<InvoiceLineItem>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/InvoiceUpcomingLinesService.java
+++ b/src/main/java/com/stripe/service/InvoiceUpcomingLinesService.java
@@ -61,6 +61,7 @@ public final class InvoiceUpcomingLinesService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<InvoiceLineItem>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/LoginLinkService.java
+++ b/src/main/java/com/stripe/service/LoginLinkService.java
@@ -66,7 +66,7 @@ public final class LoginLinkService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, LoginLink.class);
   }
 }

--- a/src/main/java/com/stripe/service/LoginLinkService.java
+++ b/src/main/java/com/stripe/service/LoginLinkService.java
@@ -66,6 +66,7 @@ public final class LoginLinkService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, LoginLink.class);
   }
 }

--- a/src/main/java/com/stripe/service/LoginLinkService.java
+++ b/src/main/java/com/stripe/service/LoginLinkService.java
@@ -66,7 +66,7 @@ public final class LoginLinkService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, LoginLink.class);
   }
 }

--- a/src/main/java/com/stripe/service/MandateService.java
+++ b/src/main/java/com/stripe/service/MandateService.java
@@ -42,7 +42,7 @@ public final class MandateService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Mandate.class);
   }
 }

--- a/src/main/java/com/stripe/service/MandateService.java
+++ b/src/main/java/com/stripe/service/MandateService.java
@@ -42,6 +42,7 @@ public final class MandateService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Mandate.class);
   }
 }

--- a/src/main/java/com/stripe/service/MandateService.java
+++ b/src/main/java/com/stripe/service/MandateService.java
@@ -42,7 +42,7 @@ public final class MandateService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Mandate.class);
   }
 }

--- a/src/main/java/com/stripe/service/PaymentIntentService.java
+++ b/src/main/java/com/stripe/service/PaymentIntentService.java
@@ -56,6 +56,7 @@ public final class PaymentIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<PaymentIntent>>() {}.getType());
   }
@@ -99,6 +100,7 @@ public final class PaymentIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentIntent.class);
   }
   /**
@@ -163,6 +165,7 @@ public final class PaymentIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentIntent.class);
   }
   /**
@@ -223,6 +226,7 @@ public final class PaymentIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentIntent.class);
   }
   /**
@@ -256,6 +260,7 @@ public final class PaymentIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeSearchResult<PaymentIntent>>() {}.getType());
   }
@@ -289,6 +294,7 @@ public final class PaymentIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentIntent.class);
   }
   /**
@@ -369,6 +375,7 @@ public final class PaymentIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentIntent.class);
   }
   /**
@@ -433,6 +440,7 @@ public final class PaymentIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentIntent.class);
   }
   /**
@@ -545,6 +553,7 @@ public final class PaymentIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentIntent.class);
   }
   /**
@@ -619,6 +628,7 @@ public final class PaymentIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentIntent.class);
   }
   /** Verifies microdeposits on a PaymentIntent object. */
@@ -651,6 +661,7 @@ public final class PaymentIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentIntent.class);
   }
 }

--- a/src/main/java/com/stripe/service/PaymentIntentService.java
+++ b/src/main/java/com/stripe/service/PaymentIntentService.java
@@ -56,7 +56,7 @@ public final class PaymentIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<PaymentIntent>>() {}.getType());
   }
@@ -100,7 +100,7 @@ public final class PaymentIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, PaymentIntent.class);
   }
   /**
@@ -165,7 +165,7 @@ public final class PaymentIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, PaymentIntent.class);
   }
   /**
@@ -226,7 +226,7 @@ public final class PaymentIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, PaymentIntent.class);
   }
   /**
@@ -260,7 +260,7 @@ public final class PaymentIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeSearchResult<PaymentIntent>>() {}.getType());
   }
@@ -294,7 +294,7 @@ public final class PaymentIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, PaymentIntent.class);
   }
   /**
@@ -375,7 +375,7 @@ public final class PaymentIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, PaymentIntent.class);
   }
   /**
@@ -440,7 +440,7 @@ public final class PaymentIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, PaymentIntent.class);
   }
   /**
@@ -553,7 +553,7 @@ public final class PaymentIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, PaymentIntent.class);
   }
   /**
@@ -628,7 +628,7 @@ public final class PaymentIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, PaymentIntent.class);
   }
   /** Verifies microdeposits on a PaymentIntent object. */
@@ -661,7 +661,7 @@ public final class PaymentIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, PaymentIntent.class);
   }
 }

--- a/src/main/java/com/stripe/service/PaymentIntentService.java
+++ b/src/main/java/com/stripe/service/PaymentIntentService.java
@@ -56,7 +56,7 @@ public final class PaymentIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<PaymentIntent>>() {}.getType());
   }
@@ -100,7 +100,7 @@ public final class PaymentIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentIntent.class);
   }
   /**
@@ -165,7 +165,7 @@ public final class PaymentIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentIntent.class);
   }
   /**
@@ -226,7 +226,7 @@ public final class PaymentIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentIntent.class);
   }
   /**
@@ -260,7 +260,7 @@ public final class PaymentIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeSearchResult<PaymentIntent>>() {}.getType());
   }
@@ -294,7 +294,7 @@ public final class PaymentIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentIntent.class);
   }
   /**
@@ -375,7 +375,7 @@ public final class PaymentIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentIntent.class);
   }
   /**
@@ -440,7 +440,7 @@ public final class PaymentIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentIntent.class);
   }
   /**
@@ -553,7 +553,7 @@ public final class PaymentIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentIntent.class);
   }
   /**
@@ -628,7 +628,7 @@ public final class PaymentIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentIntent.class);
   }
   /** Verifies microdeposits on a PaymentIntent object. */
@@ -661,7 +661,7 @@ public final class PaymentIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentIntent.class);
   }
 }

--- a/src/main/java/com/stripe/service/PaymentLinkLineItemService.java
+++ b/src/main/java/com/stripe/service/PaymentLinkLineItemService.java
@@ -64,7 +64,7 @@ public final class PaymentLinkLineItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<LineItem>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/PaymentLinkLineItemService.java
+++ b/src/main/java/com/stripe/service/PaymentLinkLineItemService.java
@@ -64,6 +64,7 @@ public final class PaymentLinkLineItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<LineItem>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/PaymentLinkLineItemService.java
+++ b/src/main/java/com/stripe/service/PaymentLinkLineItemService.java
@@ -64,7 +64,7 @@ public final class PaymentLinkLineItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<LineItem>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/PaymentLinkService.java
+++ b/src/main/java/com/stripe/service/PaymentLinkService.java
@@ -47,7 +47,7 @@ public final class PaymentLinkService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<PaymentLink>>() {}.getType());
   }
@@ -67,7 +67,7 @@ public final class PaymentLinkService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentLink.class);
   }
   /** Retrieve a payment link. */
@@ -96,7 +96,7 @@ public final class PaymentLinkService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentLink.class);
   }
   /** Updates a payment link. */
@@ -125,7 +125,7 @@ public final class PaymentLinkService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentLink.class);
   }
 

--- a/src/main/java/com/stripe/service/PaymentLinkService.java
+++ b/src/main/java/com/stripe/service/PaymentLinkService.java
@@ -47,7 +47,7 @@ public final class PaymentLinkService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<PaymentLink>>() {}.getType());
   }
@@ -67,7 +67,7 @@ public final class PaymentLinkService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, PaymentLink.class);
   }
   /** Retrieve a payment link. */
@@ -96,7 +96,7 @@ public final class PaymentLinkService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, PaymentLink.class);
   }
   /** Updates a payment link. */
@@ -125,7 +125,7 @@ public final class PaymentLinkService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, PaymentLink.class);
   }
 

--- a/src/main/java/com/stripe/service/PaymentLinkService.java
+++ b/src/main/java/com/stripe/service/PaymentLinkService.java
@@ -47,6 +47,7 @@ public final class PaymentLinkService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<PaymentLink>>() {}.getType());
   }
@@ -66,6 +67,7 @@ public final class PaymentLinkService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentLink.class);
   }
   /** Retrieve a payment link. */
@@ -94,6 +96,7 @@ public final class PaymentLinkService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentLink.class);
   }
   /** Updates a payment link. */
@@ -122,6 +125,7 @@ public final class PaymentLinkService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentLink.class);
   }
 

--- a/src/main/java/com/stripe/service/PaymentMethodConfigurationService.java
+++ b/src/main/java/com/stripe/service/PaymentMethodConfigurationService.java
@@ -49,7 +49,7 @@ public final class PaymentMethodConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(
             request, new TypeToken<StripeCollection<PaymentMethodConfiguration>>() {}.getType());
@@ -80,7 +80,7 @@ public final class PaymentMethodConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethodConfiguration.class);
   }
   /** Retrieve payment method configuration. */
@@ -114,7 +114,7 @@ public final class PaymentMethodConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethodConfiguration.class);
   }
   /** Update payment method configuration. */
@@ -147,7 +147,7 @@ public final class PaymentMethodConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethodConfiguration.class);
   }
 }

--- a/src/main/java/com/stripe/service/PaymentMethodConfigurationService.java
+++ b/src/main/java/com/stripe/service/PaymentMethodConfigurationService.java
@@ -49,6 +49,7 @@ public final class PaymentMethodConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(
             request, new TypeToken<StripeCollection<PaymentMethodConfiguration>>() {}.getType());
@@ -79,6 +80,7 @@ public final class PaymentMethodConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethodConfiguration.class);
   }
   /** Retrieve payment method configuration. */
@@ -112,6 +114,7 @@ public final class PaymentMethodConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethodConfiguration.class);
   }
   /** Update payment method configuration. */
@@ -144,6 +147,7 @@ public final class PaymentMethodConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethodConfiguration.class);
   }
 }

--- a/src/main/java/com/stripe/service/PaymentMethodConfigurationService.java
+++ b/src/main/java/com/stripe/service/PaymentMethodConfigurationService.java
@@ -49,7 +49,7 @@ public final class PaymentMethodConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(
             request, new TypeToken<StripeCollection<PaymentMethodConfiguration>>() {}.getType());
@@ -80,7 +80,7 @@ public final class PaymentMethodConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethodConfiguration.class);
   }
   /** Retrieve payment method configuration. */
@@ -114,7 +114,7 @@ public final class PaymentMethodConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethodConfiguration.class);
   }
   /** Update payment method configuration. */
@@ -147,7 +147,7 @@ public final class PaymentMethodConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethodConfiguration.class);
   }
 }

--- a/src/main/java/com/stripe/service/PaymentMethodDomainService.java
+++ b/src/main/java/com/stripe/service/PaymentMethodDomainService.java
@@ -49,6 +49,7 @@ public final class PaymentMethodDomainService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<PaymentMethodDomain>>() {}.getType());
   }
@@ -68,6 +69,7 @@ public final class PaymentMethodDomainService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethodDomain.class);
   }
   /** Retrieves the details of an existing payment method domain. */
@@ -100,6 +102,7 @@ public final class PaymentMethodDomainService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethodDomain.class);
   }
   /** Updates an existing payment method domain. */
@@ -132,6 +135,7 @@ public final class PaymentMethodDomainService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethodDomain.class);
   }
   /**
@@ -216,6 +220,7 @@ public final class PaymentMethodDomainService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethodDomain.class);
   }
 }

--- a/src/main/java/com/stripe/service/PaymentMethodDomainService.java
+++ b/src/main/java/com/stripe/service/PaymentMethodDomainService.java
@@ -49,7 +49,7 @@ public final class PaymentMethodDomainService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<PaymentMethodDomain>>() {}.getType());
   }
@@ -69,7 +69,7 @@ public final class PaymentMethodDomainService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethodDomain.class);
   }
   /** Retrieves the details of an existing payment method domain. */
@@ -102,7 +102,7 @@ public final class PaymentMethodDomainService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethodDomain.class);
   }
   /** Updates an existing payment method domain. */
@@ -135,7 +135,7 @@ public final class PaymentMethodDomainService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethodDomain.class);
   }
   /**
@@ -220,7 +220,7 @@ public final class PaymentMethodDomainService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethodDomain.class);
   }
 }

--- a/src/main/java/com/stripe/service/PaymentMethodDomainService.java
+++ b/src/main/java/com/stripe/service/PaymentMethodDomainService.java
@@ -49,7 +49,7 @@ public final class PaymentMethodDomainService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<PaymentMethodDomain>>() {}.getType());
   }
@@ -69,7 +69,7 @@ public final class PaymentMethodDomainService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethodDomain.class);
   }
   /** Retrieves the details of an existing payment method domain. */
@@ -102,7 +102,7 @@ public final class PaymentMethodDomainService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethodDomain.class);
   }
   /** Updates an existing payment method domain. */
@@ -135,7 +135,7 @@ public final class PaymentMethodDomainService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethodDomain.class);
   }
   /**
@@ -220,7 +220,7 @@ public final class PaymentMethodDomainService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethodDomain.class);
   }
 }

--- a/src/main/java/com/stripe/service/PaymentMethodService.java
+++ b/src/main/java/com/stripe/service/PaymentMethodService.java
@@ -70,6 +70,7 @@ public final class PaymentMethodService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<PaymentMethod>>() {}.getType());
   }
@@ -137,6 +138,7 @@ public final class PaymentMethodService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethod.class);
   }
   /**
@@ -186,6 +188,7 @@ public final class PaymentMethodService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethod.class);
   }
   /** Updates a PaymentMethod object. A PaymentMethod must be attached a customer to be updated. */
@@ -214,6 +217,7 @@ public final class PaymentMethodService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethod.class);
   }
   /**
@@ -267,6 +271,7 @@ public final class PaymentMethodService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethod.class);
   }
   /**
@@ -308,6 +313,7 @@ public final class PaymentMethodService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethod.class);
   }
 }

--- a/src/main/java/com/stripe/service/PaymentMethodService.java
+++ b/src/main/java/com/stripe/service/PaymentMethodService.java
@@ -70,7 +70,7 @@ public final class PaymentMethodService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<PaymentMethod>>() {}.getType());
   }
@@ -138,7 +138,7 @@ public final class PaymentMethodService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethod.class);
   }
   /**
@@ -188,7 +188,7 @@ public final class PaymentMethodService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethod.class);
   }
   /** Updates a PaymentMethod object. A PaymentMethod must be attached a customer to be updated. */
@@ -217,7 +217,7 @@ public final class PaymentMethodService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethod.class);
   }
   /**
@@ -271,7 +271,7 @@ public final class PaymentMethodService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethod.class);
   }
   /**
@@ -313,7 +313,7 @@ public final class PaymentMethodService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethod.class);
   }
 }

--- a/src/main/java/com/stripe/service/PaymentMethodService.java
+++ b/src/main/java/com/stripe/service/PaymentMethodService.java
@@ -70,7 +70,7 @@ public final class PaymentMethodService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<PaymentMethod>>() {}.getType());
   }
@@ -138,7 +138,7 @@ public final class PaymentMethodService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethod.class);
   }
   /**
@@ -188,7 +188,7 @@ public final class PaymentMethodService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethod.class);
   }
   /** Updates a PaymentMethod object. A PaymentMethod must be attached a customer to be updated. */
@@ -217,7 +217,7 @@ public final class PaymentMethodService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethod.class);
   }
   /**
@@ -271,7 +271,7 @@ public final class PaymentMethodService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethod.class);
   }
   /**
@@ -313,7 +313,7 @@ public final class PaymentMethodService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentMethod.class);
   }
 }

--- a/src/main/java/com/stripe/service/PaymentSourceService.java
+++ b/src/main/java/com/stripe/service/PaymentSourceService.java
@@ -53,7 +53,7 @@ public final class PaymentSourceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<PaymentSource>>() {}.getType());
   }
@@ -91,7 +91,7 @@ public final class PaymentSourceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, PaymentSource.class);
   }
   /** Retrieve a specified source for a given customer. */
@@ -124,7 +124,7 @@ public final class PaymentSourceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, PaymentSource.class);
   }
   /** Update a specified source for a given customer. */
@@ -157,7 +157,7 @@ public final class PaymentSourceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, PaymentSource.class);
   }
   /** Delete a specified source for a given customer. */
@@ -190,7 +190,7 @@ public final class PaymentSourceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, PaymentSource.class);
   }
   /** Verify a specified bank account for a given customer. */
@@ -223,7 +223,7 @@ public final class PaymentSourceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, BankAccount.class);
   }
 }

--- a/src/main/java/com/stripe/service/PaymentSourceService.java
+++ b/src/main/java/com/stripe/service/PaymentSourceService.java
@@ -53,7 +53,7 @@ public final class PaymentSourceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<PaymentSource>>() {}.getType());
   }
@@ -91,7 +91,7 @@ public final class PaymentSourceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentSource.class);
   }
   /** Retrieve a specified source for a given customer. */
@@ -124,7 +124,7 @@ public final class PaymentSourceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentSource.class);
   }
   /** Update a specified source for a given customer. */
@@ -157,7 +157,7 @@ public final class PaymentSourceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentSource.class);
   }
   /** Delete a specified source for a given customer. */
@@ -190,7 +190,7 @@ public final class PaymentSourceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentSource.class);
   }
   /** Verify a specified bank account for a given customer. */
@@ -223,7 +223,7 @@ public final class PaymentSourceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, BankAccount.class);
   }
 }

--- a/src/main/java/com/stripe/service/PaymentSourceService.java
+++ b/src/main/java/com/stripe/service/PaymentSourceService.java
@@ -53,6 +53,7 @@ public final class PaymentSourceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<PaymentSource>>() {}.getType());
   }
@@ -90,6 +91,7 @@ public final class PaymentSourceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentSource.class);
   }
   /** Retrieve a specified source for a given customer. */
@@ -122,6 +124,7 @@ public final class PaymentSourceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentSource.class);
   }
   /** Update a specified source for a given customer. */
@@ -154,6 +157,7 @@ public final class PaymentSourceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentSource.class);
   }
   /** Delete a specified source for a given customer. */
@@ -186,6 +190,7 @@ public final class PaymentSourceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentSource.class);
   }
   /** Verify a specified bank account for a given customer. */
@@ -218,6 +223,7 @@ public final class PaymentSourceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, BankAccount.class);
   }
 }

--- a/src/main/java/com/stripe/service/PayoutService.java
+++ b/src/main/java/com/stripe/service/PayoutService.java
@@ -65,7 +65,7 @@ public final class PayoutService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Payout>>() {}.getType());
   }
@@ -108,7 +108,7 @@ public final class PayoutService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Payout.class);
   }
   /**
@@ -147,7 +147,7 @@ public final class PayoutService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Payout.class);
   }
   /**
@@ -186,7 +186,7 @@ public final class PayoutService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Payout.class);
   }
   /**
@@ -225,7 +225,7 @@ public final class PayoutService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Payout.class);
   }
   /**
@@ -284,7 +284,7 @@ public final class PayoutService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Payout.class);
   }
 }

--- a/src/main/java/com/stripe/service/PayoutService.java
+++ b/src/main/java/com/stripe/service/PayoutService.java
@@ -65,7 +65,7 @@ public final class PayoutService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Payout>>() {}.getType());
   }
@@ -108,7 +108,7 @@ public final class PayoutService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Payout.class);
   }
   /**
@@ -147,7 +147,7 @@ public final class PayoutService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Payout.class);
   }
   /**
@@ -186,7 +186,7 @@ public final class PayoutService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Payout.class);
   }
   /**
@@ -225,7 +225,7 @@ public final class PayoutService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Payout.class);
   }
   /**
@@ -284,7 +284,7 @@ public final class PayoutService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Payout.class);
   }
 }

--- a/src/main/java/com/stripe/service/PayoutService.java
+++ b/src/main/java/com/stripe/service/PayoutService.java
@@ -65,6 +65,7 @@ public final class PayoutService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Payout>>() {}.getType());
   }
@@ -107,6 +108,7 @@ public final class PayoutService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Payout.class);
   }
   /**
@@ -145,6 +147,7 @@ public final class PayoutService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Payout.class);
   }
   /**
@@ -183,6 +186,7 @@ public final class PayoutService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Payout.class);
   }
   /**
@@ -221,6 +225,7 @@ public final class PayoutService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Payout.class);
   }
   /**
@@ -279,6 +284,7 @@ public final class PayoutService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Payout.class);
   }
 }

--- a/src/main/java/com/stripe/service/PersonService.java
+++ b/src/main/java/com/stripe/service/PersonService.java
@@ -47,6 +47,7 @@ public final class PersonService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Person.class);
   }
   /** Retrieves an existing person. */
@@ -79,6 +80,7 @@ public final class PersonService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Person.class);
   }
   /** Updates an existing person. */
@@ -111,6 +113,7 @@ public final class PersonService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Person.class);
   }
   /**
@@ -151,6 +154,7 @@ public final class PersonService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Person>>() {}.getType());
   }
@@ -178,6 +182,7 @@ public final class PersonService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Person.class);
   }
 }

--- a/src/main/java/com/stripe/service/PersonService.java
+++ b/src/main/java/com/stripe/service/PersonService.java
@@ -47,7 +47,7 @@ public final class PersonService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Person.class);
   }
   /** Retrieves an existing person. */
@@ -80,7 +80,7 @@ public final class PersonService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Person.class);
   }
   /** Updates an existing person. */
@@ -113,7 +113,7 @@ public final class PersonService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Person.class);
   }
   /**
@@ -154,7 +154,7 @@ public final class PersonService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Person>>() {}.getType());
   }
@@ -182,7 +182,7 @@ public final class PersonService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Person.class);
   }
 }

--- a/src/main/java/com/stripe/service/PersonService.java
+++ b/src/main/java/com/stripe/service/PersonService.java
@@ -47,7 +47,7 @@ public final class PersonService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Person.class);
   }
   /** Retrieves an existing person. */
@@ -80,7 +80,7 @@ public final class PersonService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Person.class);
   }
   /** Updates an existing person. */
@@ -113,7 +113,7 @@ public final class PersonService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Person.class);
   }
   /**
@@ -154,7 +154,7 @@ public final class PersonService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Person>>() {}.getType());
   }
@@ -182,7 +182,7 @@ public final class PersonService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Person.class);
   }
 }

--- a/src/main/java/com/stripe/service/PlanService.java
+++ b/src/main/java/com/stripe/service/PlanService.java
@@ -33,7 +33,7 @@ public final class PlanService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Plan.class);
   }
   /** Retrieves the plan with the given ID. */
@@ -60,7 +60,7 @@ public final class PlanService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Plan.class);
   }
   /**
@@ -103,7 +103,7 @@ public final class PlanService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Plan.class);
   }
   /** Returns a list of your plans. */
@@ -130,7 +130,7 @@ public final class PlanService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Plan>>() {}.getType());
   }
@@ -157,7 +157,7 @@ public final class PlanService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Plan.class);
   }
 }

--- a/src/main/java/com/stripe/service/PlanService.java
+++ b/src/main/java/com/stripe/service/PlanService.java
@@ -33,6 +33,7 @@ public final class PlanService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Plan.class);
   }
   /** Retrieves the plan with the given ID. */
@@ -59,6 +60,7 @@ public final class PlanService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Plan.class);
   }
   /**
@@ -101,6 +103,7 @@ public final class PlanService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Plan.class);
   }
   /** Returns a list of your plans. */
@@ -127,6 +130,7 @@ public final class PlanService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Plan>>() {}.getType());
   }
@@ -153,6 +157,7 @@ public final class PlanService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Plan.class);
   }
 }

--- a/src/main/java/com/stripe/service/PlanService.java
+++ b/src/main/java/com/stripe/service/PlanService.java
@@ -33,7 +33,7 @@ public final class PlanService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Plan.class);
   }
   /** Retrieves the plan with the given ID. */
@@ -60,7 +60,7 @@ public final class PlanService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Plan.class);
   }
   /**
@@ -103,7 +103,7 @@ public final class PlanService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Plan.class);
   }
   /** Returns a list of your plans. */
@@ -130,7 +130,7 @@ public final class PlanService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Plan>>() {}.getType());
   }
@@ -157,7 +157,7 @@ public final class PlanService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Plan.class);
   }
 }

--- a/src/main/java/com/stripe/service/PriceService.java
+++ b/src/main/java/com/stripe/service/PriceService.java
@@ -65,6 +65,7 @@ public final class PriceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Price>>() {}.getType());
   }
@@ -83,6 +84,7 @@ public final class PriceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Price.class);
   }
   /** Retrieves the price with the given ID. */
@@ -109,6 +111,7 @@ public final class PriceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Price.class);
   }
   /**
@@ -147,6 +150,7 @@ public final class PriceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Price.class);
   }
   /**
@@ -179,6 +183,7 @@ public final class PriceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeSearchResult<Price>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/PriceService.java
+++ b/src/main/java/com/stripe/service/PriceService.java
@@ -65,7 +65,7 @@ public final class PriceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Price>>() {}.getType());
   }
@@ -84,7 +84,7 @@ public final class PriceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Price.class);
   }
   /** Retrieves the price with the given ID. */
@@ -111,7 +111,7 @@ public final class PriceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Price.class);
   }
   /**
@@ -150,7 +150,7 @@ public final class PriceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Price.class);
   }
   /**
@@ -183,7 +183,7 @@ public final class PriceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeSearchResult<Price>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/PriceService.java
+++ b/src/main/java/com/stripe/service/PriceService.java
@@ -65,7 +65,7 @@ public final class PriceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Price>>() {}.getType());
   }
@@ -84,7 +84,7 @@ public final class PriceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Price.class);
   }
   /** Retrieves the price with the given ID. */
@@ -111,7 +111,7 @@ public final class PriceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Price.class);
   }
   /**
@@ -150,7 +150,7 @@ public final class PriceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Price.class);
   }
   /**
@@ -183,7 +183,7 @@ public final class PriceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeSearchResult<Price>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/ProductService.java
+++ b/src/main/java/com/stripe/service/ProductService.java
@@ -43,7 +43,7 @@ public final class ProductService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Product.class);
   }
   /**
@@ -86,7 +86,7 @@ public final class ProductService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Product.class);
   }
   /**
@@ -125,7 +125,7 @@ public final class ProductService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Product.class);
   }
   /**
@@ -164,7 +164,7 @@ public final class ProductService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Product>>() {}.getType());
   }
@@ -183,7 +183,7 @@ public final class ProductService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Product.class);
   }
   /**
@@ -216,7 +216,7 @@ public final class ProductService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeSearchResult<Product>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/ProductService.java
+++ b/src/main/java/com/stripe/service/ProductService.java
@@ -43,7 +43,7 @@ public final class ProductService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Product.class);
   }
   /**
@@ -86,7 +86,7 @@ public final class ProductService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Product.class);
   }
   /**
@@ -125,7 +125,7 @@ public final class ProductService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Product.class);
   }
   /**
@@ -164,7 +164,7 @@ public final class ProductService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Product>>() {}.getType());
   }
@@ -183,7 +183,7 @@ public final class ProductService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Product.class);
   }
   /**
@@ -216,7 +216,7 @@ public final class ProductService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeSearchResult<Product>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/ProductService.java
+++ b/src/main/java/com/stripe/service/ProductService.java
@@ -43,6 +43,7 @@ public final class ProductService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Product.class);
   }
   /**
@@ -85,6 +86,7 @@ public final class ProductService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Product.class);
   }
   /**
@@ -123,6 +125,7 @@ public final class ProductService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Product.class);
   }
   /**
@@ -161,6 +164,7 @@ public final class ProductService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Product>>() {}.getType());
   }
@@ -179,6 +183,7 @@ public final class ProductService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Product.class);
   }
   /**
@@ -211,6 +216,7 @@ public final class ProductService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeSearchResult<Product>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/PromotionCodeService.java
+++ b/src/main/java/com/stripe/service/PromotionCodeService.java
@@ -48,7 +48,7 @@ public final class PromotionCodeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<PromotionCode>>() {}.getType());
   }
@@ -74,7 +74,7 @@ public final class PromotionCodeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, PromotionCode.class);
   }
   /**
@@ -120,7 +120,7 @@ public final class PromotionCodeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, PromotionCode.class);
   }
   /**
@@ -161,7 +161,7 @@ public final class PromotionCodeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, PromotionCode.class);
   }
 }

--- a/src/main/java/com/stripe/service/PromotionCodeService.java
+++ b/src/main/java/com/stripe/service/PromotionCodeService.java
@@ -48,6 +48,7 @@ public final class PromotionCodeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<PromotionCode>>() {}.getType());
   }
@@ -73,6 +74,7 @@ public final class PromotionCodeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, PromotionCode.class);
   }
   /**
@@ -118,6 +120,7 @@ public final class PromotionCodeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, PromotionCode.class);
   }
   /**
@@ -158,6 +161,7 @@ public final class PromotionCodeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, PromotionCode.class);
   }
 }

--- a/src/main/java/com/stripe/service/PromotionCodeService.java
+++ b/src/main/java/com/stripe/service/PromotionCodeService.java
@@ -48,7 +48,7 @@ public final class PromotionCodeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<PromotionCode>>() {}.getType());
   }
@@ -74,7 +74,7 @@ public final class PromotionCodeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, PromotionCode.class);
   }
   /**
@@ -120,7 +120,7 @@ public final class PromotionCodeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, PromotionCode.class);
   }
   /**
@@ -161,7 +161,7 @@ public final class PromotionCodeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, PromotionCode.class);
   }
 }

--- a/src/main/java/com/stripe/service/QuoteComputedUpfrontLineItemsService.java
+++ b/src/main/java/com/stripe/service/QuoteComputedUpfrontLineItemsService.java
@@ -68,7 +68,7 @@ public final class QuoteComputedUpfrontLineItemsService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<LineItem>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/QuoteComputedUpfrontLineItemsService.java
+++ b/src/main/java/com/stripe/service/QuoteComputedUpfrontLineItemsService.java
@@ -68,7 +68,7 @@ public final class QuoteComputedUpfrontLineItemsService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<LineItem>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/QuoteComputedUpfrontLineItemsService.java
+++ b/src/main/java/com/stripe/service/QuoteComputedUpfrontLineItemsService.java
@@ -68,6 +68,7 @@ public final class QuoteComputedUpfrontLineItemsService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<LineItem>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/QuoteLineItemService.java
+++ b/src/main/java/com/stripe/service/QuoteLineItemService.java
@@ -62,6 +62,7 @@ public final class QuoteLineItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<LineItem>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/QuoteLineItemService.java
+++ b/src/main/java/com/stripe/service/QuoteLineItemService.java
@@ -62,7 +62,7 @@ public final class QuoteLineItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<LineItem>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/QuoteLineItemService.java
+++ b/src/main/java/com/stripe/service/QuoteLineItemService.java
@@ -62,7 +62,7 @@ public final class QuoteLineItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<LineItem>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/QuoteService.java
+++ b/src/main/java/com/stripe/service/QuoteService.java
@@ -52,7 +52,7 @@ public final class QuoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Quote>>() {}.getType());
   }
@@ -95,7 +95,7 @@ public final class QuoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Quote.class);
   }
   /** Retrieves the quote with the given ID. */
@@ -122,7 +122,7 @@ public final class QuoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Quote.class);
   }
   /** A quote models prices and services for a customer. */
@@ -149,7 +149,7 @@ public final class QuoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Quote.class);
   }
   /** Accepts the specified quote. */
@@ -176,7 +176,7 @@ public final class QuoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Quote.class);
   }
   /** Cancels the quote. */
@@ -203,7 +203,7 @@ public final class QuoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Quote.class);
   }
   /** Finalizes the quote. */
@@ -230,7 +230,7 @@ public final class QuoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Quote.class);
   }
   /** Download the PDF for a finalized quote. */
@@ -257,7 +257,7 @@ public final class QuoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().requestStream(request);
   }
 

--- a/src/main/java/com/stripe/service/QuoteService.java
+++ b/src/main/java/com/stripe/service/QuoteService.java
@@ -52,7 +52,7 @@ public final class QuoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Quote>>() {}.getType());
   }
@@ -95,7 +95,7 @@ public final class QuoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Quote.class);
   }
   /** Retrieves the quote with the given ID. */
@@ -122,7 +122,7 @@ public final class QuoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Quote.class);
   }
   /** A quote models prices and services for a customer. */
@@ -149,7 +149,7 @@ public final class QuoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Quote.class);
   }
   /** Accepts the specified quote. */
@@ -176,7 +176,7 @@ public final class QuoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Quote.class);
   }
   /** Cancels the quote. */
@@ -203,7 +203,7 @@ public final class QuoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Quote.class);
   }
   /** Finalizes the quote. */
@@ -230,7 +230,7 @@ public final class QuoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Quote.class);
   }
   /** Download the PDF for a finalized quote. */
@@ -257,7 +257,7 @@ public final class QuoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().requestStream(request);
   }
 

--- a/src/main/java/com/stripe/service/QuoteService.java
+++ b/src/main/java/com/stripe/service/QuoteService.java
@@ -52,6 +52,7 @@ public final class QuoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Quote>>() {}.getType());
   }
@@ -94,6 +95,7 @@ public final class QuoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Quote.class);
   }
   /** Retrieves the quote with the given ID. */
@@ -120,6 +122,7 @@ public final class QuoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Quote.class);
   }
   /** A quote models prices and services for a customer. */
@@ -146,6 +149,7 @@ public final class QuoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Quote.class);
   }
   /** Accepts the specified quote. */
@@ -172,6 +176,7 @@ public final class QuoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Quote.class);
   }
   /** Cancels the quote. */
@@ -198,6 +203,7 @@ public final class QuoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Quote.class);
   }
   /** Finalizes the quote. */
@@ -224,6 +230,7 @@ public final class QuoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Quote.class);
   }
   /** Download the PDF for a finalized quote. */
@@ -250,6 +257,7 @@ public final class QuoteService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().requestStream(request);
   }
 

--- a/src/main/java/com/stripe/service/RefundService.java
+++ b/src/main/java/com/stripe/service/RefundService.java
@@ -64,7 +64,7 @@ public final class RefundService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Refund>>() {}.getType());
   }
@@ -143,7 +143,7 @@ public final class RefundService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Refund.class);
   }
   /** Retrieves the details of an existing refund. */
@@ -170,7 +170,7 @@ public final class RefundService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Refund.class);
   }
   /**
@@ -217,7 +217,7 @@ public final class RefundService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Refund.class);
   }
   /**
@@ -264,7 +264,7 @@ public final class RefundService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Refund.class);
   }
 }

--- a/src/main/java/com/stripe/service/RefundService.java
+++ b/src/main/java/com/stripe/service/RefundService.java
@@ -64,6 +64,7 @@ public final class RefundService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Refund>>() {}.getType());
   }
@@ -142,6 +143,7 @@ public final class RefundService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Refund.class);
   }
   /** Retrieves the details of an existing refund. */
@@ -168,6 +170,7 @@ public final class RefundService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Refund.class);
   }
   /**
@@ -214,6 +217,7 @@ public final class RefundService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Refund.class);
   }
   /**
@@ -260,6 +264,7 @@ public final class RefundService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Refund.class);
   }
 }

--- a/src/main/java/com/stripe/service/RefundService.java
+++ b/src/main/java/com/stripe/service/RefundService.java
@@ -64,7 +64,7 @@ public final class RefundService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Refund>>() {}.getType());
   }
@@ -143,7 +143,7 @@ public final class RefundService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Refund.class);
   }
   /** Retrieves the details of an existing refund. */
@@ -170,7 +170,7 @@ public final class RefundService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Refund.class);
   }
   /**
@@ -217,7 +217,7 @@ public final class RefundService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Refund.class);
   }
   /**
@@ -264,7 +264,7 @@ public final class RefundService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Refund.class);
   }
 }

--- a/src/main/java/com/stripe/service/ReviewService.java
+++ b/src/main/java/com/stripe/service/ReviewService.java
@@ -62,7 +62,7 @@ public final class ReviewService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Review>>() {}.getType());
   }
@@ -90,7 +90,7 @@ public final class ReviewService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Review.class);
   }
   /** Approves a {@code Review} object, closing it and removing it from the list of reviews. */
@@ -117,7 +117,7 @@ public final class ReviewService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Review.class);
   }
 }

--- a/src/main/java/com/stripe/service/ReviewService.java
+++ b/src/main/java/com/stripe/service/ReviewService.java
@@ -62,7 +62,7 @@ public final class ReviewService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Review>>() {}.getType());
   }
@@ -90,7 +90,7 @@ public final class ReviewService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Review.class);
   }
   /** Approves a {@code Review} object, closing it and removing it from the list of reviews. */
@@ -117,7 +117,7 @@ public final class ReviewService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Review.class);
   }
 }

--- a/src/main/java/com/stripe/service/ReviewService.java
+++ b/src/main/java/com/stripe/service/ReviewService.java
@@ -62,6 +62,7 @@ public final class ReviewService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Review>>() {}.getType());
   }
@@ -89,6 +90,7 @@ public final class ReviewService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Review.class);
   }
   /** Approves a {@code Review} object, closing it and removing it from the list of reviews. */
@@ -115,6 +117,7 @@ public final class ReviewService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Review.class);
   }
 }

--- a/src/main/java/com/stripe/service/SetupAttemptService.java
+++ b/src/main/java/com/stripe/service/SetupAttemptService.java
@@ -36,6 +36,7 @@ public final class SetupAttemptService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<SetupAttempt>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/SetupAttemptService.java
+++ b/src/main/java/com/stripe/service/SetupAttemptService.java
@@ -36,7 +36,7 @@ public final class SetupAttemptService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<SetupAttempt>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/SetupAttemptService.java
+++ b/src/main/java/com/stripe/service/SetupAttemptService.java
@@ -36,7 +36,7 @@ public final class SetupAttemptService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<SetupAttempt>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/SetupIntentService.java
+++ b/src/main/java/com/stripe/service/SetupIntentService.java
@@ -50,7 +50,7 @@ public final class SetupIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<SetupIntent>>() {}.getType());
   }
@@ -102,7 +102,7 @@ public final class SetupIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, SetupIntent.class);
   }
   /**
@@ -167,7 +167,7 @@ public final class SetupIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, SetupIntent.class);
   }
   /** Updates a SetupIntent object. */
@@ -194,7 +194,7 @@ public final class SetupIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, SetupIntent.class);
   }
   /**
@@ -245,7 +245,7 @@ public final class SetupIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, SetupIntent.class);
   }
   /**
@@ -321,7 +321,7 @@ public final class SetupIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, SetupIntent.class);
   }
   /** Verifies microdeposits on a SetupIntent object. */
@@ -353,7 +353,7 @@ public final class SetupIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, SetupIntent.class);
   }
 }

--- a/src/main/java/com/stripe/service/SetupIntentService.java
+++ b/src/main/java/com/stripe/service/SetupIntentService.java
@@ -50,6 +50,7 @@ public final class SetupIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<SetupIntent>>() {}.getType());
   }
@@ -101,6 +102,7 @@ public final class SetupIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, SetupIntent.class);
   }
   /**
@@ -165,6 +167,7 @@ public final class SetupIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, SetupIntent.class);
   }
   /** Updates a SetupIntent object. */
@@ -191,6 +194,7 @@ public final class SetupIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, SetupIntent.class);
   }
   /**
@@ -241,6 +245,7 @@ public final class SetupIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, SetupIntent.class);
   }
   /**
@@ -316,6 +321,7 @@ public final class SetupIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, SetupIntent.class);
   }
   /** Verifies microdeposits on a SetupIntent object. */
@@ -347,6 +353,7 @@ public final class SetupIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, SetupIntent.class);
   }
 }

--- a/src/main/java/com/stripe/service/SetupIntentService.java
+++ b/src/main/java/com/stripe/service/SetupIntentService.java
@@ -50,7 +50,7 @@ public final class SetupIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<SetupIntent>>() {}.getType());
   }
@@ -102,7 +102,7 @@ public final class SetupIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, SetupIntent.class);
   }
   /**
@@ -167,7 +167,7 @@ public final class SetupIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, SetupIntent.class);
   }
   /** Updates a SetupIntent object. */
@@ -194,7 +194,7 @@ public final class SetupIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, SetupIntent.class);
   }
   /**
@@ -245,7 +245,7 @@ public final class SetupIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, SetupIntent.class);
   }
   /**
@@ -321,7 +321,7 @@ public final class SetupIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, SetupIntent.class);
   }
   /** Verifies microdeposits on a SetupIntent object. */
@@ -353,7 +353,7 @@ public final class SetupIntentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, SetupIntent.class);
   }
 }

--- a/src/main/java/com/stripe/service/ShippingRateService.java
+++ b/src/main/java/com/stripe/service/ShippingRateService.java
@@ -47,6 +47,7 @@ public final class ShippingRateService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ShippingRate>>() {}.getType());
   }
@@ -66,6 +67,7 @@ public final class ShippingRateService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, ShippingRate.class);
   }
   /** Returns the shipping rate object with the given ID. */
@@ -96,6 +98,7 @@ public final class ShippingRateService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, ShippingRate.class);
   }
   /** Updates an existing shipping rate object. */
@@ -126,6 +129,7 @@ public final class ShippingRateService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, ShippingRate.class);
   }
 }

--- a/src/main/java/com/stripe/service/ShippingRateService.java
+++ b/src/main/java/com/stripe/service/ShippingRateService.java
@@ -47,7 +47,7 @@ public final class ShippingRateService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ShippingRate>>() {}.getType());
   }
@@ -67,7 +67,7 @@ public final class ShippingRateService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, ShippingRate.class);
   }
   /** Returns the shipping rate object with the given ID. */
@@ -98,7 +98,7 @@ public final class ShippingRateService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, ShippingRate.class);
   }
   /** Updates an existing shipping rate object. */
@@ -129,7 +129,7 @@ public final class ShippingRateService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, ShippingRate.class);
   }
 }

--- a/src/main/java/com/stripe/service/ShippingRateService.java
+++ b/src/main/java/com/stripe/service/ShippingRateService.java
@@ -47,7 +47,7 @@ public final class ShippingRateService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ShippingRate>>() {}.getType());
   }
@@ -67,7 +67,7 @@ public final class ShippingRateService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, ShippingRate.class);
   }
   /** Returns the shipping rate object with the given ID. */
@@ -98,7 +98,7 @@ public final class ShippingRateService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, ShippingRate.class);
   }
   /** Updates an existing shipping rate object. */
@@ -129,7 +129,7 @@ public final class ShippingRateService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, ShippingRate.class);
   }
 }

--- a/src/main/java/com/stripe/service/SourceService.java
+++ b/src/main/java/com/stripe/service/SourceService.java
@@ -53,7 +53,7 @@ public final class SourceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, PaymentSource.class);
   }
   /**
@@ -92,7 +92,7 @@ public final class SourceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Source.class);
   }
   /**
@@ -147,7 +147,7 @@ public final class SourceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Source.class);
   }
   /** Creates a new source object. */
@@ -173,7 +173,7 @@ public final class SourceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Source.class);
   }
   /** Verify a given source. */
@@ -192,7 +192,7 @@ public final class SourceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Source.class);
   }
 

--- a/src/main/java/com/stripe/service/SourceService.java
+++ b/src/main/java/com/stripe/service/SourceService.java
@@ -53,7 +53,7 @@ public final class SourceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentSource.class);
   }
   /**
@@ -92,7 +92,7 @@ public final class SourceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Source.class);
   }
   /**
@@ -147,7 +147,7 @@ public final class SourceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Source.class);
   }
   /** Creates a new source object. */
@@ -173,7 +173,7 @@ public final class SourceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Source.class);
   }
   /** Verify a given source. */
@@ -192,7 +192,7 @@ public final class SourceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Source.class);
   }
 

--- a/src/main/java/com/stripe/service/SourceService.java
+++ b/src/main/java/com/stripe/service/SourceService.java
@@ -53,6 +53,7 @@ public final class SourceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, PaymentSource.class);
   }
   /**
@@ -91,6 +92,7 @@ public final class SourceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Source.class);
   }
   /**
@@ -145,6 +147,7 @@ public final class SourceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Source.class);
   }
   /** Creates a new source object. */
@@ -170,6 +173,7 @@ public final class SourceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Source.class);
   }
   /** Verify a given source. */
@@ -188,6 +192,7 @@ public final class SourceService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Source.class);
   }
 

--- a/src/main/java/com/stripe/service/SourceTransactionService.java
+++ b/src/main/java/com/stripe/service/SourceTransactionService.java
@@ -48,7 +48,7 @@ public final class SourceTransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<SourceTransaction>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/SourceTransactionService.java
+++ b/src/main/java/com/stripe/service/SourceTransactionService.java
@@ -48,7 +48,7 @@ public final class SourceTransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<SourceTransaction>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/SourceTransactionService.java
+++ b/src/main/java/com/stripe/service/SourceTransactionService.java
@@ -48,6 +48,7 @@ public final class SourceTransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<SourceTransaction>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/SubscriptionItemService.java
+++ b/src/main/java/com/stripe/service/SubscriptionItemService.java
@@ -62,7 +62,7 @@ public final class SubscriptionItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, SubscriptionItem.class);
   }
   /** Retrieves the subscription item with the given ID. */
@@ -91,7 +91,7 @@ public final class SubscriptionItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, SubscriptionItem.class);
   }
   /** Updates the plan or quantity of an item on a current subscription. */
@@ -120,7 +120,7 @@ public final class SubscriptionItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, SubscriptionItem.class);
   }
   /** Returns a list of your subscription items for a given subscription. */
@@ -140,7 +140,7 @@ public final class SubscriptionItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<SubscriptionItem>>() {}.getType());
   }
@@ -160,7 +160,7 @@ public final class SubscriptionItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, SubscriptionItem.class);
   }
 

--- a/src/main/java/com/stripe/service/SubscriptionItemService.java
+++ b/src/main/java/com/stripe/service/SubscriptionItemService.java
@@ -62,6 +62,7 @@ public final class SubscriptionItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, SubscriptionItem.class);
   }
   /** Retrieves the subscription item with the given ID. */
@@ -90,6 +91,7 @@ public final class SubscriptionItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, SubscriptionItem.class);
   }
   /** Updates the plan or quantity of an item on a current subscription. */
@@ -118,6 +120,7 @@ public final class SubscriptionItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, SubscriptionItem.class);
   }
   /** Returns a list of your subscription items for a given subscription. */
@@ -137,6 +140,7 @@ public final class SubscriptionItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<SubscriptionItem>>() {}.getType());
   }
@@ -156,6 +160,7 @@ public final class SubscriptionItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, SubscriptionItem.class);
   }
 

--- a/src/main/java/com/stripe/service/SubscriptionItemService.java
+++ b/src/main/java/com/stripe/service/SubscriptionItemService.java
@@ -62,7 +62,7 @@ public final class SubscriptionItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, SubscriptionItem.class);
   }
   /** Retrieves the subscription item with the given ID. */
@@ -91,7 +91,7 @@ public final class SubscriptionItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, SubscriptionItem.class);
   }
   /** Updates the plan or quantity of an item on a current subscription. */
@@ -120,7 +120,7 @@ public final class SubscriptionItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, SubscriptionItem.class);
   }
   /** Returns a list of your subscription items for a given subscription. */
@@ -140,7 +140,7 @@ public final class SubscriptionItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<SubscriptionItem>>() {}.getType());
   }
@@ -160,7 +160,7 @@ public final class SubscriptionItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, SubscriptionItem.class);
   }
 

--- a/src/main/java/com/stripe/service/SubscriptionScheduleService.java
+++ b/src/main/java/com/stripe/service/SubscriptionScheduleService.java
@@ -51,7 +51,7 @@ public final class SubscriptionScheduleService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<SubscriptionSchedule>>() {}.getType());
   }
@@ -92,7 +92,7 @@ public final class SubscriptionScheduleService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, SubscriptionSchedule.class);
   }
   /**
@@ -134,7 +134,7 @@ public final class SubscriptionScheduleService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, SubscriptionSchedule.class);
   }
   /** Updates an existing subscription schedule. */
@@ -164,7 +164,7 @@ public final class SubscriptionScheduleService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, SubscriptionSchedule.class);
   }
   /**
@@ -211,7 +211,7 @@ public final class SubscriptionScheduleService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, SubscriptionSchedule.class);
   }
   /**
@@ -266,7 +266,7 @@ public final class SubscriptionScheduleService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, SubscriptionSchedule.class);
   }
 }

--- a/src/main/java/com/stripe/service/SubscriptionScheduleService.java
+++ b/src/main/java/com/stripe/service/SubscriptionScheduleService.java
@@ -51,7 +51,7 @@ public final class SubscriptionScheduleService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<SubscriptionSchedule>>() {}.getType());
   }
@@ -92,7 +92,7 @@ public final class SubscriptionScheduleService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, SubscriptionSchedule.class);
   }
   /**
@@ -134,7 +134,7 @@ public final class SubscriptionScheduleService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, SubscriptionSchedule.class);
   }
   /** Updates an existing subscription schedule. */
@@ -164,7 +164,7 @@ public final class SubscriptionScheduleService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, SubscriptionSchedule.class);
   }
   /**
@@ -211,7 +211,7 @@ public final class SubscriptionScheduleService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, SubscriptionSchedule.class);
   }
   /**
@@ -266,7 +266,7 @@ public final class SubscriptionScheduleService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, SubscriptionSchedule.class);
   }
 }

--- a/src/main/java/com/stripe/service/SubscriptionScheduleService.java
+++ b/src/main/java/com/stripe/service/SubscriptionScheduleService.java
@@ -51,6 +51,7 @@ public final class SubscriptionScheduleService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<SubscriptionSchedule>>() {}.getType());
   }
@@ -91,6 +92,7 @@ public final class SubscriptionScheduleService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, SubscriptionSchedule.class);
   }
   /**
@@ -132,6 +134,7 @@ public final class SubscriptionScheduleService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, SubscriptionSchedule.class);
   }
   /** Updates an existing subscription schedule. */
@@ -161,6 +164,7 @@ public final class SubscriptionScheduleService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, SubscriptionSchedule.class);
   }
   /**
@@ -207,6 +211,7 @@ public final class SubscriptionScheduleService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, SubscriptionSchedule.class);
   }
   /**
@@ -261,6 +266,7 @@ public final class SubscriptionScheduleService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, SubscriptionSchedule.class);
   }
 }

--- a/src/main/java/com/stripe/service/SubscriptionService.java
+++ b/src/main/java/com/stripe/service/SubscriptionService.java
@@ -120,7 +120,7 @@ public final class SubscriptionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Subscription.class);
   }
   /** Retrieves the subscription with the given ID. */
@@ -152,7 +152,7 @@ public final class SubscriptionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Subscription.class);
   }
   /**
@@ -363,7 +363,7 @@ public final class SubscriptionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Subscription.class);
   }
   /** Removes the currently applied discount on a subscription. */
@@ -379,7 +379,7 @@ public final class SubscriptionService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Discount.class);
   }
   /**
@@ -418,7 +418,7 @@ public final class SubscriptionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Subscription>>() {}.getType());
   }
@@ -464,7 +464,7 @@ public final class SubscriptionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Subscription.class);
   }
   /**
@@ -498,7 +498,7 @@ public final class SubscriptionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeSearchResult<Subscription>>() {}.getType());
   }
@@ -553,7 +553,7 @@ public final class SubscriptionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Subscription.class);
   }
 }

--- a/src/main/java/com/stripe/service/SubscriptionService.java
+++ b/src/main/java/com/stripe/service/SubscriptionService.java
@@ -120,6 +120,7 @@ public final class SubscriptionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Subscription.class);
   }
   /** Retrieves the subscription with the given ID. */
@@ -151,6 +152,7 @@ public final class SubscriptionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Subscription.class);
   }
   /**
@@ -361,6 +363,7 @@ public final class SubscriptionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Subscription.class);
   }
   /** Removes the currently applied discount on a subscription. */
@@ -376,6 +379,7 @@ public final class SubscriptionService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Discount.class);
   }
   /**
@@ -414,6 +418,7 @@ public final class SubscriptionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Subscription>>() {}.getType());
   }
@@ -459,6 +464,7 @@ public final class SubscriptionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Subscription.class);
   }
   /**
@@ -492,6 +498,7 @@ public final class SubscriptionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeSearchResult<Subscription>>() {}.getType());
   }
@@ -546,6 +553,7 @@ public final class SubscriptionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Subscription.class);
   }
 }

--- a/src/main/java/com/stripe/service/SubscriptionService.java
+++ b/src/main/java/com/stripe/service/SubscriptionService.java
@@ -120,7 +120,7 @@ public final class SubscriptionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Subscription.class);
   }
   /** Retrieves the subscription with the given ID. */
@@ -152,7 +152,7 @@ public final class SubscriptionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Subscription.class);
   }
   /**
@@ -363,7 +363,7 @@ public final class SubscriptionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Subscription.class);
   }
   /** Removes the currently applied discount on a subscription. */
@@ -379,7 +379,7 @@ public final class SubscriptionService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Discount.class);
   }
   /**
@@ -418,7 +418,7 @@ public final class SubscriptionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Subscription>>() {}.getType());
   }
@@ -464,7 +464,7 @@ public final class SubscriptionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Subscription.class);
   }
   /**
@@ -498,7 +498,7 @@ public final class SubscriptionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeSearchResult<Subscription>>() {}.getType());
   }
@@ -553,7 +553,7 @@ public final class SubscriptionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Subscription.class);
   }
 }

--- a/src/main/java/com/stripe/service/TaxCodeService.java
+++ b/src/main/java/com/stripe/service/TaxCodeService.java
@@ -57,7 +57,7 @@ public final class TaxCodeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<TaxCode>>() {}.getType());
   }
@@ -97,7 +97,7 @@ public final class TaxCodeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, TaxCode.class);
   }
 }

--- a/src/main/java/com/stripe/service/TaxCodeService.java
+++ b/src/main/java/com/stripe/service/TaxCodeService.java
@@ -57,7 +57,7 @@ public final class TaxCodeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<TaxCode>>() {}.getType());
   }
@@ -97,7 +97,7 @@ public final class TaxCodeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, TaxCode.class);
   }
 }

--- a/src/main/java/com/stripe/service/TaxCodeService.java
+++ b/src/main/java/com/stripe/service/TaxCodeService.java
@@ -57,6 +57,7 @@ public final class TaxCodeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<TaxCode>>() {}.getType());
   }
@@ -96,6 +97,7 @@ public final class TaxCodeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, TaxCode.class);
   }
 }

--- a/src/main/java/com/stripe/service/TaxIdService.java
+++ b/src/main/java/com/stripe/service/TaxIdService.java
@@ -35,7 +35,7 @@ public final class TaxIdService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, TaxId.class);
   }
   /** Retrieves the {@code tax_id} object with the given identifier. */
@@ -67,7 +67,7 @@ public final class TaxIdService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, TaxId.class);
   }
   /** Returns a list of tax IDs for a customer. */
@@ -96,7 +96,7 @@ public final class TaxIdService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<TaxId>>() {}.getType());
   }
@@ -116,7 +116,7 @@ public final class TaxIdService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, TaxId.class);
   }
 }

--- a/src/main/java/com/stripe/service/TaxIdService.java
+++ b/src/main/java/com/stripe/service/TaxIdService.java
@@ -35,6 +35,7 @@ public final class TaxIdService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, TaxId.class);
   }
   /** Retrieves the {@code tax_id} object with the given identifier. */
@@ -66,6 +67,7 @@ public final class TaxIdService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, TaxId.class);
   }
   /** Returns a list of tax IDs for a customer. */
@@ -94,6 +96,7 @@ public final class TaxIdService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<TaxId>>() {}.getType());
   }
@@ -113,6 +116,7 @@ public final class TaxIdService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, TaxId.class);
   }
 }

--- a/src/main/java/com/stripe/service/TaxIdService.java
+++ b/src/main/java/com/stripe/service/TaxIdService.java
@@ -35,7 +35,7 @@ public final class TaxIdService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, TaxId.class);
   }
   /** Retrieves the {@code tax_id} object with the given identifier. */
@@ -67,7 +67,7 @@ public final class TaxIdService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, TaxId.class);
   }
   /** Returns a list of tax IDs for a customer. */
@@ -96,7 +96,7 @@ public final class TaxIdService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<TaxId>>() {}.getType());
   }
@@ -116,7 +116,7 @@ public final class TaxIdService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, TaxId.class);
   }
 }

--- a/src/main/java/com/stripe/service/TaxRateService.java
+++ b/src/main/java/com/stripe/service/TaxRateService.java
@@ -59,7 +59,7 @@ public final class TaxRateService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<TaxRate>>() {}.getType());
   }
@@ -78,7 +78,7 @@ public final class TaxRateService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, TaxRate.class);
   }
   /** Retrieves a tax rate with the given ID. */
@@ -105,7 +105,7 @@ public final class TaxRateService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, TaxRate.class);
   }
   /** Updates an existing tax rate. */
@@ -132,7 +132,7 @@ public final class TaxRateService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, TaxRate.class);
   }
 }

--- a/src/main/java/com/stripe/service/TaxRateService.java
+++ b/src/main/java/com/stripe/service/TaxRateService.java
@@ -59,6 +59,7 @@ public final class TaxRateService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<TaxRate>>() {}.getType());
   }
@@ -77,6 +78,7 @@ public final class TaxRateService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, TaxRate.class);
   }
   /** Retrieves a tax rate with the given ID. */
@@ -103,6 +105,7 @@ public final class TaxRateService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, TaxRate.class);
   }
   /** Updates an existing tax rate. */
@@ -129,6 +132,7 @@ public final class TaxRateService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, TaxRate.class);
   }
 }

--- a/src/main/java/com/stripe/service/TaxRateService.java
+++ b/src/main/java/com/stripe/service/TaxRateService.java
@@ -59,7 +59,7 @@ public final class TaxRateService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<TaxRate>>() {}.getType());
   }
@@ -78,7 +78,7 @@ public final class TaxRateService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, TaxRate.class);
   }
   /** Retrieves a tax rate with the given ID. */
@@ -105,7 +105,7 @@ public final class TaxRateService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, TaxRate.class);
   }
   /** Updates an existing tax rate. */
@@ -132,7 +132,7 @@ public final class TaxRateService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, TaxRate.class);
   }
 }

--- a/src/main/java/com/stripe/service/TokenService.java
+++ b/src/main/java/com/stripe/service/TokenService.java
@@ -43,7 +43,7 @@ public final class TokenService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Token.class);
   }
   /**
@@ -85,7 +85,7 @@ public final class TokenService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Token.class);
   }
 }

--- a/src/main/java/com/stripe/service/TokenService.java
+++ b/src/main/java/com/stripe/service/TokenService.java
@@ -43,7 +43,7 @@ public final class TokenService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Token.class);
   }
   /**
@@ -85,7 +85,7 @@ public final class TokenService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Token.class);
   }
 }

--- a/src/main/java/com/stripe/service/TokenService.java
+++ b/src/main/java/com/stripe/service/TokenService.java
@@ -43,6 +43,7 @@ public final class TokenService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Token.class);
   }
   /**
@@ -84,6 +85,7 @@ public final class TokenService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Token.class);
   }
 }

--- a/src/main/java/com/stripe/service/TopupService.java
+++ b/src/main/java/com/stripe/service/TopupService.java
@@ -48,7 +48,7 @@ public final class TopupService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Topup>>() {}.getType());
   }
@@ -67,7 +67,7 @@ public final class TopupService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Topup.class);
   }
   /**
@@ -110,7 +110,7 @@ public final class TopupService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Topup.class);
   }
   /** Updates the metadata of a top-up. Other top-up details are not editable by design. */
@@ -137,7 +137,7 @@ public final class TopupService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Topup.class);
   }
   /** Cancels a top-up. Only pending top-ups can be canceled. */
@@ -164,7 +164,7 @@ public final class TopupService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Topup.class);
   }
 }

--- a/src/main/java/com/stripe/service/TopupService.java
+++ b/src/main/java/com/stripe/service/TopupService.java
@@ -48,6 +48,7 @@ public final class TopupService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Topup>>() {}.getType());
   }
@@ -66,6 +67,7 @@ public final class TopupService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Topup.class);
   }
   /**
@@ -108,6 +110,7 @@ public final class TopupService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Topup.class);
   }
   /** Updates the metadata of a top-up. Other top-up details are not editable by design. */
@@ -134,6 +137,7 @@ public final class TopupService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Topup.class);
   }
   /** Cancels a top-up. Only pending top-ups can be canceled. */
@@ -160,6 +164,7 @@ public final class TopupService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Topup.class);
   }
 }

--- a/src/main/java/com/stripe/service/TopupService.java
+++ b/src/main/java/com/stripe/service/TopupService.java
@@ -48,7 +48,7 @@ public final class TopupService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Topup>>() {}.getType());
   }
@@ -67,7 +67,7 @@ public final class TopupService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Topup.class);
   }
   /**
@@ -110,7 +110,7 @@ public final class TopupService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Topup.class);
   }
   /** Updates the metadata of a top-up. Other top-up details are not editable by design. */
@@ -137,7 +137,7 @@ public final class TopupService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Topup.class);
   }
   /** Cancels a top-up. Only pending top-ups can be canceled. */
@@ -164,7 +164,7 @@ public final class TopupService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Topup.class);
   }
 }

--- a/src/main/java/com/stripe/service/TransferReversalService.java
+++ b/src/main/java/com/stripe/service/TransferReversalService.java
@@ -69,7 +69,7 @@ public final class TransferReversalService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<TransferReversal>>() {}.getType());
   }
@@ -135,7 +135,7 @@ public final class TransferReversalService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, TransferReversal.class);
   }
   /**
@@ -180,7 +180,7 @@ public final class TransferReversalService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, TransferReversal.class);
   }
   /**
@@ -233,7 +233,7 @@ public final class TransferReversalService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, TransferReversal.class);
   }
 }

--- a/src/main/java/com/stripe/service/TransferReversalService.java
+++ b/src/main/java/com/stripe/service/TransferReversalService.java
@@ -69,6 +69,7 @@ public final class TransferReversalService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<TransferReversal>>() {}.getType());
   }
@@ -134,6 +135,7 @@ public final class TransferReversalService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, TransferReversal.class);
   }
   /**
@@ -178,6 +180,7 @@ public final class TransferReversalService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, TransferReversal.class);
   }
   /**
@@ -230,6 +233,7 @@ public final class TransferReversalService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, TransferReversal.class);
   }
 }

--- a/src/main/java/com/stripe/service/TransferReversalService.java
+++ b/src/main/java/com/stripe/service/TransferReversalService.java
@@ -69,7 +69,7 @@ public final class TransferReversalService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<TransferReversal>>() {}.getType());
   }
@@ -135,7 +135,7 @@ public final class TransferReversalService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, TransferReversal.class);
   }
   /**
@@ -180,7 +180,7 @@ public final class TransferReversalService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, TransferReversal.class);
   }
   /**
@@ -233,7 +233,7 @@ public final class TransferReversalService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, TransferReversal.class);
   }
 }

--- a/src/main/java/com/stripe/service/TransferService.java
+++ b/src/main/java/com/stripe/service/TransferService.java
@@ -59,7 +59,7 @@ public final class TransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Transfer>>() {}.getType());
   }
@@ -87,7 +87,7 @@ public final class TransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Transfer.class);
   }
   /**
@@ -130,7 +130,7 @@ public final class TransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Transfer.class);
   }
   /**
@@ -177,7 +177,7 @@ public final class TransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Transfer.class);
   }
 

--- a/src/main/java/com/stripe/service/TransferService.java
+++ b/src/main/java/com/stripe/service/TransferService.java
@@ -59,6 +59,7 @@ public final class TransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Transfer>>() {}.getType());
   }
@@ -86,6 +87,7 @@ public final class TransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Transfer.class);
   }
   /**
@@ -128,6 +130,7 @@ public final class TransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Transfer.class);
   }
   /**
@@ -174,6 +177,7 @@ public final class TransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Transfer.class);
   }
 

--- a/src/main/java/com/stripe/service/TransferService.java
+++ b/src/main/java/com/stripe/service/TransferService.java
@@ -59,7 +59,7 @@ public final class TransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Transfer>>() {}.getType());
   }
@@ -87,7 +87,7 @@ public final class TransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Transfer.class);
   }
   /**
@@ -130,7 +130,7 @@ public final class TransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Transfer.class);
   }
   /**
@@ -177,7 +177,7 @@ public final class TransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Transfer.class);
   }
 

--- a/src/main/java/com/stripe/service/UsageRecordService.java
+++ b/src/main/java/com/stripe/service/UsageRecordService.java
@@ -80,7 +80,7 @@ public final class UsageRecordService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, UsageRecord.class);
   }
 }

--- a/src/main/java/com/stripe/service/UsageRecordService.java
+++ b/src/main/java/com/stripe/service/UsageRecordService.java
@@ -80,7 +80,7 @@ public final class UsageRecordService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, UsageRecord.class);
   }
 }

--- a/src/main/java/com/stripe/service/UsageRecordService.java
+++ b/src/main/java/com/stripe/service/UsageRecordService.java
@@ -80,6 +80,7 @@ public final class UsageRecordService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, UsageRecord.class);
   }
 }

--- a/src/main/java/com/stripe/service/UsageRecordSummaryService.java
+++ b/src/main/java/com/stripe/service/UsageRecordSummaryService.java
@@ -86,7 +86,7 @@ public final class UsageRecordSummaryService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<UsageRecordSummary>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/UsageRecordSummaryService.java
+++ b/src/main/java/com/stripe/service/UsageRecordSummaryService.java
@@ -86,7 +86,7 @@ public final class UsageRecordSummaryService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<UsageRecordSummary>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/UsageRecordSummaryService.java
+++ b/src/main/java/com/stripe/service/UsageRecordSummaryService.java
@@ -86,6 +86,7 @@ public final class UsageRecordSummaryService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<UsageRecordSummary>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/WebhookEndpointService.java
+++ b/src/main/java/com/stripe/service/WebhookEndpointService.java
@@ -43,7 +43,7 @@ public final class WebhookEndpointService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, WebhookEndpoint.class);
   }
   /** Retrieves the webhook endpoint with the given ID. */
@@ -74,7 +74,7 @@ public final class WebhookEndpointService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, WebhookEndpoint.class);
   }
   /**
@@ -117,7 +117,7 @@ public final class WebhookEndpointService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, WebhookEndpoint.class);
   }
   /** Returns a list of your webhook endpoints. */
@@ -145,7 +145,7 @@ public final class WebhookEndpointService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<WebhookEndpoint>>() {}.getType());
   }
@@ -181,7 +181,7 @@ public final class WebhookEndpointService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, WebhookEndpoint.class);
   }
 }

--- a/src/main/java/com/stripe/service/WebhookEndpointService.java
+++ b/src/main/java/com/stripe/service/WebhookEndpointService.java
@@ -43,6 +43,7 @@ public final class WebhookEndpointService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, WebhookEndpoint.class);
   }
   /** Retrieves the webhook endpoint with the given ID. */
@@ -73,6 +74,7 @@ public final class WebhookEndpointService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, WebhookEndpoint.class);
   }
   /**
@@ -115,6 +117,7 @@ public final class WebhookEndpointService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, WebhookEndpoint.class);
   }
   /** Returns a list of your webhook endpoints. */
@@ -142,6 +145,7 @@ public final class WebhookEndpointService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<WebhookEndpoint>>() {}.getType());
   }
@@ -177,6 +181,7 @@ public final class WebhookEndpointService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, WebhookEndpoint.class);
   }
 }

--- a/src/main/java/com/stripe/service/WebhookEndpointService.java
+++ b/src/main/java/com/stripe/service/WebhookEndpointService.java
@@ -43,7 +43,7 @@ public final class WebhookEndpointService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, WebhookEndpoint.class);
   }
   /** Retrieves the webhook endpoint with the given ID. */
@@ -74,7 +74,7 @@ public final class WebhookEndpointService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, WebhookEndpoint.class);
   }
   /**
@@ -117,7 +117,7 @@ public final class WebhookEndpointService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, WebhookEndpoint.class);
   }
   /** Returns a list of your webhook endpoints. */
@@ -145,7 +145,7 @@ public final class WebhookEndpointService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<WebhookEndpoint>>() {}.getType());
   }
@@ -181,7 +181,7 @@ public final class WebhookEndpointService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, WebhookEndpoint.class);
   }
 }

--- a/src/main/java/com/stripe/service/apps/SecretService.java
+++ b/src/main/java/com/stripe/service/apps/SecretService.java
@@ -39,7 +39,7 @@ public final class SecretService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Secret>>() {}.getType());
   }
@@ -58,7 +58,7 @@ public final class SecretService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Secret.class);
   }
   /** Finds a secret in the secret store by name and scope. */
@@ -76,7 +76,7 @@ public final class SecretService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Secret.class);
   }
   /** Deletes a secret from the secret store by name and scope. */
@@ -95,7 +95,7 @@ public final class SecretService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Secret.class);
   }
 }

--- a/src/main/java/com/stripe/service/apps/SecretService.java
+++ b/src/main/java/com/stripe/service/apps/SecretService.java
@@ -39,7 +39,7 @@ public final class SecretService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Secret>>() {}.getType());
   }
@@ -58,7 +58,7 @@ public final class SecretService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Secret.class);
   }
   /** Finds a secret in the secret store by name and scope. */
@@ -76,7 +76,7 @@ public final class SecretService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Secret.class);
   }
   /** Deletes a secret from the secret store by name and scope. */
@@ -95,7 +95,7 @@ public final class SecretService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Secret.class);
   }
 }

--- a/src/main/java/com/stripe/service/apps/SecretService.java
+++ b/src/main/java/com/stripe/service/apps/SecretService.java
@@ -39,6 +39,7 @@ public final class SecretService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Secret>>() {}.getType());
   }
@@ -57,6 +58,7 @@ public final class SecretService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Secret.class);
   }
   /** Finds a secret in the secret store by name and scope. */
@@ -74,6 +76,7 @@ public final class SecretService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Secret.class);
   }
   /** Deletes a secret from the secret store by name and scope. */
@@ -92,6 +95,7 @@ public final class SecretService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Secret.class);
   }
 }

--- a/src/main/java/com/stripe/service/billingportal/ConfigurationService.java
+++ b/src/main/java/com/stripe/service/billingportal/ConfigurationService.java
@@ -48,6 +48,7 @@ public final class ConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Configuration>>() {}.getType());
   }
@@ -67,6 +68,7 @@ public final class ConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Configuration.class);
   }
   /** Retrieves a configuration that describes the functionality of the customer portal. */
@@ -98,6 +100,7 @@ public final class ConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Configuration.class);
   }
   /** Updates a configuration that describes the functionality of the customer portal. */
@@ -128,6 +131,7 @@ public final class ConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Configuration.class);
   }
 }

--- a/src/main/java/com/stripe/service/billingportal/ConfigurationService.java
+++ b/src/main/java/com/stripe/service/billingportal/ConfigurationService.java
@@ -48,7 +48,7 @@ public final class ConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Configuration>>() {}.getType());
   }
@@ -68,7 +68,7 @@ public final class ConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Configuration.class);
   }
   /** Retrieves a configuration that describes the functionality of the customer portal. */
@@ -100,7 +100,7 @@ public final class ConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Configuration.class);
   }
   /** Updates a configuration that describes the functionality of the customer portal. */
@@ -131,7 +131,7 @@ public final class ConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Configuration.class);
   }
 }

--- a/src/main/java/com/stripe/service/billingportal/ConfigurationService.java
+++ b/src/main/java/com/stripe/service/billingportal/ConfigurationService.java
@@ -48,7 +48,7 @@ public final class ConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Configuration>>() {}.getType());
   }
@@ -68,7 +68,7 @@ public final class ConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Configuration.class);
   }
   /** Retrieves a configuration that describes the functionality of the customer portal. */
@@ -100,7 +100,7 @@ public final class ConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Configuration.class);
   }
   /** Updates a configuration that describes the functionality of the customer portal. */
@@ -131,7 +131,7 @@ public final class ConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Configuration.class);
   }
 }

--- a/src/main/java/com/stripe/service/billingportal/SessionService.java
+++ b/src/main/java/com/stripe/service/billingportal/SessionService.java
@@ -33,6 +33,7 @@ public final class SessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Session.class);
   }
 }

--- a/src/main/java/com/stripe/service/billingportal/SessionService.java
+++ b/src/main/java/com/stripe/service/billingportal/SessionService.java
@@ -33,7 +33,7 @@ public final class SessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Session.class);
   }
 }

--- a/src/main/java/com/stripe/service/billingportal/SessionService.java
+++ b/src/main/java/com/stripe/service/billingportal/SessionService.java
@@ -33,7 +33,7 @@ public final class SessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Session.class);
   }
 }

--- a/src/main/java/com/stripe/service/checkout/SessionLineItemService.java
+++ b/src/main/java/com/stripe/service/checkout/SessionLineItemService.java
@@ -64,7 +64,7 @@ public final class SessionLineItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<LineItem>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/checkout/SessionLineItemService.java
+++ b/src/main/java/com/stripe/service/checkout/SessionLineItemService.java
@@ -64,6 +64,7 @@ public final class SessionLineItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<LineItem>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/checkout/SessionLineItemService.java
+++ b/src/main/java/com/stripe/service/checkout/SessionLineItemService.java
@@ -64,7 +64,7 @@ public final class SessionLineItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<LineItem>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/checkout/SessionService.java
+++ b/src/main/java/com/stripe/service/checkout/SessionService.java
@@ -47,7 +47,7 @@ public final class SessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Session>>() {}.getType());
   }
@@ -74,7 +74,7 @@ public final class SessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Session.class);
   }
   /** Retrieves a Session object. */
@@ -101,7 +101,7 @@ public final class SessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Session.class);
   }
   /**
@@ -149,7 +149,7 @@ public final class SessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Session.class);
   }
 

--- a/src/main/java/com/stripe/service/checkout/SessionService.java
+++ b/src/main/java/com/stripe/service/checkout/SessionService.java
@@ -47,7 +47,7 @@ public final class SessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Session>>() {}.getType());
   }
@@ -74,7 +74,7 @@ public final class SessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Session.class);
   }
   /** Retrieves a Session object. */
@@ -101,7 +101,7 @@ public final class SessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Session.class);
   }
   /**
@@ -149,7 +149,7 @@ public final class SessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Session.class);
   }
 

--- a/src/main/java/com/stripe/service/checkout/SessionService.java
+++ b/src/main/java/com/stripe/service/checkout/SessionService.java
@@ -47,6 +47,7 @@ public final class SessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Session>>() {}.getType());
   }
@@ -73,6 +74,7 @@ public final class SessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Session.class);
   }
   /** Retrieves a Session object. */
@@ -99,6 +101,7 @@ public final class SessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Session.class);
   }
   /**
@@ -146,6 +149,7 @@ public final class SessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Session.class);
   }
 

--- a/src/main/java/com/stripe/service/climate/OrderService.java
+++ b/src/main/java/com/stripe/service/climate/OrderService.java
@@ -60,7 +60,7 @@ public final class OrderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Order>>() {}.getType());
   }
@@ -85,7 +85,7 @@ public final class OrderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Order.class);
   }
   /** Retrieves the details of a Climate order object with the given ID. */
@@ -112,7 +112,7 @@ public final class OrderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Order.class);
   }
   /** Updates the specified order by setting the values of the parameters passed. */
@@ -139,7 +139,7 @@ public final class OrderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Order.class);
   }
   /**
@@ -190,7 +190,7 @@ public final class OrderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Order.class);
   }
 }

--- a/src/main/java/com/stripe/service/climate/OrderService.java
+++ b/src/main/java/com/stripe/service/climate/OrderService.java
@@ -60,7 +60,7 @@ public final class OrderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Order>>() {}.getType());
   }
@@ -85,7 +85,7 @@ public final class OrderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Order.class);
   }
   /** Retrieves the details of a Climate order object with the given ID. */
@@ -112,7 +112,7 @@ public final class OrderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Order.class);
   }
   /** Updates the specified order by setting the values of the parameters passed. */
@@ -139,7 +139,7 @@ public final class OrderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Order.class);
   }
   /**
@@ -190,7 +190,7 @@ public final class OrderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Order.class);
   }
 }

--- a/src/main/java/com/stripe/service/climate/OrderService.java
+++ b/src/main/java/com/stripe/service/climate/OrderService.java
@@ -60,6 +60,7 @@ public final class OrderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Order>>() {}.getType());
   }
@@ -84,6 +85,7 @@ public final class OrderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Order.class);
   }
   /** Retrieves the details of a Climate order object with the given ID. */
@@ -110,6 +112,7 @@ public final class OrderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Order.class);
   }
   /** Updates the specified order by setting the values of the parameters passed. */
@@ -136,6 +139,7 @@ public final class OrderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Order.class);
   }
   /**
@@ -186,6 +190,7 @@ public final class OrderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Order.class);
   }
 }

--- a/src/main/java/com/stripe/service/climate/ProductService.java
+++ b/src/main/java/com/stripe/service/climate/ProductService.java
@@ -45,7 +45,7 @@ public final class ProductService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Product>>() {}.getType());
   }
@@ -73,7 +73,7 @@ public final class ProductService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Product.class);
   }
 }

--- a/src/main/java/com/stripe/service/climate/ProductService.java
+++ b/src/main/java/com/stripe/service/climate/ProductService.java
@@ -45,6 +45,7 @@ public final class ProductService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Product>>() {}.getType());
   }
@@ -72,6 +73,7 @@ public final class ProductService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Product.class);
   }
 }

--- a/src/main/java/com/stripe/service/climate/ProductService.java
+++ b/src/main/java/com/stripe/service/climate/ProductService.java
@@ -45,7 +45,7 @@ public final class ProductService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Product>>() {}.getType());
   }
@@ -73,7 +73,7 @@ public final class ProductService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Product.class);
   }
 }

--- a/src/main/java/com/stripe/service/climate/SupplierService.java
+++ b/src/main/java/com/stripe/service/climate/SupplierService.java
@@ -45,7 +45,7 @@ public final class SupplierService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Supplier>>() {}.getType());
   }
@@ -73,7 +73,7 @@ public final class SupplierService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Supplier.class);
   }
 }

--- a/src/main/java/com/stripe/service/climate/SupplierService.java
+++ b/src/main/java/com/stripe/service/climate/SupplierService.java
@@ -45,7 +45,7 @@ public final class SupplierService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Supplier>>() {}.getType());
   }
@@ -73,7 +73,7 @@ public final class SupplierService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Supplier.class);
   }
 }

--- a/src/main/java/com/stripe/service/climate/SupplierService.java
+++ b/src/main/java/com/stripe/service/climate/SupplierService.java
@@ -45,6 +45,7 @@ public final class SupplierService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Supplier>>() {}.getType());
   }
@@ -72,6 +73,7 @@ public final class SupplierService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Supplier.class);
   }
 }

--- a/src/main/java/com/stripe/service/financialconnections/AccountOwnerService.java
+++ b/src/main/java/com/stripe/service/financialconnections/AccountOwnerService.java
@@ -40,7 +40,7 @@ public final class AccountOwnerService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<AccountOwner>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/financialconnections/AccountOwnerService.java
+++ b/src/main/java/com/stripe/service/financialconnections/AccountOwnerService.java
@@ -40,7 +40,7 @@ public final class AccountOwnerService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<AccountOwner>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/financialconnections/AccountOwnerService.java
+++ b/src/main/java/com/stripe/service/financialconnections/AccountOwnerService.java
@@ -40,6 +40,7 @@ public final class AccountOwnerService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<AccountOwner>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/financialconnections/AccountService.java
+++ b/src/main/java/com/stripe/service/financialconnections/AccountService.java
@@ -49,7 +49,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Account>>() {}.getType());
   }
@@ -78,7 +78,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Account.class);
   }
   /**
@@ -119,7 +119,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Account.class);
   }
   /** Refreshes the data associated with a Financial Connections {@code Account}. */
@@ -140,7 +140,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Account.class);
   }
   /**
@@ -167,7 +167,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Account.class);
   }
   /**
@@ -196,7 +196,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Account.class);
   }
 

--- a/src/main/java/com/stripe/service/financialconnections/AccountService.java
+++ b/src/main/java/com/stripe/service/financialconnections/AccountService.java
@@ -49,7 +49,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Account>>() {}.getType());
   }
@@ -78,7 +78,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Account.class);
   }
   /**
@@ -119,7 +119,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Account.class);
   }
   /** Refreshes the data associated with a Financial Connections {@code Account}. */
@@ -140,7 +140,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Account.class);
   }
   /**
@@ -167,7 +167,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Account.class);
   }
   /**
@@ -196,7 +196,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Account.class);
   }
 

--- a/src/main/java/com/stripe/service/financialconnections/AccountService.java
+++ b/src/main/java/com/stripe/service/financialconnections/AccountService.java
@@ -49,6 +49,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Account>>() {}.getType());
   }
@@ -77,6 +78,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Account.class);
   }
   /**
@@ -117,6 +119,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Account.class);
   }
   /** Refreshes the data associated with a Financial Connections {@code Account}. */
@@ -137,6 +140,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Account.class);
   }
   /**
@@ -163,6 +167,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Account.class);
   }
   /**
@@ -191,6 +196,7 @@ public final class AccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Account.class);
   }
 

--- a/src/main/java/com/stripe/service/financialconnections/SessionService.java
+++ b/src/main/java/com/stripe/service/financialconnections/SessionService.java
@@ -44,6 +44,7 @@ public final class SessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Session.class);
   }
   /**
@@ -67,6 +68,7 @@ public final class SessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Session.class);
   }
 }

--- a/src/main/java/com/stripe/service/financialconnections/SessionService.java
+++ b/src/main/java/com/stripe/service/financialconnections/SessionService.java
@@ -44,7 +44,7 @@ public final class SessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Session.class);
   }
   /**
@@ -68,7 +68,7 @@ public final class SessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Session.class);
   }
 }

--- a/src/main/java/com/stripe/service/financialconnections/SessionService.java
+++ b/src/main/java/com/stripe/service/financialconnections/SessionService.java
@@ -44,7 +44,7 @@ public final class SessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Session.class);
   }
   /**
@@ -68,7 +68,7 @@ public final class SessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Session.class);
   }
 }

--- a/src/main/java/com/stripe/service/financialconnections/TransactionService.java
+++ b/src/main/java/com/stripe/service/financialconnections/TransactionService.java
@@ -37,7 +37,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Transaction>>() {}.getType());
   }
@@ -69,7 +69,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Transaction.class);
   }
 }

--- a/src/main/java/com/stripe/service/financialconnections/TransactionService.java
+++ b/src/main/java/com/stripe/service/financialconnections/TransactionService.java
@@ -37,7 +37,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Transaction>>() {}.getType());
   }
@@ -69,7 +69,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Transaction.class);
   }
 }

--- a/src/main/java/com/stripe/service/financialconnections/TransactionService.java
+++ b/src/main/java/com/stripe/service/financialconnections/TransactionService.java
@@ -37,6 +37,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Transaction>>() {}.getType());
   }
@@ -68,6 +69,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Transaction.class);
   }
 }

--- a/src/main/java/com/stripe/service/identity/VerificationReportService.java
+++ b/src/main/java/com/stripe/service/identity/VerificationReportService.java
@@ -46,6 +46,7 @@ public final class VerificationReportService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<VerificationReport>>() {}.getType());
   }
@@ -76,6 +77,7 @@ public final class VerificationReportService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, VerificationReport.class);
   }
 }

--- a/src/main/java/com/stripe/service/identity/VerificationReportService.java
+++ b/src/main/java/com/stripe/service/identity/VerificationReportService.java
@@ -46,7 +46,7 @@ public final class VerificationReportService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<VerificationReport>>() {}.getType());
   }
@@ -77,7 +77,7 @@ public final class VerificationReportService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, VerificationReport.class);
   }
 }

--- a/src/main/java/com/stripe/service/identity/VerificationReportService.java
+++ b/src/main/java/com/stripe/service/identity/VerificationReportService.java
@@ -46,7 +46,7 @@ public final class VerificationReportService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<VerificationReport>>() {}.getType());
   }
@@ -77,7 +77,7 @@ public final class VerificationReportService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, VerificationReport.class);
   }
 }

--- a/src/main/java/com/stripe/service/identity/VerificationSessionService.java
+++ b/src/main/java/com/stripe/service/identity/VerificationSessionService.java
@@ -50,7 +50,7 @@ public final class VerificationSessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<VerificationSession>>() {}.getType());
   }
@@ -92,7 +92,7 @@ public final class VerificationSessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, VerificationSession.class);
   }
   /**
@@ -143,7 +143,7 @@ public final class VerificationSessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, VerificationSession.class);
   }
   /**
@@ -193,7 +193,7 @@ public final class VerificationSessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, VerificationSession.class);
   }
   /**
@@ -248,7 +248,7 @@ public final class VerificationSessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, VerificationSession.class);
   }
   /**
@@ -359,7 +359,7 @@ public final class VerificationSessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, VerificationSession.class);
   }
 }

--- a/src/main/java/com/stripe/service/identity/VerificationSessionService.java
+++ b/src/main/java/com/stripe/service/identity/VerificationSessionService.java
@@ -50,7 +50,7 @@ public final class VerificationSessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<VerificationSession>>() {}.getType());
   }
@@ -92,7 +92,7 @@ public final class VerificationSessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, VerificationSession.class);
   }
   /**
@@ -143,7 +143,7 @@ public final class VerificationSessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, VerificationSession.class);
   }
   /**
@@ -193,7 +193,7 @@ public final class VerificationSessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, VerificationSession.class);
   }
   /**
@@ -248,7 +248,7 @@ public final class VerificationSessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, VerificationSession.class);
   }
   /**
@@ -359,7 +359,7 @@ public final class VerificationSessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, VerificationSession.class);
   }
 }

--- a/src/main/java/com/stripe/service/identity/VerificationSessionService.java
+++ b/src/main/java/com/stripe/service/identity/VerificationSessionService.java
@@ -50,6 +50,7 @@ public final class VerificationSessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<VerificationSession>>() {}.getType());
   }
@@ -91,6 +92,7 @@ public final class VerificationSessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, VerificationSession.class);
   }
   /**
@@ -141,6 +143,7 @@ public final class VerificationSessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, VerificationSession.class);
   }
   /**
@@ -190,6 +193,7 @@ public final class VerificationSessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, VerificationSession.class);
   }
   /**
@@ -244,6 +248,7 @@ public final class VerificationSessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, VerificationSession.class);
   }
   /**
@@ -354,6 +359,7 @@ public final class VerificationSessionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, VerificationSession.class);
   }
 }

--- a/src/main/java/com/stripe/service/issuing/AuthorizationService.java
+++ b/src/main/java/com/stripe/service/issuing/AuthorizationService.java
@@ -61,7 +61,7 @@ public final class AuthorizationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Authorization>>() {}.getType());
   }
@@ -93,7 +93,7 @@ public final class AuthorizationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Authorization.class);
   }
   /**
@@ -135,7 +135,7 @@ public final class AuthorizationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Authorization.class);
   }
   /**
@@ -195,7 +195,7 @@ public final class AuthorizationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Authorization.class);
   }
   /**
@@ -255,7 +255,7 @@ public final class AuthorizationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Authorization.class);
   }
 }

--- a/src/main/java/com/stripe/service/issuing/AuthorizationService.java
+++ b/src/main/java/com/stripe/service/issuing/AuthorizationService.java
@@ -61,7 +61,7 @@ public final class AuthorizationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Authorization>>() {}.getType());
   }
@@ -93,7 +93,7 @@ public final class AuthorizationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Authorization.class);
   }
   /**
@@ -135,7 +135,7 @@ public final class AuthorizationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Authorization.class);
   }
   /**
@@ -195,7 +195,7 @@ public final class AuthorizationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Authorization.class);
   }
   /**
@@ -255,7 +255,7 @@ public final class AuthorizationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Authorization.class);
   }
 }

--- a/src/main/java/com/stripe/service/issuing/AuthorizationService.java
+++ b/src/main/java/com/stripe/service/issuing/AuthorizationService.java
@@ -61,6 +61,7 @@ public final class AuthorizationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Authorization>>() {}.getType());
   }
@@ -92,6 +93,7 @@ public final class AuthorizationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Authorization.class);
   }
   /**
@@ -133,6 +135,7 @@ public final class AuthorizationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Authorization.class);
   }
   /**
@@ -192,6 +195,7 @@ public final class AuthorizationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Authorization.class);
   }
   /**
@@ -251,6 +255,7 @@ public final class AuthorizationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Authorization.class);
   }
 }

--- a/src/main/java/com/stripe/service/issuing/CardService.java
+++ b/src/main/java/com/stripe/service/issuing/CardService.java
@@ -59,6 +59,7 @@ public final class CardService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Card>>() {}.getType());
   }
@@ -77,6 +78,7 @@ public final class CardService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Card.class);
   }
   /** Retrieves an Issuing {@code Card} object. */
@@ -103,6 +105,7 @@ public final class CardService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Card.class);
   }
   /**
@@ -141,6 +144,7 @@ public final class CardService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Card.class);
   }
 }

--- a/src/main/java/com/stripe/service/issuing/CardService.java
+++ b/src/main/java/com/stripe/service/issuing/CardService.java
@@ -59,7 +59,7 @@ public final class CardService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Card>>() {}.getType());
   }
@@ -78,7 +78,7 @@ public final class CardService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Card.class);
   }
   /** Retrieves an Issuing {@code Card} object. */
@@ -105,7 +105,7 @@ public final class CardService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Card.class);
   }
   /**
@@ -144,7 +144,7 @@ public final class CardService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Card.class);
   }
 }

--- a/src/main/java/com/stripe/service/issuing/CardService.java
+++ b/src/main/java/com/stripe/service/issuing/CardService.java
@@ -59,7 +59,7 @@ public final class CardService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Card>>() {}.getType());
   }
@@ -78,7 +78,7 @@ public final class CardService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Card.class);
   }
   /** Retrieves an Issuing {@code Card} object. */
@@ -105,7 +105,7 @@ public final class CardService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Card.class);
   }
   /**
@@ -144,7 +144,7 @@ public final class CardService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Card.class);
   }
 }

--- a/src/main/java/com/stripe/service/issuing/CardholderService.java
+++ b/src/main/java/com/stripe/service/issuing/CardholderService.java
@@ -59,7 +59,7 @@ public final class CardholderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Cardholder>>() {}.getType());
   }
@@ -79,7 +79,7 @@ public final class CardholderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Cardholder.class);
   }
   /** Retrieves an Issuing {@code Cardholder} object. */
@@ -108,7 +108,7 @@ public final class CardholderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Cardholder.class);
   }
   /**
@@ -148,7 +148,7 @@ public final class CardholderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Cardholder.class);
   }
 }

--- a/src/main/java/com/stripe/service/issuing/CardholderService.java
+++ b/src/main/java/com/stripe/service/issuing/CardholderService.java
@@ -59,7 +59,7 @@ public final class CardholderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Cardholder>>() {}.getType());
   }
@@ -79,7 +79,7 @@ public final class CardholderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Cardholder.class);
   }
   /** Retrieves an Issuing {@code Cardholder} object. */
@@ -108,7 +108,7 @@ public final class CardholderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Cardholder.class);
   }
   /**
@@ -148,7 +148,7 @@ public final class CardholderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Cardholder.class);
   }
 }

--- a/src/main/java/com/stripe/service/issuing/CardholderService.java
+++ b/src/main/java/com/stripe/service/issuing/CardholderService.java
@@ -59,6 +59,7 @@ public final class CardholderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Cardholder>>() {}.getType());
   }
@@ -78,6 +79,7 @@ public final class CardholderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Cardholder.class);
   }
   /** Retrieves an Issuing {@code Cardholder} object. */
@@ -106,6 +108,7 @@ public final class CardholderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Cardholder.class);
   }
   /**
@@ -145,6 +148,7 @@ public final class CardholderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Cardholder.class);
   }
 }

--- a/src/main/java/com/stripe/service/issuing/DisputeService.java
+++ b/src/main/java/com/stripe/service/issuing/DisputeService.java
@@ -60,7 +60,7 @@ public final class DisputeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Dispute>>() {}.getType());
   }
@@ -111,7 +111,7 @@ public final class DisputeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Dispute.class);
   }
   /** Retrieves an Issuing {@code Dispute} object. */
@@ -138,7 +138,7 @@ public final class DisputeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Dispute.class);
   }
   /**
@@ -181,7 +181,7 @@ public final class DisputeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Dispute.class);
   }
   /**
@@ -228,7 +228,7 @@ public final class DisputeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Dispute.class);
   }
 }

--- a/src/main/java/com/stripe/service/issuing/DisputeService.java
+++ b/src/main/java/com/stripe/service/issuing/DisputeService.java
@@ -60,7 +60,7 @@ public final class DisputeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Dispute>>() {}.getType());
   }
@@ -111,7 +111,7 @@ public final class DisputeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Dispute.class);
   }
   /** Retrieves an Issuing {@code Dispute} object. */
@@ -138,7 +138,7 @@ public final class DisputeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Dispute.class);
   }
   /**
@@ -181,7 +181,7 @@ public final class DisputeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Dispute.class);
   }
   /**
@@ -228,7 +228,7 @@ public final class DisputeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Dispute.class);
   }
 }

--- a/src/main/java/com/stripe/service/issuing/DisputeService.java
+++ b/src/main/java/com/stripe/service/issuing/DisputeService.java
@@ -60,6 +60,7 @@ public final class DisputeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Dispute>>() {}.getType());
   }
@@ -110,6 +111,7 @@ public final class DisputeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Dispute.class);
   }
   /** Retrieves an Issuing {@code Dispute} object. */
@@ -136,6 +138,7 @@ public final class DisputeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Dispute.class);
   }
   /**
@@ -178,6 +181,7 @@ public final class DisputeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Dispute.class);
   }
   /**
@@ -224,6 +228,7 @@ public final class DisputeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Dispute.class);
   }
 }

--- a/src/main/java/com/stripe/service/issuing/TokenService.java
+++ b/src/main/java/com/stripe/service/issuing/TokenService.java
@@ -38,6 +38,7 @@ public final class TokenService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Token>>() {}.getType());
   }
@@ -65,6 +66,7 @@ public final class TokenService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Token.class);
   }
   /** Attempts to update the specified Issuing {@code Token} object to the status specified. */
@@ -83,6 +85,7 @@ public final class TokenService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Token.class);
   }
 }

--- a/src/main/java/com/stripe/service/issuing/TokenService.java
+++ b/src/main/java/com/stripe/service/issuing/TokenService.java
@@ -38,7 +38,7 @@ public final class TokenService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Token>>() {}.getType());
   }
@@ -66,7 +66,7 @@ public final class TokenService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Token.class);
   }
   /** Attempts to update the specified Issuing {@code Token} object to the status specified. */
@@ -85,7 +85,7 @@ public final class TokenService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Token.class);
   }
 }

--- a/src/main/java/com/stripe/service/issuing/TokenService.java
+++ b/src/main/java/com/stripe/service/issuing/TokenService.java
@@ -38,7 +38,7 @@ public final class TokenService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Token>>() {}.getType());
   }
@@ -66,7 +66,7 @@ public final class TokenService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Token.class);
   }
   /** Attempts to update the specified Issuing {@code Token} object to the status specified. */
@@ -85,7 +85,7 @@ public final class TokenService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Token.class);
   }
 }

--- a/src/main/java/com/stripe/service/issuing/TransactionService.java
+++ b/src/main/java/com/stripe/service/issuing/TransactionService.java
@@ -58,7 +58,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Transaction>>() {}.getType());
   }
@@ -89,7 +89,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Transaction.class);
   }
   /**
@@ -131,7 +131,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Transaction.class);
   }
 }

--- a/src/main/java/com/stripe/service/issuing/TransactionService.java
+++ b/src/main/java/com/stripe/service/issuing/TransactionService.java
@@ -58,6 +58,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Transaction>>() {}.getType());
   }
@@ -88,6 +89,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Transaction.class);
   }
   /**
@@ -129,6 +131,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Transaction.class);
   }
 }

--- a/src/main/java/com/stripe/service/issuing/TransactionService.java
+++ b/src/main/java/com/stripe/service/issuing/TransactionService.java
@@ -58,7 +58,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Transaction>>() {}.getType());
   }
@@ -89,7 +89,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Transaction.class);
   }
   /**
@@ -131,7 +131,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Transaction.class);
   }
 }

--- a/src/main/java/com/stripe/service/radar/EarlyFraudWarningService.java
+++ b/src/main/java/com/stripe/service/radar/EarlyFraudWarningService.java
@@ -46,7 +46,7 @@ public final class EarlyFraudWarningService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<EarlyFraudWarning>>() {}.getType());
   }
@@ -100,7 +100,7 @@ public final class EarlyFraudWarningService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, EarlyFraudWarning.class);
   }
 }

--- a/src/main/java/com/stripe/service/radar/EarlyFraudWarningService.java
+++ b/src/main/java/com/stripe/service/radar/EarlyFraudWarningService.java
@@ -46,6 +46,7 @@ public final class EarlyFraudWarningService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<EarlyFraudWarning>>() {}.getType());
   }
@@ -99,6 +100,7 @@ public final class EarlyFraudWarningService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, EarlyFraudWarning.class);
   }
 }

--- a/src/main/java/com/stripe/service/radar/EarlyFraudWarningService.java
+++ b/src/main/java/com/stripe/service/radar/EarlyFraudWarningService.java
@@ -46,7 +46,7 @@ public final class EarlyFraudWarningService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<EarlyFraudWarning>>() {}.getType());
   }
@@ -100,7 +100,7 @@ public final class EarlyFraudWarningService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, EarlyFraudWarning.class);
   }
 }

--- a/src/main/java/com/stripe/service/radar/ValueListItemService.java
+++ b/src/main/java/com/stripe/service/radar/ValueListItemService.java
@@ -32,6 +32,7 @@ public final class ValueListItemService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, ValueListItem.class);
   }
   /** Retrieves a {@code ValueListItem} object. */
@@ -60,6 +61,7 @@ public final class ValueListItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, ValueListItem.class);
   }
   /**
@@ -85,6 +87,7 @@ public final class ValueListItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ValueListItem>>() {}.getType());
   }
@@ -108,6 +111,7 @@ public final class ValueListItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, ValueListItem.class);
   }
 }

--- a/src/main/java/com/stripe/service/radar/ValueListItemService.java
+++ b/src/main/java/com/stripe/service/radar/ValueListItemService.java
@@ -32,7 +32,7 @@ public final class ValueListItemService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, ValueListItem.class);
   }
   /** Retrieves a {@code ValueListItem} object. */
@@ -61,7 +61,7 @@ public final class ValueListItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, ValueListItem.class);
   }
   /**
@@ -87,7 +87,7 @@ public final class ValueListItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ValueListItem>>() {}.getType());
   }
@@ -111,7 +111,7 @@ public final class ValueListItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, ValueListItem.class);
   }
 }

--- a/src/main/java/com/stripe/service/radar/ValueListItemService.java
+++ b/src/main/java/com/stripe/service/radar/ValueListItemService.java
@@ -32,7 +32,7 @@ public final class ValueListItemService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, ValueListItem.class);
   }
   /** Retrieves a {@code ValueListItem} object. */
@@ -61,7 +61,7 @@ public final class ValueListItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, ValueListItem.class);
   }
   /**
@@ -87,7 +87,7 @@ public final class ValueListItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ValueListItem>>() {}.getType());
   }
@@ -111,7 +111,7 @@ public final class ValueListItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, ValueListItem.class);
   }
 }

--- a/src/main/java/com/stripe/service/radar/ValueListService.java
+++ b/src/main/java/com/stripe/service/radar/ValueListService.java
@@ -39,7 +39,7 @@ public final class ValueListService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, ValueList.class);
   }
   /** Retrieves a {@code ValueList} object. */
@@ -68,7 +68,7 @@ public final class ValueListService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, ValueList.class);
   }
   /**
@@ -107,7 +107,7 @@ public final class ValueListService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, ValueList.class);
   }
   /**
@@ -146,7 +146,7 @@ public final class ValueListService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ValueList>>() {}.getType());
   }
@@ -166,7 +166,7 @@ public final class ValueListService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, ValueList.class);
   }
 }

--- a/src/main/java/com/stripe/service/radar/ValueListService.java
+++ b/src/main/java/com/stripe/service/radar/ValueListService.java
@@ -39,6 +39,7 @@ public final class ValueListService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, ValueList.class);
   }
   /** Retrieves a {@code ValueList} object. */
@@ -67,6 +68,7 @@ public final class ValueListService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, ValueList.class);
   }
   /**
@@ -105,6 +107,7 @@ public final class ValueListService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, ValueList.class);
   }
   /**
@@ -143,6 +146,7 @@ public final class ValueListService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ValueList>>() {}.getType());
   }
@@ -162,6 +166,7 @@ public final class ValueListService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, ValueList.class);
   }
 }

--- a/src/main/java/com/stripe/service/radar/ValueListService.java
+++ b/src/main/java/com/stripe/service/radar/ValueListService.java
@@ -39,7 +39,7 @@ public final class ValueListService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, ValueList.class);
   }
   /** Retrieves a {@code ValueList} object. */
@@ -68,7 +68,7 @@ public final class ValueListService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, ValueList.class);
   }
   /**
@@ -107,7 +107,7 @@ public final class ValueListService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, ValueList.class);
   }
   /**
@@ -146,7 +146,7 @@ public final class ValueListService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ValueList>>() {}.getType());
   }
@@ -166,7 +166,7 @@ public final class ValueListService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, ValueList.class);
   }
 }

--- a/src/main/java/com/stripe/service/reporting/ReportRunService.java
+++ b/src/main/java/com/stripe/service/reporting/ReportRunService.java
@@ -46,6 +46,7 @@ public final class ReportRunService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ReportRun>>() {}.getType());
   }
@@ -71,6 +72,7 @@ public final class ReportRunService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, ReportRun.class);
   }
   /** Retrieves the details of an existing Report Run. */
@@ -99,6 +101,7 @@ public final class ReportRunService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, ReportRun.class);
   }
 }

--- a/src/main/java/com/stripe/service/reporting/ReportRunService.java
+++ b/src/main/java/com/stripe/service/reporting/ReportRunService.java
@@ -46,7 +46,7 @@ public final class ReportRunService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ReportRun>>() {}.getType());
   }
@@ -72,7 +72,7 @@ public final class ReportRunService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, ReportRun.class);
   }
   /** Retrieves the details of an existing Report Run. */
@@ -101,7 +101,7 @@ public final class ReportRunService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, ReportRun.class);
   }
 }

--- a/src/main/java/com/stripe/service/reporting/ReportRunService.java
+++ b/src/main/java/com/stripe/service/reporting/ReportRunService.java
@@ -46,7 +46,7 @@ public final class ReportRunService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ReportRun>>() {}.getType());
   }
@@ -72,7 +72,7 @@ public final class ReportRunService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, ReportRun.class);
   }
   /** Retrieves the details of an existing Report Run. */
@@ -101,7 +101,7 @@ public final class ReportRunService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, ReportRun.class);
   }
 }

--- a/src/main/java/com/stripe/service/reporting/ReportTypeService.java
+++ b/src/main/java/com/stripe/service/reporting/ReportTypeService.java
@@ -45,6 +45,7 @@ public final class ReportTypeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ReportType>>() {}.getType());
   }
@@ -87,6 +88,7 @@ public final class ReportTypeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, ReportType.class);
   }
 }

--- a/src/main/java/com/stripe/service/reporting/ReportTypeService.java
+++ b/src/main/java/com/stripe/service/reporting/ReportTypeService.java
@@ -45,7 +45,7 @@ public final class ReportTypeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ReportType>>() {}.getType());
   }
@@ -88,7 +88,7 @@ public final class ReportTypeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, ReportType.class);
   }
 }

--- a/src/main/java/com/stripe/service/reporting/ReportTypeService.java
+++ b/src/main/java/com/stripe/service/reporting/ReportTypeService.java
@@ -45,7 +45,7 @@ public final class ReportTypeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ReportType>>() {}.getType());
   }
@@ -88,7 +88,7 @@ public final class ReportTypeService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, ReportType.class);
   }
 }

--- a/src/main/java/com/stripe/service/sigma/ScheduledQueryRunService.java
+++ b/src/main/java/com/stripe/service/sigma/ScheduledQueryRunService.java
@@ -46,7 +46,7 @@ public final class ScheduledQueryRunService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ScheduledQueryRun>>() {}.getType());
   }
@@ -80,7 +80,7 @@ public final class ScheduledQueryRunService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, ScheduledQueryRun.class);
   }
 }

--- a/src/main/java/com/stripe/service/sigma/ScheduledQueryRunService.java
+++ b/src/main/java/com/stripe/service/sigma/ScheduledQueryRunService.java
@@ -46,6 +46,7 @@ public final class ScheduledQueryRunService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ScheduledQueryRun>>() {}.getType());
   }
@@ -79,6 +80,7 @@ public final class ScheduledQueryRunService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, ScheduledQueryRun.class);
   }
 }

--- a/src/main/java/com/stripe/service/sigma/ScheduledQueryRunService.java
+++ b/src/main/java/com/stripe/service/sigma/ScheduledQueryRunService.java
@@ -46,7 +46,7 @@ public final class ScheduledQueryRunService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ScheduledQueryRun>>() {}.getType());
   }
@@ -80,7 +80,7 @@ public final class ScheduledQueryRunService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, ScheduledQueryRun.class);
   }
 }

--- a/src/main/java/com/stripe/service/tax/CalculationLineItemService.java
+++ b/src/main/java/com/stripe/service/tax/CalculationLineItemService.java
@@ -48,6 +48,7 @@ public final class CalculationLineItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<CalculationLineItem>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/tax/CalculationLineItemService.java
+++ b/src/main/java/com/stripe/service/tax/CalculationLineItemService.java
@@ -48,7 +48,7 @@ public final class CalculationLineItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<CalculationLineItem>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/tax/CalculationLineItemService.java
+++ b/src/main/java/com/stripe/service/tax/CalculationLineItemService.java
@@ -48,7 +48,7 @@ public final class CalculationLineItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<CalculationLineItem>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/tax/CalculationService.java
+++ b/src/main/java/com/stripe/service/tax/CalculationService.java
@@ -34,7 +34,7 @@ public final class CalculationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Calculation.class);
   }
 

--- a/src/main/java/com/stripe/service/tax/CalculationService.java
+++ b/src/main/java/com/stripe/service/tax/CalculationService.java
@@ -34,7 +34,7 @@ public final class CalculationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Calculation.class);
   }
 

--- a/src/main/java/com/stripe/service/tax/CalculationService.java
+++ b/src/main/java/com/stripe/service/tax/CalculationService.java
@@ -34,6 +34,7 @@ public final class CalculationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Calculation.class);
   }
 

--- a/src/main/java/com/stripe/service/tax/RegistrationService.java
+++ b/src/main/java/com/stripe/service/tax/RegistrationService.java
@@ -47,7 +47,7 @@ public final class RegistrationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Registration>>() {}.getType());
   }
@@ -67,7 +67,7 @@ public final class RegistrationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Registration.class);
   }
   /** Returns a Tax {@code Registration} object. */
@@ -95,7 +95,7 @@ public final class RegistrationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Registration.class);
   }
   /**
@@ -142,7 +142,7 @@ public final class RegistrationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Registration.class);
   }
 }

--- a/src/main/java/com/stripe/service/tax/RegistrationService.java
+++ b/src/main/java/com/stripe/service/tax/RegistrationService.java
@@ -47,7 +47,7 @@ public final class RegistrationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Registration>>() {}.getType());
   }
@@ -67,7 +67,7 @@ public final class RegistrationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Registration.class);
   }
   /** Returns a Tax {@code Registration} object. */
@@ -95,7 +95,7 @@ public final class RegistrationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Registration.class);
   }
   /**
@@ -142,7 +142,7 @@ public final class RegistrationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Registration.class);
   }
 }

--- a/src/main/java/com/stripe/service/tax/RegistrationService.java
+++ b/src/main/java/com/stripe/service/tax/RegistrationService.java
@@ -47,6 +47,7 @@ public final class RegistrationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Registration>>() {}.getType());
   }
@@ -66,6 +67,7 @@ public final class RegistrationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Registration.class);
   }
   /** Returns a Tax {@code Registration} object. */
@@ -93,6 +95,7 @@ public final class RegistrationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Registration.class);
   }
   /**
@@ -139,6 +142,7 @@ public final class RegistrationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Registration.class);
   }
 }

--- a/src/main/java/com/stripe/service/tax/SettingsService.java
+++ b/src/main/java/com/stripe/service/tax/SettingsService.java
@@ -43,7 +43,7 @@ public final class SettingsService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Settings.class);
   }
   /**
@@ -82,7 +82,7 @@ public final class SettingsService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Settings.class);
   }
 }

--- a/src/main/java/com/stripe/service/tax/SettingsService.java
+++ b/src/main/java/com/stripe/service/tax/SettingsService.java
@@ -43,6 +43,7 @@ public final class SettingsService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Settings.class);
   }
   /**
@@ -81,6 +82,7 @@ public final class SettingsService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Settings.class);
   }
 }

--- a/src/main/java/com/stripe/service/tax/SettingsService.java
+++ b/src/main/java/com/stripe/service/tax/SettingsService.java
@@ -43,7 +43,7 @@ public final class SettingsService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Settings.class);
   }
   /**
@@ -82,7 +82,7 @@ public final class SettingsService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Settings.class);
   }
 }

--- a/src/main/java/com/stripe/service/tax/TransactionLineItemService.java
+++ b/src/main/java/com/stripe/service/tax/TransactionLineItemService.java
@@ -48,7 +48,7 @@ public final class TransactionLineItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<TransactionLineItem>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/tax/TransactionLineItemService.java
+++ b/src/main/java/com/stripe/service/tax/TransactionLineItemService.java
@@ -48,6 +48,7 @@ public final class TransactionLineItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<TransactionLineItem>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/tax/TransactionLineItemService.java
+++ b/src/main/java/com/stripe/service/tax/TransactionLineItemService.java
@@ -48,7 +48,7 @@ public final class TransactionLineItemService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<TransactionLineItem>>() {}.getType());
   }

--- a/src/main/java/com/stripe/service/tax/TransactionService.java
+++ b/src/main/java/com/stripe/service/tax/TransactionService.java
@@ -46,6 +46,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Transaction.class);
   }
   /** Creates a Tax {@code Transaction} from a calculation. */
@@ -66,6 +67,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Transaction.class);
   }
   /** Partially or fully reverses a previously created {@code Transaction}. */
@@ -84,6 +86,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Transaction.class);
   }
 

--- a/src/main/java/com/stripe/service/tax/TransactionService.java
+++ b/src/main/java/com/stripe/service/tax/TransactionService.java
@@ -46,7 +46,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Transaction.class);
   }
   /** Creates a Tax {@code Transaction} from a calculation. */
@@ -67,7 +67,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Transaction.class);
   }
   /** Partially or fully reverses a previously created {@code Transaction}. */
@@ -86,7 +86,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Transaction.class);
   }
 

--- a/src/main/java/com/stripe/service/tax/TransactionService.java
+++ b/src/main/java/com/stripe/service/tax/TransactionService.java
@@ -46,7 +46,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Transaction.class);
   }
   /** Creates a Tax {@code Transaction} from a calculation. */
@@ -67,7 +67,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Transaction.class);
   }
   /** Partially or fully reverses a previously created {@code Transaction}. */
@@ -86,7 +86,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Transaction.class);
   }
 

--- a/src/main/java/com/stripe/service/terminal/ConfigurationService.java
+++ b/src/main/java/com/stripe/service/terminal/ConfigurationService.java
@@ -34,7 +34,7 @@ public final class ConfigurationService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Configuration.class);
   }
   /** Retrieves a {@code Configuration} object. */
@@ -65,7 +65,7 @@ public final class ConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Configuration.class);
   }
   /** Updates a new {@code Configuration} object. */
@@ -95,7 +95,7 @@ public final class ConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Configuration.class);
   }
   /** Returns a list of {@code Configuration} objects. */
@@ -123,7 +123,7 @@ public final class ConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Configuration>>() {}.getType());
   }
@@ -151,7 +151,7 @@ public final class ConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Configuration.class);
   }
 }

--- a/src/main/java/com/stripe/service/terminal/ConfigurationService.java
+++ b/src/main/java/com/stripe/service/terminal/ConfigurationService.java
@@ -34,6 +34,7 @@ public final class ConfigurationService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Configuration.class);
   }
   /** Retrieves a {@code Configuration} object. */
@@ -64,6 +65,7 @@ public final class ConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Configuration.class);
   }
   /** Updates a new {@code Configuration} object. */
@@ -93,6 +95,7 @@ public final class ConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Configuration.class);
   }
   /** Returns a list of {@code Configuration} objects. */
@@ -120,6 +123,7 @@ public final class ConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Configuration>>() {}.getType());
   }
@@ -147,6 +151,7 @@ public final class ConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Configuration.class);
   }
 }

--- a/src/main/java/com/stripe/service/terminal/ConfigurationService.java
+++ b/src/main/java/com/stripe/service/terminal/ConfigurationService.java
@@ -34,7 +34,7 @@ public final class ConfigurationService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Configuration.class);
   }
   /** Retrieves a {@code Configuration} object. */
@@ -65,7 +65,7 @@ public final class ConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Configuration.class);
   }
   /** Updates a new {@code Configuration} object. */
@@ -95,7 +95,7 @@ public final class ConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Configuration.class);
   }
   /** Returns a list of {@code Configuration} objects. */
@@ -123,7 +123,7 @@ public final class ConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Configuration>>() {}.getType());
   }
@@ -151,7 +151,7 @@ public final class ConfigurationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Configuration.class);
   }
 }

--- a/src/main/java/com/stripe/service/terminal/ConnectionTokenService.java
+++ b/src/main/java/com/stripe/service/terminal/ConnectionTokenService.java
@@ -58,7 +58,7 @@ public final class ConnectionTokenService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, ConnectionToken.class);
   }
 }

--- a/src/main/java/com/stripe/service/terminal/ConnectionTokenService.java
+++ b/src/main/java/com/stripe/service/terminal/ConnectionTokenService.java
@@ -58,6 +58,7 @@ public final class ConnectionTokenService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, ConnectionToken.class);
   }
 }

--- a/src/main/java/com/stripe/service/terminal/ConnectionTokenService.java
+++ b/src/main/java/com/stripe/service/terminal/ConnectionTokenService.java
@@ -58,7 +58,7 @@ public final class ConnectionTokenService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, ConnectionToken.class);
   }
 }

--- a/src/main/java/com/stripe/service/terminal/LocationService.java
+++ b/src/main/java/com/stripe/service/terminal/LocationService.java
@@ -33,7 +33,7 @@ public final class LocationService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Location.class);
   }
   /** Retrieves a {@code Location} object. */
@@ -60,7 +60,7 @@ public final class LocationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Location.class);
   }
   /**
@@ -99,7 +99,7 @@ public final class LocationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Location.class);
   }
   /** Returns a list of {@code Location} objects. */
@@ -126,7 +126,7 @@ public final class LocationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Location>>() {}.getType());
   }
@@ -154,7 +154,7 @@ public final class LocationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Location.class);
   }
 }

--- a/src/main/java/com/stripe/service/terminal/LocationService.java
+++ b/src/main/java/com/stripe/service/terminal/LocationService.java
@@ -33,6 +33,7 @@ public final class LocationService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Location.class);
   }
   /** Retrieves a {@code Location} object. */
@@ -59,6 +60,7 @@ public final class LocationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Location.class);
   }
   /**
@@ -97,6 +99,7 @@ public final class LocationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Location.class);
   }
   /** Returns a list of {@code Location} objects. */
@@ -123,6 +126,7 @@ public final class LocationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Location>>() {}.getType());
   }
@@ -150,6 +154,7 @@ public final class LocationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Location.class);
   }
 }

--- a/src/main/java/com/stripe/service/terminal/LocationService.java
+++ b/src/main/java/com/stripe/service/terminal/LocationService.java
@@ -33,7 +33,7 @@ public final class LocationService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Location.class);
   }
   /** Retrieves a {@code Location} object. */
@@ -60,7 +60,7 @@ public final class LocationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Location.class);
   }
   /**
@@ -99,7 +99,7 @@ public final class LocationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Location.class);
   }
   /** Returns a list of {@code Location} objects. */
@@ -126,7 +126,7 @@ public final class LocationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Location>>() {}.getType());
   }
@@ -154,7 +154,7 @@ public final class LocationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Location.class);
   }
 }

--- a/src/main/java/com/stripe/service/terminal/ReaderService.java
+++ b/src/main/java/com/stripe/service/terminal/ReaderService.java
@@ -38,6 +38,7 @@ public final class ReaderService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Reader.class);
   }
   /** Retrieves a {@code Reader} object. */
@@ -64,6 +65,7 @@ public final class ReaderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Reader.class);
   }
   /**
@@ -102,6 +104,7 @@ public final class ReaderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Reader.class);
   }
   /** Returns a list of {@code Reader} objects. */
@@ -128,6 +131,7 @@ public final class ReaderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Reader>>() {}.getType());
   }
@@ -146,6 +150,7 @@ public final class ReaderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Reader.class);
   }
   /** Cancels the current reader action. */
@@ -174,6 +179,7 @@ public final class ReaderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Reader.class);
   }
   /** Initiates a payment flow on a Reader. */
@@ -196,6 +202,7 @@ public final class ReaderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Reader.class);
   }
   /** Initiates a setup intent flow on a Reader. */
@@ -218,6 +225,7 @@ public final class ReaderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Reader.class);
   }
   /** Initiates a refund on a Reader. */
@@ -247,6 +255,7 @@ public final class ReaderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Reader.class);
   }
   /** Sets reader display to show cart details. */
@@ -269,6 +278,7 @@ public final class ReaderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Reader.class);
   }
 }

--- a/src/main/java/com/stripe/service/terminal/ReaderService.java
+++ b/src/main/java/com/stripe/service/terminal/ReaderService.java
@@ -38,7 +38,7 @@ public final class ReaderService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Reader.class);
   }
   /** Retrieves a {@code Reader} object. */
@@ -65,7 +65,7 @@ public final class ReaderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Reader.class);
   }
   /**
@@ -104,7 +104,7 @@ public final class ReaderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Reader.class);
   }
   /** Returns a list of {@code Reader} objects. */
@@ -131,7 +131,7 @@ public final class ReaderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Reader>>() {}.getType());
   }
@@ -150,7 +150,7 @@ public final class ReaderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Reader.class);
   }
   /** Cancels the current reader action. */
@@ -179,7 +179,7 @@ public final class ReaderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Reader.class);
   }
   /** Initiates a payment flow on a Reader. */
@@ -202,7 +202,7 @@ public final class ReaderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Reader.class);
   }
   /** Initiates a setup intent flow on a Reader. */
@@ -225,7 +225,7 @@ public final class ReaderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Reader.class);
   }
   /** Initiates a refund on a Reader. */
@@ -255,7 +255,7 @@ public final class ReaderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Reader.class);
   }
   /** Sets reader display to show cart details. */
@@ -278,7 +278,7 @@ public final class ReaderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Reader.class);
   }
 }

--- a/src/main/java/com/stripe/service/terminal/ReaderService.java
+++ b/src/main/java/com/stripe/service/terminal/ReaderService.java
@@ -38,7 +38,7 @@ public final class ReaderService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Reader.class);
   }
   /** Retrieves a {@code Reader} object. */
@@ -65,7 +65,7 @@ public final class ReaderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Reader.class);
   }
   /**
@@ -104,7 +104,7 @@ public final class ReaderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Reader.class);
   }
   /** Returns a list of {@code Reader} objects. */
@@ -131,7 +131,7 @@ public final class ReaderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Reader>>() {}.getType());
   }
@@ -150,7 +150,7 @@ public final class ReaderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Reader.class);
   }
   /** Cancels the current reader action. */
@@ -179,7 +179,7 @@ public final class ReaderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Reader.class);
   }
   /** Initiates a payment flow on a Reader. */
@@ -202,7 +202,7 @@ public final class ReaderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Reader.class);
   }
   /** Initiates a setup intent flow on a Reader. */
@@ -225,7 +225,7 @@ public final class ReaderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Reader.class);
   }
   /** Initiates a refund on a Reader. */
@@ -255,7 +255,7 @@ public final class ReaderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Reader.class);
   }
   /** Sets reader display to show cart details. */
@@ -278,7 +278,7 @@ public final class ReaderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Reader.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/CustomerService.java
+++ b/src/main/java/com/stripe/service/testhelpers/CustomerService.java
@@ -38,6 +38,7 @@ public final class CustomerService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, CustomerCashBalanceTransaction.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/CustomerService.java
+++ b/src/main/java/com/stripe/service/testhelpers/CustomerService.java
@@ -38,7 +38,7 @@ public final class CustomerService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, CustomerCashBalanceTransaction.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/CustomerService.java
+++ b/src/main/java/com/stripe/service/testhelpers/CustomerService.java
@@ -38,7 +38,7 @@ public final class CustomerService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, CustomerCashBalanceTransaction.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/RefundService.java
+++ b/src/main/java/com/stripe/service/testhelpers/RefundService.java
@@ -43,6 +43,7 @@ public final class RefundService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Refund.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/RefundService.java
+++ b/src/main/java/com/stripe/service/testhelpers/RefundService.java
@@ -43,7 +43,7 @@ public final class RefundService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Refund.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/RefundService.java
+++ b/src/main/java/com/stripe/service/testhelpers/RefundService.java
@@ -43,7 +43,7 @@ public final class RefundService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Refund.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/TestClockService.java
+++ b/src/main/java/com/stripe/service/testhelpers/TestClockService.java
@@ -34,6 +34,7 @@ public final class TestClockService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, TestClock.class);
   }
   /** Retrieves a test clock. */
@@ -63,6 +64,7 @@ public final class TestClockService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, TestClock.class);
   }
   /** Returns a list of your test clocks. */
@@ -89,6 +91,7 @@ public final class TestClockService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<TestClock>>() {}.getType());
   }
@@ -108,6 +111,7 @@ public final class TestClockService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, TestClock.class);
   }
   /**
@@ -134,6 +138,7 @@ public final class TestClockService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, TestClock.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/TestClockService.java
+++ b/src/main/java/com/stripe/service/testhelpers/TestClockService.java
@@ -34,7 +34,7 @@ public final class TestClockService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, TestClock.class);
   }
   /** Retrieves a test clock. */
@@ -64,7 +64,7 @@ public final class TestClockService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, TestClock.class);
   }
   /** Returns a list of your test clocks. */
@@ -91,7 +91,7 @@ public final class TestClockService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<TestClock>>() {}.getType());
   }
@@ -111,7 +111,7 @@ public final class TestClockService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, TestClock.class);
   }
   /**
@@ -138,7 +138,7 @@ public final class TestClockService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, TestClock.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/TestClockService.java
+++ b/src/main/java/com/stripe/service/testhelpers/TestClockService.java
@@ -34,7 +34,7 @@ public final class TestClockService extends ApiService {
     ApiRequest request =
         new ApiRequest(
             BaseAddress.API, ApiResource.RequestMethod.DELETE, path, null, options, ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, TestClock.class);
   }
   /** Retrieves a test clock. */
@@ -64,7 +64,7 @@ public final class TestClockService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, TestClock.class);
   }
   /** Returns a list of your test clocks. */
@@ -91,7 +91,7 @@ public final class TestClockService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<TestClock>>() {}.getType());
   }
@@ -111,7 +111,7 @@ public final class TestClockService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, TestClock.class);
   }
   /**
@@ -138,7 +138,7 @@ public final class TestClockService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, TestClock.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/issuing/AuthorizationService.java
+++ b/src/main/java/com/stripe/service/testhelpers/issuing/AuthorizationService.java
@@ -38,6 +38,7 @@ public final class AuthorizationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Authorization.class);
   }
   /** Capture a test-mode authorization. */
@@ -70,6 +71,7 @@ public final class AuthorizationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Authorization.class);
   }
   /** Expire a test-mode Authorization. */
@@ -101,6 +103,7 @@ public final class AuthorizationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Authorization.class);
   }
   /** Increment a test-mode Authorization. */
@@ -124,6 +127,7 @@ public final class AuthorizationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Authorization.class);
   }
   /** Reverse a test-mode Authorization. */
@@ -156,6 +160,7 @@ public final class AuthorizationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Authorization.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/issuing/AuthorizationService.java
+++ b/src/main/java/com/stripe/service/testhelpers/issuing/AuthorizationService.java
@@ -38,7 +38,7 @@ public final class AuthorizationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Authorization.class);
   }
   /** Capture a test-mode authorization. */
@@ -71,7 +71,7 @@ public final class AuthorizationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Authorization.class);
   }
   /** Expire a test-mode Authorization. */
@@ -103,7 +103,7 @@ public final class AuthorizationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Authorization.class);
   }
   /** Increment a test-mode Authorization. */
@@ -127,7 +127,7 @@ public final class AuthorizationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Authorization.class);
   }
   /** Reverse a test-mode Authorization. */
@@ -160,7 +160,7 @@ public final class AuthorizationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Authorization.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/issuing/AuthorizationService.java
+++ b/src/main/java/com/stripe/service/testhelpers/issuing/AuthorizationService.java
@@ -38,7 +38,7 @@ public final class AuthorizationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Authorization.class);
   }
   /** Capture a test-mode authorization. */
@@ -71,7 +71,7 @@ public final class AuthorizationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Authorization.class);
   }
   /** Expire a test-mode Authorization. */
@@ -103,7 +103,7 @@ public final class AuthorizationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Authorization.class);
   }
   /** Increment a test-mode Authorization. */
@@ -127,7 +127,7 @@ public final class AuthorizationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Authorization.class);
   }
   /** Reverse a test-mode Authorization. */
@@ -160,7 +160,7 @@ public final class AuthorizationService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Authorization.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/issuing/CardService.java
+++ b/src/main/java/com/stripe/service/testhelpers/issuing/CardService.java
@@ -55,7 +55,7 @@ public final class CardService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Card.class);
   }
   /**
@@ -92,7 +92,7 @@ public final class CardService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Card.class);
   }
   /**
@@ -129,7 +129,7 @@ public final class CardService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Card.class);
   }
   /**
@@ -166,7 +166,7 @@ public final class CardService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Card.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/issuing/CardService.java
+++ b/src/main/java/com/stripe/service/testhelpers/issuing/CardService.java
@@ -55,6 +55,7 @@ public final class CardService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Card.class);
   }
   /**
@@ -91,6 +92,7 @@ public final class CardService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Card.class);
   }
   /**
@@ -127,6 +129,7 @@ public final class CardService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Card.class);
   }
   /**
@@ -163,6 +166,7 @@ public final class CardService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Card.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/issuing/CardService.java
+++ b/src/main/java/com/stripe/service/testhelpers/issuing/CardService.java
@@ -55,7 +55,7 @@ public final class CardService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Card.class);
   }
   /**
@@ -92,7 +92,7 @@ public final class CardService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Card.class);
   }
   /**
@@ -129,7 +129,7 @@ public final class CardService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Card.class);
   }
   /**
@@ -166,7 +166,7 @@ public final class CardService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Card.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/issuing/TransactionService.java
+++ b/src/main/java/com/stripe/service/testhelpers/issuing/TransactionService.java
@@ -49,7 +49,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Transaction.class);
   }
   /** Allows the user to capture an arbitrary amount, also known as a forced capture. */
@@ -69,7 +69,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Transaction.class);
   }
   /** Allows the user to refund an arbitrary amount, also known as a unlinked refund. */
@@ -89,7 +89,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Transaction.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/issuing/TransactionService.java
+++ b/src/main/java/com/stripe/service/testhelpers/issuing/TransactionService.java
@@ -49,7 +49,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Transaction.class);
   }
   /** Allows the user to capture an arbitrary amount, also known as a forced capture. */
@@ -69,7 +69,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Transaction.class);
   }
   /** Allows the user to refund an arbitrary amount, also known as a unlinked refund. */
@@ -89,7 +89,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Transaction.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/issuing/TransactionService.java
+++ b/src/main/java/com/stripe/service/testhelpers/issuing/TransactionService.java
@@ -49,6 +49,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Transaction.class);
   }
   /** Allows the user to capture an arbitrary amount, also known as a forced capture. */
@@ -68,6 +69,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Transaction.class);
   }
   /** Allows the user to refund an arbitrary amount, also known as a unlinked refund. */
@@ -87,6 +89,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Transaction.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/terminal/ReaderService.java
+++ b/src/main/java/com/stripe/service/testhelpers/terminal/ReaderService.java
@@ -60,7 +60,7 @@ public final class ReaderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Reader.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/terminal/ReaderService.java
+++ b/src/main/java/com/stripe/service/testhelpers/terminal/ReaderService.java
@@ -60,7 +60,7 @@ public final class ReaderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Reader.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/terminal/ReaderService.java
+++ b/src/main/java/com/stripe/service/testhelpers/terminal/ReaderService.java
@@ -60,6 +60,7 @@ public final class ReaderService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Reader.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/treasury/InboundTransferService.java
+++ b/src/main/java/com/stripe/service/testhelpers/treasury/InboundTransferService.java
@@ -58,7 +58,7 @@ public final class InboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, InboundTransfer.class);
   }
   /**
@@ -103,7 +103,7 @@ public final class InboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, InboundTransfer.class);
   }
   /**
@@ -146,7 +146,7 @@ public final class InboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, InboundTransfer.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/treasury/InboundTransferService.java
+++ b/src/main/java/com/stripe/service/testhelpers/treasury/InboundTransferService.java
@@ -58,7 +58,7 @@ public final class InboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, InboundTransfer.class);
   }
   /**
@@ -103,7 +103,7 @@ public final class InboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, InboundTransfer.class);
   }
   /**
@@ -146,7 +146,7 @@ public final class InboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, InboundTransfer.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/treasury/InboundTransferService.java
+++ b/src/main/java/com/stripe/service/testhelpers/treasury/InboundTransferService.java
@@ -58,6 +58,7 @@ public final class InboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, InboundTransfer.class);
   }
   /**
@@ -102,6 +103,7 @@ public final class InboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, InboundTransfer.class);
   }
   /**
@@ -144,6 +146,7 @@ public final class InboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, InboundTransfer.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/treasury/OutboundPaymentService.java
+++ b/src/main/java/com/stripe/service/testhelpers/treasury/OutboundPaymentService.java
@@ -58,6 +58,7 @@ public final class OutboundPaymentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, OutboundPayment.class);
   }
   /**
@@ -98,6 +99,7 @@ public final class OutboundPaymentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, OutboundPayment.class);
   }
   /**
@@ -142,6 +144,7 @@ public final class OutboundPaymentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, OutboundPayment.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/treasury/OutboundPaymentService.java
+++ b/src/main/java/com/stripe/service/testhelpers/treasury/OutboundPaymentService.java
@@ -58,7 +58,7 @@ public final class OutboundPaymentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, OutboundPayment.class);
   }
   /**
@@ -99,7 +99,7 @@ public final class OutboundPaymentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, OutboundPayment.class);
   }
   /**
@@ -144,7 +144,7 @@ public final class OutboundPaymentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, OutboundPayment.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/treasury/OutboundPaymentService.java
+++ b/src/main/java/com/stripe/service/testhelpers/treasury/OutboundPaymentService.java
@@ -58,7 +58,7 @@ public final class OutboundPaymentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, OutboundPayment.class);
   }
   /**
@@ -99,7 +99,7 @@ public final class OutboundPaymentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, OutboundPayment.class);
   }
   /**
@@ -144,7 +144,7 @@ public final class OutboundPaymentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, OutboundPayment.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/treasury/OutboundTransferService.java
+++ b/src/main/java/com/stripe/service/testhelpers/treasury/OutboundTransferService.java
@@ -62,7 +62,7 @@ public final class OutboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, OutboundTransfer.class);
   }
   /**
@@ -107,7 +107,7 @@ public final class OutboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, OutboundTransfer.class);
   }
   /**
@@ -159,7 +159,7 @@ public final class OutboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, OutboundTransfer.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/treasury/OutboundTransferService.java
+++ b/src/main/java/com/stripe/service/testhelpers/treasury/OutboundTransferService.java
@@ -62,7 +62,7 @@ public final class OutboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, OutboundTransfer.class);
   }
   /**
@@ -107,7 +107,7 @@ public final class OutboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, OutboundTransfer.class);
   }
   /**
@@ -159,7 +159,7 @@ public final class OutboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, OutboundTransfer.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/treasury/OutboundTransferService.java
+++ b/src/main/java/com/stripe/service/testhelpers/treasury/OutboundTransferService.java
@@ -62,6 +62,7 @@ public final class OutboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, OutboundTransfer.class);
   }
   /**
@@ -106,6 +107,7 @@ public final class OutboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, OutboundTransfer.class);
   }
   /**
@@ -157,6 +159,7 @@ public final class OutboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, OutboundTransfer.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/treasury/ReceivedCreditService.java
+++ b/src/main/java/com/stripe/service/testhelpers/treasury/ReceivedCreditService.java
@@ -40,7 +40,7 @@ public final class ReceivedCreditService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, ReceivedCredit.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/treasury/ReceivedCreditService.java
+++ b/src/main/java/com/stripe/service/testhelpers/treasury/ReceivedCreditService.java
@@ -40,7 +40,7 @@ public final class ReceivedCreditService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, ReceivedCredit.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/treasury/ReceivedCreditService.java
+++ b/src/main/java/com/stripe/service/testhelpers/treasury/ReceivedCreditService.java
@@ -40,6 +40,7 @@ public final class ReceivedCreditService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, ReceivedCredit.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/treasury/ReceivedDebitService.java
+++ b/src/main/java/com/stripe/service/testhelpers/treasury/ReceivedDebitService.java
@@ -40,6 +40,7 @@ public final class ReceivedDebitService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, ReceivedDebit.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/treasury/ReceivedDebitService.java
+++ b/src/main/java/com/stripe/service/testhelpers/treasury/ReceivedDebitService.java
@@ -40,7 +40,7 @@ public final class ReceivedDebitService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, ReceivedDebit.class);
   }
 }

--- a/src/main/java/com/stripe/service/testhelpers/treasury/ReceivedDebitService.java
+++ b/src/main/java/com/stripe/service/testhelpers/treasury/ReceivedDebitService.java
@@ -40,7 +40,7 @@ public final class ReceivedDebitService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, ReceivedDebit.class);
   }
 }

--- a/src/main/java/com/stripe/service/treasury/CreditReversalService.java
+++ b/src/main/java/com/stripe/service/treasury/CreditReversalService.java
@@ -39,7 +39,7 @@ public final class CreditReversalService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<CreditReversal>>() {}.getType());
   }
@@ -59,7 +59,7 @@ public final class CreditReversalService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, CreditReversal.class);
   }
   /**
@@ -102,7 +102,7 @@ public final class CreditReversalService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, CreditReversal.class);
   }
 }

--- a/src/main/java/com/stripe/service/treasury/CreditReversalService.java
+++ b/src/main/java/com/stripe/service/treasury/CreditReversalService.java
@@ -39,6 +39,7 @@ public final class CreditReversalService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<CreditReversal>>() {}.getType());
   }
@@ -58,6 +59,7 @@ public final class CreditReversalService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, CreditReversal.class);
   }
   /**
@@ -100,6 +102,7 @@ public final class CreditReversalService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, CreditReversal.class);
   }
 }

--- a/src/main/java/com/stripe/service/treasury/CreditReversalService.java
+++ b/src/main/java/com/stripe/service/treasury/CreditReversalService.java
@@ -39,7 +39,7 @@ public final class CreditReversalService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<CreditReversal>>() {}.getType());
   }
@@ -59,7 +59,7 @@ public final class CreditReversalService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, CreditReversal.class);
   }
   /**
@@ -102,7 +102,7 @@ public final class CreditReversalService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, CreditReversal.class);
   }
 }

--- a/src/main/java/com/stripe/service/treasury/DebitReversalService.java
+++ b/src/main/java/com/stripe/service/treasury/DebitReversalService.java
@@ -39,7 +39,7 @@ public final class DebitReversalService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<DebitReversal>>() {}.getType());
   }
@@ -59,7 +59,7 @@ public final class DebitReversalService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, DebitReversal.class);
   }
   /** Retrieves a DebitReversal object. */
@@ -90,7 +90,7 @@ public final class DebitReversalService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, DebitReversal.class);
   }
 }

--- a/src/main/java/com/stripe/service/treasury/DebitReversalService.java
+++ b/src/main/java/com/stripe/service/treasury/DebitReversalService.java
@@ -39,7 +39,7 @@ public final class DebitReversalService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<DebitReversal>>() {}.getType());
   }
@@ -59,7 +59,7 @@ public final class DebitReversalService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, DebitReversal.class);
   }
   /** Retrieves a DebitReversal object. */
@@ -90,7 +90,7 @@ public final class DebitReversalService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, DebitReversal.class);
   }
 }

--- a/src/main/java/com/stripe/service/treasury/DebitReversalService.java
+++ b/src/main/java/com/stripe/service/treasury/DebitReversalService.java
@@ -39,6 +39,7 @@ public final class DebitReversalService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<DebitReversal>>() {}.getType());
   }
@@ -58,6 +59,7 @@ public final class DebitReversalService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, DebitReversal.class);
   }
   /** Retrieves a DebitReversal object. */
@@ -88,6 +90,7 @@ public final class DebitReversalService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, DebitReversal.class);
   }
 }

--- a/src/main/java/com/stripe/service/treasury/FinancialAccountFeaturesService.java
+++ b/src/main/java/com/stripe/service/treasury/FinancialAccountFeaturesService.java
@@ -50,6 +50,7 @@ public final class FinancialAccountFeaturesService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, FinancialAccountFeatures.class);
   }
   /** Retrieves Features information associated with the FinancialAccount. */
@@ -82,6 +83,7 @@ public final class FinancialAccountFeaturesService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, FinancialAccountFeatures.class);
   }
 }

--- a/src/main/java/com/stripe/service/treasury/FinancialAccountFeaturesService.java
+++ b/src/main/java/com/stripe/service/treasury/FinancialAccountFeaturesService.java
@@ -50,7 +50,7 @@ public final class FinancialAccountFeaturesService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, FinancialAccountFeatures.class);
   }
   /** Retrieves Features information associated with the FinancialAccount. */
@@ -83,7 +83,7 @@ public final class FinancialAccountFeaturesService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, FinancialAccountFeatures.class);
   }
 }

--- a/src/main/java/com/stripe/service/treasury/FinancialAccountFeaturesService.java
+++ b/src/main/java/com/stripe/service/treasury/FinancialAccountFeaturesService.java
@@ -50,7 +50,7 @@ public final class FinancialAccountFeaturesService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, FinancialAccountFeatures.class);
   }
   /** Retrieves Features information associated with the FinancialAccount. */
@@ -83,7 +83,7 @@ public final class FinancialAccountFeaturesService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, FinancialAccountFeatures.class);
   }
 }

--- a/src/main/java/com/stripe/service/treasury/FinancialAccountService.java
+++ b/src/main/java/com/stripe/service/treasury/FinancialAccountService.java
@@ -48,6 +48,7 @@ public final class FinancialAccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<FinancialAccount>>() {}.getType());
   }
@@ -73,6 +74,7 @@ public final class FinancialAccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, FinancialAccount.class);
   }
   /** Retrieves the details of a FinancialAccount. */
@@ -104,6 +106,7 @@ public final class FinancialAccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, FinancialAccount.class);
   }
   /** Updates the details of a FinancialAccount. */
@@ -135,6 +138,7 @@ public final class FinancialAccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, FinancialAccount.class);
   }
 

--- a/src/main/java/com/stripe/service/treasury/FinancialAccountService.java
+++ b/src/main/java/com/stripe/service/treasury/FinancialAccountService.java
@@ -48,7 +48,7 @@ public final class FinancialAccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<FinancialAccount>>() {}.getType());
   }
@@ -74,7 +74,7 @@ public final class FinancialAccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, FinancialAccount.class);
   }
   /** Retrieves the details of a FinancialAccount. */
@@ -106,7 +106,7 @@ public final class FinancialAccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, FinancialAccount.class);
   }
   /** Updates the details of a FinancialAccount. */
@@ -138,7 +138,7 @@ public final class FinancialAccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, FinancialAccount.class);
   }
 

--- a/src/main/java/com/stripe/service/treasury/FinancialAccountService.java
+++ b/src/main/java/com/stripe/service/treasury/FinancialAccountService.java
@@ -48,7 +48,7 @@ public final class FinancialAccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<FinancialAccount>>() {}.getType());
   }
@@ -74,7 +74,7 @@ public final class FinancialAccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, FinancialAccount.class);
   }
   /** Retrieves the details of a FinancialAccount. */
@@ -106,7 +106,7 @@ public final class FinancialAccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, FinancialAccount.class);
   }
   /** Updates the details of a FinancialAccount. */
@@ -138,7 +138,7 @@ public final class FinancialAccountService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, FinancialAccount.class);
   }
 

--- a/src/main/java/com/stripe/service/treasury/InboundTransferService.java
+++ b/src/main/java/com/stripe/service/treasury/InboundTransferService.java
@@ -40,7 +40,7 @@ public final class InboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<InboundTransfer>>() {}.getType());
   }
@@ -60,7 +60,7 @@ public final class InboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, InboundTransfer.class);
   }
   /** Retrieves the details of an existing InboundTransfer. */
@@ -89,7 +89,7 @@ public final class InboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, InboundTransfer.class);
   }
   /** Cancels an InboundTransfer. */
@@ -121,7 +121,7 @@ public final class InboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, InboundTransfer.class);
   }
 }

--- a/src/main/java/com/stripe/service/treasury/InboundTransferService.java
+++ b/src/main/java/com/stripe/service/treasury/InboundTransferService.java
@@ -40,7 +40,7 @@ public final class InboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<InboundTransfer>>() {}.getType());
   }
@@ -60,7 +60,7 @@ public final class InboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, InboundTransfer.class);
   }
   /** Retrieves the details of an existing InboundTransfer. */
@@ -89,7 +89,7 @@ public final class InboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, InboundTransfer.class);
   }
   /** Cancels an InboundTransfer. */
@@ -121,7 +121,7 @@ public final class InboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, InboundTransfer.class);
   }
 }

--- a/src/main/java/com/stripe/service/treasury/InboundTransferService.java
+++ b/src/main/java/com/stripe/service/treasury/InboundTransferService.java
@@ -40,6 +40,7 @@ public final class InboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<InboundTransfer>>() {}.getType());
   }
@@ -59,6 +60,7 @@ public final class InboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, InboundTransfer.class);
   }
   /** Retrieves the details of an existing InboundTransfer. */
@@ -87,6 +89,7 @@ public final class InboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, InboundTransfer.class);
   }
   /** Cancels an InboundTransfer. */
@@ -118,6 +121,7 @@ public final class InboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, InboundTransfer.class);
   }
 }

--- a/src/main/java/com/stripe/service/treasury/OutboundPaymentService.java
+++ b/src/main/java/com/stripe/service/treasury/OutboundPaymentService.java
@@ -40,6 +40,7 @@ public final class OutboundPaymentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<OutboundPayment>>() {}.getType());
   }
@@ -59,6 +60,7 @@ public final class OutboundPaymentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, OutboundPayment.class);
   }
   /**
@@ -99,6 +101,7 @@ public final class OutboundPaymentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, OutboundPayment.class);
   }
   /** Cancel an OutboundPayment. */
@@ -128,6 +131,7 @@ public final class OutboundPaymentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, OutboundPayment.class);
   }
 }

--- a/src/main/java/com/stripe/service/treasury/OutboundPaymentService.java
+++ b/src/main/java/com/stripe/service/treasury/OutboundPaymentService.java
@@ -40,7 +40,7 @@ public final class OutboundPaymentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<OutboundPayment>>() {}.getType());
   }
@@ -60,7 +60,7 @@ public final class OutboundPaymentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, OutboundPayment.class);
   }
   /**
@@ -101,7 +101,7 @@ public final class OutboundPaymentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, OutboundPayment.class);
   }
   /** Cancel an OutboundPayment. */
@@ -131,7 +131,7 @@ public final class OutboundPaymentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, OutboundPayment.class);
   }
 }

--- a/src/main/java/com/stripe/service/treasury/OutboundPaymentService.java
+++ b/src/main/java/com/stripe/service/treasury/OutboundPaymentService.java
@@ -40,7 +40,7 @@ public final class OutboundPaymentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<OutboundPayment>>() {}.getType());
   }
@@ -60,7 +60,7 @@ public final class OutboundPaymentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, OutboundPayment.class);
   }
   /**
@@ -101,7 +101,7 @@ public final class OutboundPaymentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, OutboundPayment.class);
   }
   /** Cancel an OutboundPayment. */
@@ -131,7 +131,7 @@ public final class OutboundPaymentService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, OutboundPayment.class);
   }
 }

--- a/src/main/java/com/stripe/service/treasury/OutboundTransferService.java
+++ b/src/main/java/com/stripe/service/treasury/OutboundTransferService.java
@@ -40,7 +40,7 @@ public final class OutboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<OutboundTransfer>>() {}.getType());
   }
@@ -60,7 +60,7 @@ public final class OutboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, OutboundTransfer.class);
   }
   /**
@@ -104,7 +104,7 @@ public final class OutboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, OutboundTransfer.class);
   }
   /** An OutboundTransfer can be canceled if the funds have not yet been paid out. */
@@ -136,7 +136,7 @@ public final class OutboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, OutboundTransfer.class);
   }
 }

--- a/src/main/java/com/stripe/service/treasury/OutboundTransferService.java
+++ b/src/main/java/com/stripe/service/treasury/OutboundTransferService.java
@@ -40,7 +40,7 @@ public final class OutboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<OutboundTransfer>>() {}.getType());
   }
@@ -60,7 +60,7 @@ public final class OutboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, OutboundTransfer.class);
   }
   /**
@@ -104,7 +104,7 @@ public final class OutboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, OutboundTransfer.class);
   }
   /** An OutboundTransfer can be canceled if the funds have not yet been paid out. */
@@ -136,7 +136,7 @@ public final class OutboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, OutboundTransfer.class);
   }
 }

--- a/src/main/java/com/stripe/service/treasury/OutboundTransferService.java
+++ b/src/main/java/com/stripe/service/treasury/OutboundTransferService.java
@@ -40,6 +40,7 @@ public final class OutboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<OutboundTransfer>>() {}.getType());
   }
@@ -59,6 +60,7 @@ public final class OutboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, OutboundTransfer.class);
   }
   /**
@@ -102,6 +104,7 @@ public final class OutboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, OutboundTransfer.class);
   }
   /** An OutboundTransfer can be canceled if the funds have not yet been paid out. */
@@ -133,6 +136,7 @@ public final class OutboundTransferService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, OutboundTransfer.class);
   }
 }

--- a/src/main/java/com/stripe/service/treasury/ReceivedCreditService.java
+++ b/src/main/java/com/stripe/service/treasury/ReceivedCreditService.java
@@ -38,6 +38,7 @@ public final class ReceivedCreditService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ReceivedCredit>>() {}.getType());
   }
@@ -79,6 +80,7 @@ public final class ReceivedCreditService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, ReceivedCredit.class);
   }
 }

--- a/src/main/java/com/stripe/service/treasury/ReceivedCreditService.java
+++ b/src/main/java/com/stripe/service/treasury/ReceivedCreditService.java
@@ -38,7 +38,7 @@ public final class ReceivedCreditService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ReceivedCredit>>() {}.getType());
   }
@@ -80,7 +80,7 @@ public final class ReceivedCreditService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, ReceivedCredit.class);
   }
 }

--- a/src/main/java/com/stripe/service/treasury/ReceivedCreditService.java
+++ b/src/main/java/com/stripe/service/treasury/ReceivedCreditService.java
@@ -38,7 +38,7 @@ public final class ReceivedCreditService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ReceivedCredit>>() {}.getType());
   }
@@ -80,7 +80,7 @@ public final class ReceivedCreditService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, ReceivedCredit.class);
   }
 }

--- a/src/main/java/com/stripe/service/treasury/ReceivedDebitService.java
+++ b/src/main/java/com/stripe/service/treasury/ReceivedDebitService.java
@@ -38,6 +38,7 @@ public final class ReceivedDebitService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ReceivedDebit>>() {}.getType());
   }
@@ -79,6 +80,7 @@ public final class ReceivedDebitService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, ReceivedDebit.class);
   }
 }

--- a/src/main/java/com/stripe/service/treasury/ReceivedDebitService.java
+++ b/src/main/java/com/stripe/service/treasury/ReceivedDebitService.java
@@ -38,7 +38,7 @@ public final class ReceivedDebitService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ReceivedDebit>>() {}.getType());
   }
@@ -80,7 +80,7 @@ public final class ReceivedDebitService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, ReceivedDebit.class);
   }
 }

--- a/src/main/java/com/stripe/service/treasury/ReceivedDebitService.java
+++ b/src/main/java/com/stripe/service/treasury/ReceivedDebitService.java
@@ -38,7 +38,7 @@ public final class ReceivedDebitService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<ReceivedDebit>>() {}.getType());
   }
@@ -80,7 +80,7 @@ public final class ReceivedDebitService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, ReceivedDebit.class);
   }
 }

--- a/src/main/java/com/stripe/service/treasury/TransactionEntryService.java
+++ b/src/main/java/com/stripe/service/treasury/TransactionEntryService.java
@@ -38,6 +38,7 @@ public final class TransactionEntryService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<TransactionEntry>>() {}.getType());
   }
@@ -67,6 +68,7 @@ public final class TransactionEntryService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, TransactionEntry.class);
   }
 }

--- a/src/main/java/com/stripe/service/treasury/TransactionEntryService.java
+++ b/src/main/java/com/stripe/service/treasury/TransactionEntryService.java
@@ -38,7 +38,7 @@ public final class TransactionEntryService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<TransactionEntry>>() {}.getType());
   }
@@ -68,7 +68,7 @@ public final class TransactionEntryService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, TransactionEntry.class);
   }
 }

--- a/src/main/java/com/stripe/service/treasury/TransactionEntryService.java
+++ b/src/main/java/com/stripe/service/treasury/TransactionEntryService.java
@@ -38,7 +38,7 @@ public final class TransactionEntryService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<TransactionEntry>>() {}.getType());
   }
@@ -68,7 +68,7 @@ public final class TransactionEntryService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, TransactionEntry.class);
   }
 }

--- a/src/main/java/com/stripe/service/treasury/TransactionService.java
+++ b/src/main/java/com/stripe/service/treasury/TransactionService.java
@@ -37,7 +37,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Transaction>>() {}.getType());
   }
@@ -65,7 +65,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request.addUsage("stripe_client");
+    request = request.withAddedUsage("stripe_client");
     return getResponseGetter().request(request, Transaction.class);
   }
 }

--- a/src/main/java/com/stripe/service/treasury/TransactionService.java
+++ b/src/main/java/com/stripe/service/treasury/TransactionService.java
@@ -37,7 +37,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Transaction>>() {}.getType());
   }
@@ -65,7 +65,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
-    request = request.withAddedUsage("stripe_client");
+    request = request.addUsage("stripe_client");
     return getResponseGetter().request(request, Transaction.class);
   }
 }

--- a/src/main/java/com/stripe/service/treasury/TransactionService.java
+++ b/src/main/java/com/stripe/service/treasury/TransactionService.java
@@ -37,6 +37,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter()
         .request(request, new TypeToken<StripeCollection<Transaction>>() {}.getType());
   }
@@ -64,6 +65,7 @@ public final class TransactionService extends ApiService {
             ApiRequestParams.paramsToMap(params),
             options,
             ApiMode.V1);
+    request.addUsage("stripe_client");
     return getResponseGetter().request(request, Transaction.class);
   }
 }

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -125,6 +125,9 @@ public class BaseStripeTest {
     httpClientSpy = Mockito.spy(new HttpURLConnectionClient());
     networkSpy = Mockito.spy(new LiveStripeResponseGetter(null, httpClientSpy));
     mockClient = new StripeClient(networkSpy);
+    // The StripeClient constructor calls .setUsage on networkSpy, let's reset that so
+    // in the test cases we can just verify the calls we care about.
+    Mockito.reset(networkSpy);
     ApiResource.setStripeResponseGetter(networkSpy);
     OAuth.setGlobalResponseGetter(networkSpy);
   }

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -126,9 +126,6 @@ public class BaseStripeTest {
     httpClientSpy = Mockito.spy(new HttpURLConnectionClient());
     networkSpy = Mockito.spy(new LiveStripeResponseGetter(null, httpClientSpy));
     mockClient = new StripeClient(networkSpy);
-    // The StripeClient constructor calls .setUsage on networkSpy, let's reset that so
-    // in the test cases we can just verify the calls we care about.
-    Mockito.reset(networkSpy);
     ApiResource.setStripeResponseGetter(networkSpy);
     OAuth.setGlobalResponseGetter(networkSpy);
   }

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 import lombok.Cleanup;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -192,6 +193,27 @@ public class BaseStripeTest {
       RequestOptions options)
       throws StripeException {
 
+    verifyRequest(
+        (req) -> {
+          assertEquals(baseAddress, req.getBaseAddress());
+          assertEquals(method, req.getMethod());
+          assertEquals(path, req.getPath());
+          if (params != null) {
+            final String msg =
+                String.format(
+                    "Params did not match - expected: %s, received: %s", params, req.getParams());
+            assertTrue(msg, compareParamObjects(params, req.getParams()));
+          }
+          if (options != null) {
+            assertEquals(options, req.getOptions());
+          }
+        });
+  }
+
+  @SuppressWarnings("AssertionFailureIgnored")
+  public static <T extends StripeObjectInterface> void verifyRequest(
+      Consumer<ApiRequest> assertOnApiRequest) throws StripeException {
+
     ArgumentCaptor<ApiRequest> requestCaptor = ArgumentCaptor.forClass(ApiRequest.class);
     List<AssertionError> exceptions = new ArrayList<AssertionError>();
     try {
@@ -203,19 +225,35 @@ public class BaseStripeTest {
 
     for (ApiRequest req : requestCaptor.getAllValues()) {
       try {
-        assertEquals(baseAddress, req.getBaseAddress());
-        assertEquals(method, req.getMethod());
-        assertEquals(path, req.getPath());
-        if (params != null) {
-          final String msg =
-              String.format(
-                  "Params did not match - expected: %s, received: %s", params, req.getParams());
-          assertTrue(msg, compareParamObjects(params, req.getParams()));
-        }
-        if (options != null) {
-          assertEquals(options, req.getOptions());
-        }
-        // If we get here, we have found a request that triggered no assertion failures.
+        assertOnApiRequest.accept(req);
+        return;
+      } catch (AssertionError e) {
+        exceptions.add(e);
+      }
+    }
+
+    // If we get here, each request failed an assertion.
+    if (exceptions.size() != 0) {
+      // Combine all exceptions into a single message
+      String msg = "";
+      for (AssertionError e : exceptions) {
+        msg += e.getMessage() + "\n\n";
+      }
+      throw new AssertionError(msg);
+    }
+  }
+
+  @SuppressWarnings("AssertionFailureIgnored")
+  public static <T extends StripeObjectInterface> void verifyStripeRequest(
+      Consumer<StripeRequest> assertOnStripeRequest) throws StripeException {
+
+    ArgumentCaptor<StripeRequest> requestCaptor = ArgumentCaptor.forClass(StripeRequest.class);
+    List<AssertionError> exceptions = new ArrayList<AssertionError>();
+    Mockito.verify(httpClientSpy, Mockito.atLeastOnce()).request(requestCaptor.capture());
+
+    for (StripeRequest req : requestCaptor.getAllValues()) {
+      try {
+        assertOnStripeRequest.accept(req);
         return;
       } catch (AssertionError e) {
         exceptions.add(e);

--- a/src/test/java/com/stripe/functional/LiveStripeResponseGetterTest.java
+++ b/src/test/java/com/stripe/functional/LiveStripeResponseGetterTest.java
@@ -4,14 +4,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
 import com.stripe.BaseStripeTest;
-import com.stripe.Stripe;
 import com.stripe.exception.ApiException;
 import com.stripe.exception.StripeException;
-import com.stripe.model.Customer;
 import com.stripe.model.Subscription;
 import com.stripe.net.ApiResource;
 import com.stripe.net.HttpClient;
@@ -21,17 +17,12 @@ import com.stripe.net.LiveStripeResponseGetter;
 import com.stripe.net.StripeRequest;
 import com.stripe.net.StripeResponse;
 import com.stripe.net.StripeResponseGetter;
-import com.stripe.param.CustomerCreateParams;
-import com.stripe.param.CustomerUpdateParams;
 import java.util.Collections;
 import org.hamcrest.CoreMatchers;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class LiveStripeResponseGetterTest extends BaseStripeTest {
-
   @Test
   public void testInvalidJson() throws StripeException {
     HttpClient spy = Mockito.spy(new HttpURLConnectionClient());
@@ -50,45 +41,5 @@ public class LiveStripeResponseGetterTest extends BaseStripeTest {
         exception.getMessage(), CoreMatchers.containsString("Invalid response object from API"));
     assertNotNull(exception.getCause());
     assertThat(exception.getCause(), CoreMatchers.instanceOf(JsonSyntaxException.class));
-  }
-
-  private Boolean originalTelemetry;
-
-  @BeforeEach
-  public void setUp() {
-    this.originalTelemetry = Stripe.enableTelemetry;
-    Stripe.enableTelemetry = true;
-  }
-
-  @AfterEach
-  public void tearDown() {
-    Stripe.enableTelemetry = originalTelemetry;
-  }
-
-  @Test
-  public void testGlobalClientTelemetryTest() throws StripeException {
-    StripeResponseGetter responseGetterSpy =
-        Mockito.spy(new LiveStripeResponseGetter(null, httpClientSpy));
-    // We need to explicitly override the ApiResource.responseGetter = networkSpy that's set
-    // in BaseStripeTest. Unfortunately, BaseStripeTest shares the response getter spy across
-    // StripeClient and the Global Client, and so the global client will erroneously report stripe
-    // client usage.
-    ApiResource.setStripeResponseGetter(responseGetterSpy);
-    Customer cus = Customer.create(CustomerCreateParams.builder().build());
-    Mockito.reset(httpClientSpy);
-    cus.update(CustomerUpdateParams.builder().setDescription("hello").build());
-    Mockito.verify(httpClientSpy)
-        .request(
-            Mockito.argThat(
-                stripeRequest -> {
-                  JsonObject metrics =
-                      new Gson()
-                          .fromJson(
-                              stripeRequest.headers().firstValue("X-Stripe-Client-Telemetry").get(),
-                              JsonObject.class)
-                          .get("last_request_metrics")
-                          .getAsJsonObject();
-                  return !metrics.has("usage") && metrics.has("request_duration_ms");
-                }));
   }
 }

--- a/src/test/java/com/stripe/functional/LiveStripeResponseGetterTest.java
+++ b/src/test/java/com/stripe/functional/LiveStripeResponseGetterTest.java
@@ -4,10 +4,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
 import com.stripe.BaseStripeTest;
+import com.stripe.Stripe;
 import com.stripe.exception.ApiException;
 import com.stripe.exception.StripeException;
+import com.stripe.model.Customer;
 import com.stripe.model.Subscription;
 import com.stripe.net.ApiResource;
 import com.stripe.net.HttpClient;
@@ -17,8 +21,12 @@ import com.stripe.net.LiveStripeResponseGetter;
 import com.stripe.net.StripeRequest;
 import com.stripe.net.StripeResponse;
 import com.stripe.net.StripeResponseGetter;
+import com.stripe.param.CustomerCreateParams;
+import com.stripe.param.CustomerUpdateParams;
 import java.util.Collections;
 import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -42,5 +50,45 @@ public class LiveStripeResponseGetterTest extends BaseStripeTest {
         exception.getMessage(), CoreMatchers.containsString("Invalid response object from API"));
     assertNotNull(exception.getCause());
     assertThat(exception.getCause(), CoreMatchers.instanceOf(JsonSyntaxException.class));
+  }
+
+  private Boolean originalTelemetry;
+
+  @BeforeEach
+  public void setUp() {
+    this.originalTelemetry = Stripe.enableTelemetry;
+    Stripe.enableTelemetry = true;
+  }
+
+  @AfterEach
+  public void tearDown() {
+    Stripe.enableTelemetry = originalTelemetry;
+  }
+
+  @Test
+  public void testGlobalClientTelemetryTest() throws StripeException {
+    StripeResponseGetter responseGetterSpy =
+        Mockito.spy(new LiveStripeResponseGetter(null, httpClientSpy));
+    // We need to explicitly override the ApiResource.responseGetter = networkSpy that's set
+    // in BaseStripeTest. Unfortunately, BaseStripeTest shares the response getter spy across
+    // StripeClient and the Global Client, and so the global client will erroneously report stripe
+    // client usage.
+    ApiResource.setStripeResponseGetter(responseGetterSpy);
+    Customer cus = Customer.create(CustomerCreateParams.builder().build());
+    Mockito.reset(httpClientSpy);
+    cus.update(CustomerUpdateParams.builder().setDescription("hello").build());
+    Mockito.verify(httpClientSpy)
+        .request(
+            Mockito.argThat(
+                stripeRequest -> {
+                  JsonObject metrics =
+                      new Gson()
+                          .fromJson(
+                              stripeRequest.headers().firstValue("X-Stripe-Client-Telemetry").get(),
+                              JsonObject.class)
+                          .get("last_request_metrics")
+                          .getAsJsonObject();
+                  return !metrics.has("usage") && metrics.has("request_duration_ms");
+                }));
   }
 }

--- a/src/test/java/com/stripe/functional/StripeClientTest.java
+++ b/src/test/java/com/stripe/functional/StripeClientTest.java
@@ -32,7 +32,7 @@ public class StripeClientTest extends BaseStripeTest {
     mockClient.customers().update("cus_xyz");
     verifyStripeRequest(
         (stripeRequest) -> {
-          assert(stripeRequest.headers().firstValue("X-Stripe-Client-Telemetry").isPresent());
+          assert (stripeRequest.headers().firstValue("X-Stripe-Client-Telemetry").isPresent());
           String usage =
               new Gson()
                   .fromJson(

--- a/src/test/java/com/stripe/functional/StripeClientTest.java
+++ b/src/test/java/com/stripe/functional/StripeClientTest.java
@@ -1,0 +1,49 @@
+package com.stripe.functional;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.stripe.BaseStripeTest;
+import com.stripe.Stripe;
+import com.stripe.exception.StripeException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class StripeClientTest extends BaseStripeTest {
+
+  private Boolean originalTelemetry;
+
+  @BeforeEach
+  public void setUp() {
+    this.originalTelemetry = Stripe.enableTelemetry;
+    Stripe.enableTelemetry = true;
+  }
+
+  @AfterEach
+  public void tearDown() {
+    Stripe.enableTelemetry = originalTelemetry;
+  }
+
+  @Test
+  public void testReportsUsageTelemetry() throws StripeException {
+    mockClient.customers().create();
+    Mockito.reset(httpClientSpy);
+    mockClient.customers().update("cus_xyz");
+    Mockito.verify(httpClientSpy)
+        .request(
+            Mockito.argThat(
+                stripeRequest -> {
+                  String usage =
+                      new Gson()
+                          .fromJson(
+                              stripeRequest.headers().firstValue("X-Stripe-Client-Telemetry").get(),
+                              JsonObject.class)
+                          .get("last_request_metrics")
+                          .getAsJsonObject()
+                          .get("usage")
+                          .getAsString();
+                  return usage.equals("stripe_client");
+                }));
+  }
+}

--- a/src/test/java/com/stripe/functional/TelemetryTest.java
+++ b/src/test/java/com/stripe/functional/TelemetryTest.java
@@ -24,7 +24,6 @@ import lombok.Cleanup;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## Changelog
* Reports use of the new `StripeClient` in `X-Stripe-Client-Telemetry`. (You can disable telemetry via `Stripe.enableTelemetry = false;`, see the [README](https://github.com/stripe/stripe-java/blob/master/README.md#telemetry).)

## Details
* A different approach to #1698. This one sets `usage` on each callsite to `StripeResponseGetter.request` from `StripeClient`, rather than attempting to wrap `LiveStripeResponseGetter`.
* Modifies `RequestTelemetry` to accept usage and set it appropriately on `X-Stripe-Client-Telemetry`. Had to add a parameter to a public method, so I made a new overload and deprecated the old one. Had to disable a linter rule to do this.