### PR TITLE
Move request telemetry to LiveStripeResponseGetter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,10 @@ tasks.withType(JavaCompile) {
       // com.stripe.param.AccountUpdateParams.Individual.Address] within this file.)
       // We should fix this by having autogen use the fully-qualified class to eliminate ambiguity.
       check("SameNameButDifferent", net.ltgt.gradle.errorprone.CheckSeverity.OFF)
+
+      // InlineMe (https://errorprone.info/docs/inlineme) seems neat, but in order to add these annotations
+      // we would be imposing another dependency on `errorprone` to our users, not worth it.
+      check("InlineMeSuggester", net.ltgt.gradle.errorprone.CheckSeverity.OFF)
     }
 }
 

--- a/src/main/java/com/stripe/net/RequestTelemetry.java
+++ b/src/main/java/com/stripe/net/RequestTelemetry.java
@@ -26,12 +26,18 @@ class RequestTelemetry {
    * metrics, or if telemetry is disabled, then the returned {@code Optional} is empty.
    *
    * @param headers the request headers
+   * @deprecated Use {$ling {@link #pollPayload()} instead.
    */
+  @Deprecated
   public Optional<String> getHeaderValue(HttpHeaders headers) {
     if (headers.firstValue(HEADER_NAME).isPresent()) {
       return Optional.empty();
     }
 
+    return this.pollPayload();
+  }
+
+  public Optional<String> pollPayload() {
     RequestMetrics requestMetrics = prevRequestMetrics.poll();
     if (requestMetrics == null) {
       return Optional.empty();


### PR DESCRIPTION
## Summary
Moves responsibility for calculating queuing/calculating telemetry payloads and setting the `X-Stripe-Client-Telemetry` header from `HTTPClient` to `LiveStripeResponseGetter`.

## Details
There are public `requestWithTelemetry` methods on HTTPClient that I changed to not trigger any (additional) telemetry anymore. It's a significant behavior change for a hypothetical user calling these methods directly, but I don't consider this a supported use.

## Motivation
HTTPClient should be responsible for sending already-calculated HTTP requests, it shouldn't be responsible for calculating what to put in the HTTP request itself. See discussion at https://github.com/stripe/stripe-java/pull/1721/files#r1454137531

## Test strategy

Pretty good existing end-to-end telemetry test: https://github.com/stripe/stripe-java/blob/c044fabc4e5bf15bf2e8a717070511befab1b266/src/test/java/com/stripe/functional/TelemetryTest.java#L25