### PR TITLE
Rename `parseSnapshotEvent` back to `constructEvent`

### DIFF
--- a/src/main/java/com/stripe/StripeClient.java
+++ b/src/main/java/com/stripe/StripeClient.java
@@ -70,7 +70,7 @@ public class StripeClient {
    * @return the Event instance
    * @throws SignatureVerificationException if the verification fails.
    */
-  public com.stripe.model.Event parseSnapshotEvent(String payload, String sigHeader, String secret)
+  public com.stripe.model.Event constructEvent(String payload, String sigHeader, String secret)
       throws SignatureVerificationException {
     com.stripe.model.Event event = Webhook.constructEvent(payload, sigHeader, secret);
     event.setResponseGetter(this.getResponseGetter());
@@ -90,7 +90,7 @@ public class StripeClient {
    * @return the Event instance
    * @throws SignatureVerificationException if the verification fails.
    */
-  public com.stripe.model.Event parseSnapshotEvent(
+  public com.stripe.model.Event constructEvent(
       String payload, String sigHeader, String secret, long tolerance)
       throws SignatureVerificationException {
     com.stripe.model.Event event = Webhook.constructEvent(payload, sigHeader, secret, tolerance);

--- a/src/main/java/com/stripe/StripeClient.java
+++ b/src/main/java/com/stripe/StripeClient.java
@@ -59,6 +59,45 @@ public class StripeClient {
     return ApiResource.GSON.fromJson(payload, ThinEvent.class);
   }
 
+  /**
+   * Returns an Event instance using the provided JSON payload. Throws a JsonSyntaxException if the
+   * payload is not valid JSON, and a SignatureVerificationException if the signature verification
+   * fails for any reason.
+   *
+   * @param payload the payload sent by Stripe.
+   * @param sigHeader the contents of the signature header sent by Stripe.
+   * @param secret secret used to generate the signature.
+   * @return the Event instance
+   * @throws SignatureVerificationException if the verification fails.
+   */
+  public com.stripe.model.Event parseSnapshotEvent(String payload, String sigHeader, String secret)
+      throws SignatureVerificationException {
+    com.stripe.model.Event event = Webhook.constructEvent(payload, sigHeader, secret);
+    event.setResponseGetter(this.getResponseGetter());
+    return event;
+  }
+
+  /**
+   * Returns an Event instance using the provided JSON payload. Throws a JsonSyntaxException if the
+   * payload is not valid JSON, and a SignatureVerificationException if the signature verification
+   * fails for any reason.
+   *
+   * @param payload the payload sent by Stripe.
+   * @param sigHeader the contents of the signature header sent by Stripe.
+   * @param secret secret used to generate the signature.
+   * @param tolerance maximum difference in seconds allowed between the header's timestamp and the
+   *     current time
+   * @return the Event instance
+   * @throws SignatureVerificationException if the verification fails.
+   */
+  public com.stripe.model.Event parseSnapshotEvent(
+      String payload, String sigHeader, String secret, long tolerance)
+      throws SignatureVerificationException {
+    com.stripe.model.Event event = Webhook.constructEvent(payload, sigHeader, secret, tolerance);
+    event.setResponseGetter(this.getResponseGetter());
+    return event;
+  }
+
   // The beginning of the section generated from our OpenAPI spec
   public com.stripe.service.AccountLinkService accountLinks() {
     return new com.stripe.service.AccountLinkService(this.getResponseGetter());

--- a/src/test/java/com/stripe/net/WebhookTest.java
+++ b/src/test/java/com/stripe/net/WebhookTest.java
@@ -7,10 +7,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.gson.JsonSyntaxException;
 import com.stripe.BaseStripeTest;
 import com.stripe.Stripe;
+import com.stripe.StripeClient;
 import com.stripe.exception.SignatureVerificationException;
 import com.stripe.exception.StripeException;
 import com.stripe.model.Account;
 import com.stripe.model.Event;
+import com.stripe.model.terminal.Reader;
+import java.lang.reflect.Type;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.time.Clock;
@@ -20,6 +23,8 @@ import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
 
 public class WebhookTest extends BaseStripeTest {
   public static String secret = null;
@@ -253,5 +258,71 @@ public class WebhookTest extends BaseStripeTest {
     final Clock clock = Clock.fixed(Instant.ofEpochMilli(12), ZoneId.of("UTC"));
 
     assertTrue(Webhook.Signature.verifyHeader(payload, sigHeader, secret, 10, clock));
+  }
+
+  @Test
+  public void testStripeClientConstructEvent()
+      throws StripeException, NoSuchAlgorithmException, InvalidKeyException {
+    StripeResponseGetter responseGetter = Mockito.spy(new LiveStripeResponseGetter());
+    StripeClient client = new StripeClient(responseGetter);
+
+    Mockito.doAnswer((Answer<Reader>) invocation -> new Reader())
+        .when(responseGetter)
+        .request(
+            Mockito.<ApiRequest>argThat(
+                (req) ->
+                    req.getMethod().equals(ApiResource.RequestMethod.DELETE)
+                        && req.getPath().equals("/v1/terminal/readers/rdr_123")),
+            Mockito.<Type>any());
+
+    final String payload =
+        "{\"id\": \"evt_test_webhook\",\"api_version\":\""
+            + Stripe.API_VERSION
+            + "\","
+            + "\"object\": \"event\",\"data\": {\"object\": {\"id\": \"rdr_123\",\"object\": \"terminal.reader\"}}}";
+
+    final Map<String, Object> options = new HashMap<>();
+    options.put("payload", payload);
+    final String sigHeader = generateSigHeader(options);
+
+    final Event event = client.parseSnapshotEvent(payload, sigHeader, secret);
+
+    final Reader reader = (Reader) event.getDataObjectDeserializer().getObject().get();
+    reader.delete();
+
+    Mockito.verify(responseGetter).request(Mockito.any(), Mockito.any());
+  }
+
+  @Test
+  public void testStripeClientConstructEventWithTolerance()
+      throws StripeException, NoSuchAlgorithmException, InvalidKeyException {
+    StripeResponseGetter responseGetter = Mockito.spy(new LiveStripeResponseGetter());
+    StripeClient client = new StripeClient(responseGetter);
+
+    Mockito.doAnswer((Answer<Reader>) invocation -> new Reader())
+        .when(responseGetter)
+        .request(
+            Mockito.argThat(
+                (req) ->
+                    req.getMethod().equals(ApiResource.RequestMethod.DELETE)
+                        && req.getPath().equals("/v1/terminal/readers/rdr_123")),
+            Mockito.any());
+
+    final String payload =
+        "{\"id\": \"evt_test_webhook\",\"api_version\":\""
+            + Stripe.API_VERSION
+            + "\","
+            + "\"object\": \"event\",\"data\": {\"object\": {\"id\": \"rdr_123\",\"object\": \"terminal.reader\"}}}";
+
+    final Map<String, Object> options = new HashMap<>();
+    options.put("payload", payload);
+    final String sigHeader = generateSigHeader(options);
+
+    final Event event = client.parseSnapshotEvent(payload, sigHeader, secret, 500);
+
+    final Reader reader = (Reader) event.getDataObjectDeserializer().getObject().get();
+    reader.delete();
+
+    Mockito.verify(responseGetter).request(Mockito.any(), Mockito.any());
   }
 }

--- a/src/test/java/com/stripe/net/WebhookTest.java
+++ b/src/test/java/com/stripe/net/WebhookTest.java
@@ -285,7 +285,7 @@ public class WebhookTest extends BaseStripeTest {
     options.put("payload", payload);
     final String sigHeader = generateSigHeader(options);
 
-    final Event event = client.parseSnapshotEvent(payload, sigHeader, secret);
+    final Event event = client.constructEvent(payload, sigHeader, secret);
 
     final Reader reader = (Reader) event.getDataObjectDeserializer().getObject().get();
     reader.delete();
@@ -318,7 +318,7 @@ public class WebhookTest extends BaseStripeTest {
     options.put("payload", payload);
     final String sigHeader = generateSigHeader(options);
 
-    final Event event = client.parseSnapshotEvent(payload, sigHeader, secret, 500);
+    final Event event = client.constructEvent(payload, sigHeader, secret, 500);
 
     final Reader reader = (Reader) event.getDataObjectDeserializer().getObject().get();
     reader.delete();


### PR DESCRIPTION
## Why?

We actually don't want to call this parseSnapshotEvent for now. We are thinking of unifying our snapshot and thin event parsers soon, so let's leave this as is.