### PR TITLE
Support for StripeAccount in StripeClient, and StripeContext on V1

### DIFF
--- a/src/main/java/com/stripe/StripeClient.java
+++ b/src/main/java/com/stripe/StripeClient.java
@@ -431,6 +431,9 @@ public class StripeClient {
     private final String meterEventsBase;
 
     @Getter(onMethod_ = {@Override})
+    private final String stripeAccount;
+
+    @Getter(onMethod_ = {@Override})
     private final String stripeContext;
 
     ClientStripeResponseGetterOptions(
@@ -445,6 +448,7 @@ public class StripeClient {
         String filesBase,
         String connectBase,
         String meterEventsBase,
+        String stripeAccount,
         String stripeContext) {
       this.authenticator = authenticator;
       this.clientId = clientId;
@@ -457,6 +461,7 @@ public class StripeClient {
       this.filesBase = filesBase;
       this.connectBase = connectBase;
       this.meterEventsBase = meterEventsBase;
+      this.stripeAccount = stripeAccount;
       this.stripeContext = stripeContext;
     }
   }
@@ -481,6 +486,7 @@ public class StripeClient {
     private String filesBase = Stripe.UPLOAD_API_BASE;
     private String connectBase = Stripe.CONNECT_API_BASE;
     private String meterEventsBase = Stripe.METER_EVENTS_API_BASE;
+    private String stripeAccount;
     private String stripeContext;
 
     /**
@@ -667,6 +673,15 @@ public class StripeClient {
       return this.meterEventsBase;
     }
 
+    public StripeClientBuilder setStripeAccount(String account) {
+      this.stripeAccount = account;
+      return this;
+    }
+
+    public String getStripeAccount() {
+      return this.stripeAccount;
+    }
+
     public StripeClientBuilder setStripeContext(String context) {
       this.stripeContext = context;
       return this;
@@ -689,15 +704,16 @@ public class StripeClient {
       return new ClientStripeResponseGetterOptions(
           this.authenticator,
           this.clientId,
-          connectTimeout,
-          readTimeout,
-          maxNetworkRetries,
-          connectionProxy,
-          proxyCredential,
-          apiBase,
-          filesBase,
-          connectBase,
-          meterEventsBase,
+          this.connectTimeout,
+          this.readTimeout,
+          this.maxNetworkRetries,
+          this.connectionProxy,
+          this.proxyCredential,
+          this.apiBase,
+          this.filesBase,
+          this.connectBase,
+          this.meterEventsBase,
+          this.stripeAccount,
           this.stripeContext);
     }
   }

--- a/src/main/java/com/stripe/net/GlobalStripeResponseGetterOptions.java
+++ b/src/main/java/com/stripe/net/GlobalStripeResponseGetterOptions.java
@@ -73,6 +73,11 @@ public class GlobalStripeResponseGetterOptions extends StripeResponseGetterOptio
   }
 
   @Override
+  public String getStripeAccount() {
+    return null;
+  }
+
+  @Override
   public String getStripeContext() {
     return null;
   }

--- a/src/main/java/com/stripe/net/RequestOptions.java
+++ b/src/main/java/com/stripe/net/RequestOptions.java
@@ -462,7 +462,7 @@ public class RequestOptions {
           clientOptions.getClientId(), // clientId
           null, // idempotencyKey
           clientOptions.getStripeContext(), // stripeContext
-          null, // stripeAccount
+          clientOptions.getStripeAccount(), // stripeAccount
           null, // stripeVersionOverride
           null, // baseUrl
           clientOptions.getConnectTimeout(), // connectTimeout
@@ -481,7 +481,9 @@ public class RequestOptions {
         options.getStripeContext() != null
             ? options.getStripeContext()
             : clientOptions.getStripeContext(),
-        options.getStripeAccount(),
+        options.getStripeAccount() != null
+            ? options.getStripeAccount()
+            : clientOptions.getStripeAccount(),
         RequestOptions.unsafeGetStripeVersionOverride(options),
         options.getBaseUrl(),
         options.getConnectTimeout() != null

--- a/src/main/java/com/stripe/net/StripeRequest.java
+++ b/src/main/java/com/stripe/net/StripeRequest.java
@@ -311,17 +311,15 @@ public class StripeRequest {
       headerMap.put("Stripe-Version", Arrays.asList(options.getStripeVersion()));
     }
 
-    if (apiMode == ApiMode.V1) {
-      if (options.getStripeContext() != null) {
-        throw new UnsupportedOperationException("Context is not supported in V1 APIs");
-      }
-    } else {
-      if (options.getStripeContext() != null) {
-        headerMap.put("Stripe-Context", Arrays.asList(options.getStripeContext()));
-      }
+    if (apiMode == ApiMode.V2) {
       if (content != null) {
         headerMap.put("Content-Type", Arrays.asList(content.contentType()));
       }
+    }
+
+    // Stripe-Context
+    if (options.getStripeContext() != null) {
+      headerMap.put("Stripe-Context", Arrays.asList(options.getStripeContext()));
     }
 
     // Stripe-Account

--- a/src/main/java/com/stripe/net/StripeResponseGetterOptions.java
+++ b/src/main/java/com/stripe/net/StripeResponseGetterOptions.java
@@ -29,5 +29,7 @@ public abstract class StripeResponseGetterOptions {
 
   public abstract int getReadTimeout();
 
+  public abstract String getStripeAccount();
+
   public abstract String getStripeContext();
 }

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -146,6 +146,10 @@ public class BaseStripeTest {
     Stripe.clientId = this.origClientId;
   }
 
+  public static String getStripeMockUrl() {
+    return "http://localhost:" + port;
+  }
+
   /**
    * {@code params} and {@code options} defaults to {@code null}.
    *

--- a/src/test/java/com/stripe/net/StripeRequestTest.java
+++ b/src/test/java/com/stripe/net/StripeRequestTest.java
@@ -278,6 +278,19 @@ public class StripeRequestTest extends BaseStripeTest {
   }
 
   @Test
+  public void testBuildHeadersHasStripeAccount() throws StripeException {
+    StripeRequest request =
+        StripeRequest.create(
+            ApiResource.RequestMethod.POST,
+            "http://example.com/post",
+            null,
+            RequestOptions.builder().setStripeAccount("acct").setApiKey("123").build(),
+            ApiMode.V2);
+
+    assertEquals("acct", request.headers().firstValue("Stripe-Account").get());
+  }
+
+  @Test
   public void testBuildHeadersHasStripeContext() throws StripeException {
     StripeRequest request =
         StripeRequest.create(

--- a/src/test/java/com/stripe/net/TestStripeResponseGetterOptions.java
+++ b/src/test/java/com/stripe/net/TestStripeResponseGetterOptions.java
@@ -21,6 +21,7 @@ public class TestStripeResponseGetterOptions extends StripeResponseGetterOptions
   private final String filesBase;
   private final String connectBase;
   private final String meterEventsBase;
+  private final String stripeAccount;
   private final String stripeContext;
 
   public TestStripeResponseGetterOptions(
@@ -35,6 +36,7 @@ public class TestStripeResponseGetterOptions extends StripeResponseGetterOptions
       String filesBase,
       String connectBase,
       String meterEventsBase,
+      String stripeAccount,
       String stripeContext) {
     this.authenticator = authenticator;
     this.clientId = clientId;
@@ -47,6 +49,7 @@ public class TestStripeResponseGetterOptions extends StripeResponseGetterOptions
     this.filesBase = filesBase;
     this.connectBase = connectBase;
     this.meterEventsBase = meterEventsBase;
+    this.stripeAccount = stripeAccount;
     this.stripeContext = stripeContext;
   }
 }


### PR DESCRIPTION
### Why?
The SDK should support setting StripeAccount and StripeContext at the client level, and StripeClient should be accepted in the same way across V1 and V2 APIs.

### What?
- added StripeAccount to StripeClientBuilder
- removed v1 limitation on using StripeContext
- added tests

### See Also
<!-- Include any links or additional information that help explain this change. -->

## Changelog
* ⚠️ Adds `getStripeAccount` to `StripeResponseGetterOptions`.  If you have a class that extends `StripeResponseGetterOptions` you will need to implement this method.
* Adds `setStripeAccount` to StripeClientBuilder, so you can specify the Stripe-Account header at the client (instead of the individual request) level.