### PR TITLE
Branch coverage tool

### DIFF
--- a/src/main/java/com/stripe/BranchCoverageUtil.java
+++ b/src/main/java/com/stripe/BranchCoverageUtil.java
@@ -1,0 +1,67 @@
+package com.stripe;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.io.File;
+
+public class BranchCoverageUtil {
+  public static void writeDefault() {
+    String filePath = "branchCoverage.txt";
+
+    File file = new File(filePath);
+    try {
+      file.createNewFile();
+    } catch (IOException e) {
+      Logger.getLogger(BranchCoverageUtil.class.getName()).log(Level.SEVERE, "Failed to create to file: " + filePath, e);
+    }
+
+    try (BufferedWriter writer = Files.newBufferedWriter(Paths.get(filePath), StandardCharsets.UTF_8)) {
+      // Writing an empty string to the file
+      for (int i = 0; i < 4 * 20; i++)
+      {
+        writer.write("0");
+      }
+    } catch (IOException e) {
+      Logger.getLogger(BranchCoverageUtil.class.getName()).log(Level.SEVERE, "Failed to write to file: " + filePath, e);
+    }
+  }
+
+  // This function is to be called in main code
+  // For each branch you are supposed to call it with a different uid assigned to you
+  public static void insertXAtIndex(int index) {
+    String filePath = "branchCoverage.txt";
+
+    try {
+      Path path = Paths.get(filePath);
+      if (Files.notExists(path)) {
+        System.out.println("File does not exist.");
+        return;
+      }
+
+      List<String> lines = Files.readAllLines(path, StandardCharsets.UTF_8);
+      StringBuilder content = new StringBuilder();
+      for (String line : lines) {
+        content.append(line);
+      }
+
+      if (index < 0 || index > content.length()) {
+        System.out.println("Index out of bounds.");
+        return;
+      }
+      content.setCharAt(index, 'X');
+      try (BufferedWriter writer = Files.newBufferedWriter(path, StandardCharsets.UTF_8, StandardOpenOption.TRUNCATE_EXISTING)) {
+        writer.write(content.toString());
+      }
+    } catch (IOException e) {
+      Logger.getLogger(BranchCoverageUtil.class.getName()).log(Level.SEVERE, "Failed to read from or write to file: " + filePath, e);
+    }
+  }
+}

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -112,6 +112,7 @@ public class BaseStripeTest {
               version, MOCK_MINIMUM_VERSION));
     }
   }
+  
   /**
    * Activates usage of stripe-mock by overriding the API host and putting a test key into the
    * environment. This is required independent of how stripe-mock is started.

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -68,6 +68,13 @@ public class BaseStripeTest {
   }
 
   /** Checks that stripe-mock is running and up-to-date. */
+
+  // Our Coverage tests
+  @BeforeAll
+    public static void createCoverageFile() {
+    BranchCoverageUtil.writeDefault();
+  }
+
   @BeforeAll
   public static void checkStripeMock() throws Exception {
     if (StripeMockProcess.start()) {
@@ -105,7 +112,6 @@ public class BaseStripeTest {
               version, MOCK_MINIMUM_VERSION));
     }
   }
-
   /**
    * Activates usage of stripe-mock by overriding the API host and putting a test key into the
    * environment. This is required independent of how stripe-mock is started.


### PR DESCRIPTION
I've created our own branch coverage tool. It creates a file in the root of the repo directory. That file is initially filles with 0's but we can update them with X's by using BranchCoverageUtil.insertXAtIndex() function. That function is static. You are expected to use it once in every branch in your 2 functions with a UID as an argument. We can then run the whole test framework without and then with our tests to see how we increase the branch coverage (More X's = Better branch coverage).
👍 