### PR TITLE
Fix StripeException#getUserMessage on v1 API errors

### DIFF
--- a/src/main/java/com/stripe/exception/StripeException.java
+++ b/src/main/java/com/stripe/exception/StripeException.java
@@ -15,6 +15,8 @@ public abstract class StripeException extends Exception {
   // implement Serializable
   transient StripeError stripeError;
 
+  // This field and its getter are used internally and may change in a non-major version
+  // of the SDK
   ApiMode stripeErrorApiMode;
 
   public void setStripeError(StripeError err) {

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -409,7 +409,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
     error.setLastResponse(response);
     exception =
         new ApiException(error.getMessage(), response.requestId(), code, response.code(), null);
-    exception.setStripeError(error);
+    exception.setStripeV2Error(error);
     throw exception;
   }
 

--- a/src/test/java/com/stripe/exception/StripeExceptionTest.java
+++ b/src/test/java/com/stripe/exception/StripeExceptionTest.java
@@ -1,0 +1,61 @@
+package com.stripe.exception;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.google.gson.JsonObject;
+import com.stripe.BaseStripeTest;
+import com.stripe.model.StripeError;
+import com.stripe.net.ApiMode;
+import com.stripe.net.ApiResource;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+public class StripeExceptionTest extends BaseStripeTest {
+
+  @Test
+  public void testSetStripeError() throws IOException {
+    final String data = getResourceAsString("/api_fixtures/error_invalid_request.json");
+    final JsonObject jsonObject =
+        ApiResource.GSON.fromJson(data, JsonObject.class).getAsJsonObject("error");
+    final StripeError error = ApiResource.GSON.fromJson(jsonObject, StripeError.class);
+    error.setUserMessage("it broke");
+
+    StripeException exception =
+        new StripeException(error.getMessage(), "1234", error.getCode(), 400) {};
+
+    exception.setStripeError(error);
+
+    assertNotNull(exception.getStripeError());
+    assertEquals(ApiMode.V1, exception.getStripeErrorApiMode());
+
+    assertEquals("parameter_unknown", exception.getCode());
+    assertEquals(
+        "Received unknown parameter: foo; code: parameter_unknown; request-id: 1234",
+        exception.getMessage());
+    assertEquals(error.getMessage(), exception.getUserMessage());
+  }
+
+  @Test
+  public void testSetStripeV2Error() throws IOException {
+    final String data = getResourceAsString("/api_fixtures/error_invalid_request.json");
+    final JsonObject jsonObject =
+        ApiResource.GSON.fromJson(data, JsonObject.class).getAsJsonObject("error");
+    final StripeError error = ApiResource.GSON.fromJson(jsonObject, StripeError.class);
+    StripeException exception =
+        new StripeException(error.getMessage(), "1234", error.getCode(), 400) {};
+    error.setUserMessage("it broke");
+
+    exception.setStripeV2Error(error);
+
+    assertNotNull(exception.getStripeError());
+    assertEquals(ApiMode.V2, exception.getStripeErrorApiMode());
+
+    assertNotNull(error);
+    assertEquals("parameter_unknown", exception.getCode());
+    assertEquals(
+        "Received unknown parameter: foo; code: parameter_unknown; request-id: 1234; user-message: it broke",
+        exception.getMessage());
+    assertEquals("it broke", exception.getUserMessage());
+  }
+}


### PR DESCRIPTION
### Why?
This issue https://github.com/stripe/stripe-java/issues/1899 reports that CardException#getUserMessage() returns null after upgrading to SDK v27.1.  The root cause is that the underlying StripeError#getUserMessage is only valid for v2 errors.  Because it is not present on v1 errors, it will be null in the StripeError object.  This PR fixes the issue by ensuring we only access the user message in StripeError for v2 errors.

### What
- Adds stripeErrorApiMode internal field to StripeException to store which API version returned the error
- Adds setStripeV2Error method to set the error and set the stripeErrorApiMode to V2; modified setStripeError to set the stripeErrorApiMode to V1
- Modifies StripeException getUserMessage to return error.getMessage() if we've wrapped a v1 error
- Modifies StripeException getMessage to not include user message if we've wrapped a v1 error
- Adds unit tests for setting v1 and v2 errors in StripeException
