### PR TITLE
Update AddBetaVersion behavior

### DIFF
--- a/src/test/java/com/stripe/functional/StripeTest.java
+++ b/src/test/java/com/stripe/functional/StripeTest.java
@@ -16,11 +16,21 @@ public class StripeTest extends BaseStripeTest {
     assertNotEquals(Stripe.stripeVersion, Stripe.API_VERSION + "; super_cool_beta=v1");
     assertEquals(
         Stripe.getStripeVersionWithBetaHeaders(), Stripe.API_VERSION + "; super_cool_beta=v1");
-    assertThrows(
-        RuntimeException.class,
-        () -> {
-          Stripe.addBetaVersion("super_cool_beta", "v1");
-        });
+
+    // Add the same beta version again
+    Stripe.addBetaVersion("super_cool_beta", "v1");
+    assertEquals(
+      Stripe.getStripeVersionWithBetaHeaders(), Stripe.API_VERSION + "; super_cool_beta=v1");
+
+    // Add a higher beta version
+    Stripe.addBetaVersion("super_cool_beta", "v3");
+    assertEquals(
+      Stripe.getStripeVersionWithBetaHeaders(), Stripe.API_VERSION + "; super_cool_beta=v3");
+
+    // Add a lower beta version
+    Stripe.addBetaVersion("super_cool_beta", "v2");
+    assertEquals(
+      Stripe.getStripeVersionWithBetaHeaders(), Stripe.API_VERSION + "; super_cool_beta=v3");
   }
 
   @Test
@@ -35,10 +45,15 @@ public class StripeTest extends BaseStripeTest {
     assertEquals(
         Stripe.API_VERSION + "; super_cool_beta=v1; super_hot_beta=v2",
         Stripe.getStripeVersionWithBetaHeaders());
-    assertThrows(
-        RuntimeException.class,
-        () -> {
-          Stripe.addBetaVersion("super_hot_beta", "v1");
-        });
+
+    Stripe.addBetaVersion("super_hot_beta", "v1");
+    assertEquals(
+      Stripe.API_VERSION + "; super_cool_beta=v1; super_hot_beta=v2",
+      Stripe.getStripeVersionWithBetaHeaders());
+
+    Stripe.addBetaVersion("super_cool_beta", "v11");
+    assertEquals(
+      Stripe.API_VERSION + "; super_hot_beta=v1; super_cool_beta=v11",
+      Stripe.getStripeVersionWithBetaHeaders());
   }
 }


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
We agreed to allow re-setting an existing beta header.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- Validate beta version format to ensure it follows 'v<number>' pattern.
- Prevent adding a lower beta version if a higher version already exists.
- Update tests to cover new behavior for adding beta versions.


### See Also
<!-- Include any links or additional information that help explain this change. -->

## Changelog
- AddBetaVersion will use the highest version number used for a beta feature instead of return an `error` on a conflict as it had done previously.
