### PR TITLE
Ensure `getRawJsonObject` returns data for constructed webhooks

### DIFF
--- a/src/main/java/com/stripe/net/Webhook.java
+++ b/src/main/java/com/stripe/net/Webhook.java
@@ -9,6 +9,7 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.time.Clock;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -72,6 +73,12 @@ public final class Webhook {
         StripeObject.deserializeStripeObject(
             payload, Event.class, ApiResource.getGlobalResponseGetter());
     Signature.verifyHeader(payload, sigHeader, secret, tolerance, clock);
+    // StripeObjects source their raw JSON object from their last response, but constructed webhooks don't have that
+    // in order to make the raw object available on parsed events, we fake the response.
+    if (event.getLastResponse() == null) {
+      event.setLastResponse(
+          new StripeResponse(200, HttpHeaders.of(Collections.emptyMap()), payload));
+    }
 
     return event;
   }

--- a/src/main/java/com/stripe/net/Webhook.java
+++ b/src/main/java/com/stripe/net/Webhook.java
@@ -73,7 +73,8 @@ public final class Webhook {
         StripeObject.deserializeStripeObject(
             payload, Event.class, ApiResource.getGlobalResponseGetter());
     Signature.verifyHeader(payload, sigHeader, secret, tolerance, clock);
-    // StripeObjects source their raw JSON object from their last response, but constructed webhooks don't have that
+    // StripeObjects source their raw JSON object from their last response, but constructed webhooks
+    // don't have that
     // in order to make the raw object available on parsed events, we fake the response.
     if (event.getLastResponse() == null) {
       event.setLastResponse(

--- a/src/test/java/com/stripe/net/WebhookTest.java
+++ b/src/test/java/com/stripe/net/WebhookTest.java
@@ -1,5 +1,6 @@
 package com.stripe.net;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -324,5 +325,14 @@ public class WebhookTest extends BaseStripeTest {
     reader.delete();
 
     Mockito.verify(responseGetter).request(Mockito.any(), Mockito.any());
+  }
+
+  @Test
+  public void testConstructEventWithRawJson()
+      throws StripeException, NoSuchAlgorithmException, InvalidKeyException {
+
+    final Event event = Webhook.constructEvent(payload, generateSigHeader(), secret);
+
+    assertNotNull(event.getRawJsonObject());
   }
 }


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

`StripeObject`s make their raw JSON available via `getRawJsonObject()`. But, that data is sourced from the `lastResponse` (the API call that created that object).  Constructed webhooks don't have a last response, so that raw object was unavailable. This fixes that.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- construct fake response during webhook parsing
- add test

### See Also
<!-- Include any links or additional information that help explain this change. -->

- https://github.com/stripe/stripe-java/issues/1945
- [RUN_DEVSDK-1470](https://go/j/RUN_DEVSDK-1470)