### PR TITLE
update justfile import & pin CI ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     name: Build
 
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-24.04"
 
     steps:
       - uses: extractions/setup-just@v2
@@ -46,7 +46,7 @@ jobs:
   test:
     name: Test
 
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-24.04"
 
     strategy:
       fail-fast: false
@@ -98,7 +98,7 @@ jobs:
       startsWith(github.ref, 'refs/tags/v') &&
       endsWith(github.actor, '-stripe')
     needs: [build, test]
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-24.04"
     steps:
       - uses: actions/checkout@master
       - name: Setup Java
@@ -138,7 +138,7 @@ jobs:
       !contains(github.ref, 'beta') &&
       endsWith(github.actor, '-stripe')
     needs: [build, test]
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-24.04"
     steps:
       - uses: actions/checkout@master
       - name: Setup Java
@@ -158,7 +158,7 @@ jobs:
           GRGIT_PASS: ${{ secrets.GITHUB_TOKEN }}
 
   compat:
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-24.04"
 
     steps:
       - name: Checkout repository

--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 set quiet
 
-import? '../sdk-codegen/justfile'
+import? '../sdk-codegen/utils.just'
 
 _default:
     just --list --unsorted


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

During this project, we changed where the shared justfile lived, so this import needed updating. We also pinned the ubuntu version to the latest supported so that it wouldn't auto-update on us.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

### See Also
<!-- Include any links or additional information that help explain this change. -->
