### PR TITLE
Update readme with clarification on resource based call patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ public class StripeExample {
 
 See the project's [functional tests][functional-tests] for more examples.
 
+### StripeClient vs legacy pattern
+
+We introduced the `StripeClient` class in v23 of the Java SDK. The legacy pattern used prior to that version is still available to use but will be marked as deprecated soon. Review the [migration guide to use StripeClient](https://github.com/stripe/stripe-java/wiki/Migration-guide-for-v23#stripeclient) to move from the legacy pattern.
+
+Once the legacy pattern is deprecated, new API endpoints will only be accessible in the StripeClient. While there are no current plans to remove the legacy pattern for existing API endpoints, this may change in the future.
+
 ### Per-request Configuration
 
 All of the request methods accept an optional `RequestOptions` object. This is


### PR DESCRIPTION
### Why?
The readme uses StripeClient while rest of Stripe docs still use the older resource based call patterns. Users will need some clarity until all the Stripe docs get updated in the coming months

### What?
Added a section in the readme just like we did in PHP a few years ago

