### PR TITLE
Fixed java compat crash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,8 @@ tasks.withType(Test) {
 
 compileJava {
     options.compilerArgs << "-Werror"
+    options.forkOptions.jvmArgs << '-Xmx1024m'
+    options.fork=true
 }
 
 configurations.all {


### PR DESCRIPTION
Fixes crash caused by `OutOfMemoryException` by the compiler. Heap dump suggested that Lombok might need more memory. Therefore increased the maximum heap size for gradle worker daemon. 