### PR TITLE
Update snapshot endpoint in deploy.gradle

### DIFF
--- a/deploy.gradle
+++ b/deploy.gradle
@@ -20,7 +20,7 @@ def getReleaseRepositoryUrl() {
 
 def getSnapshotRepositoryUrl() {
     return hasProperty("SNAPSHOT_REPOSITORY_URL") ? SNAPSHOT_REPOSITORY_URL
-            : "https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots/"
+            : "https://central.sonatype.com/repository/maven-snapshots/"
 }
 
 def getRepositoryUsername() {


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
This is a follow up to https://github.com/stripe/stripe-java/pull/2019, where we updated the Sonatype endpoints. It turns out snapshot endpoint needs to be `https://central.sonatype.com/repository/maven-snapshots/` according to: https://central.sonatype.org/publish/publish-portal-snapshots/#publishing-via-other-methods
### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- Updates snapshots endpoint in `deploy.gradle` to https://central.sonatype.com/repository/maven-snapshots/

### See Also
<!-- Include any links or additional information that help explain this change. -->
