### PR TITLE
don't return dev messages in `getUserMessage()`

### DIFF
--- a/src/main/java/com/stripe/exception/StripeException.java
+++ b/src/main/java/com/stripe/exception/StripeException.java
@@ -64,13 +64,24 @@ public abstract class StripeException extends Exception {
   }
 
   /**
-   * Returns a developer-facing description of the exception, including the HTTP status code and
-   * request ID (if applicable).
+   * Returns a description of the issue suitable to show an end-user (if available).
+   *
+   * @return a string representation of the user facing exception (or `null`).
+   */
+  public String getUserMessage() {
+    if (this.stripeError == null) {
+      return null;
+    }
+    // pulls the `user_message` field, which _may_ be present in v2 errors
+    return this.stripeError.getUserMessage();
+  }
+
+  /**
+   * Returns a developer-facing description of the exception, including the HTTP status code and request ID (if applicable). Not suitable for showing to end users.
    *
    * @return a string representation of the exception.
    */
-  @Override
-  public String getMessage() {
+  public String getDebugMessage() {
     String additionalInfo = "";
     if (code != null) {
       additionalInfo += "; code: " + code;
@@ -84,19 +95,6 @@ public abstract class StripeException extends Exception {
       additionalInfo += "; user-message: " + userMessage;
     }
     return super.getMessage() + additionalInfo;
-  }
-
-  /**
-   * Returns a description of the issue suitable to show an end-user (if available).
-   *
-   * @return a string representation of the user facing exception (or null).
-   */
-  public String getUserMessage() {
-    // only V2 errors have (optional) user messages
-    if (this.getStripeError() != null && stripeErrorApiMode == ApiMode.V2) {
-      return this.getStripeError().getUserMessage();
-    }
-    return null;
   }
 
   public static StripeException parseV2Exception(

--- a/src/main/java/com/stripe/exception/StripeException.java
+++ b/src/main/java/com/stripe/exception/StripeException.java
@@ -64,8 +64,8 @@ public abstract class StripeException extends Exception {
   }
 
   /**
-   * Returns a description of the exception, including the HTTP status code and request ID (if
-   * applicable).
+   * Returns a developer-facing description of the exception, including the HTTP status code and
+   * request ID (if applicable).
    *
    * @return a string representation of the exception.
    */
@@ -79,25 +79,22 @@ public abstract class StripeException extends Exception {
       additionalInfo += "; request-id: " + requestId;
     }
     // a separate user message is only available on v2 errors
-    if (stripeErrorApiMode == ApiMode.V2 && this.getUserMessage() != null) {
-      additionalInfo += "; user-message: " + this.getUserMessage();
+    String userMessage = this.getUserMessage();
+    if (userMessage != null) {
+      additionalInfo += "; user-message: " + userMessage;
     }
     return super.getMessage() + additionalInfo;
   }
 
   /**
-   * Returns a description of the user facing exception
+   * Returns a description of the issue suitable to show an end-user (if available).
    *
-   * @return a string representation of the user facing exception.
+   * @return a string representation of the user facing exception (or null).
    */
   public String getUserMessage() {
-    if (this.getStripeError() != null) {
-      switch (stripeErrorApiMode) {
-        case V1:
-          return this.getStripeError().getMessage();
-        case V2:
-          return this.getStripeError().getUserMessage();
-      }
+    // only V2 errors have (optional) user messages
+    if (this.getStripeError() != null && stripeErrorApiMode == ApiMode.V2) {
+      return this.getStripeError().getUserMessage();
     }
     return null;
   }

--- a/src/test/java/com/stripe/exception/StripeExceptionTest.java
+++ b/src/test/java/com/stripe/exception/StripeExceptionTest.java
@@ -33,7 +33,8 @@ public class StripeExceptionTest extends BaseStripeTest {
     assertEquals(
         "Received unknown parameter: foo; code: parameter_unknown; request-id: 1234",
         exception.getMessage());
-    assertEquals(error.getMessage(), exception.getUserMessage());
+    // v1 errors don't have user messages
+    assertEquals(null, exception.getUserMessage());
   }
 
   @Test


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Per guidance in [V2 error guidelines](http://go/th/trh_doc_OxndOeFIEt3KHL), the `user_message` response field can be shown directly to users, but the `message` field is meant only for developers. The previous java implementation (https://github.com/stripe/stripe-java/pull/1911) conflated the two, which I worry may be confusing for users. I think the intended use case here is someting like:

1. stripe error happened!
1. if .getUserMessage() != null, return that to the user that triggered this action
1. otherwise, check which error class it is and handle/log accordingly

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- return `null` from `getUserMessage()` for v1 errors
- tweak docstrings
- simplify version checking logic
- update test

### See Also
<!-- Include any links or additional information that help explain this change. -->

- [DEVSDK-2262](https://go/j/DEVSDK-2262)
- [V2 error guidelines](http://go/th/trh_doc_OxndOeFIEt3KHL)

## Changelog

- `stripeException.getUserMessage()` now returns `null` for v1 errors instead of the developer-facing message
    - `getUserMessage()`, if non-null, can be passed directly to your users to explain what went wrong
    - if `getUserMessage()` is null, then you should handle the error as usual, per the [error handling docs](https://docs.stripe.com/error-handling?lang=java#catch-exceptions).