### PR TITLE
Add livemode as a field in ThinEvent

### DIFF
--- a/src/main/java/com/stripe/model/ThinEvent.java
+++ b/src/main/java/com/stripe/model/ThinEvent.java
@@ -24,7 +24,7 @@ public class ThinEvent {
   @SerializedName("created")
   public Instant created;
 
-  /** Livemode indicates if the event is from a production(true) or test(false) account.  */
+  /** Livemode indicates if the event is from a production(true) or test(false) account. */
   @SerializedName("livemode")
   public Boolean livemode;
 

--- a/src/main/java/com/stripe/model/ThinEvent.java
+++ b/src/main/java/com/stripe/model/ThinEvent.java
@@ -24,6 +24,10 @@ public class ThinEvent {
   @SerializedName("created")
   public Instant created;
 
+  /** Livemode indicates if the event is from a production(true) or test(false) account.  */
+  @SerializedName("livemode")
+  public Boolean livemode;
+
   /** [Optional] Authentication context needed to fetch the event or related object. */
   @SerializedName("context")
   public String context;
@@ -31,4 +35,8 @@ public class ThinEvent {
   /** [Optional] Object containing the reference to API resource relevant to the event. */
   @SerializedName("related_object")
   public ThinEventRelatedObject relatedObject;
+
+  /** [Optional] Reason for the event. */
+  @SerializedName("reason")
+  public com.stripe.model.v2.Event.Reason reason;
 }

--- a/src/test/java/com/stripe/StripeClientTest.java
+++ b/src/test/java/com/stripe/StripeClientTest.java
@@ -151,6 +151,7 @@ public class StripeClientTest extends BaseStripeTest {
           + "  \"id\": \"evt_234\",\n"
           + "  \"object\": \"event\",\n"
           + "  \"type\": \"financial_account.balance.opened\",\n"
+          + "  \"livemode\": \"false\",\n"
           + "  \"created\": \"2022-02-15T00:27:45.330Z\",\n"
           + "  \"context\": \"context 123\",\n"
           + "  \"related_object\": {\n"
@@ -166,6 +167,7 @@ public class StripeClientTest extends BaseStripeTest {
           + "  \"id\": \"evt_234\",\n"
           + "  \"object\": \"event\",\n"
           + "  \"type\": \"financial_account.balance.opened\",\n"
+          + "  \"livemode\": \"false\",\n"
           + "  \"created\": \"2022-02-15T00:27:45.330Z\"\n"
           + "}";
 

--- a/src/test/java/com/stripe/StripeClientTest.java
+++ b/src/test/java/com/stripe/StripeClientTest.java
@@ -151,7 +151,7 @@ public class StripeClientTest extends BaseStripeTest {
           + "  \"id\": \"evt_234\",\n"
           + "  \"object\": \"event\",\n"
           + "  \"type\": \"financial_account.balance.opened\",\n"
-          + "  \"livemode\": \"false\",\n"
+          + "  \"livemode\": false,\n"
           + "  \"created\": \"2022-02-15T00:27:45.330Z\",\n"
           + "  \"context\": \"context 123\",\n"
           + "  \"related_object\": {\n"
@@ -167,7 +167,7 @@ public class StripeClientTest extends BaseStripeTest {
           + "  \"id\": \"evt_234\",\n"
           + "  \"object\": \"event\",\n"
           + "  \"type\": \"financial_account.balance.opened\",\n"
-          + "  \"livemode\": \"false\",\n"
+          + "  \"livemode\": false,\n"
           + "  \"created\": \"2022-02-15T00:27:45.330Z\"\n"
           + "}";
 


### PR DESCRIPTION
## Why?

This field is being returned from the API. It should be typed in our SDKs.


## Changelog

* Update the class for `ThinEvent` to include `livemode` and `reason`