### PR TITLE
Add back IdempotencyException and add a test

### DIFF
--- a/src/main/java/com/stripe/exception/IdempotencyException.java
+++ b/src/main/java/com/stripe/exception/IdempotencyException.java
@@ -1,0 +1,9 @@
+package com.stripe.exception;
+
+public class IdempotencyException extends StripeException {
+  private static final long serialVersionUID = 2L;
+
+  public IdempotencyException(String message, String requestId, String code, Integer statusCode) {
+    super(message, requestId, code, statusCode);
+  }
+}

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -320,12 +320,8 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
       case 404:
         if ("idempotency_error".equals(error.getType())) {
           exception =
-              StripeException.parseV2Exception(
-                  "idempotency_error",
-                  ApiResource.GSON.fromJson(response.body(), JsonObject.class),
-                  response.code(),
-                  response.requestId(),
-                  this);
+              new IdempotencyException(
+                  error.getMessage(), response.requestId(), error.getCode(), response.code());
         } else {
           exception =
               new InvalidRequestException(


### PR DESCRIPTION
## Why?

We changed all of the APIs to use the v2 parsing, but this fails for v1 methods since a v2 IdempotencyException doesn't exist right now.

Adds a test to verify.