### PR TITLE
Remove parts of the API that is no longer publicly documented 

### DIFF
--- a/src/main/java/com/stripe/model/BalanceTransaction.java
+++ b/src/main/java/com/stripe/model/BalanceTransaction.java
@@ -148,9 +148,8 @@ public class BalanceTransaction extends ApiResource implements HasId {
    * payment_unreconciled}, {@code payout}, {@code payout_cancel}, {@code payout_failure}, {@code
    * refund}, {@code refund_failure}, {@code reserve_transaction}, {@code reserved_funds}, {@code
    * stripe_fee}, {@code stripe_fx_fee}, {@code tax_fee}, {@code topup}, {@code topup_reversal},
-   * {@code transfer}, {@code transfer_cancel}, {@code transfer_failure}, {@code transfer_refund},
-   * {@code obligation_inbound}, {@code obligation_payout}, {@code obligation_payout_failure}, or
-   * {@code obligation_reversal_outbound}.
+   * {@code transfer}, {@code transfer_cancel}, {@code transfer_failure}, or {@code
+   * transfer_refund}.
    */
   @SerializedName("type")
   String type;

--- a/src/main/java/com/stripe/model/Event.java
+++ b/src/main/java/com/stripe/model/Event.java
@@ -198,10 +198,8 @@ public class Event extends ApiResource implements HasId {
    * treasury.outbound_transfer.expected_arrival_date_updated}, {@code
    * treasury.outbound_transfer.failed}, {@code treasury.outbound_transfer.posted}, {@code
    * treasury.outbound_transfer.returned}, {@code treasury.received_credit.created}, {@code
-   * treasury.received_credit.failed}, {@code treasury.received_credit.succeeded}, {@code
-   * treasury.received_debit.created}, {@code invoiceitem.updated}, {@code order.created}, {@code
-   * recipient.created}, {@code recipient.deleted}, {@code recipient.updated}, {@code sku.created},
-   * {@code sku.deleted}, or {@code sku.updated}.
+   * treasury.received_credit.failed}, {@code treasury.received_credit.succeeded}, or {@code
+   * treasury.received_debit.created}.
    */
   @SerializedName("type")
   String type;

--- a/src/main/java/com/stripe/model/PaymentMethodConfiguration.java
+++ b/src/main/java/com/stripe/model/PaymentMethodConfiguration.java
@@ -123,9 +123,6 @@ public class PaymentMethodConfiguration extends ApiResource implements HasId {
   @SerializedName("id")
   String id;
 
-  @SerializedName("id_bank_transfer")
-  IdBankTransfer idBankTransfer;
-
   @SerializedName("ideal")
   Ideal ideal;
 
@@ -152,15 +149,9 @@ public class PaymentMethodConfiguration extends ApiResource implements HasId {
   @SerializedName("livemode")
   Boolean livemode;
 
-  @SerializedName("multibanco")
-  Multibanco multibanco;
-
   /** The configuration's name. */
   @SerializedName("name")
   String name;
-
-  @SerializedName("netbanking")
-  Netbanking netbanking;
 
   /**
    * String representing the object's type. Objects of the same type share the same value.
@@ -180,9 +171,6 @@ public class PaymentMethodConfiguration extends ApiResource implements HasId {
   @SerializedName("parent")
   String parent;
 
-  @SerializedName("pay_by_bank")
-  PayByBank payByBank;
-
   @SerializedName("paynow")
   Paynow paynow;
 
@@ -200,9 +188,6 @@ public class PaymentMethodConfiguration extends ApiResource implements HasId {
 
   @SerializedName("sofort")
   Sofort sofort;
-
-  @SerializedName("upi")
-  Upi upi;
 
   @SerializedName("us_bank_account")
   UsBankAccount usBankAccount;
@@ -1192,49 +1177,6 @@ public class PaymentMethodConfiguration extends ApiResource implements HasId {
   @Getter
   @Setter
   @EqualsAndHashCode(callSuper = false)
-  public static class IdBankTransfer extends StripeObject {
-    /**
-     * Whether this payment method may be offered at checkout. True if {@code display_preference} is
-     * {@code on} and the payment method's capability is active.
-     */
-    @SerializedName("available")
-    Boolean available;
-
-    @SerializedName("display_preference")
-    DisplayPreference displayPreference;
-
-    @Getter
-    @Setter
-    @EqualsAndHashCode(callSuper = false)
-    public static class DisplayPreference extends StripeObject {
-      /**
-       * For child configs, whether or not the account's preference will be observed. If {@code
-       * false}, the parent configuration's default is used.
-       */
-      @SerializedName("overridable")
-      Boolean overridable;
-
-      /**
-       * The account's display preference.
-       *
-       * <p>One of {@code none}, {@code off}, or {@code on}.
-       */
-      @SerializedName("preference")
-      String preference;
-
-      /**
-       * The effective display preference value.
-       *
-       * <p>One of {@code off}, or {@code on}.
-       */
-      @SerializedName("value")
-      String value;
-    }
-  }
-
-  @Getter
-  @Setter
-  @EqualsAndHashCode(callSuper = false)
   public static class Ideal extends StripeObject {
     /**
      * Whether this payment method may be offered at checkout. True if {@code display_preference} is
@@ -1450,92 +1392,6 @@ public class PaymentMethodConfiguration extends ApiResource implements HasId {
   @Getter
   @Setter
   @EqualsAndHashCode(callSuper = false)
-  public static class Multibanco extends StripeObject {
-    /**
-     * Whether this payment method may be offered at checkout. True if {@code display_preference} is
-     * {@code on} and the payment method's capability is active.
-     */
-    @SerializedName("available")
-    Boolean available;
-
-    @SerializedName("display_preference")
-    DisplayPreference displayPreference;
-
-    @Getter
-    @Setter
-    @EqualsAndHashCode(callSuper = false)
-    public static class DisplayPreference extends StripeObject {
-      /**
-       * For child configs, whether or not the account's preference will be observed. If {@code
-       * false}, the parent configuration's default is used.
-       */
-      @SerializedName("overridable")
-      Boolean overridable;
-
-      /**
-       * The account's display preference.
-       *
-       * <p>One of {@code none}, {@code off}, or {@code on}.
-       */
-      @SerializedName("preference")
-      String preference;
-
-      /**
-       * The effective display preference value.
-       *
-       * <p>One of {@code off}, or {@code on}.
-       */
-      @SerializedName("value")
-      String value;
-    }
-  }
-
-  @Getter
-  @Setter
-  @EqualsAndHashCode(callSuper = false)
-  public static class Netbanking extends StripeObject {
-    /**
-     * Whether this payment method may be offered at checkout. True if {@code display_preference} is
-     * {@code on} and the payment method's capability is active.
-     */
-    @SerializedName("available")
-    Boolean available;
-
-    @SerializedName("display_preference")
-    DisplayPreference displayPreference;
-
-    @Getter
-    @Setter
-    @EqualsAndHashCode(callSuper = false)
-    public static class DisplayPreference extends StripeObject {
-      /**
-       * For child configs, whether or not the account's preference will be observed. If {@code
-       * false}, the parent configuration's default is used.
-       */
-      @SerializedName("overridable")
-      Boolean overridable;
-
-      /**
-       * The account's display preference.
-       *
-       * <p>One of {@code none}, {@code off}, or {@code on}.
-       */
-      @SerializedName("preference")
-      String preference;
-
-      /**
-       * The effective display preference value.
-       *
-       * <p>One of {@code off}, or {@code on}.
-       */
-      @SerializedName("value")
-      String value;
-    }
-  }
-
-  @Getter
-  @Setter
-  @EqualsAndHashCode(callSuper = false)
   public static class Oxxo extends StripeObject {
     /**
      * Whether this payment method may be offered at checkout. True if {@code display_preference} is
@@ -1580,49 +1436,6 @@ public class PaymentMethodConfiguration extends ApiResource implements HasId {
   @Setter
   @EqualsAndHashCode(callSuper = false)
   public static class P24 extends StripeObject {
-    /**
-     * Whether this payment method may be offered at checkout. True if {@code display_preference} is
-     * {@code on} and the payment method's capability is active.
-     */
-    @SerializedName("available")
-    Boolean available;
-
-    @SerializedName("display_preference")
-    DisplayPreference displayPreference;
-
-    @Getter
-    @Setter
-    @EqualsAndHashCode(callSuper = false)
-    public static class DisplayPreference extends StripeObject {
-      /**
-       * For child configs, whether or not the account's preference will be observed. If {@code
-       * false}, the parent configuration's default is used.
-       */
-      @SerializedName("overridable")
-      Boolean overridable;
-
-      /**
-       * The account's display preference.
-       *
-       * <p>One of {@code none}, {@code off}, or {@code on}.
-       */
-      @SerializedName("preference")
-      String preference;
-
-      /**
-       * The effective display preference value.
-       *
-       * <p>One of {@code off}, or {@code on}.
-       */
-      @SerializedName("value")
-      String value;
-    }
-  }
-
-  @Getter
-  @Setter
-  @EqualsAndHashCode(callSuper = false)
-  public static class PayByBank extends StripeObject {
     /**
      * Whether this payment method may be offered at checkout. True if {@code display_preference} is
      * {@code on} and the payment method's capability is active.
@@ -1923,49 +1736,6 @@ public class PaymentMethodConfiguration extends ApiResource implements HasId {
   @Getter
   @Setter
   @EqualsAndHashCode(callSuper = false)
-  public static class Upi extends StripeObject {
-    /**
-     * Whether this payment method may be offered at checkout. True if {@code display_preference} is
-     * {@code on} and the payment method's capability is active.
-     */
-    @SerializedName("available")
-    Boolean available;
-
-    @SerializedName("display_preference")
-    DisplayPreference displayPreference;
-
-    @Getter
-    @Setter
-    @EqualsAndHashCode(callSuper = false)
-    public static class DisplayPreference extends StripeObject {
-      /**
-       * For child configs, whether or not the account's preference will be observed. If {@code
-       * false}, the parent configuration's default is used.
-       */
-      @SerializedName("overridable")
-      Boolean overridable;
-
-      /**
-       * The account's display preference.
-       *
-       * <p>One of {@code none}, {@code off}, or {@code on}.
-       */
-      @SerializedName("preference")
-      String preference;
-
-      /**
-       * The effective display preference value.
-       *
-       * <p>One of {@code off}, or {@code on}.
-       */
-      @SerializedName("value")
-      String value;
-    }
-  }
-
-  @Getter
-  @Setter
-  @EqualsAndHashCode(callSuper = false)
   public static class UsBankAccount extends StripeObject {
     /**
      * Whether this payment method may be offered at checkout. True if {@code display_preference} is
@@ -2071,24 +1841,19 @@ public class PaymentMethodConfiguration extends ApiResource implements HasId {
     trySetResponseGetter(giropay, responseGetter);
     trySetResponseGetter(googlePay, responseGetter);
     trySetResponseGetter(grabpay, responseGetter);
-    trySetResponseGetter(idBankTransfer, responseGetter);
     trySetResponseGetter(ideal, responseGetter);
     trySetResponseGetter(jcb, responseGetter);
     trySetResponseGetter(klarna, responseGetter);
     trySetResponseGetter(konbini, responseGetter);
     trySetResponseGetter(link, responseGetter);
-    trySetResponseGetter(multibanco, responseGetter);
-    trySetResponseGetter(netbanking, responseGetter);
     trySetResponseGetter(oxxo, responseGetter);
     trySetResponseGetter(p24, responseGetter);
-    trySetResponseGetter(payByBank, responseGetter);
     trySetResponseGetter(paynow, responseGetter);
     trySetResponseGetter(paypal, responseGetter);
     trySetResponseGetter(promptpay, responseGetter);
     trySetResponseGetter(revolutPay, responseGetter);
     trySetResponseGetter(sepaDebit, responseGetter);
     trySetResponseGetter(sofort, responseGetter);
-    trySetResponseGetter(upi, responseGetter);
     trySetResponseGetter(usBankAccount, responseGetter);
     trySetResponseGetter(wechatPay, responseGetter);
   }

--- a/src/main/java/com/stripe/model/PaymentSource.java
+++ b/src/main/java/com/stripe/model/PaymentSource.java
@@ -1,12 +1,4 @@
 // File generated from our OpenAPI spec
 package com.stripe.model;
 
-import com.stripe.exception.StripeException;
-import com.stripe.net.RequestOptions;
-import java.util.Map;
-
-public interface PaymentSource extends StripeObjectInterface, HasId {
-  PaymentSource update(Map<String, Object> params, RequestOptions options) throws StripeException;
-
-  PaymentSource update(Map<String, Object> params) throws StripeException;
-}
+public interface PaymentSource extends StripeObjectInterface, HasId {}

--- a/src/main/java/com/stripe/model/PaymentSourceTypeAdapterFactory.java
+++ b/src/main/java/com/stripe/model/PaymentSourceTypeAdapterFactory.java
@@ -9,10 +9,7 @@ import com.google.gson.TypeAdapterFactory;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
-import com.stripe.exception.StripeException;
-import com.stripe.net.RequestOptions;
 import java.io.IOException;
-import java.util.Map;
 import lombok.Getter;
 
 /**
@@ -88,27 +85,6 @@ public class PaymentSourceTypeAdapterFactory implements TypeAdapterFactory {
     @Override
     public String getId() {
       return this.id;
-    }
-    /** Unsupported operation for unknown subtype. */
-    @Override
-    public PaymentSource update(Map<String, Object> params, RequestOptions options)
-        throws StripeException {
-      throw new UnsupportedOperationException(
-          String.format(
-              "Unknown subtype of PaymentSource with id: %s, object: %s, "
-                  + "does not implement method: update. "
-                  + "Please contact support@stripe.com for assistance.",
-              this.id, this.object));
-    }
-    /** Unsupported operation for unknown subtype. */
-    @Override
-    public PaymentSource update(Map<String, Object> params) throws StripeException {
-      throw new UnsupportedOperationException(
-          String.format(
-              "Unknown subtype of PaymentSource with id: %s, object: %s, "
-                  + "does not implement method: update. "
-                  + "Please contact support@stripe.com for assistance.",
-              this.id, this.object));
     }
   }
 }

--- a/src/main/java/com/stripe/model/SetupIntent.java
+++ b/src/main/java/com/stripe/model/SetupIntent.java
@@ -1068,7 +1068,7 @@ public class SetupIntent extends ApiResource implements HasId, MetadataStore<Set
        * requesting 3D Secure</a> for more information on how this configuration interacts with
        * Radar and our SCA Engine.
        *
-       * <p>One of {@code any}, {@code automatic}, {@code challenge}, or {@code challenge_only}.
+       * <p>One of {@code any}, {@code automatic}, or {@code challenge}.
        */
       @SerializedName("request_three_d_secure")
       String requestThreeDSecure;

--- a/src/main/java/com/stripe/model/TaxRate.java
+++ b/src/main/java/com/stripe/model/TaxRate.java
@@ -143,7 +143,7 @@ public class TaxRate extends ApiResource implements HasId, MetadataStore<TaxRate
    *
    * <p>One of {@code amusement_tax}, {@code communications_tax}, {@code gst}, {@code hst}, {@code
    * igst}, {@code jct}, {@code lease_tax}, {@code pst}, {@code qst}, {@code rst}, {@code
-   * sales_tax}, {@code vat}, or {@code service_tax}.
+   * sales_tax}, or {@code vat}.
    */
   @SerializedName("tax_type")
   String taxType;

--- a/src/main/java/com/stripe/model/climate/Supplier.java
+++ b/src/main/java/com/stripe/model/climate/Supplier.java
@@ -60,8 +60,8 @@ public class Supplier extends ApiResource implements HasId {
   /**
    * The scientific pathway used for carbon removal.
    *
-   * <p>One of {@code biomass_carbon_removal_and_storage}, {@code direct_air_capture}, {@code
-   * enhanced_weathering}, or {@code various}.
+   * <p>One of {@code biomass_carbon_removal_and_storage}, {@code direct_air_capture}, or {@code
+   * enhanced_weathering}.
    */
   @SerializedName("removal_pathway")
   String removalPathway;

--- a/src/main/java/com/stripe/param/InvoiceCreateParams.java
+++ b/src/main/java/com/stripe/param/InvoiceCreateParams.java
@@ -5099,10 +5099,7 @@ public class InvoiceCreateParams extends ApiRequestParams {
     EXCLUDE("exclude"),
 
     @SerializedName("include")
-    INCLUDE("include"),
-
-    @SerializedName("include_and_require")
-    INCLUDE_AND_REQUIRE("include_and_require");
+    INCLUDE("include");
 
     @Getter(onMethod_ = {@Override})
     private final String value;

--- a/src/main/java/com/stripe/param/InvoiceLineItemUpdateParams.java
+++ b/src/main/java/com/stripe/param/InvoiceLineItemUpdateParams.java
@@ -1573,10 +1573,7 @@ public class InvoiceLineItemUpdateParams extends ApiRequestParams {
         SALES_TAX("sales_tax"),
 
         @SerializedName("vat")
-        VAT("vat"),
-
-        @SerializedName("service_tax")
-        SERVICE_TAX("service_tax");
+        VAT("vat");
 
         @Getter(onMethod_ = {@Override})
         private final String value;

--- a/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
@@ -9772,10 +9772,6 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       @SerializedName("request_extended_authorization")
       Boolean requestExtendedAuthorization;
 
-      /** This field was released by mistake and will be removed in the next major version. */
-      @SerializedName("request_incremental_authorization")
-      RequestIncrementalAuthorization requestIncrementalAuthorization;
-
       /**
        * Request ability to <a
        * href="https://stripe.com/docs/terminal/features/incremental-authorizations">increment</a>
@@ -9790,11 +9786,9 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
       private CardPresent(
           Map<String, Object> extraParams,
           Boolean requestExtendedAuthorization,
-          RequestIncrementalAuthorization requestIncrementalAuthorization,
           Boolean requestIncrementalAuthorizationSupport) {
         this.extraParams = extraParams;
         this.requestExtendedAuthorization = requestExtendedAuthorization;
-        this.requestIncrementalAuthorization = requestIncrementalAuthorization;
         this.requestIncrementalAuthorizationSupport = requestIncrementalAuthorizationSupport;
       }
 
@@ -9807,8 +9801,6 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
 
         private Boolean requestExtendedAuthorization;
 
-        private RequestIncrementalAuthorization requestIncrementalAuthorization;
-
         private Boolean requestIncrementalAuthorizationSupport;
 
         /** Finalize and obtain parameter instance from this builder. */
@@ -9816,7 +9808,6 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
           return new PaymentIntentConfirmParams.PaymentMethodOptions.CardPresent(
               this.extraParams,
               this.requestExtendedAuthorization,
-              this.requestIncrementalAuthorization,
               this.requestIncrementalAuthorizationSupport);
         }
 
@@ -9858,15 +9849,6 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
           return this;
         }
 
-        /** This field was released by mistake and will be removed in the next major version. */
-        public Builder setRequestIncrementalAuthorization(
-            PaymentIntentConfirmParams.PaymentMethodOptions.CardPresent
-                    .RequestIncrementalAuthorization
-                requestIncrementalAuthorization) {
-          this.requestIncrementalAuthorization = requestIncrementalAuthorization;
-          return this;
-        }
-
         /**
          * Request ability to <a
          * href="https://stripe.com/docs/terminal/features/incremental-authorizations">increment</a>
@@ -9879,21 +9861,6 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
             Boolean requestIncrementalAuthorizationSupport) {
           this.requestIncrementalAuthorizationSupport = requestIncrementalAuthorizationSupport;
           return this;
-        }
-      }
-
-      public enum RequestIncrementalAuthorization implements ApiRequestParams.EnumParam {
-        @SerializedName("if_available")
-        IF_AVAILABLE("if_available"),
-
-        @SerializedName("never")
-        NEVER("never");
-
-        @Getter(onMethod_ = {@Override})
-        private final String value;
-
-        RequestIncrementalAuthorization(String value) {
-          this.value = value;
         }
       }
     }

--- a/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
@@ -10304,10 +10304,6 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       @SerializedName("request_extended_authorization")
       Boolean requestExtendedAuthorization;
 
-      /** This field was released by mistake and will be removed in the next major version. */
-      @SerializedName("request_incremental_authorization")
-      RequestIncrementalAuthorization requestIncrementalAuthorization;
-
       /**
        * Request ability to <a
        * href="https://stripe.com/docs/terminal/features/incremental-authorizations">increment</a>
@@ -10322,11 +10318,9 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
       private CardPresent(
           Map<String, Object> extraParams,
           Boolean requestExtendedAuthorization,
-          RequestIncrementalAuthorization requestIncrementalAuthorization,
           Boolean requestIncrementalAuthorizationSupport) {
         this.extraParams = extraParams;
         this.requestExtendedAuthorization = requestExtendedAuthorization;
-        this.requestIncrementalAuthorization = requestIncrementalAuthorization;
         this.requestIncrementalAuthorizationSupport = requestIncrementalAuthorizationSupport;
       }
 
@@ -10339,8 +10333,6 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
 
         private Boolean requestExtendedAuthorization;
 
-        private RequestIncrementalAuthorization requestIncrementalAuthorization;
-
         private Boolean requestIncrementalAuthorizationSupport;
 
         /** Finalize and obtain parameter instance from this builder. */
@@ -10348,7 +10340,6 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
           return new PaymentIntentCreateParams.PaymentMethodOptions.CardPresent(
               this.extraParams,
               this.requestExtendedAuthorization,
-              this.requestIncrementalAuthorization,
               this.requestIncrementalAuthorizationSupport);
         }
 
@@ -10390,15 +10381,6 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
           return this;
         }
 
-        /** This field was released by mistake and will be removed in the next major version. */
-        public Builder setRequestIncrementalAuthorization(
-            PaymentIntentCreateParams.PaymentMethodOptions.CardPresent
-                    .RequestIncrementalAuthorization
-                requestIncrementalAuthorization) {
-          this.requestIncrementalAuthorization = requestIncrementalAuthorization;
-          return this;
-        }
-
         /**
          * Request ability to <a
          * href="https://stripe.com/docs/terminal/features/incremental-authorizations">increment</a>
@@ -10411,21 +10393,6 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
             Boolean requestIncrementalAuthorizationSupport) {
           this.requestIncrementalAuthorizationSupport = requestIncrementalAuthorizationSupport;
           return this;
-        }
-      }
-
-      public enum RequestIncrementalAuthorization implements ApiRequestParams.EnumParam {
-        @SerializedName("if_available")
-        IF_AVAILABLE("if_available"),
-
-        @SerializedName("never")
-        NEVER("never");
-
-        @Getter(onMethod_ = {@Override})
-        private final String value;
-
-        RequestIncrementalAuthorization(String value) {
-          this.value = value;
         }
       }
     }

--- a/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
@@ -9857,10 +9857,6 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       @SerializedName("request_extended_authorization")
       Boolean requestExtendedAuthorization;
 
-      /** This field was released by mistake and will be removed in the next major version. */
-      @SerializedName("request_incremental_authorization")
-      RequestIncrementalAuthorization requestIncrementalAuthorization;
-
       /**
        * Request ability to <a
        * href="https://stripe.com/docs/terminal/features/incremental-authorizations">increment</a>
@@ -9875,11 +9871,9 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
       private CardPresent(
           Map<String, Object> extraParams,
           Boolean requestExtendedAuthorization,
-          RequestIncrementalAuthorization requestIncrementalAuthorization,
           Boolean requestIncrementalAuthorizationSupport) {
         this.extraParams = extraParams;
         this.requestExtendedAuthorization = requestExtendedAuthorization;
-        this.requestIncrementalAuthorization = requestIncrementalAuthorization;
         this.requestIncrementalAuthorizationSupport = requestIncrementalAuthorizationSupport;
       }
 
@@ -9892,8 +9886,6 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
 
         private Boolean requestExtendedAuthorization;
 
-        private RequestIncrementalAuthorization requestIncrementalAuthorization;
-
         private Boolean requestIncrementalAuthorizationSupport;
 
         /** Finalize and obtain parameter instance from this builder. */
@@ -9901,7 +9893,6 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
           return new PaymentIntentUpdateParams.PaymentMethodOptions.CardPresent(
               this.extraParams,
               this.requestExtendedAuthorization,
-              this.requestIncrementalAuthorization,
               this.requestIncrementalAuthorizationSupport);
         }
 
@@ -9943,15 +9934,6 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
           return this;
         }
 
-        /** This field was released by mistake and will be removed in the next major version. */
-        public Builder setRequestIncrementalAuthorization(
-            PaymentIntentUpdateParams.PaymentMethodOptions.CardPresent
-                    .RequestIncrementalAuthorization
-                requestIncrementalAuthorization) {
-          this.requestIncrementalAuthorization = requestIncrementalAuthorization;
-          return this;
-        }
-
         /**
          * Request ability to <a
          * href="https://stripe.com/docs/terminal/features/incremental-authorizations">increment</a>
@@ -9964,21 +9946,6 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
             Boolean requestIncrementalAuthorizationSupport) {
           this.requestIncrementalAuthorizationSupport = requestIncrementalAuthorizationSupport;
           return this;
-        }
-      }
-
-      public enum RequestIncrementalAuthorization implements ApiRequestParams.EnumParam {
-        @SerializedName("if_available")
-        IF_AVAILABLE("if_available"),
-
-        @SerializedName("never")
-        NEVER("never");
-
-        @Getter(onMethod_ = {@Override})
-        private final String value;
-
-        RequestIncrementalAuthorization(String value) {
-          this.value = value;
         }
       }
     }

--- a/src/main/java/com/stripe/param/TaxRateCreateParams.java
+++ b/src/main/java/com/stripe/param/TaxRateCreateParams.java
@@ -345,10 +345,7 @@ public class TaxRateCreateParams extends ApiRequestParams {
     SALES_TAX("sales_tax"),
 
     @SerializedName("vat")
-    VAT("vat"),
-
-    @SerializedName("service_tax")
-    SERVICE_TAX("service_tax");
+    VAT("vat");
 
     @Getter(onMethod_ = {@Override})
     private final String value;

--- a/src/main/java/com/stripe/param/TaxRateUpdateParams.java
+++ b/src/main/java/com/stripe/param/TaxRateUpdateParams.java
@@ -379,10 +379,7 @@ public class TaxRateUpdateParams extends ApiRequestParams {
     SALES_TAX("sales_tax"),
 
     @SerializedName("vat")
-    VAT("vat"),
-
-    @SerializedName("service_tax")
-    SERVICE_TAX("service_tax");
+    VAT("vat");
 
     @Getter(onMethod_ = {@Override})
     private final String value;

--- a/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
+++ b/src/main/java/com/stripe/param/WebhookEndpointCreateParams.java
@@ -1277,31 +1277,7 @@ public class WebhookEndpointCreateParams extends ApiRequestParams {
     TREASURY__RECEIVED_CREDIT__SUCCEEDED("treasury.received_credit.succeeded"),
 
     @SerializedName("treasury.received_debit.created")
-    TREASURY__RECEIVED_DEBIT__CREATED("treasury.received_debit.created"),
-
-    @SerializedName("invoiceitem.updated")
-    INVOICEITEM__UPDATED("invoiceitem.updated"),
-
-    @SerializedName("order.created")
-    ORDER__CREATED("order.created"),
-
-    @SerializedName("recipient.created")
-    RECIPIENT__CREATED("recipient.created"),
-
-    @SerializedName("recipient.deleted")
-    RECIPIENT__DELETED("recipient.deleted"),
-
-    @SerializedName("recipient.updated")
-    RECIPIENT__UPDATED("recipient.updated"),
-
-    @SerializedName("sku.created")
-    SKU__CREATED("sku.created"),
-
-    @SerializedName("sku.deleted")
-    SKU__DELETED("sku.deleted"),
-
-    @SerializedName("sku.updated")
-    SKU__UPDATED("sku.updated");
+    TREASURY__RECEIVED_DEBIT__CREATED("treasury.received_debit.created");
 
     @Getter(onMethod_ = {@Override})
     private final String value;

--- a/src/main/java/com/stripe/param/WebhookEndpointUpdateParams.java
+++ b/src/main/java/com/stripe/param/WebhookEndpointUpdateParams.java
@@ -947,31 +947,7 @@ public class WebhookEndpointUpdateParams extends ApiRequestParams {
     TREASURY__RECEIVED_CREDIT__SUCCEEDED("treasury.received_credit.succeeded"),
 
     @SerializedName("treasury.received_debit.created")
-    TREASURY__RECEIVED_DEBIT__CREATED("treasury.received_debit.created"),
-
-    @SerializedName("invoiceitem.updated")
-    INVOICEITEM__UPDATED("invoiceitem.updated"),
-
-    @SerializedName("order.created")
-    ORDER__CREATED("order.created"),
-
-    @SerializedName("recipient.created")
-    RECIPIENT__CREATED("recipient.created"),
-
-    @SerializedName("recipient.deleted")
-    RECIPIENT__DELETED("recipient.deleted"),
-
-    @SerializedName("recipient.updated")
-    RECIPIENT__UPDATED("recipient.updated"),
-
-    @SerializedName("sku.created")
-    SKU__CREATED("sku.created"),
-
-    @SerializedName("sku.deleted")
-    SKU__DELETED("sku.deleted"),
-
-    @SerializedName("sku.updated")
-    SKU__UPDATED("sku.updated");
+    TREASURY__RECEIVED_DEBIT__CREATED("treasury.received_debit.created");
 
     @Getter(onMethod_ = {@Override})
     private final String value;

--- a/src/main/java/com/stripe/param/reporting/ReportRunCreateParams.java
+++ b/src/main/java/com/stripe/param/reporting/ReportRunCreateParams.java
@@ -464,10 +464,7 @@ public class ReportRunCreateParams extends ApiRequestParams {
       TRANSFER_REVERSAL("transfer_reversal"),
 
       @SerializedName("unreconciled_customer_funds")
-      UNRECONCILED_CUSTOMER_FUNDS("unreconciled_customer_funds"),
-
-      @SerializedName("obligation")
-      OBLIGATION("obligation");
+      UNRECONCILED_CUSTOMER_FUNDS("unreconciled_customer_funds");
 
       @Getter(onMethod_ = {@Override})
       private final String value;


### PR DESCRIPTION
This PR contains the changes generated after removing the shared overrides from our code generator that were added for backcompat

## Changelog

* Remove the support for the below deprecated values in `BalanceTransaction.Type`
    * `obligation_inbound`
    * `obligation_payout`
    * `obligation_payout_failure`
    * `obligation_reversal_outbound`
* Remove the below deprecated events from `Event.Type`, `WebhookEndpointCreateOptions.EnabledEvent`, `WebhookEndpointUpdateOptions.EnabledEvent`
   * `invoiceitem.updated`
   * `order.created`
   * `recipient.created`
   * `recipient.deleted`
   * `recipient.updated`
   * `sku.created`
   * `sku.deleted`
   * `sku.updated`
* Remove support for `id_bank_transfer`, `multibanco`, `netbanking`, `pay_by_bank`, and `upi` on `PaymentMethodConfiguration` by removing the below classes
   * `PaymentMethodConfiguration.IdBankTransfer`
   * `PaymentMethodConfiguration.Multibanco`
   * `PaymentMethodConfiguration.Netbanking`
   * `PaymentMethodConfiguration.PayByBank`
   * `PaymentMethodConfiguration.Upi`
* Remove the support for `challenge_only` in `SetupIntent.PaymentMethodOptions.Card.RequestThreeDSecure`
* Remove the support for deprecated value `service_tax` in `TaxRate.TaxType`, `InvoiceLinetItemUpdateParams.TaxAmount.TaxRateData.TaxType`,pweb`TaxRateCreateParams.TaxType`, `TaxRateUpdateParams.TaxType`
* Remove the support for `various` in `Climate.Supplier.removalPathway` 
* Remove the deprecated value `INCLUDE_AND_REQUIRE` on the enum `InvoiceCreateParams.PendingInvoiceItemsBehavior`
* Remove the property `RequestIncrementalAuthorization` on `PaymentIntentConfirmParams.PaymentMethodOptions.CardPresent`, `PaymentIntentCreateParams.PaymentMethodOptions.CardPresent` and `PaymentIntentUpdateParams.PaymentMethodOptions.CardPresent`. This was shipped by mistake.
* Remove the support for deprecated value `obligation` on `ReportRunCreateParams.ReportingCategory`


 


 
 

