### PR TITLE
Address TODO (MAJOR) comments

### DIFF
--- a/src/main/java/com/stripe/model/StripeCollectionInterface.java
+++ b/src/main/java/com/stripe/model/StripeCollectionInterface.java
@@ -36,6 +36,5 @@ public interface StripeCollectionInterface<T> extends StripeObjectInterface {
    */
   void setRequestParams(Map<String, Object> requestParams);
 
-  // TODO (major) remove the default implementation and make this required
-  default void setPageTypeToken(Type type) {};
+  void setPageTypeToken(Type type);
 }

--- a/src/main/java/com/stripe/net/BaseApiRequest.java
+++ b/src/main/java/com/stripe/net/BaseApiRequest.java
@@ -14,12 +14,5 @@ class BaseApiRequest {
   private final RequestOptions options;
   private final ApiMode apiMode;
 
-  // TODO (major): Remove setter and make final
-  private List<String> usage;
-
-  /** @deprecated Use {@link com.stripe.net.ApiRequest#addUsage(String)} instead. */
-  @Deprecated
-  public void setUsage(List<String> usage) {
-    this.usage = usage;
-  }
+  private final List<String> usage;
 }

--- a/src/main/java/com/stripe/net/RequestTelemetry.java
+++ b/src/main/java/com/stripe/net/RequestTelemetry.java
@@ -53,15 +53,6 @@ class RequestTelemetry {
     return Optional.of(gson.toJson(payload));
   }
 
-  // TODO (major) remove this overload
-  /**
-   * @deprecated use {@link #maybeEnqueueMetrics(AbstractStripeResponse, Duration, List)} instead.
-   */
-  @Deprecated
-  public void maybeEnqueueMetrics(AbstractStripeResponse<?> response, Duration duration) {
-    maybeEnqueueMetrics(response, duration, new ArrayList<String>());
-  }
-
   /**
    * If telemetry is enabled and the queue is not full, then enqueue a new metrics item; otherwise,
    * do nothing.


### PR DESCRIPTION
## Changelog
* ⚠️ Update `setPageTypeToken` method on `StripeCollectionInterface` to be required and remove default implementation.
* ⚠️ Remove deprecated `setUsage` method on `BaseApiRequest`.
* ⚠️ Update `usage` on `BaseApiRequest` class to be `final`.
* ⚠️ Remove deprecated `maybeEnqueueMetrics` method on `RequestTelemetry`.