### PR TITLE
Update Sonatype endpoints in deploy.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,6 @@
 buildscript {
     repositories {
         mavenCentral()
-        //Add only for SNAPSHOT versions
-        //maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
     }
 }
 

--- a/deploy.gradle
+++ b/deploy.gradle
@@ -15,12 +15,12 @@ def isReleaseBuild() {
 
 def getReleaseRepositoryUrl() {
     return hasProperty("RELEASE_REPOSITORY_URL") ? RELEASE_REPOSITORY_URL
-            : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+            : "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/"
 }
 
 def getSnapshotRepositoryUrl() {
     return hasProperty("SNAPSHOT_REPOSITORY_URL") ? SNAPSHOT_REPOSITORY_URL
-            : "https://oss.sonatype.org/content/repositories/snapshots/"
+            : "https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots/"
 }
 
 def getRepositoryUsername() {


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
On June 30, 2025, the OSSRH publishing service run by Sonatype will be sunset: https://central.sonatype.org/publish/publish-guide/.

As part of their migration guide, we need to update the endpoints we use are part of publishing through Gradle: https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#configuration.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- Updates the hostnames in the Gradle publish enpoint from `oss.sonatype.org` to `ossrh-staging-api.central.sonatype.com`.

### See Also
<!-- Include any links or additional information that help explain this change. -->
