### PR TITLE
Fixes fetchRelatedObject calls on V2 events with V1 payloads

### DIFF
--- a/src/main/java/com/stripe/model/v2/EventDataClassLookup.java
+++ b/src/main/java/com/stripe/model/v2/EventDataClassLookup.java
@@ -14,6 +14,8 @@ final class EventDataClassLookup {
   public static final Map<String, Class<? extends Event>> eventClassLookup = new HashMap<>();
 
   static {
+    classLookup.put("billing.meter", com.stripe.model.billing.Meter.class);
+
     classLookup.put("billing.meter_event", com.stripe.model.v2.billing.MeterEvent.class);
     classLookup.put(
         "billing.meter_event_adjustment", com.stripe.model.v2.billing.MeterEventAdjustment.class);


### PR DESCRIPTION
### Why?
We support a V2 event V1BillingMeterErrorReportTriggeredEvent that has a related object accessed via a v1 api/service.  During dog fooding it was discovered that we fail to build this object when fetched.  This is because the object tag to object mapping class for V2 did not contain any V1 objects.  The fix is to ensure all v2 event related objects are represented in the V2 class lookup class.

### What?
- added v1 `billing.meter` to v2.EventDataClassLookup class

### See Also
http://go/j/DEVSDK-2182