### PR TITLE
Include Java versions 21, 22, 23, 24 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,10 @@ jobs:
           - "18"
           - "19"
           - "20"
+          - "21"
+          - "22"
+          - "23"
+          - "24"
 
     steps:
       - uses: extractions/setup-just@v2


### PR DESCRIPTION
### Why?
In order to keep supporting new versions of PHP we need to test against them.

### What?
Added Java versions 21, 22, 23, 24 to our CI workflow. 

### See Also

