### PR TITLE
Specify nexusUrl in deploy.gradle

### DIFF
--- a/deploy.gradle
+++ b/deploy.gradle
@@ -37,6 +37,9 @@ nexusPublishing {
 
     repositories {
         sonatype {
+            // The default nexusUrl is the sunsetted endpoint "https://oss.sonatype.org/service/local/"
+            // This URL comes from https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/.
+            nexusUrl = uri("https://ossrh-staging-api.central.sonatype.com/service/local/")
             username = getRepositoryUsername()
             password = getRepositoryPassword()
         }


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
The default URL for the `maven-publish` Gradle plugin is the sunset `https://oss.sonatype.org/service/local/`. We need to update it following https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- Set `nexusUrl` to "https://ossrh-staging-api.central.sonatype.com/service/local/"

### See Also
<!-- Include any links or additional information that help explain this change. -->
