### PR TITLE
Increase heap size maximums for compile task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ tasks.withType(JavaCompile) {
         throw new GradleException("JDK 17 is required to build Stripe")
     }
 
+    options.fork = true
+    options.forkOptions.jvmArgs += ['-Xms256M', '-Xmx512M']
+
     options.release = project.targetCompatibility.majorVersion as Integer
 
     options.compilerArgs << "-Xlint:all" << "-Xlint:-options" << "-Xlint:-processing"


### PR DESCRIPTION
Tested locally and on helenye-ooming off of latest-codegen-beta. This forces the compile task to fork and increases that task's memory limits. The side effects are this slightly slows build times (does not seem significant comparing to previous builds) and may use slightly more memory, but the limits are not extremely high.