### PR TITLE
backport beta fixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,8 +19,9 @@
   "java.configuration.updateBuildConfiguration": "automatic",
   // LSP was ooming and it recommended this change
   // (jar) added -Xss8m so lombok would run without stack overflowing
-  "java.jdt.ls.vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx2G -Xms100m -Xlog:disable -Xss8m",
+  // (xavdid) added -Xmx8G so LSP would be happy
+  "java.jdt.ls.vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx8G -Xms100m -Xlog:disable -Xss8m",
   "java.test.config": {
-    "vmargs": [ "-Dstripe.disallowGlobalResponseGetterFallback=true"]
-  },
+    "vmargs": ["-Dstripe.disallowGlobalResponseGetterFallback=true"]
+  }
 }

--- a/src/test/java/com/stripe/functional/EventTest.java
+++ b/src/test/java/com/stripe/functional/EventTest.java
@@ -68,6 +68,13 @@ public class EventTest extends BaseStripeTest {
   @Test
   public void testGetDataObjectWithNewApiVersionInSameReleaseTrain() throws StripeException {
     String expectedReleaseTrain = Stripe.API_VERSION.split("\\.")[1];
+
+    // this test only makes sense on GA versions- the exact version for preview versions doesn't
+    // work this way and we can't mock private methods from this test class.
+    if (expectedReleaseTrain.equals("preview")) {
+      return;
+    }
+
     final Event event = Event.retrieve(EVENT_ID);
     // Suppose event has a different API version within the same release train as the
     // library's pinned version

--- a/src/test/java/com/stripe/model/EventDataObjectDeserializerTest.java
+++ b/src/test/java/com/stripe/model/EventDataObjectDeserializerTest.java
@@ -201,13 +201,29 @@ public class EventDataObjectDeserializerTest extends BaseStripeTest {
   }
 
   @Test
+  public void testGetDataObjectWithGaVersionMatch() throws Exception {
+    final String data = getCurrentEventStringFixture();
+    final Event event = ApiResource.GSON.fromJson(data, Event.class);
+
+    final String ApiVersion = "2025-04-01.basil";
+
+    // the SDK is on a GA version that matches the event version exactly
+    event.setApiVersion(ApiVersion);
+
+    EventDataObjectDeserializer deserializer =
+        stubIntegrationApiVersion(event.getDataObjectDeserializer(), ApiVersion);
+
+    assertTrue(deserializer.getObject().isPresent());
+  }
+
+  @Test
   public void testGetDataObjectWithPreviewVersionMatch() throws Exception {
     final String data = getCurrentEventStringFixture();
     final Event event = ApiResource.GSON.fromJson(data, Event.class);
 
     final String ApiVersion = "2025-04-01.preview";
 
-    // the SDK is on a preview version that is different from the preview version of the event
+    // the SDK is on a preview version that matches the event version exactly
     event.setApiVersion(ApiVersion);
 
     EventDataObjectDeserializer deserializer =
@@ -222,6 +238,40 @@ public class EventDataObjectDeserializerTest extends BaseStripeTest {
     final Event event = ApiResource.GSON.fromJson(data, Event.class);
 
     final String eventApiVersion = "2025-04-01.preview";
+    final String sdkApiVersion = "2025-05-01.preview";
+
+    // the SDK is on a preview version that is different from the preview version of the event
+    event.setApiVersion(eventApiVersion);
+
+    EventDataObjectDeserializer deserializer =
+        stubIntegrationApiVersion(event.getDataObjectDeserializer(), sdkApiVersion);
+
+    assertFalse(deserializer.getObject().isPresent());
+  }
+
+  @Test
+  public void testGetDataObjectWithGaVersionMismatch() throws Exception {
+    final String data = getCurrentEventStringFixture();
+    final Event event = ApiResource.GSON.fromJson(data, Event.class);
+
+    final String eventApiVersion = "2025-04-01.preview";
+    final String sdkApiVersion = "2025-05-01.basil";
+
+    // the SDK is on a preview version that is different from the preview version of the event
+    event.setApiVersion(eventApiVersion);
+
+    EventDataObjectDeserializer deserializer =
+        stubIntegrationApiVersion(event.getDataObjectDeserializer(), sdkApiVersion);
+
+    assertFalse(deserializer.getObject().isPresent());
+  }
+
+  @Test
+  public void testGetDataObjectWithGaPreviewVersionMismatch() throws Exception {
+    final String data = getCurrentEventStringFixture();
+    final Event event = ApiResource.GSON.fromJson(data, Event.class);
+
+    final String eventApiVersion = "2025-04-01.basil";
     final String sdkApiVersion = "2025-05-01.preview";
 
     // the SDK is on a preview version that is different from the preview version of the event


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

moves some fixes from https://github.com/stripe/stripe-java/pull/1975 to master. Also adds an additional test.

It _might_ create additional merge conflicts, but they should be easy to resolve.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- allow VSCode to use more memory
- skip a test for preview versions
- 

### See Also
<!-- Include any links or additional information that help explain this change. -->
