### PR TITLE
Enhancing Readability and Efficiency with Java `List.of()`

### DIFF
--- a/src/main/java/com/stripe/net/HttpHeaders.java
+++ b/src/main/java/com/stripe/net/HttpHeaders.java
@@ -3,7 +3,6 @@ package com.stripe.net;
 import static java.util.Objects.requireNonNull;
 
 import com.stripe.util.CaseInsensitiveMap;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -48,7 +47,7 @@ public class HttpHeaders {
   public HttpHeaders withAdditionalHeader(String name, String value) {
     requireNonNull(name);
     requireNonNull(value);
-    return this.withAdditionalHeader(name, Arrays.asList(value));
+    return this.withAdditionalHeader(name, List.of(value));
   }
 
   /**

--- a/src/main/java/com/stripe/net/HttpURLConnectionClient.java
+++ b/src/main/java/com/stripe/net/HttpURLConnectionClient.java
@@ -8,7 +8,6 @@ import java.io.OutputStream;
 import java.net.Authenticator;
 import java.net.HttpURLConnection;
 import java.net.PasswordAuthentication;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -83,9 +82,9 @@ public class HttpURLConnectionClient extends HttpClient {
   static HttpHeaders getHeaders(StripeRequest request) {
     Map<String, List<String>> userAgentHeadersMap = new HashMap<>();
 
-    userAgentHeadersMap.put("User-Agent", Arrays.asList(buildUserAgentString()));
+    userAgentHeadersMap.put("User-Agent", List.of(buildUserAgentString()));
     userAgentHeadersMap.put(
-        "X-Stripe-Client-User-Agent", Arrays.asList(buildXStripeClientUserAgentString()));
+        "X-Stripe-Client-User-Agent", List.of(buildXStripeClientUserAgentString()));
 
     return request.headers().withAdditionalHeaders(userAgentHeadersMap);
   }

--- a/src/main/java/com/stripe/net/StripeRequest.java
+++ b/src/main/java/com/stripe/net/StripeRequest.java
@@ -7,7 +7,6 @@ import com.stripe.exception.StripeException;
 import com.stripe.util.StringUtils;
 import java.io.IOException;
 import java.net.URL;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -142,10 +141,10 @@ public class StripeRequest {
     Map<String, List<String>> headerMap = new HashMap<String, List<String>>();
 
     // Accept
-    headerMap.put("Accept", Arrays.asList("application/json"));
+    headerMap.put("Accept", List.of("application/json"));
 
     // Accept-Charset
-    headerMap.put("Accept-Charset", Arrays.asList(ApiResource.CHARSET.name()));
+    headerMap.put("Accept-Charset", List.of(ApiResource.CHARSET.name()));
 
     // Authorization
     String apiKey = options.getApiKey();
@@ -177,14 +176,14 @@ public class StripeRequest {
           null,
           0);
     }
-    headerMap.put("Authorization", Arrays.asList(String.format("Bearer %s", apiKey)));
+    headerMap.put("Authorization", List.of(String.format("Bearer %s", apiKey)));
 
     // Stripe-Version
     if (RequestOptions.unsafeGetStripeVersionOverride(options) != null) {
       headerMap.put(
-          "Stripe-Version", Arrays.asList(RequestOptions.unsafeGetStripeVersionOverride(options)));
+          "Stripe-Version", List.of(RequestOptions.unsafeGetStripeVersionOverride(options)));
     } else if (options.getStripeVersion() != null) {
-      headerMap.put("Stripe-Version", Arrays.asList(options.getStripeVersion()));
+      headerMap.put("Stripe-Version", List.of(options.getStripeVersion()));
     } else {
       throw new IllegalStateException(
           "Either `stripeVersion` or `stripeVersionOverride` value must be set.");
@@ -192,14 +191,14 @@ public class StripeRequest {
 
     // Stripe-Account
     if (options.getStripeAccount() != null) {
-      headerMap.put("Stripe-Account", Arrays.asList(options.getStripeAccount()));
+      headerMap.put("Stripe-Account", List.of(options.getStripeAccount()));
     }
 
     // Idempotency-Key
     if (options.getIdempotencyKey() != null) {
-      headerMap.put("Idempotency-Key", Arrays.asList(options.getIdempotencyKey()));
+      headerMap.put("Idempotency-Key", List.of(options.getIdempotencyKey()));
     } else if (method == ApiResource.RequestMethod.POST) {
-      headerMap.put("Idempotency-Key", Arrays.asList(UUID.randomUUID().toString()));
+      headerMap.put("Idempotency-Key", List.of(UUID.randomUUID().toString()));
     }
 
     return HttpHeaders.of(headerMap);

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -20,7 +20,6 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -594,10 +593,10 @@ public class BaseStripeTest {
     }
 
     if (thisValue instanceof Object[]) {
-      thisValue = Arrays.asList((Object[]) thisValue);
+      thisValue = List.of((Object[]) thisValue);
     }
     if (otherValue instanceof Object[]) {
-      otherValue = Arrays.asList((Object[]) otherValue);
+      otherValue = List.of((Object[]) otherValue);
     }
 
     if (thisValue instanceof List<?> && otherValue instanceof List<?>) {

--- a/src/test/java/com/stripe/functional/InvoiceTest.java
+++ b/src/test/java/com/stripe/functional/InvoiceTest.java
@@ -15,7 +15,6 @@ import com.stripe.param.InvoiceUpcomingParams;
 import com.stripe.param.InvoiceUpdateParams;
 import com.stripe.param.common.EmptyParam;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -79,7 +78,7 @@ public class InvoiceTest extends BaseStripeTest {
     customField2.put("value", "val2");
 
     final Map<String, Object> params = new HashMap<>();
-    params.put("custom_fields", Arrays.asList(customField1, customField2));
+    params.put("custom_fields", List.of(customField1, customField2));
     params.put("metadata", metadata);
 
     InvoiceUpdateParams.CustomField typedCustomField1 =
@@ -90,7 +89,7 @@ public class InvoiceTest extends BaseStripeTest {
 
     InvoiceUpdateParams typedParams =
         InvoiceUpdateParams.builder()
-            .setCustomFields(Arrays.asList(typedCustomField1, typedCustomField2))
+            .setCustomFields(List.of(typedCustomField1, typedCustomField2))
             .putMetadata("key", "value")
             .build();
 
@@ -153,7 +152,7 @@ public class InvoiceTest extends BaseStripeTest {
         // param with extra param has the same map as that using standard builder
         InvoiceCreateParams.builder()
             .setCustomFields(
-                Arrays.asList(
+                List.of(
                     InvoiceCreateParams.CustomField.builder().setName("A").setValue("1").build(),
                     InvoiceCreateParams.CustomField.builder().setName("B").setValue("2").build()))
             .build()
@@ -253,7 +252,7 @@ public class InvoiceTest extends BaseStripeTest {
     Map<String, Object> params = new HashMap<>();
     params.put(
         "invoice_items",
-        Arrays.asList(
+        List.of(
             ImmutableMap.of("amount", 123L, "currency", "usd"),
             ImmutableMap.of("amount", 456L, "currency", "jpy")));
 

--- a/src/test/java/com/stripe/functional/PaymentIntentTest.java
+++ b/src/test/java/com/stripe/functional/PaymentIntentTest.java
@@ -16,7 +16,6 @@ import com.stripe.net.RequestOptions;
 import com.stripe.param.PaymentIntentListParams;
 import com.stripe.param.PaymentIntentRetrieveParams;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -66,7 +65,7 @@ public class PaymentIntentTest extends BaseStripeTest {
             .addExpand("application")
             .addExpand("customer")
             .addExpand("on_behalf_of")
-            .addAllExpand(Arrays.asList("review", "transfer_data.destination"))
+            .addAllExpand(List.of("review", "transfer_data.destination"))
             .build();
 
     final PaymentIntent resource =

--- a/src/test/java/com/stripe/model/InvoiceItemTest.java
+++ b/src/test/java/com/stripe/model/InvoiceItemTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.stripe.BaseStripeTest;
 import com.stripe.net.ApiResource;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
@@ -79,11 +78,11 @@ public class InvoiceItemTest extends BaseStripeTest {
     List<String> discountIds = discounts.stream().map(x -> x.getId()).collect(Collectors.toList());
     invoiceItem.setDiscounts(discountIds);
     assertEquals(discounts, invoiceItem.getDiscountObjects());
-    invoiceItem.setDiscounts(Arrays.asList(discountIds.get(0)));
+    invoiceItem.setDiscounts(List.of(discountIds.get(0)));
     assertEquals(invoiceItem.getDiscountObjects().size(), 1);
     assertNull(invoiceItem.getDiscountObjects().get(0));
     invoiceItem.setDiscounts(discountIds);
-    assertEquals(Arrays.asList(null, null), invoiceItem.getDiscountObjects());
+    assertEquals(List.of(null, null), invoiceItem.getDiscountObjects());
     invoiceItem.setDiscountObjects(discounts);
     assertEquals(discounts, invoiceItem.getDiscountObjects());
   }

--- a/src/test/java/com/stripe/net/ApiRequestParamsConverterTest.java
+++ b/src/test/java/com/stripe/net/ApiRequestParamsConverterTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.gson.annotations.SerializedName;
 import com.stripe.param.common.EmptyParam;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -165,14 +164,14 @@ public class ApiRequestParamsConverterTest {
   public void testHasListExtraParams() {
     ModelHasListExtraParams params = new ModelHasListExtraParams();
     params.paramFooList =
-        Arrays.asList(
+        List.of(
             new ModelHasExtraParams(ParamCode.ENUM_FOO),
             new ModelHasExtraParams(ParamCode.ENUM_BAR));
 
     Map<String, Object> expected = new HashMap<>();
     expected.put(
         "param_foo_list",
-        Arrays.asList(
+        List.of(
             ModelHasExtraParams.expectedParams("enum_foo"),
             ModelHasExtraParams.expectedParams("enum_bar")));
     assertEquals(expected, toMap(params));

--- a/src/test/java/com/stripe/net/FormEncoderTest.java
+++ b/src/test/java/com/stripe/net/FormEncoderTest.java
@@ -14,7 +14,6 @@ import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
@@ -585,7 +584,7 @@ public class FormEncoderTest extends BaseStripeTest {
     nestedList.add("C");
 
     List<Collection<String>> collections =
-        Arrays.asList(nestedTreeSet, nestedDequeue, nestedLinkedHashSet, nestedList);
+        List.of(nestedTreeSet, nestedDequeue, nestedLinkedHashSet, nestedList);
 
     for (Collection<String> collection : collections) {
       final Map<String, Object> params = new LinkedHashMap<>();

--- a/src/test/java/com/stripe/net/UntypedMapDeserializerTest.java
+++ b/src/test/java/com/stripe/net/UntypedMapDeserializerTest.java
@@ -9,7 +9,6 @@ import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import java.math.BigDecimal;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -121,7 +120,7 @@ public class UntypedMapDeserializerTest {
 
     Object untyped = flatteningDeserializer.deserializeJsonElement(jsonArray);
     assertEquals(
-        Arrays.asList(
+        List.of(
             ImmutableMap.of("grand_child", 1L),
             ImmutableMap.of("grand_child", 2L),
             ImmutableMap.of("grand_child", 3L)),


### PR DESCRIPTION
## Updated Usage of Java `List.of()`

In this project, we've updated the usage of `List.of()` to replace the older `Arrays.asList()` method. This not only makes the code more readable but also enhances efficiency by leveraging the newer features introduced in Java.

### What's Changed?

Previously, we were using `Arrays.asList()` to create lists, which returns a fixed-size list backed by the array. With Java's introduction of `List.of()` in Java 9, we can now create immutable lists easily without relying on an intermediate array.

### Benefits:

- **Readability**: The usage of `List.of()` provides a more concise and clear way to create lists compared to `Arrays.asList()`.
- **Efficiency**: `List.of()` creates immutable lists directly without the need for an intermediate array, enhancing efficiency and reducing memory overhead.

### Example:

```java
// Using Arrays.asList()
headerMap.put("Accept", Arrays.asList("application/json"));
// Using List.of()
headerMap.put("Accept", List.of("application/json"));



By adopting this updated feature of Java, we aim to maintain code readability and efficiency standards in our project.
