### PR TITLE
Adds generated Customer retrievePaymentMethod overload

### DIFF
--- a/src/main/java/com/stripe/model/Customer.java
+++ b/src/main/java/com/stripe/model/Customer.java
@@ -658,6 +658,12 @@ public class Customer extends ApiResource implements HasId, MetadataStore<Custom
   }
 
   /** Retrieves a PaymentMethod object for a given Customer. */
+  public PaymentMethod retrievePaymentMethod(String paymentMethod, RequestOptions options)
+      throws StripeException {
+    return retrievePaymentMethod(paymentMethod, (Map<String, Object>) null, options);
+  }
+
+  /** Retrieves a PaymentMethod object for a given Customer. */
   public PaymentMethod retrievePaymentMethod(String paymentMethod, Map<String, Object> params)
       throws StripeException {
     return retrievePaymentMethod(paymentMethod, params, (RequestOptions) null);

--- a/src/test/java/com/stripe/model/StandardizationTest.java
+++ b/src/test/java/com/stripe/model/StandardizationTest.java
@@ -87,13 +87,6 @@ public class StandardizationTest {
           continue;
         }
 
-        // Skip `public static Foo retrieve(String id) {...` helper methods
-        if (String.class.equals(finalParamType)
-            && parameters.size() == 1
-            && method.getName().startsWith("retrieve")) {
-          continue;
-        }
-
         // Skip the `public static Card createCard(String id) {...` helper method on Customer.
         if (String.class.equals(finalParamType)
             && parameters.size() == 1


### PR DESCRIPTION
### Why?
There was an issue in our code generator where custom methods inside child resources would be missing overloads that accept the child resource id and RequestOptions.  This PR includes the generated code after addressing that issue.  This doesn't add any net new functionality (it is functionally equivalent to the overload that only accepts the child resource id), but it is more in line with the tests in StandardizedTests.

### What?
- adds Customer retrievePaymentMethod overload that takes payment method id and request options
- removes "retrieve" special case from StandardizedTest `allNonDeprecatedMethodsTakeOptions`

### See Also
<!-- Include any links or additional information that help explain this change. -->

## Changelog
* Adds `retrievePaymentMethod` overload to `Customer` that accepts a payment method id and `RequestOptions` object
