### PR TITLE
Remove the need for an OAuth API mode

### DIFF
--- a/src/main/java/com/stripe/net/ApiMode.java
+++ b/src/main/java/com/stripe/net/ApiMode.java
@@ -1,6 +1,5 @@
 package com.stripe.net;
 
 public enum ApiMode {
-  V1,
-  OAuth
+  V1
 }

--- a/src/main/java/com/stripe/net/OAuth.java
+++ b/src/main/java/com/stripe/net/OAuth.java
@@ -53,7 +53,7 @@ public final class OAuth {
             "/oauth/token",
             params,
             options,
-            ApiMode.OAuth);
+            ApiMode.V1);
     return OAuth.globalResponseGetter.request(request, TokenResponse.class);
   }
 
@@ -77,7 +77,7 @@ public final class OAuth {
             "/oauth/deauthorize",
             paramsCopy,
             options,
-            ApiMode.OAuth);
+            ApiMode.V1);
     return OAuth.globalResponseGetter.request(request, DeauthorizedAccount.class);
   }
 

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -9,7 +9,6 @@ import com.google.gson.reflect.TypeToken;
 import com.stripe.exception.StripeException;
 import com.stripe.model.StripeObjectInterface;
 import com.stripe.net.*;
-import com.stripe.net.ApiMode;
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -347,12 +346,7 @@ public class BaseStripeTest {
       Class<T> clazz, String response) throws StripeException {
     Mockito.doReturn(ApiResource.GSON.fromJson(response, clazz))
         .when(networkSpy)
-        .request(
-            Mockito.argThat(
-                (req) -> {
-                  return req.getApiMode() == ApiMode.OAuth;
-                }),
-            Mockito.<Type>any());
+        .request(Mockito.any(ApiRequest.class), Mockito.<Type>any());
   }
 
   /**


### PR DESCRIPTION
This PR refactors the code to not require an OAuth API mode. Instead we use the same logic as we do in other language Stripe SDKs to determine any special handling of error responses