### PR TITLE
add justfile tweak readme, remove coveralls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: extractions/setup-just@v2
       - uses: actions/checkout@master
 
       - name: Setup Java
@@ -37,7 +38,7 @@ jobs:
         run: echo "JAVA_TEST_HOME=${{ steps.setup-jre.outputs.path }}" >> $GITHUB_ENV
 
       - name: Spotless
-        run: ./gradlew spotlessCheck
+        run: just format-check
 
       - name: Build artifacts
         run: ./gradlew assemble javadoc
@@ -59,6 +60,7 @@ jobs:
           - "20"
 
     steps:
+      - uses: extractions/setup-just@v2
       - uses: actions/checkout@master
 
       - name: Setup Test Java Runtime
@@ -88,20 +90,13 @@ jobs:
 
       - uses: stripe/openapi/actions/stripe-mock@master
       - name: Run test suite
-        run: make ci-test
-
-      - name: Send code coverage report to coveralls.io
-        run: ./gradlew jacocoTestReport coveralls
-        if: env.COVERALLS_REPO_TOKEN && matrix.java-version == '17'
-        env:
-          CI_NAME: github-actions
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        run: just test
 
   publish:
     if: >-
-        ((github.event_name == 'workflow_dispatch') || (github.event_name == 'push')) &&
-        startsWith(github.ref, 'refs/tags/v') &&
-        endsWith(github.actor, '-stripe')
+      ((github.event_name == 'workflow_dispatch') || (github.event_name == 'push')) &&
+      startsWith(github.ref, 'refs/tags/v') &&
+      endsWith(github.actor, '-stripe')
     needs: [build, test]
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+# NOTE: this file is deprecated and slated for deletion; prefer using the equivalent `just` commands.
+
 .PHONY: update-version codegen-format
 update-version:
 	@echo "$(VERSION)" > VERSION

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Maven Central](https://img.shields.io/badge/maven--central-v28.2.0-blue)](https://mvnrepository.com/artifact/com.stripe/stripe-java)
 [![JavaDoc](http://img.shields.io/badge/javadoc-reference-blue.svg)](https://stripe.dev/stripe-java)
 [![Build Status](https://github.com/stripe/stripe-java/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/stripe/stripe-java/actions?query=branch%3Amaster)
-[![Coverage Status](https://coveralls.io/repos/github/stripe/stripe-java/badge.svg?branch=master)](https://coveralls.io/github/stripe/stripe-java?branch=master)
 
 The official [Stripe][stripe] Java client library.
 
@@ -308,6 +307,8 @@ go get -u github.com/stripe/stripe-mock
 stripe-mock
 ```
 
+We use [just](https://github.com/casey/just) for conveniently running development tasks. You can use them directly, or copy the commands out of the `justfile`. To our help docs, run `just`.
+
 To run all checks (tests and code formatting):
 
 ```sh
@@ -317,16 +318,20 @@ To run all checks (tests and code formatting):
 To run the tests:
 
 ```sh
-./gradlew test
+just test
+# or: ./gradlew test
 ```
 
 You can run particular tests by passing `--tests Class#method`. Make sure you
 use the fully qualified class name. For example:
 
 ```sh
-./gradlew test --tests com.stripe.model.AccountTest
-./gradlew test --tests com.stripe.functional.CustomerTest
-./gradlew test --tests com.stripe.functional.CustomerTest.testCustomerCreate
+just test-one com.stripe.model.AccountTest
+just test-one com.stripe.functional.CustomerTest
+just test-one com.stripe.functional.CustomerTest.testCustomerCreate
+# or: ./gradlew test --tests com.stripe.model.AccountTest
+# or: ./gradlew test --tests com.stripe.functional.CustomerTest
+# or: ./gradlew test --tests com.stripe.functional.CustomerTest.testCustomerCreate
 ```
 
 The library uses [Spotless][spotless] along with
@@ -335,7 +340,8 @@ formatted before PRs are submitted, otherwise CI will fail. Run the formatter
 with:
 
 ```sh
-./gradlew spotlessApply
+just format
+# or: ./gradlew spotlessApply
 ```
 
 The library uses [Project Lombok][lombok]. While it is not a requirement, you

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,6 @@ plugins {
     id "io.freefair.lombok" version "6.3.0"
     id "com.diffplug.spotless" version "6.4.0"
     id "net.ltgt.errorprone" version "2.0.2"
-    id "com.github.kt3k.coveralls" version "2.12.0"
     id "biz.aQute.bnd.builder" version "6.1.0"
     id "org.ajoberstar.git-publish" version "3.0.1"
 }
@@ -135,17 +134,6 @@ spotless {
         googleJavaFormat("1.7") // 1.7 is the last version that supports Java 8
         removeUnusedImports()
     }
-}
-
-jacocoTestReport {
-    reports {
-        xml.required = true // coveralls plugin depends on xml format report
-        html.required = true
-    }
-}
-
-coveralls {
-    jacocoReportPath "build/reports/jacoco/test/jacocoTestReport.xml"
 }
 
 gitPublish {

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-# set quiet
+set quiet
 
 import? '../sdk-codegen/justfile'
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,35 @@
+# set quiet
+
+import? '../sdk-codegen/justfile'
+
+_default:
+    just --list --unsorted
+
+# ⭐ run the whole test suite
+[no-exit-message]
+test *args:
+    ./gradlew test {{ args }}
+
+# run a single test
+test-one modelPath: (test "--tests" modelPath)
+
+# ⭐ format all files
+[no-exit-message]
+format:
+    ./gradlew spotlessApply
+
+# check, but don't change, the formatting
+[no-exit-message]
+format-check:
+    ./gradlew spotlessCheck
+
+# called by tooling
+[private]
+update-version version:
+    echo "{{ version }}" > VERSION
+    perl -pi -e 's|badge/maven--central-v[.\d\-\w]+-blue|badge/maven--central-v{{ version }}-blue|' README.md
+    perl -pi -e 's|https:\/\/search\.maven\.org\/remotecontent\?filepath=com\/stripe\/stripe-java\/[.\d\-\w]+\/stripe-java-[.\d\-\w]+.jar|https://search.maven.org/remotecontent?filepath=com/stripe/stripe-java/{{ version }}/stripe-java-{{ version }}.jar|' README.md
+    perl -pi -e 's|implementation "com\.stripe:stripe-java:[.\d\-\w]+"|implementation "com.stripe:stripe-java:{{ version }}"|' README.md
+    perl -pi -e 's|<version>[.\d\-\w]+<\/version>|<version>{{ version }}</version>|' README.md
+    perl -pi -e 's|VERSION_NAME=[.\d\-\w]+|VERSION_NAME={{ version }}|' gradle.properties
+    perl -pi -e 's|public static final String VERSION = "[.\d\-\w]+";|public static final String VERSION = "{{ version }}";|' src/main/java/com/stripe/Stripe.java


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

In an effort to modernize and simplify our local tooling, we're moving our dev commands from makefiles to [justfiles](https://github.com/casey/just). This is intended to be mostly a drop-in replacement, but some command names may change per standardization efforts.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- add justfile
- add just commands to CI
- tweak readme
- remove coveralls

### See Also
<!-- Include any links or additional information that help explain this change. -->

[DEVSDK-2325](https://go/j/DEVSDK-2325)