### PR TITLE
Increase heap size for builds

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -32,4 +32,5 @@ org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAME
  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
- --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+ --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
+ -Xmx2g -Xms2g


### PR DESCRIPTION
We recently had beta builds fail due to reaching heap size maximums. This should (I believe) about double them.