### PR TITLE
beta SDKs should match API version exactly

### DIFF
--- a/src/main/java/com/stripe/model/EventDataObjectDeserializer.java
+++ b/src/main/java/com/stripe/model/EventDataObjectDeserializer.java
@@ -6,7 +6,6 @@ import com.stripe.Stripe;
 import com.stripe.exception.EventDataObjectDeserializationException;
 import com.stripe.net.ApiMode;
 import com.stripe.net.StripeResponseGetter;
-import com.stripe.util.StringUtils;
 import java.util.Map;
 import java.util.Optional;
 import lombok.EqualsAndHashCode;
@@ -198,23 +197,9 @@ public class EventDataObjectDeserializer {
   }
 
   private boolean apiVersionMatch() {
-
-    String eventApiVersion = StringUtils.trimApiVersion(this.apiVersion);
-    if (!Stripe.API_VERSION.contains(".")) {
-      return eventApiVersion.equals(Stripe.API_VERSION);
-    }
-
-    // If the event api version is from before we started adding
-    // a major release identifier, there's no way its compatible with this
-    // version
-    if (!eventApiVersion.contains(".")) {
-      return false;
-    }
-
-    // versions are yyyy-MM-dd.releaseIdentifier
-    String eventReleaseTrain = eventApiVersion.split("\\.", 2)[1];
-    String currentReleaseTrain = Stripe.API_VERSION.split("\\.", 2)[1];
-    return eventReleaseTrain.equals(currentReleaseTrain);
+    // for beta SDKs, API version must match exactly (because breaking
+    // changes are both more frequent and more likely)
+    return Stripe.API_VERSION.equals(this.apiVersion);
   }
 
   /**

--- a/src/test/java/com/stripe/functional/EventTest.java
+++ b/src/test/java/com/stripe/functional/EventTest.java
@@ -68,6 +68,20 @@ public class EventTest extends BaseStripeTest {
   }
 
   @Test
+  public void testGetDataObjectWithNewApiVersionInSameReleaseTrain() throws StripeException {
+    String expectedReleaseTrain = Stripe.API_VERSION.split("\\.")[1];
+    final Event event = Event.retrieve(EVENT_ID);
+    // Suppose event has a different API version within the same release train as the
+    // library's pinned version
+    event.setApiVersion("2999-10-10." + expectedReleaseTrain);
+
+    Optional<StripeObject> stripeObject = event.getDataObjectDeserializer().getObject();
+
+    // true in GA, but false in beta
+    assertFalse(stripeObject.isPresent());
+  }
+
+  @Test
   public void testGetDataObjectWithLegacyApiVersion() throws StripeException {
     final Event event = Event.retrieve(EVENT_ID);
     // Suppose event has different API version from the library's pinned version

--- a/src/test/java/com/stripe/functional/EventTest.java
+++ b/src/test/java/com/stripe/functional/EventTest.java
@@ -68,19 +68,6 @@ public class EventTest extends BaseStripeTest {
   }
 
   @Test
-  public void testGetDataObjectWithNewApiVersionInSameReleaseTrain() throws StripeException {
-    String expectedReleaseTrain = Stripe.API_VERSION.split("\\.")[1];
-    final Event event = Event.retrieve(EVENT_ID);
-    // Suppose event has a different API version within the same release train as the
-    // library's pinned version
-    event.setApiVersion("2999-10-10." + expectedReleaseTrain);
-
-    Optional<StripeObject> stripeObject = event.getDataObjectDeserializer().getObject();
-
-    assertTrue(stripeObject.isPresent());
-  }
-
-  @Test
   public void testGetDataObjectWithLegacyApiVersion() throws StripeException {
     final Event event = Event.retrieve(EVENT_ID);
     // Suppose event has different API version from the library's pinned version


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

During workshop, we discussed tightening the API version during Event deserialization in beta SDKs. Because breaking changes happen more frequently and more unexpectedly in beta environments, we decided that the beta SDKs should do an exact API version match instead of only matching on a release train.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- tweak `apiVersionMatch` to just do an exact string match
- update test to invert assertion

### See Also
<!-- Include any links or additional information that help explain this change. -->
