### PR TITLE
update object tags for meter-related classes

### DIFF
--- a/src/main/java/com/stripe/model/v2/EventDataClassLookup.java
+++ b/src/main/java/com/stripe/model/v2/EventDataClassLookup.java
@@ -18,11 +18,12 @@ public final class EventDataClassLookup {
   static {
     classLookup.put("billing.meter", com.stripe.model.billing.Meter.class);
 
-    classLookup.put("billing.meter_event", com.stripe.model.v2.billing.MeterEvent.class);
+    classLookup.put("v2.billing.meter_event", com.stripe.model.v2.billing.MeterEvent.class);
     classLookup.put(
-        "billing.meter_event_adjustment", com.stripe.model.v2.billing.MeterEventAdjustment.class);
+        "v2.billing.meter_event_adjustment",
+        com.stripe.model.v2.billing.MeterEventAdjustment.class);
     classLookup.put(
-        "billing.meter_event_session", com.stripe.model.v2.billing.MeterEventSession.class);
+        "v2.billing.meter_event_session", com.stripe.model.v2.billing.MeterEventSession.class);
 
     classLookup.put("v2.core.event", com.stripe.model.v2.Event.class);
 

--- a/src/main/java/com/stripe/model/v2/billing/MeterEvent.java
+++ b/src/main/java/com/stripe/model/v2/billing/MeterEvent.java
@@ -39,7 +39,7 @@ public class MeterEvent extends StripeObject {
    * String representing the object's type. Objects of the same type share the same value of the
    * object field.
    *
-   * <p>Equal to {@code billing.meter_event}.
+   * <p>Equal to {@code v2.billing.meter_event}.
    */
   @SerializedName("object")
   String object;

--- a/src/main/java/com/stripe/model/v2/billing/MeterEventAdjustment.java
+++ b/src/main/java/com/stripe/model/v2/billing/MeterEventAdjustment.java
@@ -41,7 +41,7 @@ public class MeterEventAdjustment extends StripeObject implements HasId {
    * String representing the object's type. Objects of the same type share the same value of the
    * object field.
    *
-   * <p>Equal to {@code billing.meter_event_adjustment}.
+   * <p>Equal to {@code v2.billing.meter_event_adjustment}.
    */
   @SerializedName("object")
   String object;
@@ -63,6 +63,10 @@ public class MeterEventAdjustment extends StripeObject implements HasId {
   @SerializedName("type")
   String type;
 
+  /**
+   * For more details about Cancel, please refer to the <a href="https://docs.stripe.com/api">API
+   * Reference.</a>
+   */
   @Getter
   @Setter
   @EqualsAndHashCode(callSuper = false)

--- a/src/main/java/com/stripe/model/v2/billing/MeterEventSession.java
+++ b/src/main/java/com/stripe/model/v2/billing/MeterEventSession.java
@@ -44,7 +44,7 @@ public class MeterEventSession extends StripeObject implements HasId {
    * String representing the object's type. Objects of the same type share the same value of the
    * object field.
    *
-   * <p>Equal to {@code billing.meter_event_session}.
+   * <p>Equal to {@code v2.billing.meter_event_session}.
    */
   @SerializedName("object")
   String object;

--- a/src/test/java/com/stripe/RawRequestTest.java
+++ b/src/test/java/com/stripe/RawRequestTest.java
@@ -305,7 +305,7 @@ public class RawRequestTest extends BaseStripeTest {
     server.enqueue(
         new MockResponse()
             .setBody(
-                "{\"object\":\"billing.meter_event\",\"created\":\"2024-10-01T04:46:22.861Z\",\"event_name\":\"new_meter\",\"identifier\":\"d8a5ab2e-81ec-4bdf-acbf-48bf346\",\"livemode\":false,\"payload\":{\"stripe_customer_id\":\"cus_QvF3b2W6\",\"value\":\"25\"},\"timestamp\":\"2024-10-01T04:46:22.836Z\"}"));
+                "{\"object\":\"v2.billing.meter_event\",\"created\":\"2024-10-01T04:46:22.861Z\",\"event_name\":\"new_meter\",\"identifier\":\"d8a5ab2e-81ec-4bdf-acbf-48bf346\",\"livemode\":false,\"payload\":{\"stripe_customer_id\":\"cus_QvF3b2W6\",\"value\":\"25\"},\"timestamp\":\"2024-10-01T04:46:22.836Z\"}"));
 
     final RawRequestOptions options = RawRequestOptions.builder().setApiKey("sk_123").build();
     String param =


### PR DESCRIPTION
CI failures are expected because stripe-mock doesn't yet have the changes these this PR is responding to

## Changelog

- fixes a bug where the `object` property of the `MeterEvent`, `MeterEventAdjustment`, and `MeterEventSession` didn't match the server.