### PR TITLE
Xavdid/merge java beta & fix version matching tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,8 +19,8 @@
   "java.configuration.updateBuildConfiguration": "automatic",
   // LSP was ooming and it recommended this change
   // (jar) added -Xss8m so lombok would run without stack overflowing
-  "java.jdt.ls.vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx2G -Xms100m -Xlog:disable -Xss8m",
+  "java.jdt.ls.vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx4G -Xms100m -Xlog:disable -Xss8m",
   "java.test.config": {
-    "vmargs": [ "-Dstripe.disallowGlobalResponseGetterFallback=true"]
-  },
+    "vmargs": ["-Dstripe.disallowGlobalResponseGetterFallback=true"]
+  }
 }

--- a/src/main/java/com/stripe/model/EventDataObjectDeserializer.java
+++ b/src/main/java/com/stripe/model/EventDataObjectDeserializer.java
@@ -203,9 +203,9 @@ public class EventDataObjectDeserializer {
 
     // Preserved for testing; we have tests that hook getIntegrationApiVersion
     // to test with other api versions.
-    String currentApiVersion = getIntegrationApiVersion();
-    if (!currentApiVersion.contains(".")) {
-      return eventApiVersion.equals(currentApiVersion);
+    String sdkApiVersion = getIntegrationApiVersion();
+    if (!sdkApiVersion.contains(".")) {
+      return eventApiVersion.equals(sdkApiVersion);
     }
 
     // If the event api version is from before we started adding
@@ -216,15 +216,15 @@ public class EventDataObjectDeserializer {
     }
 
     // versions are yyyy-MM-dd.releaseIdentifier
-    String currentReleaseTrain = getIntegrationApiVersion().split("\\.", 2)[1];
+    String sdkReleaseTrain = sdkApiVersion.split("\\.", 2)[1];
 
     // beta SDKs have to match their API version exactly
-    if (currentReleaseTrain.equals("preview")) {
-      return eventApiVersion.equals(currentApiVersion);
+    if (sdkReleaseTrain.equals("preview")) {
+      return eventApiVersion.equals(sdkApiVersion);
     }
 
     String eventReleaseTrain = eventApiVersion.split("\\.", 2)[1];
-    return eventReleaseTrain.equals(currentReleaseTrain);
+    return eventReleaseTrain.equals(sdkReleaseTrain);
   }
 
   /** Internal method to allow for testing with different Stripe version. */

--- a/src/main/java/com/stripe/model/EventDataObjectDeserializer.java
+++ b/src/main/java/com/stripe/model/EventDataObjectDeserializer.java
@@ -198,10 +198,14 @@ public class EventDataObjectDeserializer {
   }
 
   private boolean apiVersionMatch() {
-
+    // the pure event API version, minus any beta signifiers
     String eventApiVersion = StringUtils.trimApiVersion(this.apiVersion);
-    if (!Stripe.API_VERSION.contains(".")) {
-      return eventApiVersion.equals(Stripe.API_VERSION);
+
+    // Preserved for testing; we have tests that hook getIntegrationApiVersion
+    // to test with other api versions.
+    String currentApiVersion = getIntegrationApiVersion();
+    if (!currentApiVersion.contains(".")) {
+      return eventApiVersion.equals(currentApiVersion);
     }
 
     // If the event api version is from before we started adding
@@ -212,9 +216,21 @@ public class EventDataObjectDeserializer {
     }
 
     // versions are yyyy-MM-dd.releaseIdentifier
+    String currentReleaseTrain = getIntegrationApiVersion().split("\\.", 2)[1];
+
+    // beta SDKs have to match their API version exactly
+    if (currentReleaseTrain.equals("preview")) {
+      return eventApiVersion.equals(currentApiVersion);
+    }
+
     String eventReleaseTrain = eventApiVersion.split("\\.", 2)[1];
-    String currentReleaseTrain = Stripe.API_VERSION.split("\\.", 2)[1];
     return eventReleaseTrain.equals(currentReleaseTrain);
+  }
+
+  /** Internal method to allow for testing with different Stripe version. */
+  String getIntegrationApiVersion() {
+    System.out.println("Stripe API version: " + Stripe.API_VERSION);
+    return Stripe.API_VERSION;
   }
 
   /**

--- a/src/test/java/com/stripe/functional/EventTest.java
+++ b/src/test/java/com/stripe/functional/EventTest.java
@@ -70,6 +70,13 @@ public class EventTest extends BaseStripeTest {
   @Test
   public void testGetDataObjectWithNewApiVersionInSameReleaseTrain() throws StripeException {
     String expectedReleaseTrain = Stripe.API_VERSION.split("\\.")[1];
+
+    // this test only makes sense on GA versions- the exact version for preview versions doesn't
+    // work this way and we can't mock private methods from this test class.
+    if (expectedReleaseTrain.equals("preview")) {
+      return;
+    }
+
     final Event event = Event.retrieve(EVENT_ID);
     // Suppose event has a different API version within the same release train as the
     // library's pinned version

--- a/src/test/java/com/stripe/model/EventDataObjectDeserializerTest.java
+++ b/src/test/java/com/stripe/model/EventDataObjectDeserializerTest.java
@@ -13,6 +13,7 @@ import com.stripe.net.ApiResource;
 import java.io.IOException;
 import java.util.HashMap;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 public class EventDataObjectDeserializerTest extends BaseStripeTest {
   private static final String OLD_EVENT_VERSION = "2013-08-15";
@@ -233,6 +234,13 @@ public class EventDataObjectDeserializerTest extends BaseStripeTest {
     assertEquals(event.getData().object.toString(), rawJson);
   }
 
+  private EventDataObjectDeserializer stubIntegrationApiVersion(
+      EventDataObjectDeserializer data, String stripeVersion) {
+    EventDataObjectDeserializer dataSpy = Mockito.spy(data);
+    Mockito.doReturn(stripeVersion).when(dataSpy).getIntegrationApiVersion();
+    return dataSpy;
+  }
+
   @Test
   public void testDeserializeSetsResponseGetter() throws Exception {
     final String data = getCurrentEventStringFixture();
@@ -243,5 +251,54 @@ public class EventDataObjectDeserializerTest extends BaseStripeTest {
 
     assertTrue(deserializer.getObject().isPresent());
     verifyDeserializedStripeObject(deserializer.getObject().get());
+  }
+
+  @Test
+  public void testGetDataObjectWithGaVersionMatch() throws Exception {
+    final String data = getCurrentEventStringFixture();
+    final Event event = ApiResource.GSON.fromJson(data, Event.class);
+
+    final String ApiVersion = "2025-04-01.basil";
+
+    // the SDK is on a preview version that is different from the preview version of the event
+    event.setApiVersion(ApiVersion);
+
+    EventDataObjectDeserializer deserializer =
+        stubIntegrationApiVersion(event.getDataObjectDeserializer(), "2025-04-01.basil");
+
+    assertTrue(deserializer.getObject().isPresent());
+  }
+
+  @Test
+  public void testGetDataObjectWithPreviewVersionMatch() throws Exception {
+    final String data = getCurrentEventStringFixture();
+    final Event event = ApiResource.GSON.fromJson(data, Event.class);
+
+    final String ApiVersion = "2025-04-01.preview";
+
+    // the SDK is on a preview version that is different from the preview version of the event
+    event.setApiVersion(ApiVersion);
+
+    EventDataObjectDeserializer deserializer =
+        stubIntegrationApiVersion(event.getDataObjectDeserializer(), ApiVersion);
+
+    assertTrue(deserializer.getObject().isPresent());
+  }
+
+  @Test
+  public void testGetDataObjectWithPreviewVersionMismatch() throws Exception {
+    final String data = getCurrentEventStringFixture();
+    final Event event = ApiResource.GSON.fromJson(data, Event.class);
+
+    final String eventApiVersion = "2025-04-01.preview";
+    final String sdkApiVersion = "2025-05-01.preview";
+
+    // the SDK is on a preview version that is different from the preview version of the event
+    event.setApiVersion(eventApiVersion);
+
+    EventDataObjectDeserializer deserializer =
+        stubIntegrationApiVersion(event.getDataObjectDeserializer(), sdkApiVersion);
+
+    assertFalse(deserializer.getObject().isPresent());
   }
 }


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

The merge script had a conflict which I fixed. But _then_ the tests I wrote in https://github.com/stripe/stripe-java/pull/1971 were failing. I added the helper methods we have in master and an extra test (noted in description)

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- `just merge java-beta`
- copy code that was in master to support mocking API versions in tests
- fix some tests

### See Also
<!-- Include any links or additional information that help explain this change. -->
