### PR TITLE
Do not allow setting Stripe.stripeVersion

### DIFF
--- a/src/main/java/com/stripe/Stripe.java
+++ b/src/main/java/com/stripe/Stripe.java
@@ -4,6 +4,7 @@ import java.net.PasswordAuthentication;
 import java.net.Proxy;
 import java.util.HashMap;
 import java.util.Map;
+import lombok.Getter;
 
 public abstract class Stripe {
   public static final int DEFAULT_CONNECT_TIMEOUT = 30 * 1000;
@@ -21,24 +22,30 @@ public abstract class Stripe {
   public static volatile boolean enableTelemetry = true;
 
   /**
-   * Stripe API version which is sent by default on requests. This can be updated to include beta
-   * headers.
-   *
-   * <p>Pointing to different API versions than {@code API_VERSION} can lead to deserialziation
-   * errors and should be avoided.
+   * Stripe API version which is sent by default on requests. This is set to the API version that is
+   * linked to this SDK version. Call {@link Stripe#addBetaVersion(String,String)} to add beta
+   * version information.
    */
-  public static volatile String stripeVersion = API_VERSION;
+  public static final String stripeVersion = API_VERSION;
+
+  // Used to set the default version in RequestOptions
+  @Getter private static String stripeVersionWithBetaHeaders = stripeVersion;
 
   /** Add a specified beta to the global Stripe API Version. Only call this method once per beta. */
   public static void addBetaVersion(String betaName, String betaVersion) {
-    if (stripeVersion.indexOf("; " + betaName + "=") >= 0) {
+    if (stripeVersionWithBetaHeaders.indexOf("; " + betaName + "=") >= 0) {
       throw new RuntimeException(
           String.format(
               "Stripe version header %s already contains entry for beta %s",
-              stripeVersion, betaName));
+              stripeVersionWithBetaHeaders, betaName));
     }
 
-    stripeVersion = String.format("%s; %s=%s", stripeVersion, betaName, betaVersion);
+    stripeVersionWithBetaHeaders = String.format("%s; %s=%s", stripeVersion, betaName, betaVersion);
+  }
+
+  // For testing only.  This is not part of a stable API and could change in non-major versions.
+  public static void clearBetaVersion() {
+    stripeVersionWithBetaHeaders = stripeVersion;
   }
 
   // Note that URLConnection reserves the value of 0 to mean "infinite

--- a/src/main/java/com/stripe/model/EventDataObjectDeserializer.java
+++ b/src/main/java/com/stripe/model/EventDataObjectDeserializer.java
@@ -165,7 +165,10 @@ public class EventDataObjectDeserializer {
                     + "consider transforming the raw JSON data object to be compatible with this "
                     + "current model class schemas using `deserializeUnsafeWith`. "
                     + "Original error message: %s",
-                Stripe.stripeVersion, this.apiVersion, Stripe.stripeVersion, e.getMessage());
+                Stripe.getStripeVersionWithBetaHeaders(),
+                this.apiVersion,
+                Stripe.getStripeVersionWithBetaHeaders(),
+                e.getMessage());
       } else {
         errorMessage =
             String.format(

--- a/src/main/java/com/stripe/model/EventDataObjectDeserializer.java
+++ b/src/main/java/com/stripe/model/EventDataObjectDeserializer.java
@@ -195,15 +195,10 @@ public class EventDataObjectDeserializer {
   }
 
   private boolean apiVersionMatch() {
-    // Trim the locally configured API version to not include beta headers, since the payload won't
-    // have any.
-    String localApiVersion = StringUtils.trimApiVersion(Stripe.stripeVersion);
-    String eventApiVersion = StringUtils.trimApiVersion(this.apiVersion);
 
-    // Preserved for testing; we have tests that hook getIntegrationApiVersion
-    // to test with other api versions.
-    if (!localApiVersion.contains(".")) {
-      return eventApiVersion.equals(localApiVersion);
+    String eventApiVersion = StringUtils.trimApiVersion(this.apiVersion);
+    if (!Stripe.API_VERSION.contains(".")) {
+      return eventApiVersion.equals(Stripe.API_VERSION);
     }
 
     // If the event api version is from before we started adding
@@ -215,7 +210,7 @@ public class EventDataObjectDeserializer {
 
     // versions are yyyy-MM-dd.releaseIdentifier
     String eventReleaseTrain = eventApiVersion.split("\\.", 2)[1];
-    String currentReleaseTrain = localApiVersion.split("\\.", 2)[1];
+    String currentReleaseTrain = Stripe.API_VERSION.split("\\.", 2)[1];
     return eventReleaseTrain.equals(currentReleaseTrain);
   }
 

--- a/src/main/java/com/stripe/net/RequestOptions.java
+++ b/src/main/java/com/stripe/net/RequestOptions.java
@@ -17,8 +17,8 @@ public class RequestOptions {
   private final String stripeAccount;
 
   private final String baseUrl;
-  /** Uses the globally set version by defaeult, unless an override is provided. */
-  private final String stripeVersion = Stripe.stripeVersion;
+  /** Uses the globally set version by default, unless an override is provided. */
+  private final String stripeVersion = Stripe.getStripeVersionWithBetaHeaders();
 
   /**
    * Stripe version override when made on behalf of others. This can be used when the returned

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -46,7 +46,6 @@ public class BaseStripeTest {
   private String origApiKey;
   private String origClientId;
   private String origUploadBase;
-  private String origStripeVersion;
   protected static final String TEST_API_KEY = "sk_test_123";
 
   static {
@@ -117,7 +116,8 @@ public class BaseStripeTest {
     this.origUploadBase = Stripe.getUploadBase();
     this.origApiKey = Stripe.apiKey;
     this.origClientId = Stripe.clientId;
-    this.origStripeVersion = Stripe.stripeVersion;
+
+    Stripe.clearBetaVersion();
 
     Stripe.overrideApiBase("http://localhost:" + port);
     Stripe.overrideUploadBase("http://localhost:" + port);
@@ -145,7 +145,6 @@ public class BaseStripeTest {
     Stripe.overrideUploadBase(this.origUploadBase);
     Stripe.apiKey = this.origApiKey;
     Stripe.clientId = this.origClientId;
-    Stripe.stripeVersion = this.origStripeVersion;
   }
 
   /**

--- a/src/test/java/com/stripe/functional/StripeTest.java
+++ b/src/test/java/com/stripe/functional/StripeTest.java
@@ -11,9 +11,8 @@ public class StripeTest extends BaseStripeTest {
 
   @Test
   public void testAddBetaVersion() {
-    Stripe.stripeVersion = "2024-02-23";
     Stripe.addBetaVersion("super_cool_beta", "v1");
-    assertEquals(Stripe.stripeVersion, "2024-02-23; super_cool_beta=v1");
+    assertEquals(Stripe.stripeVersion, Stripe.API_VERSION + "; super_cool_beta=v1");
     assertThrows(
         RuntimeException.class,
         () -> {

--- a/src/test/java/com/stripe/functional/StripeTest.java
+++ b/src/test/java/com/stripe/functional/StripeTest.java
@@ -1,6 +1,7 @@
 package com.stripe.functional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.stripe.BaseStripeTest;
@@ -12,7 +13,9 @@ public class StripeTest extends BaseStripeTest {
   @Test
   public void testAddBetaVersion() {
     Stripe.addBetaVersion("super_cool_beta", "v1");
-    assertEquals(Stripe.stripeVersion, Stripe.API_VERSION + "; super_cool_beta=v1");
+    assertNotEquals(Stripe.stripeVersion, Stripe.API_VERSION + "; super_cool_beta=v1");
+    assertEquals(
+        Stripe.getStripeVersionWithBetaHeaders(), Stripe.API_VERSION + "; super_cool_beta=v1");
     assertThrows(
         RuntimeException.class,
         () -> {

--- a/src/test/java/com/stripe/net/RequestOptionsTest.java
+++ b/src/test/java/com/stripe/net/RequestOptionsTest.java
@@ -51,24 +51,6 @@ public class RequestOptionsTest extends BaseStripeTest {
   }
 
   @Test
-  public void testUsesGlobalStripeVersionWithDefault() {
-    String originalVersion = Stripe.stripeVersion;
-    assertEquals(originalVersion, RequestOptions.getDefault().getStripeVersion());
-
-    Stripe.stripeVersion = "2022-08-19";
-    assertEquals("2022-08-19", RequestOptions.getDefault().getStripeVersion());
-  }
-
-  @Test
-  public void testUsesGlobalStripeVersionWithBuilder() {
-    String originalVersion = Stripe.stripeVersion;
-    assertEquals(originalVersion, RequestOptions.builder().build().getStripeVersion());
-
-    Stripe.stripeVersion = "2022-08-19";
-    assertEquals("2022-08-19", RequestOptions.builder().build().getStripeVersion());
-  }
-
-  @Test
   public void testToBuilderFullCopy() {
     RequestOptions opts =
         RequestOptionsBuilder.unsafeSetStripeVersionOverride(

--- a/src/test/java/com/stripe/net/StripeRequestTest.java
+++ b/src/test/java/com/stripe/net/StripeRequestTest.java
@@ -1,3 +1,5 @@
+package com.stripe.net;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -8,7 +10,6 @@ import com.stripe.BaseStripeTest;
 import com.stripe.Stripe;
 import com.stripe.exception.AuthenticationException;
 import com.stripe.exception.StripeException;
-import com.stripe.net.*;
 import com.stripe.net.RequestOptions.RequestOptionsBuilder;
 import com.stripe.param.common.EmptyParam;
 import java.nio.charset.StandardCharsets;


### PR DESCRIPTION
## Why?

When we introduced beta SDKs, we allowed users to directly update the global configuration for API Version since they needed to pass beta headers in https://github.com/stripe/stripe-java/pull/1424. We soon realized that was not safe and was error prone if users didnt pass in the right format and so introduced a helper method in https://github.com/stripe/stripe-java/pull/1752 and advertised that as the right way of doing things in the README

Proper deserialization of classes from Events can be guaranteed only when the Webhook API version matches the API version used to generate the SDKs. Therefore, in this PR we are dropping the ability to directly update the API version.

## What?

- Make `Stripe.stripeVersion` final and initialized to the API version
- Add `Stripe.stripeVersionWithBetaHeaders` with public getter to hold the full api version + beta version string, and updated RequestOptions to use this by default
- Update `EventDataObjectDeserializer` to use the API_VERSION directly, and update api version mismatch to include the full stripe version with beta headers
- Update version mismatch tests to change the incoming event version instead of setting stripeVersion directly
- Fix package string on unrelated test so that tests pass without error in VS code

## Changelog
* `Stripe.stripeVersion` is no longer settable. If you were using this to set the beta headers, use the helper method `Stripe.addBetaVersion()` instead.

