### PR TITLE
Add webhook parsing method on StripeClient

### DIFF
--- a/src/main/java/com/stripe/StripeClient.java
+++ b/src/main/java/com/stripe/StripeClient.java
@@ -1,5 +1,8 @@
 package com.stripe;
 
+import com.stripe.exception.SignatureVerificationException;
+import com.stripe.model.Event;
+import com.stripe.model.StripeObject;
 import com.stripe.net.*;
 import java.net.PasswordAuthentication;
 import java.net.Proxy;
@@ -34,6 +37,45 @@ public class StripeClient {
 
   protected StripeResponseGetter getResponseGetter() {
     return responseGetter;
+  }
+
+  /**
+   * Returns an Event instance using the provided JSON payload. Throws a JsonSyntaxException if the
+   * payload is not valid JSON, and a SignatureVerificationException if the signature verification
+   * fails for any reason.
+   *
+   * @param payload the payload sent by Stripe.
+   * @param sigHeader the contents of the signature header sent by Stripe.
+   * @param secret secret used to generate the signature.
+   * @return the Event instance
+   * @throws SignatureVerificationException if the verification fails.
+   */
+  public Event constructEvent(String payload, String sigHeader, String secret)
+          throws SignatureVerificationException {
+    Event event = Webhook.constructEvent(payload, sigHeader, secret);
+    event.setResponseGetter(this.getResponseGetter());
+    return event;
+  }
+
+  /**
+   * Returns an Event instance using the provided JSON payload. Throws a JsonSyntaxException if the
+   * payload is not valid JSON, and a SignatureVerificationException if the signature verification
+   * fails for any reason.
+   *
+   * @param payload the payload sent by Stripe.
+   * @param sigHeader the contents of the signature header sent by Stripe.
+   * @param secret secret used to generate the signature.
+   * @param tolerance maximum difference in seconds allowed between the header's timestamp and the
+   *     current time
+   * @return the Event instance
+   * @throws SignatureVerificationException if the verification fails.
+   */
+  public Event constructEvent(
+          String payload, String sigHeader, String secret, long tolerance)
+          throws SignatureVerificationException {
+    Event event = Webhook.constructEvent(payload, sigHeader, secret, tolerance);
+    event.setResponseGetter(this.getResponseGetter());
+    return event;
   }
 
   // The beginning of the section generated from our OpenAPI spec

--- a/src/main/java/com/stripe/StripeClient.java
+++ b/src/main/java/com/stripe/StripeClient.java
@@ -2,7 +2,6 @@ package com.stripe;
 
 import com.stripe.exception.SignatureVerificationException;
 import com.stripe.model.Event;
-import com.stripe.model.StripeObject;
 import com.stripe.net.*;
 import java.net.PasswordAuthentication;
 import java.net.Proxy;
@@ -51,7 +50,7 @@ public class StripeClient {
    * @throws SignatureVerificationException if the verification fails.
    */
   public Event constructEvent(String payload, String sigHeader, String secret)
-          throws SignatureVerificationException {
+      throws SignatureVerificationException {
     Event event = Webhook.constructEvent(payload, sigHeader, secret);
     event.setResponseGetter(this.getResponseGetter());
     return event;
@@ -70,9 +69,8 @@ public class StripeClient {
    * @return the Event instance
    * @throws SignatureVerificationException if the verification fails.
    */
-  public Event constructEvent(
-          String payload, String sigHeader, String secret, long tolerance)
-          throws SignatureVerificationException {
+  public Event constructEvent(String payload, String sigHeader, String secret, long tolerance)
+      throws SignatureVerificationException {
     Event event = Webhook.constructEvent(payload, sigHeader, secret, tolerance);
     event.setResponseGetter(this.getResponseGetter());
     return event;

--- a/src/test/java/com/stripe/StripeClientTest.java
+++ b/src/test/java/com/stripe/StripeClientTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
-public class StripeClientTest {
+public class StripeClientTest extends BaseStripeTest {
   @Test
   public void testFlowsStripeResponseGetter() throws Exception {
     StripeResponseGetter responseGetter = Mockito.spy(new LiveStripeResponseGetter());

--- a/src/test/java/com/stripe/net/WebhookTest.java
+++ b/src/test/java/com/stripe/net/WebhookTest.java
@@ -12,14 +12,12 @@ import com.stripe.exception.SignatureVerificationException;
 import com.stripe.exception.StripeException;
 import com.stripe.model.Account;
 import com.stripe.model.Event;
-
+import com.stripe.model.terminal.Reader;
 import java.lang.reflect.Type;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.Map;
-
-import com.stripe.model.terminal.Reader;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -219,21 +217,24 @@ public class WebhookTest extends BaseStripeTest {
 
   @Test
   public void testStripeClientConstructEvent()
-          throws StripeException, NoSuchAlgorithmException, InvalidKeyException {
+      throws StripeException, NoSuchAlgorithmException, InvalidKeyException {
     StripeResponseGetter responseGetter = Mockito.spy(new LiveStripeResponseGetter());
     StripeClient client = new StripeClient(responseGetter);
 
     Mockito.doAnswer((Answer<Reader>) invocation -> new Reader())
-            .when(responseGetter)
-            .request(Mockito.<ApiRequest>argThat(
-                    (req) -> req.getMethod().equals(ApiResource.RequestMethod.DELETE) &&
-                            req.getPath().equals("/v1/terminal/readers/rdr_123")), Mockito.<Type>any());
+        .when(responseGetter)
+        .request(
+            Mockito.<ApiRequest>argThat(
+                (req) ->
+                    req.getMethod().equals(ApiResource.RequestMethod.DELETE)
+                        && req.getPath().equals("/v1/terminal/readers/rdr_123")),
+            Mockito.<Type>any());
 
     final String payload =
-            "{\"id\": \"evt_test_webhook\",\"api_version\":\""
-                    + Stripe.API_VERSION
-                    + "\","
-                    + "\"object\": \"event\",\"data\": {\"object\": {\"id\": \"rdr_123\",\"object\": \"terminal.reader\"}}}";
+        "{\"id\": \"evt_test_webhook\",\"api_version\":\""
+            + Stripe.API_VERSION
+            + "\","
+            + "\"object\": \"event\",\"data\": {\"object\": {\"id\": \"rdr_123\",\"object\": \"terminal.reader\"}}}";
 
     final Map<String, Object> options = new HashMap<>();
     options.put("payload", payload);
@@ -249,21 +250,24 @@ public class WebhookTest extends BaseStripeTest {
 
   @Test
   public void testStripeClientConstructEventWithTolerance()
-          throws StripeException, NoSuchAlgorithmException, InvalidKeyException {
+      throws StripeException, NoSuchAlgorithmException, InvalidKeyException {
     StripeResponseGetter responseGetter = Mockito.spy(new LiveStripeResponseGetter());
     StripeClient client = new StripeClient(responseGetter);
 
     Mockito.doAnswer((Answer<Reader>) invocation -> new Reader())
-            .when(responseGetter)
-            .request(Mockito.argThat(
-                    (req) -> req.getMethod().equals(ApiResource.RequestMethod.DELETE) &&
-                            req.getPath().equals("/v1/terminal/readers/rdr_123")), Mockito.any());
+        .when(responseGetter)
+        .request(
+            Mockito.argThat(
+                (req) ->
+                    req.getMethod().equals(ApiResource.RequestMethod.DELETE)
+                        && req.getPath().equals("/v1/terminal/readers/rdr_123")),
+            Mockito.any());
 
     final String payload =
-            "{\"id\": \"evt_test_webhook\",\"api_version\":\""
-                    + Stripe.API_VERSION
-                    + "\","
-                    + "\"object\": \"event\",\"data\": {\"object\": {\"id\": \"rdr_123\",\"object\": \"terminal.reader\"}}}";
+        "{\"id\": \"evt_test_webhook\",\"api_version\":\""
+            + Stripe.API_VERSION
+            + "\","
+            + "\"object\": \"event\",\"data\": {\"object\": {\"id\": \"rdr_123\",\"object\": \"terminal.reader\"}}}";
 
     final Map<String, Object> options = new HashMap<>();
     options.put("payload", payload);


### PR DESCRIPTION
Add a `StripeClient.constructEvent` instance method that parses Webhook events and uses the settings inherited from the StripeClient instance to make further requests.

Fixes https://github.com/stripe/stripe-java/issues/1719