### PR TITLE
Rename beta SDKs to public preview SDKs in readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,18 +255,16 @@ You can disable this behavior if you prefer:
 Stripe.enableTelemetry = false;
 ```
 
-### Beta SDKs
+### Public Preview SDKs
 
-Stripe has features in the beta phase that can be accessed via the beta version of this package.
-We would love for you to try these and share feedback with us before these features reach the stable phase.
-To install a beta version of stripe-java follow steps [installation steps above](#installation) using the beta library version.
+Stripe has features in the [public preview phase](https://docs.stripe.com/release-phases) that can be accessed via the beta version of this package.
+We would love for you to try these as we incrementally release new features and improve them based on your feedback.
+To install the public preview SDK, pick the version you want to use from the [releases page](https://github.com/stripe/stripe-java/releases/) and then use it [installation steps above](#installation).
 
 > **Note**
-> There can be breaking changes between beta versions. Therefore we recommend pinning the package version to a specific version. This way you can install the same version each time without breaking changes unless you are intentionally looking for the latest beta version.
+> There can be breaking changes between two versions of the public preview SDKs without a bump in the major version. Therefore we recommend pinning the package version to a specific version. This way you can install the same version each time without breaking changes unless you are intentionally looking for the latest public preview SDK.
 
-We highly recommend keeping an eye on when the beta feature you are interested in goes from beta to stable so that you can move from using a beta version of the SDK to the stable version.
-
-If your beta feature requires a `Stripe-Version` header to be sent, set the `Stripe.stripeVersion` field by calling `Stripe.addBetaVersion`:
+If your beta feature requires a `Stripe-Version` header to be sent, set the `Stripe.stripeVersion` field by calling `Stripe.addBetaVersion` (available only in the public preview SDKs):
 
 > **Note**
 > Beta version headers can only be set in beta versions of the library.

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Stripe.enableTelemetry = false;
 Stripe has features in the [public preview phase](https://docs.stripe.com/release-phases) that can be accessed via the beta version of this package.
 We would love for you to try these as we incrementally release new features and improve them based on your feedback.
 
-The public preview SDKs are just a different version of the same package and are appended with `-beta.X` such as `45.0.0-beta.1`. To install, choose the version that includes support for the preview feature you are interested in by reviewing the [releases page](https://github.com/stripe/stripe-java/releases/) and then use it [installation steps above](#installation).
+The public preview SDKs are different version of the same package as the stable SDKs. These versions are appended with `-beta.X` such as `25.1.0-beta.1`. To install, choose the version that includes support for the preview feature you are interested in by reviewing the [releases page](https://github.com/stripe/stripe-java/releases/) and then use it [installation steps above](#installation).
 
 > **Note**
 > There can be breaking changes between two versions of the public preview SDKs without a bump in the major version. Therefore we recommend pinning the package version to a specific version. This way you can install the same version each time without breaking changes unless you are intentionally looking for the latest public preview SDK.

--- a/README.md
+++ b/README.md
@@ -259,7 +259,8 @@ Stripe.enableTelemetry = false;
 
 Stripe has features in the [public preview phase](https://docs.stripe.com/release-phases) that can be accessed via the beta version of this package.
 We would love for you to try these as we incrementally release new features and improve them based on your feedback.
-To install the public preview SDK, pick the version you want to use from the [releases page](https://github.com/stripe/stripe-java/releases/) and then use it [installation steps above](#installation).
+
+The public preview SDKs are just a different version of the same package and are appended with `-beta.X` such as `45.0.0-beta.1`. To install, choose the version that includes support for the preview feature you are interested in by reviewing the [releases page](https://github.com/stripe/stripe-java/releases/) and then use it [installation steps above](#installation).
 
 > **Note**
 > There can be breaking changes between two versions of the public preview SDKs without a bump in the major version. Therefore we recommend pinning the package version to a specific version. This way you can install the same version each time without breaking changes unless you are intentionally looking for the latest public preview SDK.

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Stripe.enableTelemetry = false;
 Stripe has features in the [public preview phase](https://docs.stripe.com/release-phases) that can be accessed via the beta version of this package.
 We would love for you to try these as we incrementally release new features and improve them based on your feedback.
 
-The public preview SDKs are different version of the same package as the stable SDKs. These versions are appended with `-beta.X` such as `25.1.0-beta.1`. To install, choose the version that includes support for the preview feature you are interested in by reviewing the [releases page](https://github.com/stripe/stripe-java/releases/) and then use it [installation steps above](#installation).
+The public preview SDKs are different versions of the same package as the stable SDKs. These versions are appended with `-beta.X` such as `25.1.0-beta.1`. To install, choose the version that includes support for the preview feature you are interested in by reviewing the [releases page](https://github.com/stripe/stripe-java/releases/) and then use it [installation steps above](#installation).
 
 > **Note**
 > There can be breaking changes between two versions of the public preview SDKs without a bump in the major version. Therefore we recommend pinning the package version to a specific version. This way you can install the same version each time without breaking changes unless you are intentionally looking for the latest public preview SDK.


### PR DESCRIPTION
### Why?
Beta SDKs are being re-branded as public preview SDKs

### What?
- Reword the beta SDKs section to use the term "public preview" unless talking about the actual version string
- Link to https://docs.stripe.com/release-phases and re-use verbiage from there
- Add info as to how to find the beta versions


