### PR TITLE
Simplify public preview SDK instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,18 +257,15 @@ Stripe.enableTelemetry = false;
 
 ### Public Preview SDKs
 
-Stripe has features in the [public preview phase](https://docs.stripe.com/release-phases) that can be accessed via the beta version of this package.
+Stripe has features in the [public preview phase](https://docs.stripe.com/release-phases) that can be accessed via versions of this package that have the `-beta.X` suffix like `25.2.0-beta.2`.
 We would love for you to try these as we incrementally release new features and improve them based on your feedback.
 
-The public preview SDKs are different versions of the same package as the stable SDKs. These versions are appended with `-beta.X` such as `25.1.0-beta.1`. To install, choose the version that includes support for the preview feature you are interested in by reviewing the [releases page](https://github.com/stripe/stripe-java/releases/) and then use it [installation steps above](#installation).
+ To install, choose the version that includes support for the preview feature you are interested in by reviewing the [releases page](https://github.com/stripe/stripe-java/releases/) and then use it [installation steps above](#installation).
 
 > **Note**
 > There can be breaking changes between two versions of the public preview SDKs without a bump in the major version. Therefore we recommend pinning the package version to a specific version. This way you can install the same version each time without breaking changes unless you are intentionally looking for the latest public preview SDK.
 
-If your beta feature requires a `Stripe-Version` header to be sent, set the `Stripe.stripeVersion` field by calling `Stripe.addBetaVersion` (available only in the public preview SDKs):
-
-> **Note**
-> Beta version headers can only be set in beta versions of the library.
+Some preview features require a name and version to be set in the `Stripe-Version` header like `feature_beta=v3`. If your preview feature has this requirement, use the `Stripe.addBetaVersion` function (available only in the public preview SDKs):
 
 ```java
 Stripe.addBetaVersion("feature_beta", "v3");


### PR DESCRIPTION
### Why?
Follow up to https://github.com/stripe/stripe-java/pull/1998

### What?
- Avoid mentioning "beta version"
- Add more explanation to beta header usage

