### PR TITLE
Fix multiple calls to addBetaVersion

### DIFF
--- a/src/main/java/com/stripe/Stripe.java
+++ b/src/main/java/com/stripe/Stripe.java
@@ -40,7 +40,8 @@ public abstract class Stripe {
               stripeVersionWithBetaHeaders, betaName));
     }
 
-    stripeVersionWithBetaHeaders = String.format("%s; %s=%s", stripeVersion, betaName, betaVersion);
+    stripeVersionWithBetaHeaders =
+        String.format("%s; %s=%s", stripeVersionWithBetaHeaders, betaName, betaVersion);
   }
 
   // For testing only.  This is not part of a stable API and could change in non-major versions.

--- a/src/test/java/com/stripe/functional/StripeTest.java
+++ b/src/test/java/com/stripe/functional/StripeTest.java
@@ -22,4 +22,23 @@ public class StripeTest extends BaseStripeTest {
           Stripe.addBetaVersion("super_cool_beta", "v1");
         });
   }
+
+  @Test
+  public void testAddSecondBetaVersion() {
+    Stripe.addBetaVersion("super_cool_beta", "v1");
+    assertNotEquals(Stripe.stripeVersion, Stripe.API_VERSION + "; super_cool_beta=v1");
+    assertEquals(
+        Stripe.API_VERSION + "; super_cool_beta=v1", Stripe.getStripeVersionWithBetaHeaders());
+
+    Stripe.addBetaVersion("super_hot_beta", "v2");
+    assertNotEquals(Stripe.stripeVersion, Stripe.API_VERSION + "; super_cool_beta=v1");
+    assertEquals(
+        Stripe.API_VERSION + "; super_cool_beta=v1; super_hot_beta=v2",
+        Stripe.getStripeVersionWithBetaHeaders());
+    assertThrows(
+        RuntimeException.class,
+        () -> {
+          Stripe.addBetaVersion("super_hot_beta", "v1");
+        });
+  }
 }


### PR DESCRIPTION
### Why
Follow up to https://github.com/stripe/stripe-java/pull/1909.  In that PR, we made stripeVersion immutable and changed addBetaVersion to modify a new variable.  In that process, we removed the ability for a user to set multiple different beta versions.  This PR restores this functionality.

### What
- replaces `stripeVersion` with `stripeVersionWithBetaHeaders` when constructing the new `stripeVersionWithBetaHeaders` in `addBetaVersion`
- added test for adding multiple different beta versions
