### PR TITLE
Fixes requests with null params

### DIFF
--- a/src/main/java/com/stripe/net/JsonEncoder.java
+++ b/src/main/java/com/stripe/net/JsonEncoder.java
@@ -4,6 +4,7 @@ import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
 final class JsonEncoder {
@@ -14,6 +15,9 @@ final class JsonEncoder {
           .create();
 
   public static HttpContent createHttpContent(Map<String, Object> params) throws IOException {
+    if (params == null) {
+      params = new HashMap<String, Object>();
+    }
     return HttpContent.buildJsonContent(BODY_GSON.toJson(params));
   }
 }


### PR DESCRIPTION
### Why?
When testing the meter event stream examples, I saw error code 400 returned from the stripe server when creating a MeterEventSession (using MeterEventSessionService.create()).  The issue was that we were sending the string "null" as the json body of the request.  The fix here is to ensure we never call the GSON encoder with a null object; we can do this by testing for null in createHttpContent and substituting an empty map if needed.

### What?
- changed JsonEncoder.createHttpContent to test for null and create a new HashMap if true.  this ensures we never encode a "null"
