### PR TITLE
Remove tests that refer to fields that are being removed in the March release

### DIFF
--- a/src/test/java/com/stripe/model/ChargeTest.java
+++ b/src/test/java/com/stripe/model/ChargeTest.java
@@ -20,7 +20,6 @@ public class ChargeTest extends BaseStripeTest {
     assertNull(charge.getApplicationFeeObject());
     assertNull(charge.getBalanceTransactionObject());
     assertNull(charge.getCustomerObject());
-    assertNull(charge.getInvoiceObject());
     assertNull(charge.getOnBehalfOfObject());
     assertNull(charge.getReviewObject());
     assertNull(charge.getSourceTransferObject());
@@ -57,10 +56,6 @@ public class ChargeTest extends BaseStripeTest {
     assertNotNull(customer);
     assertNotNull(customer.getId());
     assertEquals(charge.getCustomer(), customer.getId());
-    final Invoice invoice = charge.getInvoiceObject();
-    assertNotNull(invoice);
-    assertNotNull(invoice.getId());
-    assertEquals(charge.getInvoice(), invoice.getId());
     final Account onBehalfOf = charge.getOnBehalfOfObject();
     assertNotNull(onBehalfOf);
     assertNotNull(onBehalfOf.getId());

--- a/src/test/java/com/stripe/model/InvoiceItemTest.java
+++ b/src/test/java/com/stripe/model/InvoiceItemTest.java
@@ -21,7 +21,6 @@ public class InvoiceItemTest extends BaseStripeTest {
     assertEquals("invoiceitem", invoiceItem.getObject());
     assertNull(invoiceItem.getCustomerObject());
     assertNull(invoiceItem.getInvoiceObject());
-    assertNull(invoiceItem.getSubscriptionObject());
   }
 
   @Test
@@ -40,10 +39,6 @@ public class InvoiceItemTest extends BaseStripeTest {
     assertNotNull(invoice);
     assertNotNull(invoice.getId());
     assertEquals(invoiceItem.getInvoice(), invoice.getId());
-    final Subscription subscription = invoiceItem.getSubscriptionObject();
-    assertNotNull(subscription);
-    assertNotNull(subscription.getId());
-    assertEquals(invoiceItem.getSubscription(), subscription.getId());
   }
 
   @Test

--- a/src/test/java/com/stripe/model/InvoiceTest.java
+++ b/src/test/java/com/stripe/model/InvoiceTest.java
@@ -16,7 +16,7 @@ public class InvoiceTest extends BaseStripeTest {
     assertNotNull(invoice);
     assertNotNull(invoice.getId());
     assertEquals("invoice", invoice.getObject());
-    assertNull(invoice.getChargeObject());
+    assertNull(invoice.getApplicationObject());
   }
 
   @Test
@@ -29,10 +29,6 @@ public class InvoiceTest extends BaseStripeTest {
     final Invoice invoice = ApiResource.GSON.fromJson(data, Invoice.class);
     assertNotNull(invoice);
     assertNotNull(invoice.getId());
-    final Charge charge = invoice.getChargeObject();
-    assertNotNull(charge);
-    assertNotNull(charge.getId());
-    assertEquals(invoice.getCharge(), charge.getId());
     final Customer customer = invoice.getCustomerObject();
     assertNotNull(customer);
     assertNotNull(customer.getId());

--- a/src/test/java/com/stripe/model/PaymentIntentTest.java
+++ b/src/test/java/com/stripe/model/PaymentIntentTest.java
@@ -72,10 +72,6 @@ public class PaymentIntentTest extends BaseStripeTest {
     assertNotNull(customer);
     assertNotNull(customer.getId());
     assertEquals(resource.getCustomer(), customer.getId());
-    final Invoice invoice = resource.getInvoiceObject();
-    assertNotNull(invoice);
-    assertNotNull(invoice.getId());
-    assertEquals(resource.getInvoice(), invoice.getId());
     final Account account = resource.getOnBehalfOfObject();
     assertNotNull(account);
     assertNotNull(account.getId());


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Additional failures that are happening due to field removals. I missed these since I didn't re-run the tests on latest-codegen-master.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

Remove tests with references to fields that have been removed.

### See Also
<!-- Include any links or additional information that help explain this change. -->
