### PR TITLE
Update formatting settings for VSCode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
   "recommendations": [
     "EditorConfig.editorconfig", // default
     "vscjava.vscode-java-pack", // intellisense and tooling
+    "richardwillis.vscode-spotless-gradle", // formatting
     "naco-siren.gradle-language" // also, gradle
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,18 @@
 
   "editor.renderWhitespace": "all",
   "[java]": {
-    "editor.rulers": [100]
+    "editor.rulers": [100],
+    // use spotless for formatting (to match makefile)
+    "spotlessGradle.format.enable": true,
+    "spotlessGradle.diagnostics.enable": true,
+    "editor.defaultFormatter": "richardwillis.vscode-spotless-gradle",
+    "editor.codeActionsOnSave": {
+      "source.fixAll.spotlessGradle": "explicit",
+      // let spotless handle organizing imports, not the more general tooling
+      "source.organizeImports": "never"
+    }
   },
-  "java.configuration.updateBuildConfiguration": "automatic"
+  "java.configuration.updateBuildConfiguration": "automatic",
+  // LSP was ooming and it recommended this change
+  "java.jdt.ls.vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx2G -Xms100m -Xlog:disable"
 }


### PR DESCRIPTION
While working on another Java PR, I noticed our default VSCode java formatter and what was produced by `make codegen-format` didn't line up. So I added a recommended extension that used the same formatter under the hood and adjusted the settings.

I also added a recommended line to help the Java LSP not OOM (which the extension auto-generated).