### PR TITLE
Updated upload artifact ci action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,7 @@ jobs:
           mv ../japi-compliance-checker/compat_reports/stripe-java/*/compat_report.html report.html
 
       - name: Upload report as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: JAPI Compliance Report
           path: report.html


### PR DESCRIPTION
### Why?
`upload-artifact@v3` is being deprecated https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/