### PR TITLE
Added deprecated annotation to builder methods

### DIFF
--- a/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentConfirmParams.java
@@ -12384,6 +12384,7 @@ public class PaymentIntentConfirmParams extends ApiRequestParams {
         }
 
         /** [Deprecated] This is a legacy parameter that no longer has any function. */
+        @Deprecated
         public Builder setPersistentToken(String persistentToken) {
           this.persistentToken = persistentToken;
           return this;

--- a/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentCreateParams.java
@@ -12875,6 +12875,7 @@ public class PaymentIntentCreateParams extends ApiRequestParams {
         }
 
         /** [Deprecated] This is a legacy parameter that no longer has any function. */
+        @Deprecated
         public Builder setPersistentToken(String persistentToken) {
           this.persistentToken = persistentToken;
           return this;

--- a/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
+++ b/src/main/java/com/stripe/param/PaymentIntentUpdateParams.java
@@ -12438,12 +12438,14 @@ public class PaymentIntentUpdateParams extends ApiRequestParams {
         }
 
         /** [Deprecated] This is a legacy parameter that no longer has any function. */
+        @Deprecated
         public Builder setPersistentToken(String persistentToken) {
           this.persistentToken = persistentToken;
           return this;
         }
 
         /** [Deprecated] This is a legacy parameter that no longer has any function. */
+        @Deprecated
         public Builder setPersistentToken(EmptyParam persistentToken) {
           this.persistentToken = persistentToken;
           return this;

--- a/src/main/java/com/stripe/param/SetupIntentConfirmParams.java
+++ b/src/main/java/com/stripe/param/SetupIntentConfirmParams.java
@@ -6756,6 +6756,7 @@ public class SetupIntentConfirmParams extends ApiRequestParams {
         }
 
         /** [Deprecated] This is a legacy parameter that no longer has any function. */
+        @Deprecated
         public Builder setPersistentToken(String persistentToken) {
           this.persistentToken = persistentToken;
           return this;

--- a/src/main/java/com/stripe/param/SetupIntentCreateParams.java
+++ b/src/main/java/com/stripe/param/SetupIntentCreateParams.java
@@ -7210,6 +7210,7 @@ public class SetupIntentCreateParams extends ApiRequestParams {
         }
 
         /** [Deprecated] This is a legacy parameter that no longer has any function. */
+        @Deprecated
         public Builder setPersistentToken(String persistentToken) {
           this.persistentToken = persistentToken;
           return this;

--- a/src/main/java/com/stripe/param/SetupIntentUpdateParams.java
+++ b/src/main/java/com/stripe/param/SetupIntentUpdateParams.java
@@ -6755,12 +6755,14 @@ public class SetupIntentUpdateParams extends ApiRequestParams {
         }
 
         /** [Deprecated] This is a legacy parameter that no longer has any function. */
+        @Deprecated
         public Builder setPersistentToken(String persistentToken) {
           this.persistentToken = persistentToken;
           return this;
         }
 
         /** [Deprecated] This is a legacy parameter that no longer has any function. */
+        @Deprecated
         public Builder setPersistentToken(EmptyParam persistentToken) {
           this.persistentToken = persistentToken;
           return this;


### PR DESCRIPTION
## Changelog
* Deprecate Java builder params based on OpenAPI spec
  * Mark as deprecated the setters for persistent_token property on `PaymentIntentConfirmParams`, `PaymentIntentCreateParams`, `PaymentIntentUpdateParams`, `SetupIntentConfirmParams`, `SetupIntentCreateParams`, `SetupIntentUpdateParams`. This is a legacy parameter that no longer has any function.