### PR TITLE
Deprecate Java params based on OpenAPI spec

### DIFF
--- a/src/main/java/com/stripe/model/ConfirmationToken.java
+++ b/src/main/java/com/stripe/model/ConfirmationToken.java
@@ -1098,6 +1098,7 @@ public class ConfirmationToken extends ApiResource implements HasId {
 
       /** [Deprecated] This is a legacy parameter that no longer has any function. */
       @SerializedName("persistent_token")
+      @Deprecated
       String persistentToken;
     }
 

--- a/src/main/java/com/stripe/model/PaymentIntent.java
+++ b/src/main/java/com/stripe/model/PaymentIntent.java
@@ -3365,6 +3365,7 @@ public class PaymentIntent extends ApiResource implements HasId, MetadataStore<P
 
       /** [Deprecated] This is a legacy parameter that no longer has any function. */
       @SerializedName("persistent_token")
+      @Deprecated
       String persistentToken;
 
       /**

--- a/src/main/java/com/stripe/model/PaymentMethod.java
+++ b/src/main/java/com/stripe/model/PaymentMethod.java
@@ -1386,6 +1386,7 @@ public class PaymentMethod extends ApiResource implements HasId, MetadataStore<P
 
     /** [Deprecated] This is a legacy parameter that no longer has any function. */
     @SerializedName("persistent_token")
+    @Deprecated
     String persistentToken;
   }
 

--- a/src/main/java/com/stripe/model/SetupIntent.java
+++ b/src/main/java/com/stripe/model/SetupIntent.java
@@ -1166,6 +1166,7 @@ public class SetupIntent extends ApiResource implements HasId, MetadataStore<Set
     public static class Link extends StripeObject {
       /** [Deprecated] This is a legacy parameter that no longer has any function. */
       @SerializedName("persistent_token")
+      @Deprecated
       String persistentToken;
     }
 

--- a/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
@@ -12232,6 +12232,7 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
 
       /** [Deprecated] This is a legacy parameter that no longer has any function. */
       @SerializedName("persistent_token")
+      @Deprecated
       String persistentToken;
 
       /**

--- a/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
@@ -12762,6 +12762,7 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
 
       /** [Deprecated] This is a legacy parameter that no longer has any function. */
       @SerializedName("persistent_token")
+      @Deprecated
       String persistentToken;
 
       /**

--- a/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
@@ -12325,6 +12325,7 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
 
       /** [Deprecated] This is a legacy parameter that no longer has any function. */
       @SerializedName("persistent_token")
+      @Deprecated
       Object persistentToken;
 
       /**

--- a/src/main/java/com/stripe/param/SetupIntentConfirmParams.java
+++ b/src/main/java/com/stripe/param/SetupIntentConfirmParams.java
@@ -6704,6 +6704,7 @@ public class SetupIntentConfirmParams extends ApiRequestParams {
 
       /** [Deprecated] This is a legacy parameter that no longer has any function. */
       @SerializedName("persistent_token")
+      @Deprecated
       String persistentToken;
 
       private Link(Map<String, Object> extraParams, String persistentToken) {

--- a/src/main/java/com/stripe/param/SetupIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/SetupIntentCreateParams.java
@@ -7158,6 +7158,7 @@ public class SetupIntentCreateParams extends ApiRequestParams {
 
       /** [Deprecated] This is a legacy parameter that no longer has any function. */
       @SerializedName("persistent_token")
+      @Deprecated
       String persistentToken;
 
       private Link(Map<String, Object> extraParams, String persistentToken) {

--- a/src/main/java/com/stripe/param/SetupIntentUpdateParams.java
+++ b/src/main/java/com/stripe/param/SetupIntentUpdateParams.java
@@ -6703,6 +6703,7 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
 
       /** [Deprecated] This is a legacy parameter that no longer has any function. */
       @SerializedName("persistent_token")
+      @Deprecated
       Object persistentToken;
 
       private Link(Map<String, Object> extraParams, Object persistentToken) {


### PR DESCRIPTION
This PR adds Java SDK support for automatically marking methods and params as deprecated. 

## Changelog
- Mark as deprecated the `persistent_token` property on `ConfirmationToken.Link.persistentToken`, `PaymentIntent.Link.persistentToken`, `PaymentMethod.Link.persistentToken`, `SetupIntent.Link.persistentToken`, `PaymentIntentConfirmParams.Link.persistentToken`, `PaymentIntentCreateParams.Link.persistentToken`, `PaymentIntentUpdateParams.Link.persistentToken`, `SetupIntentConfirmParams.Link.persistentToken`, `SetupIntentCreateParams.Link.persistentToken`, `SetupIntentUpdateParams.Link.persistentToken`. This is a legacy parameter that no longer has any function.