### PR TITLE
Update webhook API version validation

### DIFF
--- a/src/main/java/com/stripe/model/EventDataObjectDeserializer.java
+++ b/src/main/java/com/stripe/model/EventDataObjectDeserializer.java
@@ -206,15 +206,15 @@ public class EventDataObjectDeserializer {
     }
 
     // If the event api version is from before we started adding
-    // a release train, there's no way its compatible with this
+    // a major release identifier, there's no way its compatible with this
     // version
     if (!this.apiVersion.contains(".")) {
       return false;
     }
 
-    // versions are yyyy-MM-dd.train
-    String eventReleaseTrain = this.apiVersion.split("\\.")[1];
-    String currentReleaseTrain = getIntegrationApiVersion().split("\\.")[1];
+    // versions are yyyy-MM-dd.releaseIdentifier
+    String eventReleaseTrain = this.apiVersion.split("\\.", 2)[1];
+    String currentReleaseTrain = getIntegrationApiVersion().split("\\.", 2)[1];
     return eventReleaseTrain.equals(currentReleaseTrain);
   }
 

--- a/src/main/java/com/stripe/model/EventDataObjectDeserializer.java
+++ b/src/main/java/com/stripe/model/EventDataObjectDeserializer.java
@@ -198,10 +198,17 @@ public class EventDataObjectDeserializer {
 
   private boolean apiVersionMatch() {
 
+    // Preserved for testing; we have tests that hook getIntegrationApiVersion
+    // to test with other api versions.
+    String currentApiVersion = getIntegrationApiVersion();
+    if (!currentApiVersion.contains(".")) {
+      return this.apiVersion.equals(currentApiVersion);
+    }
+
     // If the event api version is from before we started adding
     // a release train, there's no way its compatible with this
     // version
-    if (this.apiVersion.indexOf(".") < 0) {
+    if (!this.apiVersion.contains(".")) {
       return false;
     }
 

--- a/src/main/java/com/stripe/model/EventDataObjectDeserializer.java
+++ b/src/main/java/com/stripe/model/EventDataObjectDeserializer.java
@@ -197,7 +197,18 @@ public class EventDataObjectDeserializer {
   }
 
   private boolean apiVersionMatch() {
-    return getIntegrationApiVersion().equals(this.apiVersion);
+
+    // If the event api version is from before we started adding
+    // a release train, there's no way its compatible with this
+    // version
+    if (this.apiVersion.indexOf(".") < 0) {
+      return false;
+    }
+
+    // versions are yyyy-MM-dd.train
+    String eventReleaseTrain = this.apiVersion.split("\\.")[1];
+    String currentReleaseTrain = getIntegrationApiVersion().split("\\.")[1];
+    return eventReleaseTrain.equals(currentReleaseTrain);
   }
 
   /** Internal method to allow for testing with different Stripe version. */

--- a/src/test/java/com/stripe/functional/EventTest.java
+++ b/src/test/java/com/stripe/functional/EventTest.java
@@ -55,7 +55,7 @@ public class EventTest extends BaseStripeTest {
   }
 
   @Test
-  public void tesGetDataObjectWithSameApiVersion() throws StripeException {
+  public void testGetDataObjectWithSameApiVersion() throws StripeException {
     final Event event = Event.retrieve(EVENT_ID);
     // Suppose event has the same API version as the library's pinned version
     event.setApiVersion(Stripe.API_VERSION);
@@ -66,10 +66,37 @@ public class EventTest extends BaseStripeTest {
   }
 
   @Test
-  public void tesGetDataObjectWithDifferentApiVersion() throws StripeException {
+  public void testGetDataObjectWithNewApiVersionInSameReleaseTrain() throws StripeException {
+    String expectedReleaseTrain = Stripe.API_VERSION.split("\\.")[1];
+    final Event event = Event.retrieve(EVENT_ID);
+    // Suppose event has a different API version within the same release train as the
+    // library's pinned version
+    event.setApiVersion("2999-10-10." + expectedReleaseTrain);
+
+    Optional<StripeObject> stripeObject = event.getDataObjectDeserializer().getObject();
+
+    assertTrue(stripeObject.isPresent());
+  }
+
+  @Test
+  public void testGetDataObjectWithLegacyApiVersion() throws StripeException {
     final Event event = Event.retrieve(EVENT_ID);
     // Suppose event has different API version from the library's pinned version
     event.setApiVersion("2017-05-25");
+
+    Optional<StripeObject> stripeObject = event.getDataObjectDeserializer().getObject();
+
+    // See compatibility helper in `EventDataObjectDeserializerTest` for
+    // handling schema incompatibility
+    assertFalse(stripeObject.isPresent());
+  }
+
+  @Test
+  public void testGetDataObjectWithReleaseTrainMismatch() throws StripeException {
+    final Event event = Event.retrieve(EVENT_ID);
+    // Suppose event has different API version and different release train from
+    // the libraries pinned version
+    event.setApiVersion("2999-10-10.the_larch");
 
     Optional<StripeObject> stripeObject = event.getDataObjectDeserializer().getObject();
 


### PR DESCRIPTION
### What
[Stripe API versions now contain two parts](https://stripe.com/blog/introducing-stripes-new-api-release-process): a date part (as before) and an identifier.  The SDKs validate that webhook events received are in the shape expected by the pinned version in the SDK but going forward, that will be true for different versions with the same identifier.  For example, the September API release was 2024-09-30.acacia, and we expect that webhook events sent with version 2024-09-30.acacia will be compatible with an SDK pinned to 2025-10-28.acacia.  This PR updates the version checking logic to make sure we don't reject webhook events incorrectly.

### What
- changed apiVersionMatch in EventDataObjectDeserializer to test if the release identifier of the webhook event api version matches the identifier of the pinned version.  this false for any api event version that does not have an identifier, except in specific test scenarios
- updated tests to match

## Changelog
- Update webhook event processing to accept events from any API version within the supported major release