### PR TITLE
Restore `testReportsRawRequestUsageTelemetry` test

### DIFF
--- a/src/test/java/com/stripe/StripeClientTest.java
+++ b/src/test/java/com/stripe/StripeClientTest.java
@@ -60,8 +60,7 @@ public class StripeClientTest extends BaseStripeTest {
         });
   }
 
-  // TODO: https://go/j/DEVSDK-2178
-  // @Test
+  @Test
   public void testReportsRawRequestUsageTelemetry() throws StripeException {
     mockClient.rawRequest(
         com.stripe.net.ApiResource.RequestMethod.POST, "/v1/customers", "description=foo", null);


### PR DESCRIPTION
At some point this test was failing, but whatever issue there was seems to have been resolved.

fixes http://go/j/DEVSDK-2178