### PR TITLE
Pull in V2 FinancialAccount changes for June release

### DIFF
--- a/src/main/java/com/stripe/events/V2CoreAccountIncludingConfigurationStorerCapabilityStatusUpdatedEvent.java
+++ b/src/main/java/com/stripe/events/V2CoreAccountIncludingConfigurationStorerCapabilityStatusUpdatedEvent.java
@@ -1,0 +1,43 @@
+// File generated from our OpenAPI spec
+package com.stripe.events;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.exception.StripeException;
+import com.stripe.model.v2.Event;
+import com.stripe.model.v2.core.Account;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+public final class V2CoreAccountIncludingConfigurationStorerCapabilityStatusUpdatedEvent
+    extends Event {
+  /** Data for the v2.core.account[configuration.storer].capability_status_updated event. */
+  @SerializedName("data")
+  V2CoreAccountIncludingConfigurationStorerCapabilityStatusUpdatedEvent.EventData data;
+
+  @Getter
+  @Setter
+  public static final class EventData {
+    /**
+     * Open Enum. The capability which had its status updated.
+     *
+     * <p>One of {@code financial_addressses.bank_accounts}, {@code holds_currencies.eur}, {@code
+     * holds_currencies.gbp}, {@code holds_currencies.usd}, {@code inbound_transfers.bank_accounts},
+     * {@code outbound_payments.bank_accounts}, {@code outbound_payments.cards}, {@code
+     * outbound_payments.financial_accounts}, {@code outbound_transfers.bank_accounts}, or {@code
+     * outbound_transfers.financial_accounts}.
+     */
+    @SerializedName("updated_capability")
+    String updatedCapability;
+  }
+
+  @SerializedName("related_object")
+
+  /** Object containing the reference to API resource relevant to the event. */
+  RelatedObject relatedObject;
+
+  /** Retrieves the related object from the API. Make an API request on every call. */
+  public Account fetchRelatedObject() throws StripeException {
+    return (Account) super.fetchRelatedObject(this.relatedObject);
+  }
+}

--- a/src/main/java/com/stripe/events/V2CoreAccountIncludingConfigurationStorerUpdatedEvent.java
+++ b/src/main/java/com/stripe/events/V2CoreAccountIncludingConfigurationStorerUpdatedEvent.java
@@ -1,0 +1,21 @@
+// File generated from our OpenAPI spec
+package com.stripe.events;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.exception.StripeException;
+import com.stripe.model.v2.Event;
+import com.stripe.model.v2.core.Account;
+import lombok.Getter;
+
+@Getter
+public final class V2CoreAccountIncludingConfigurationStorerUpdatedEvent extends Event {
+  @SerializedName("related_object")
+
+  /** Object containing the reference to API resource relevant to the event. */
+  RelatedObject relatedObject;
+
+  /** Retrieves the related object from the API. Make an API request on every call. */
+  public Account fetchRelatedObject() throws StripeException {
+    return (Account) super.fetchRelatedObject(this.relatedObject);
+  }
+}

--- a/src/main/java/com/stripe/exception/AlreadyExistsException.java
+++ b/src/main/java/com/stripe/exception/AlreadyExistsException.java
@@ -1,0 +1,32 @@
+// File generated from our OpenAPI spec
+package com.stripe.exception;
+
+import com.google.gson.JsonObject;
+import com.stripe.model.StripeError;
+import com.stripe.model.StripeObject;
+import com.stripe.net.StripeResponseGetter;
+
+/** The resource already exists. */
+public final class AlreadyExistsException extends ApiException {
+  private static final long serialVersionUID = 2L;
+
+  private AlreadyExistsException(
+      String message, String requestId, String code, Integer statusCode, Throwable e) {
+    super(message, requestId, code, statusCode, e);
+  }
+
+  static AlreadyExistsException parse(
+      JsonObject body, int statusCode, String requestId, StripeResponseGetter responseGetter) {
+    AlreadyExistsException.AlreadyExistsError error =
+        (AlreadyExistsException.AlreadyExistsError)
+            StripeObject.deserializeStripeObject(
+                body, AlreadyExistsException.AlreadyExistsError.class, responseGetter);
+    AlreadyExistsException exception =
+        new AlreadyExistsException(
+            error.getMessage(), requestId, error.getCode(), statusCode, null);
+    exception.setStripeError(error);
+    return exception;
+  }
+
+  public static class AlreadyExistsError extends StripeError {}
+}

--- a/src/main/java/com/stripe/exception/NonZeroBalanceException.java
+++ b/src/main/java/com/stripe/exception/NonZeroBalanceException.java
@@ -1,0 +1,32 @@
+// File generated from our OpenAPI spec
+package com.stripe.exception;
+
+import com.google.gson.JsonObject;
+import com.stripe.model.StripeError;
+import com.stripe.model.StripeObject;
+import com.stripe.net.StripeResponseGetter;
+
+/** Error thrown if a user tries to close an account that has non-zero balances. */
+public final class NonZeroBalanceException extends ApiException {
+  private static final long serialVersionUID = 2L;
+
+  private NonZeroBalanceException(
+      String message, String requestId, String code, Integer statusCode, Throwable e) {
+    super(message, requestId, code, statusCode, e);
+  }
+
+  static NonZeroBalanceException parse(
+      JsonObject body, int statusCode, String requestId, StripeResponseGetter responseGetter) {
+    NonZeroBalanceException.NonZeroBalanceError error =
+        (NonZeroBalanceException.NonZeroBalanceError)
+            StripeObject.deserializeStripeObject(
+                body, NonZeroBalanceException.NonZeroBalanceError.class, responseGetter);
+    NonZeroBalanceException exception =
+        new NonZeroBalanceException(
+            error.getMessage(), requestId, error.getCode(), statusCode, null);
+    exception.setStripeError(error);
+    return exception;
+  }
+
+  public static class NonZeroBalanceError extends StripeError {}
+}

--- a/src/main/java/com/stripe/exception/StripeException.java
+++ b/src/main/java/com/stripe/exception/StripeException.java
@@ -113,11 +113,17 @@ public abstract class StripeException extends Exception {
       case "temporary_session_expired":
         return com.stripe.exception.TemporarySessionExpiredException.parse(
             body, statusCode, requestId, responseGetter);
-      case "financial_account_not_open":
-        return com.stripe.exception.FinancialAccountNotOpenException.parse(
+      case "non_zero_balance":
+        return com.stripe.exception.NonZeroBalanceException.parse(
+            body, statusCode, requestId, responseGetter);
+      case "already_exists":
+        return com.stripe.exception.AlreadyExistsException.parse(
             body, statusCode, requestId, responseGetter);
       case "feature_not_enabled":
         return com.stripe.exception.FeatureNotEnabledException.parse(
+            body, statusCode, requestId, responseGetter);
+      case "financial_account_not_open":
+        return com.stripe.exception.FinancialAccountNotOpenException.parse(
             body, statusCode, requestId, responseGetter);
       case "blocked_by_stripe":
         return com.stripe.exception.BlockedByStripeException.parse(

--- a/src/main/java/com/stripe/model/v2/EventDataClassLookup.java
+++ b/src/main/java/com/stripe/model/v2/EventDataClassLookup.java
@@ -132,6 +132,13 @@ public final class EventDataClassLookup {
         "v2.core.account[configuration.recipient].updated",
         com.stripe.events.V2CoreAccountIncludingConfigurationRecipientUpdatedEvent.class);
     eventClassLookup.put(
+        "v2.core.account[configuration.storer].capability_status_updated",
+        com.stripe.events.V2CoreAccountIncludingConfigurationStorerCapabilityStatusUpdatedEvent
+            .class);
+    eventClassLookup.put(
+        "v2.core.account[configuration.storer].updated",
+        com.stripe.events.V2CoreAccountIncludingConfigurationStorerUpdatedEvent.class);
+    eventClassLookup.put(
         "v2.money_management.adjustment.created",
         com.stripe.events.V2MoneyManagementAdjustmentCreatedEvent.class);
     eventClassLookup.put(

--- a/src/main/java/com/stripe/model/v2/core/Account.java
+++ b/src/main/java/com/stripe/model/v2/core/Account.java
@@ -128,6 +128,13 @@ public class Account extends StripeObject implements HasId {
     Recipient recipient;
 
     /**
+     * The Storer Configuration allows the Account to store and move funds using stored-value
+     * FinancialAccounts.
+     */
+    @SerializedName("storer")
+    Storer storer;
+
+    /**
      * For more details about Customer, please refer to the <a
      * href="https://docs.stripe.com/api">API Reference.</a>
      */
@@ -4032,6 +4039,619 @@ public class Account extends StripeObject implements HasId {
         String type;
       }
     }
+
+    /**
+     * For more details about Storer, please refer to the <a href="https://docs.stripe.com/api">API
+     * Reference.</a>
+     */
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class Storer extends StripeObject {
+      /** Capabilities that have been requested on the Storer Configuration. */
+      @SerializedName("capabilities")
+      Capabilities capabilities;
+
+      /**
+       * For more details about Capabilities, please refer to the <a
+       * href="https://docs.stripe.com/api">API Reference.</a>
+       */
+      @Getter
+      @Setter
+      @EqualsAndHashCode(callSuper = false)
+      public static class Capabilities extends StripeObject {
+        /** Can provision a financial address to credit/debit a FinancialAccount. */
+        @SerializedName("financial_addresses")
+        FinancialAddresses financialAddresses;
+
+        /** Can hold storage-type funds on Stripe. */
+        @SerializedName("holds_currencies")
+        HoldsCurrencies holdsCurrencies;
+
+        /** Can pull funds from an external source, owned by yourself, to a FinancialAccount. */
+        @SerializedName("inbound_transfers")
+        InboundTransfers inboundTransfers;
+
+        /** Can send funds from a FinancialAccount to a destination owned by someone else. */
+        @SerializedName("outbound_payments")
+        OutboundPayments outboundPayments;
+
+        /** Can send funds from a FinancialAccount to a destination owned by yourself. */
+        @SerializedName("outbound_transfers")
+        OutboundTransfers outboundTransfers;
+
+        /**
+         * For more details about FinancialAddresses, please refer to the <a
+         * href="https://docs.stripe.com/api">API Reference.</a>
+         */
+        @Getter
+        @Setter
+        @EqualsAndHashCode(callSuper = false)
+        public static class FinancialAddresses extends StripeObject {
+          /**
+           * Can provision a bank-account like financial address (VBAN) to credit/debit a
+           * FinancialAccount.
+           */
+          @SerializedName("bank_accounts")
+          BankAccounts bankAccounts;
+
+          /**
+           * For more details about BankAccounts, please refer to the <a
+           * href="https://docs.stripe.com/api">API Reference.</a>
+           */
+          @Getter
+          @Setter
+          @EqualsAndHashCode(callSuper = false)
+          public static class BankAccounts extends StripeObject {
+            /** Whether the Capability has been requested. */
+            @SerializedName("requested")
+            Boolean requested;
+
+            /**
+             * The status of the Capability.
+             *
+             * <p>One of {@code active}, {@code pending}, {@code restricted}, or {@code
+             * unsupported}.
+             */
+            @SerializedName("status")
+            String status;
+
+            /**
+             * Additional details regarding the status of the Capability. {@code status_details}
+             * will be empty if the Capability's status is {@code active}.
+             */
+            @SerializedName("status_details")
+            List<
+                    Account.Configuration.Storer.Capabilities.FinancialAddresses.BankAccounts
+                        .StatusDetail>
+                statusDetails;
+
+            /**
+             * For more details about StatusDetail, please refer to the <a
+             * href="https://docs.stripe.com/api">API Reference.</a>
+             */
+            @Getter
+            @Setter
+            @EqualsAndHashCode(callSuper = false)
+            public static class StatusDetail extends StripeObject {
+              /**
+               * Machine-readable code explaining the reason for the Capability to be in its current
+               * status.
+               *
+               * <p>One of {@code determining_status}, {@code requirements_past_due}, {@code
+               * requirements_pending_verification}, {@code restricted_other}, {@code
+               * unsupported_business}, {@code unsupported_country}, or {@code
+               * unsupported_entity_type}.
+               */
+              @SerializedName("code")
+              String code;
+
+              /**
+               * Machine-readable code explaining how to make the Capability active.
+               *
+               * <p>One of {@code contact_stripe}, {@code no_resolution}, or {@code provide_info}.
+               */
+              @SerializedName("resolution")
+              String resolution;
+            }
+          }
+        }
+
+        /**
+         * For more details about HoldsCurrencies, please refer to the <a
+         * href="https://docs.stripe.com/api">API Reference.</a>
+         */
+        @Getter
+        @Setter
+        @EqualsAndHashCode(callSuper = false)
+        public static class HoldsCurrencies extends StripeObject {
+          /** Can hold storage-type funds on Stripe in GBP. */
+          @SerializedName("gbp")
+          Gbp gbp;
+
+          /**
+           * For more details about Gbp, please refer to the <a
+           * href="https://docs.stripe.com/api">API Reference.</a>
+           */
+          @Getter
+          @Setter
+          @EqualsAndHashCode(callSuper = false)
+          public static class Gbp extends StripeObject {
+            /** Whether the Capability has been requested. */
+            @SerializedName("requested")
+            Boolean requested;
+
+            /**
+             * The status of the Capability.
+             *
+             * <p>One of {@code active}, {@code pending}, {@code restricted}, or {@code
+             * unsupported}.
+             */
+            @SerializedName("status")
+            String status;
+
+            /**
+             * Additional details regarding the status of the Capability. {@code status_details}
+             * will be empty if the Capability's status is {@code active}.
+             */
+            @SerializedName("status_details")
+            List<Account.Configuration.Storer.Capabilities.HoldsCurrencies.Gbp.StatusDetail>
+                statusDetails;
+
+            /**
+             * For more details about StatusDetail, please refer to the <a
+             * href="https://docs.stripe.com/api">API Reference.</a>
+             */
+            @Getter
+            @Setter
+            @EqualsAndHashCode(callSuper = false)
+            public static class StatusDetail extends StripeObject {
+              /**
+               * Machine-readable code explaining the reason for the Capability to be in its current
+               * status.
+               *
+               * <p>One of {@code determining_status}, {@code requirements_past_due}, {@code
+               * requirements_pending_verification}, {@code restricted_other}, {@code
+               * unsupported_business}, {@code unsupported_country}, or {@code
+               * unsupported_entity_type}.
+               */
+              @SerializedName("code")
+              String code;
+
+              /**
+               * Machine-readable code explaining how to make the Capability active.
+               *
+               * <p>One of {@code contact_stripe}, {@code no_resolution}, or {@code provide_info}.
+               */
+              @SerializedName("resolution")
+              String resolution;
+            }
+          }
+        }
+
+        /**
+         * For more details about InboundTransfers, please refer to the <a
+         * href="https://docs.stripe.com/api">API Reference.</a>
+         */
+        @Getter
+        @Setter
+        @EqualsAndHashCode(callSuper = false)
+        public static class InboundTransfers extends StripeObject {
+          /**
+           * Can pull funds from an external bank account, owned by yourself, to a FinancialAccount.
+           */
+          @SerializedName("bank_accounts")
+          BankAccounts bankAccounts;
+
+          /**
+           * For more details about BankAccounts, please refer to the <a
+           * href="https://docs.stripe.com/api">API Reference.</a>
+           */
+          @Getter
+          @Setter
+          @EqualsAndHashCode(callSuper = false)
+          public static class BankAccounts extends StripeObject {
+            /** Whether the Capability has been requested. */
+            @SerializedName("requested")
+            Boolean requested;
+
+            /**
+             * The status of the Capability.
+             *
+             * <p>One of {@code active}, {@code pending}, {@code restricted}, or {@code
+             * unsupported}.
+             */
+            @SerializedName("status")
+            String status;
+
+            /**
+             * Additional details regarding the status of the Capability. {@code status_details}
+             * will be empty if the Capability's status is {@code active}.
+             */
+            @SerializedName("status_details")
+            List<
+                    Account.Configuration.Storer.Capabilities.InboundTransfers.BankAccounts
+                        .StatusDetail>
+                statusDetails;
+
+            /**
+             * For more details about StatusDetail, please refer to the <a
+             * href="https://docs.stripe.com/api">API Reference.</a>
+             */
+            @Getter
+            @Setter
+            @EqualsAndHashCode(callSuper = false)
+            public static class StatusDetail extends StripeObject {
+              /**
+               * Machine-readable code explaining the reason for the Capability to be in its current
+               * status.
+               *
+               * <p>One of {@code determining_status}, {@code requirements_past_due}, {@code
+               * requirements_pending_verification}, {@code restricted_other}, {@code
+               * unsupported_business}, {@code unsupported_country}, or {@code
+               * unsupported_entity_type}.
+               */
+              @SerializedName("code")
+              String code;
+
+              /**
+               * Machine-readable code explaining how to make the Capability active.
+               *
+               * <p>One of {@code contact_stripe}, {@code no_resolution}, or {@code provide_info}.
+               */
+              @SerializedName("resolution")
+              String resolution;
+            }
+          }
+        }
+
+        /**
+         * For more details about OutboundPayments, please refer to the <a
+         * href="https://docs.stripe.com/api">API Reference.</a>
+         */
+        @Getter
+        @Setter
+        @EqualsAndHashCode(callSuper = false)
+        public static class OutboundPayments extends StripeObject {
+          /** Can send funds from a FinancialAccount to a bank account, owned by someone else. */
+          @SerializedName("bank_accounts")
+          BankAccounts bankAccounts;
+
+          /** Can send funds from a FinancialAccount to a debit card, owned by someone else. */
+          @SerializedName("cards")
+          Cards cards;
+
+          /**
+           * Can send funds from a FinancialAccount to another FinancialAccount, owned by someone
+           * else.
+           */
+          @SerializedName("financial_accounts")
+          FinancialAccounts financialAccounts;
+
+          /**
+           * For more details about BankAccounts, please refer to the <a
+           * href="https://docs.stripe.com/api">API Reference.</a>
+           */
+          @Getter
+          @Setter
+          @EqualsAndHashCode(callSuper = false)
+          public static class BankAccounts extends StripeObject {
+            /** Whether the Capability has been requested. */
+            @SerializedName("requested")
+            Boolean requested;
+
+            /**
+             * The status of the Capability.
+             *
+             * <p>One of {@code active}, {@code pending}, {@code restricted}, or {@code
+             * unsupported}.
+             */
+            @SerializedName("status")
+            String status;
+
+            /**
+             * Additional details regarding the status of the Capability. {@code status_details}
+             * will be empty if the Capability's status is {@code active}.
+             */
+            @SerializedName("status_details")
+            List<
+                    Account.Configuration.Storer.Capabilities.OutboundPayments.BankAccounts
+                        .StatusDetail>
+                statusDetails;
+
+            /**
+             * For more details about StatusDetail, please refer to the <a
+             * href="https://docs.stripe.com/api">API Reference.</a>
+             */
+            @Getter
+            @Setter
+            @EqualsAndHashCode(callSuper = false)
+            public static class StatusDetail extends StripeObject {
+              /**
+               * Machine-readable code explaining the reason for the Capability to be in its current
+               * status.
+               *
+               * <p>One of {@code determining_status}, {@code requirements_past_due}, {@code
+               * requirements_pending_verification}, {@code restricted_other}, {@code
+               * unsupported_business}, {@code unsupported_country}, or {@code
+               * unsupported_entity_type}.
+               */
+              @SerializedName("code")
+              String code;
+
+              /**
+               * Machine-readable code explaining how to make the Capability active.
+               *
+               * <p>One of {@code contact_stripe}, {@code no_resolution}, or {@code provide_info}.
+               */
+              @SerializedName("resolution")
+              String resolution;
+            }
+          }
+
+          /**
+           * For more details about Cards, please refer to the <a
+           * href="https://docs.stripe.com/api">API Reference.</a>
+           */
+          @Getter
+          @Setter
+          @EqualsAndHashCode(callSuper = false)
+          public static class Cards extends StripeObject {
+            /** Whether the Capability has been requested. */
+            @SerializedName("requested")
+            Boolean requested;
+
+            /**
+             * The status of the Capability.
+             *
+             * <p>One of {@code active}, {@code pending}, {@code restricted}, or {@code
+             * unsupported}.
+             */
+            @SerializedName("status")
+            String status;
+
+            /**
+             * Additional details regarding the status of the Capability. {@code status_details}
+             * will be empty if the Capability's status is {@code active}.
+             */
+            @SerializedName("status_details")
+            List<Account.Configuration.Storer.Capabilities.OutboundPayments.Cards.StatusDetail>
+                statusDetails;
+
+            /**
+             * For more details about StatusDetail, please refer to the <a
+             * href="https://docs.stripe.com/api">API Reference.</a>
+             */
+            @Getter
+            @Setter
+            @EqualsAndHashCode(callSuper = false)
+            public static class StatusDetail extends StripeObject {
+              /**
+               * Machine-readable code explaining the reason for the Capability to be in its current
+               * status.
+               *
+               * <p>One of {@code determining_status}, {@code requirements_past_due}, {@code
+               * requirements_pending_verification}, {@code restricted_other}, {@code
+               * unsupported_business}, {@code unsupported_country}, or {@code
+               * unsupported_entity_type}.
+               */
+              @SerializedName("code")
+              String code;
+
+              /**
+               * Machine-readable code explaining how to make the Capability active.
+               *
+               * <p>One of {@code contact_stripe}, {@code no_resolution}, or {@code provide_info}.
+               */
+              @SerializedName("resolution")
+              String resolution;
+            }
+          }
+
+          /**
+           * For more details about FinancialAccounts, please refer to the <a
+           * href="https://docs.stripe.com/api">API Reference.</a>
+           */
+          @Getter
+          @Setter
+          @EqualsAndHashCode(callSuper = false)
+          public static class FinancialAccounts extends StripeObject {
+            /** Whether the Capability has been requested. */
+            @SerializedName("requested")
+            Boolean requested;
+
+            /**
+             * The status of the Capability.
+             *
+             * <p>One of {@code active}, {@code pending}, {@code restricted}, or {@code
+             * unsupported}.
+             */
+            @SerializedName("status")
+            String status;
+
+            /**
+             * Additional details regarding the status of the Capability. {@code status_details}
+             * will be empty if the Capability's status is {@code active}.
+             */
+            @SerializedName("status_details")
+            List<
+                    Account.Configuration.Storer.Capabilities.OutboundPayments.FinancialAccounts
+                        .StatusDetail>
+                statusDetails;
+
+            /**
+             * For more details about StatusDetail, please refer to the <a
+             * href="https://docs.stripe.com/api">API Reference.</a>
+             */
+            @Getter
+            @Setter
+            @EqualsAndHashCode(callSuper = false)
+            public static class StatusDetail extends StripeObject {
+              /**
+               * Machine-readable code explaining the reason for the Capability to be in its current
+               * status.
+               *
+               * <p>One of {@code determining_status}, {@code requirements_past_due}, {@code
+               * requirements_pending_verification}, {@code restricted_other}, {@code
+               * unsupported_business}, {@code unsupported_country}, or {@code
+               * unsupported_entity_type}.
+               */
+              @SerializedName("code")
+              String code;
+
+              /**
+               * Machine-readable code explaining how to make the Capability active.
+               *
+               * <p>One of {@code contact_stripe}, {@code no_resolution}, or {@code provide_info}.
+               */
+              @SerializedName("resolution")
+              String resolution;
+            }
+          }
+        }
+
+        /**
+         * For more details about OutboundTransfers, please refer to the <a
+         * href="https://docs.stripe.com/api">API Reference.</a>
+         */
+        @Getter
+        @Setter
+        @EqualsAndHashCode(callSuper = false)
+        public static class OutboundTransfers extends StripeObject {
+          /** Can send funds from a FinancialAccount, to a bank account, owned by yourself. */
+          @SerializedName("bank_accounts")
+          BankAccounts bankAccounts;
+
+          /**
+           * Can send funds from a FinancialAccount to another FinancialAccount, owned by yourself.
+           */
+          @SerializedName("financial_accounts")
+          FinancialAccounts financialAccounts;
+
+          /**
+           * For more details about BankAccounts, please refer to the <a
+           * href="https://docs.stripe.com/api">API Reference.</a>
+           */
+          @Getter
+          @Setter
+          @EqualsAndHashCode(callSuper = false)
+          public static class BankAccounts extends StripeObject {
+            /** Whether the Capability has been requested. */
+            @SerializedName("requested")
+            Boolean requested;
+
+            /**
+             * The status of the Capability.
+             *
+             * <p>One of {@code active}, {@code pending}, {@code restricted}, or {@code
+             * unsupported}.
+             */
+            @SerializedName("status")
+            String status;
+
+            /**
+             * Additional details regarding the status of the Capability. {@code status_details}
+             * will be empty if the Capability's status is {@code active}.
+             */
+            @SerializedName("status_details")
+            List<
+                    Account.Configuration.Storer.Capabilities.OutboundTransfers.BankAccounts
+                        .StatusDetail>
+                statusDetails;
+
+            /**
+             * For more details about StatusDetail, please refer to the <a
+             * href="https://docs.stripe.com/api">API Reference.</a>
+             */
+            @Getter
+            @Setter
+            @EqualsAndHashCode(callSuper = false)
+            public static class StatusDetail extends StripeObject {
+              /**
+               * Machine-readable code explaining the reason for the Capability to be in its current
+               * status.
+               *
+               * <p>One of {@code determining_status}, {@code requirements_past_due}, {@code
+               * requirements_pending_verification}, {@code restricted_other}, {@code
+               * unsupported_business}, {@code unsupported_country}, or {@code
+               * unsupported_entity_type}.
+               */
+              @SerializedName("code")
+              String code;
+
+              /**
+               * Machine-readable code explaining how to make the Capability active.
+               *
+               * <p>One of {@code contact_stripe}, {@code no_resolution}, or {@code provide_info}.
+               */
+              @SerializedName("resolution")
+              String resolution;
+            }
+          }
+
+          /**
+           * For more details about FinancialAccounts, please refer to the <a
+           * href="https://docs.stripe.com/api">API Reference.</a>
+           */
+          @Getter
+          @Setter
+          @EqualsAndHashCode(callSuper = false)
+          public static class FinancialAccounts extends StripeObject {
+            /** Whether the Capability has been requested. */
+            @SerializedName("requested")
+            Boolean requested;
+
+            /**
+             * The status of the Capability.
+             *
+             * <p>One of {@code active}, {@code pending}, {@code restricted}, or {@code
+             * unsupported}.
+             */
+            @SerializedName("status")
+            String status;
+
+            /**
+             * Additional details regarding the status of the Capability. {@code status_details}
+             * will be empty if the Capability's status is {@code active}.
+             */
+            @SerializedName("status_details")
+            List<
+                    Account.Configuration.Storer.Capabilities.OutboundTransfers.FinancialAccounts
+                        .StatusDetail>
+                statusDetails;
+
+            /**
+             * For more details about StatusDetail, please refer to the <a
+             * href="https://docs.stripe.com/api">API Reference.</a>
+             */
+            @Getter
+            @Setter
+            @EqualsAndHashCode(callSuper = false)
+            public static class StatusDetail extends StripeObject {
+              /**
+               * Machine-readable code explaining the reason for the Capability to be in its current
+               * status.
+               *
+               * <p>One of {@code determining_status}, {@code requirements_past_due}, {@code
+               * requirements_pending_verification}, {@code restricted_other}, {@code
+               * unsupported_business}, {@code unsupported_country}, or {@code
+               * unsupported_entity_type}.
+               */
+              @SerializedName("code")
+              String code;
+
+              /**
+               * Machine-readable code explaining how to make the Capability active.
+               *
+               * <p>One of {@code contact_stripe}, {@code no_resolution}, or {@code provide_info}.
+               */
+              @SerializedName("resolution")
+              String resolution;
+            }
+          }
+        }
+      }
+    }
   }
 
   /**
@@ -6216,18 +6836,23 @@ public class Account extends StripeObject implements HasId {
            * {@code bacs_debit_payments}, {@code bancontact_payments}, {@code bank_accounts.local},
            * {@code bank_accounts.wire}, {@code blik_payments}, {@code boleto_payments}, {@code
            * cards}, {@code card_payments}, {@code cartes_bancaires_payments}, {@code
-           * cashapp_payments}, {@code eps_payments}, {@code fpx_payments}, {@code
-           * gb_bank_transfer_payments}, {@code grabpay_payments}, {@code ideal_payments}, {@code
-           * jcb_payments}, {@code jp_bank_transfer_payments}, {@code kakao_pay_payments}, {@code
-           * klarna_payments}, {@code konbini_payments}, {@code kr_card_payments}, {@code
-           * link_payments}, {@code mobilepay_payments}, {@code multibanco_payments}, {@code
-           * mx_bank_transfer_payments}, {@code naver_pay_payments}, {@code oxxo_payments}, {@code
-           * p24_payments}, {@code payco_payments}, {@code paynow_payments}, {@code
-           * pay_by_bank_payments}, {@code promptpay_payments}, {@code revolut_pay_payments}, {@code
-           * samsung_pay_payments}, {@code sepa_bank_transfer_payments}, {@code
-           * sepa_debit_payments}, {@code stripe_balance.payouts}, {@code
-           * stripe_balance.stripe_transfers}, {@code swish_payments}, {@code twint_payments},
-           * {@code us_bank_transfer_payments}, or {@code zip_payments}.
+           * cashapp_payments}, {@code eps_payments}, {@code financial_addresses.bank_accounts},
+           * {@code fpx_payments}, {@code gb_bank_transfer_payments}, {@code grabpay_payments},
+           * {@code holds_currencies.gbp}, {@code ideal_payments}, {@code
+           * inbound_transfers.financial_accounts}, {@code jcb_payments}, {@code
+           * jp_bank_transfer_payments}, {@code kakao_pay_payments}, {@code klarna_payments}, {@code
+           * konbini_payments}, {@code kr_card_payments}, {@code link_payments}, {@code
+           * mobilepay_payments}, {@code multibanco_payments}, {@code mx_bank_transfer_payments},
+           * {@code naver_pay_payments}, {@code outbound_payments.bank_accounts}, {@code
+           * outbound_payments.cards}, {@code outbound_payments.financial_accounts}, {@code
+           * outbound_transfers.bank_accounts}, {@code outbound_transfers.financial_accounts},
+           * {@code oxxo_payments}, {@code p24_payments}, {@code payco_payments}, {@code
+           * paynow_payments}, {@code pay_by_bank_payments}, {@code promptpay_payments}, {@code
+           * revolut_pay_payments}, {@code samsung_pay_payments}, {@code
+           * sepa_bank_transfer_payments}, {@code sepa_debit_payments}, {@code
+           * stripe_balance.payouts}, {@code stripe_balance.stripe_transfers}, {@code
+           * swish_payments}, {@code twint_payments}, {@code us_bank_transfer_payments}, or {@code
+           * zip_payments}.
            */
           @SerializedName("capability")
           String capability;
@@ -6235,7 +6860,7 @@ public class Account extends StripeObject implements HasId {
           /**
            * The configuration which specifies the Capability which will be restricted.
            *
-           * <p>One of {@code customer}, {@code merchant}, or {@code recipient}.
+           * <p>One of {@code customer}, {@code merchant}, {@code recipient}, or {@code storer}.
            */
           @SerializedName("configuration")
           String configuration;

--- a/src/main/java/com/stripe/model/v2/moneymanagement/FinancialAccount.java
+++ b/src/main/java/com/stripe/model/v2/moneymanagement/FinancialAccount.java
@@ -109,6 +109,9 @@ public class FinancialAccount extends StripeObject implements HasId {
   @SerializedName("status")
   String status;
 
+  @SerializedName("status_details")
+  StatusDetails statusDetails;
+
   /**
    * If this is a {@code storage} FinancialAccount, this hash includes details specific to {@code
    * storage} FinancialAccounts.
@@ -161,6 +164,50 @@ public class FinancialAccount extends StripeObject implements HasId {
      */
     @SerializedName("type")
     String type;
+  }
+
+  /**
+   * For more details about StatusDetails, please refer to the <a
+   * href="https://docs.stripe.com/api">API Reference.</a>
+   */
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class StatusDetails extends StripeObject {
+    @SerializedName("closed")
+    Closed closed;
+
+    /**
+     * For more details about Closed, please refer to the <a href="https://docs.stripe.com/api">API
+     * Reference.</a>
+     */
+    @Getter
+    @Setter
+    @EqualsAndHashCode(callSuper = false)
+    public static class Closed extends StripeObject {
+      @SerializedName("forwarding_settings")
+      ForwardingSettings forwardingSettings;
+
+      @SerializedName("reason")
+      String reason;
+
+      /**
+       * For more details about ForwardingSettings, please refer to the <a
+       * href="https://docs.stripe.com/api">API Reference.</a>
+       */
+      @Getter
+      @Setter
+      @EqualsAndHashCode(callSuper = false)
+      public static class ForwardingSettings extends StripeObject {
+        /** The address to send forwarded payments to. */
+        @SerializedName("payment_method")
+        String paymentMethod;
+
+        /** The address to send forwarded payouts to. */
+        @SerializedName("payout_method")
+        String payoutMethod;
+      }
+    }
   }
 
   /**

--- a/src/main/java/com/stripe/param/v2/core/AccountCloseParams.java
+++ b/src/main/java/com/stripe/param/v2/core/AccountCloseParams.java
@@ -112,7 +112,10 @@ public class AccountCloseParams extends ApiRequestParams {
     MERCHANT("merchant"),
 
     @SerializedName("recipient")
-    RECIPIENT("recipient");
+    RECIPIENT("recipient"),
+
+    @SerializedName("storer")
+    STORER("storer");
 
     @Getter(onMethod_ = {@Override})
     private final String value;

--- a/src/main/java/com/stripe/param/v2/core/AccountCreateParams.java
+++ b/src/main/java/com/stripe/param/v2/core/AccountCreateParams.java
@@ -284,15 +284,24 @@ public class AccountCreateParams extends ApiRequestParams {
     @SerializedName("recipient")
     Recipient recipient;
 
+    /**
+     * The Storer Configuration allows the Account to store and move funds using stored-value
+     * FinancialAccounts.
+     */
+    @SerializedName("storer")
+    Storer storer;
+
     private Configuration(
         Customer customer,
         Map<String, Object> extraParams,
         Merchant merchant,
-        Recipient recipient) {
+        Recipient recipient,
+        Storer storer) {
       this.customer = customer;
       this.extraParams = extraParams;
       this.merchant = merchant;
       this.recipient = recipient;
+      this.storer = storer;
     }
 
     public static Builder builder() {
@@ -308,10 +317,12 @@ public class AccountCreateParams extends ApiRequestParams {
 
       private Recipient recipient;
 
+      private Storer storer;
+
       /** Finalize and obtain parameter instance from this builder. */
       public AccountCreateParams.Configuration build() {
         return new AccountCreateParams.Configuration(
-            this.customer, this.extraParams, this.merchant, this.recipient);
+            this.customer, this.extraParams, this.merchant, this.recipient, this.storer);
       }
 
       /** The Customer Configuration allows the Account to be used in inbound payment flows. */
@@ -359,6 +370,15 @@ public class AccountCreateParams extends ApiRequestParams {
       /** The Recipient Configuration allows the Account to receive funds. */
       public Builder setRecipient(AccountCreateParams.Configuration.Recipient recipient) {
         this.recipient = recipient;
+        return this;
+      }
+
+      /**
+       * The Storer Configuration allows the Account to store and move funds using stored-value
+       * FinancialAccounts.
+       */
+      public Builder setStorer(AccountCreateParams.Configuration.Storer storer) {
+        this.storer = storer;
         return this;
       }
     }
@@ -9139,6 +9159,1346 @@ public class AccountCreateParams extends ApiRequestParams {
                * first `put/putAll` call, and subsequent calls add additional key/value pairs to the
                * original map. See {@link
                * AccountCreateParams.Configuration.Recipient.Capabilities.StripeBalance.StripeTransfers#extraParams}
+               * for the field documentation.
+               */
+              public Builder putAllExtraParam(Map<String, Object> map) {
+                if (this.extraParams == null) {
+                  this.extraParams = new HashMap<>();
+                }
+                this.extraParams.putAll(map);
+                return this;
+              }
+
+              /**
+               * <strong>Required.</strong> To request a new Capability for an account, pass true.
+               * There can be a delay before the requested Capability becomes active.
+               */
+              public Builder setRequested(Boolean requested) {
+                this.requested = requested;
+                return this;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    @Getter
+    @EqualsAndHashCode(callSuper = false)
+    public static class Storer {
+      /** Capabilities to request on the Storer Configuration. */
+      @SerializedName("capabilities")
+      Capabilities capabilities;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private Storer(Capabilities capabilities, Map<String, Object> extraParams) {
+        this.capabilities = capabilities;
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Capabilities capabilities;
+
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public AccountCreateParams.Configuration.Storer build() {
+          return new AccountCreateParams.Configuration.Storer(this.capabilities, this.extraParams);
+        }
+
+        /** Capabilities to request on the Storer Configuration. */
+        public Builder setCapabilities(
+            AccountCreateParams.Configuration.Storer.Capabilities capabilities) {
+          this.capabilities = capabilities;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link AccountCreateParams.Configuration.Storer#extraParams} for the field
+         * documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link AccountCreateParams.Configuration.Storer#extraParams} for the field
+         * documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+      }
+
+      @Getter
+      @EqualsAndHashCode(callSuper = false)
+      public static class Capabilities {
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /** Can provision a financial address to credit/debit a FinancialAccount. */
+        @SerializedName("financial_addresses")
+        FinancialAddresses financialAddresses;
+
+        /** Can hold storage-type funds on Stripe. */
+        @SerializedName("holds_currencies")
+        HoldsCurrencies holdsCurrencies;
+
+        /** Can pull funds from an external source, owned by yourself, to a FinancialAccount. */
+        @SerializedName("inbound_transfers")
+        InboundTransfers inboundTransfers;
+
+        /** Can send funds from a FinancialAccount to a destination owned by someone else. */
+        @SerializedName("outbound_payments")
+        OutboundPayments outboundPayments;
+
+        /** Can send funds from a FinancialAccount to a destination owned by yourself. */
+        @SerializedName("outbound_transfers")
+        OutboundTransfers outboundTransfers;
+
+        private Capabilities(
+            Map<String, Object> extraParams,
+            FinancialAddresses financialAddresses,
+            HoldsCurrencies holdsCurrencies,
+            InboundTransfers inboundTransfers,
+            OutboundPayments outboundPayments,
+            OutboundTransfers outboundTransfers) {
+          this.extraParams = extraParams;
+          this.financialAddresses = financialAddresses;
+          this.holdsCurrencies = holdsCurrencies;
+          this.inboundTransfers = inboundTransfers;
+          this.outboundPayments = outboundPayments;
+          this.outboundTransfers = outboundTransfers;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Map<String, Object> extraParams;
+
+          private FinancialAddresses financialAddresses;
+
+          private HoldsCurrencies holdsCurrencies;
+
+          private InboundTransfers inboundTransfers;
+
+          private OutboundPayments outboundPayments;
+
+          private OutboundTransfers outboundTransfers;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public AccountCreateParams.Configuration.Storer.Capabilities build() {
+            return new AccountCreateParams.Configuration.Storer.Capabilities(
+                this.extraParams,
+                this.financialAddresses,
+                this.holdsCurrencies,
+                this.inboundTransfers,
+                this.outboundPayments,
+                this.outboundTransfers);
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link AccountCreateParams.Configuration.Storer.Capabilities#extraParams} for
+           * the field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link AccountCreateParams.Configuration.Storer.Capabilities#extraParams} for
+           * the field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /** Can provision a financial address to credit/debit a FinancialAccount. */
+          public Builder setFinancialAddresses(
+              AccountCreateParams.Configuration.Storer.Capabilities.FinancialAddresses
+                  financialAddresses) {
+            this.financialAddresses = financialAddresses;
+            return this;
+          }
+
+          /** Can hold storage-type funds on Stripe. */
+          public Builder setHoldsCurrencies(
+              AccountCreateParams.Configuration.Storer.Capabilities.HoldsCurrencies
+                  holdsCurrencies) {
+            this.holdsCurrencies = holdsCurrencies;
+            return this;
+          }
+
+          /** Can pull funds from an external source, owned by yourself, to a FinancialAccount. */
+          public Builder setInboundTransfers(
+              AccountCreateParams.Configuration.Storer.Capabilities.InboundTransfers
+                  inboundTransfers) {
+            this.inboundTransfers = inboundTransfers;
+            return this;
+          }
+
+          /** Can send funds from a FinancialAccount to a destination owned by someone else. */
+          public Builder setOutboundPayments(
+              AccountCreateParams.Configuration.Storer.Capabilities.OutboundPayments
+                  outboundPayments) {
+            this.outboundPayments = outboundPayments;
+            return this;
+          }
+
+          /** Can send funds from a FinancialAccount to a destination owned by yourself. */
+          public Builder setOutboundTransfers(
+              AccountCreateParams.Configuration.Storer.Capabilities.OutboundTransfers
+                  outboundTransfers) {
+            this.outboundTransfers = outboundTransfers;
+            return this;
+          }
+        }
+
+        @Getter
+        @EqualsAndHashCode(callSuper = false)
+        public static class FinancialAddresses {
+          /**
+           * Can provision a bank-account-like financial address (VBAN) to credit/debit a
+           * FinancialAccount.
+           */
+          @SerializedName("bank_accounts")
+          BankAccounts bankAccounts;
+
+          /**
+           * Map of extra parameters for custom features not available in this client library. The
+           * content in this map is not serialized under this field's {@code @SerializedName} value.
+           * Instead, each key/value pair is serialized as if the key is a root-level field
+           * (serialized) name in this param object. Effectively, this map is flattened to its
+           * parent instance.
+           */
+          @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+          Map<String, Object> extraParams;
+
+          private FinancialAddresses(BankAccounts bankAccounts, Map<String, Object> extraParams) {
+            this.bankAccounts = bankAccounts;
+            this.extraParams = extraParams;
+          }
+
+          public static Builder builder() {
+            return new Builder();
+          }
+
+          public static class Builder {
+            private BankAccounts bankAccounts;
+
+            private Map<String, Object> extraParams;
+
+            /** Finalize and obtain parameter instance from this builder. */
+            public AccountCreateParams.Configuration.Storer.Capabilities.FinancialAddresses
+                build() {
+              return new AccountCreateParams.Configuration.Storer.Capabilities.FinancialAddresses(
+                  this.bankAccounts, this.extraParams);
+            }
+
+            /**
+             * Can provision a bank-account-like financial address (VBAN) to credit/debit a
+             * FinancialAccount.
+             */
+            public Builder setBankAccounts(
+                AccountCreateParams.Configuration.Storer.Capabilities.FinancialAddresses
+                        .BankAccounts
+                    bankAccounts) {
+              this.bankAccounts = bankAccounts;
+              return this;
+            }
+
+            /**
+             * Add a key/value pair to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * AccountCreateParams.Configuration.Storer.Capabilities.FinancialAddresses#extraParams}
+             * for the field documentation.
+             */
+            public Builder putExtraParam(String key, Object value) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.put(key, value);
+              return this;
+            }
+
+            /**
+             * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * AccountCreateParams.Configuration.Storer.Capabilities.FinancialAddresses#extraParams}
+             * for the field documentation.
+             */
+            public Builder putAllExtraParam(Map<String, Object> map) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.putAll(map);
+              return this;
+            }
+          }
+
+          @Getter
+          @EqualsAndHashCode(callSuper = false)
+          public static class BankAccounts {
+            /**
+             * Map of extra parameters for custom features not available in this client library. The
+             * content in this map is not serialized under this field's {@code @SerializedName}
+             * value. Instead, each key/value pair is serialized as if the key is a root-level field
+             * (serialized) name in this param object. Effectively, this map is flattened to its
+             * parent instance.
+             */
+            @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+            Map<String, Object> extraParams;
+
+            /**
+             * <strong>Required.</strong> To request a new Capability for an account, pass true.
+             * There can be a delay before the requested Capability becomes active.
+             */
+            @SerializedName("requested")
+            Boolean requested;
+
+            private BankAccounts(Map<String, Object> extraParams, Boolean requested) {
+              this.extraParams = extraParams;
+              this.requested = requested;
+            }
+
+            public static Builder builder() {
+              return new Builder();
+            }
+
+            public static class Builder {
+              private Map<String, Object> extraParams;
+
+              private Boolean requested;
+
+              /** Finalize and obtain parameter instance from this builder. */
+              public AccountCreateParams.Configuration.Storer.Capabilities.FinancialAddresses
+                      .BankAccounts
+                  build() {
+                return new AccountCreateParams.Configuration.Storer.Capabilities.FinancialAddresses
+                    .BankAccounts(this.extraParams, this.requested);
+              }
+
+              /**
+               * Add a key/value pair to `extraParams` map. A map is initialized for the first
+               * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+               * original map. See {@link
+               * AccountCreateParams.Configuration.Storer.Capabilities.FinancialAddresses.BankAccounts#extraParams}
+               * for the field documentation.
+               */
+              public Builder putExtraParam(String key, Object value) {
+                if (this.extraParams == null) {
+                  this.extraParams = new HashMap<>();
+                }
+                this.extraParams.put(key, value);
+                return this;
+              }
+
+              /**
+               * Add all map key/value pairs to `extraParams` map. A map is initialized for the
+               * first `put/putAll` call, and subsequent calls add additional key/value pairs to the
+               * original map. See {@link
+               * AccountCreateParams.Configuration.Storer.Capabilities.FinancialAddresses.BankAccounts#extraParams}
+               * for the field documentation.
+               */
+              public Builder putAllExtraParam(Map<String, Object> map) {
+                if (this.extraParams == null) {
+                  this.extraParams = new HashMap<>();
+                }
+                this.extraParams.putAll(map);
+                return this;
+              }
+
+              /**
+               * <strong>Required.</strong> To request a new Capability for an account, pass true.
+               * There can be a delay before the requested Capability becomes active.
+               */
+              public Builder setRequested(Boolean requested) {
+                this.requested = requested;
+                return this;
+              }
+            }
+          }
+        }
+
+        @Getter
+        @EqualsAndHashCode(callSuper = false)
+        public static class HoldsCurrencies {
+          /**
+           * Map of extra parameters for custom features not available in this client library. The
+           * content in this map is not serialized under this field's {@code @SerializedName} value.
+           * Instead, each key/value pair is serialized as if the key is a root-level field
+           * (serialized) name in this param object. Effectively, this map is flattened to its
+           * parent instance.
+           */
+          @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+          Map<String, Object> extraParams;
+
+          /** Can hold storage-type funds on Stripe in GBP. */
+          @SerializedName("gbp")
+          Gbp gbp;
+
+          private HoldsCurrencies(Map<String, Object> extraParams, Gbp gbp) {
+            this.extraParams = extraParams;
+            this.gbp = gbp;
+          }
+
+          public static Builder builder() {
+            return new Builder();
+          }
+
+          public static class Builder {
+            private Map<String, Object> extraParams;
+
+            private Gbp gbp;
+
+            /** Finalize and obtain parameter instance from this builder. */
+            public AccountCreateParams.Configuration.Storer.Capabilities.HoldsCurrencies build() {
+              return new AccountCreateParams.Configuration.Storer.Capabilities.HoldsCurrencies(
+                  this.extraParams, this.gbp);
+            }
+
+            /**
+             * Add a key/value pair to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * AccountCreateParams.Configuration.Storer.Capabilities.HoldsCurrencies#extraParams}
+             * for the field documentation.
+             */
+            public Builder putExtraParam(String key, Object value) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.put(key, value);
+              return this;
+            }
+
+            /**
+             * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * AccountCreateParams.Configuration.Storer.Capabilities.HoldsCurrencies#extraParams}
+             * for the field documentation.
+             */
+            public Builder putAllExtraParam(Map<String, Object> map) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.putAll(map);
+              return this;
+            }
+
+            /** Can hold storage-type funds on Stripe in GBP. */
+            public Builder setGbp(
+                AccountCreateParams.Configuration.Storer.Capabilities.HoldsCurrencies.Gbp gbp) {
+              this.gbp = gbp;
+              return this;
+            }
+          }
+
+          @Getter
+          @EqualsAndHashCode(callSuper = false)
+          public static class Gbp {
+            /**
+             * Map of extra parameters for custom features not available in this client library. The
+             * content in this map is not serialized under this field's {@code @SerializedName}
+             * value. Instead, each key/value pair is serialized as if the key is a root-level field
+             * (serialized) name in this param object. Effectively, this map is flattened to its
+             * parent instance.
+             */
+            @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+            Map<String, Object> extraParams;
+
+            /**
+             * <strong>Required.</strong> To request a new Capability for an account, pass true.
+             * There can be a delay before the requested Capability becomes active.
+             */
+            @SerializedName("requested")
+            Boolean requested;
+
+            private Gbp(Map<String, Object> extraParams, Boolean requested) {
+              this.extraParams = extraParams;
+              this.requested = requested;
+            }
+
+            public static Builder builder() {
+              return new Builder();
+            }
+
+            public static class Builder {
+              private Map<String, Object> extraParams;
+
+              private Boolean requested;
+
+              /** Finalize and obtain parameter instance from this builder. */
+              public AccountCreateParams.Configuration.Storer.Capabilities.HoldsCurrencies.Gbp
+                  build() {
+                return new AccountCreateParams.Configuration.Storer.Capabilities.HoldsCurrencies
+                    .Gbp(this.extraParams, this.requested);
+              }
+
+              /**
+               * Add a key/value pair to `extraParams` map. A map is initialized for the first
+               * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+               * original map. See {@link
+               * AccountCreateParams.Configuration.Storer.Capabilities.HoldsCurrencies.Gbp#extraParams}
+               * for the field documentation.
+               */
+              public Builder putExtraParam(String key, Object value) {
+                if (this.extraParams == null) {
+                  this.extraParams = new HashMap<>();
+                }
+                this.extraParams.put(key, value);
+                return this;
+              }
+
+              /**
+               * Add all map key/value pairs to `extraParams` map. A map is initialized for the
+               * first `put/putAll` call, and subsequent calls add additional key/value pairs to the
+               * original map. See {@link
+               * AccountCreateParams.Configuration.Storer.Capabilities.HoldsCurrencies.Gbp#extraParams}
+               * for the field documentation.
+               */
+              public Builder putAllExtraParam(Map<String, Object> map) {
+                if (this.extraParams == null) {
+                  this.extraParams = new HashMap<>();
+                }
+                this.extraParams.putAll(map);
+                return this;
+              }
+
+              /**
+               * <strong>Required.</strong> To request a new Capability for an account, pass true.
+               * There can be a delay before the requested Capability becomes active.
+               */
+              public Builder setRequested(Boolean requested) {
+                this.requested = requested;
+                return this;
+              }
+            }
+          }
+        }
+
+        @Getter
+        @EqualsAndHashCode(callSuper = false)
+        public static class InboundTransfers {
+          /**
+           * Can pull funds from an external bank account owned by yourself to a FinancialAccount.
+           */
+          @SerializedName("bank_accounts")
+          BankAccounts bankAccounts;
+
+          /**
+           * Map of extra parameters for custom features not available in this client library. The
+           * content in this map is not serialized under this field's {@code @SerializedName} value.
+           * Instead, each key/value pair is serialized as if the key is a root-level field
+           * (serialized) name in this param object. Effectively, this map is flattened to its
+           * parent instance.
+           */
+          @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+          Map<String, Object> extraParams;
+
+          private InboundTransfers(BankAccounts bankAccounts, Map<String, Object> extraParams) {
+            this.bankAccounts = bankAccounts;
+            this.extraParams = extraParams;
+          }
+
+          public static Builder builder() {
+            return new Builder();
+          }
+
+          public static class Builder {
+            private BankAccounts bankAccounts;
+
+            private Map<String, Object> extraParams;
+
+            /** Finalize and obtain parameter instance from this builder. */
+            public AccountCreateParams.Configuration.Storer.Capabilities.InboundTransfers build() {
+              return new AccountCreateParams.Configuration.Storer.Capabilities.InboundTransfers(
+                  this.bankAccounts, this.extraParams);
+            }
+
+            /**
+             * Can pull funds from an external bank account owned by yourself to a FinancialAccount.
+             */
+            public Builder setBankAccounts(
+                AccountCreateParams.Configuration.Storer.Capabilities.InboundTransfers.BankAccounts
+                    bankAccounts) {
+              this.bankAccounts = bankAccounts;
+              return this;
+            }
+
+            /**
+             * Add a key/value pair to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * AccountCreateParams.Configuration.Storer.Capabilities.InboundTransfers#extraParams}
+             * for the field documentation.
+             */
+            public Builder putExtraParam(String key, Object value) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.put(key, value);
+              return this;
+            }
+
+            /**
+             * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * AccountCreateParams.Configuration.Storer.Capabilities.InboundTransfers#extraParams}
+             * for the field documentation.
+             */
+            public Builder putAllExtraParam(Map<String, Object> map) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.putAll(map);
+              return this;
+            }
+          }
+
+          @Getter
+          @EqualsAndHashCode(callSuper = false)
+          public static class BankAccounts {
+            /**
+             * Map of extra parameters for custom features not available in this client library. The
+             * content in this map is not serialized under this field's {@code @SerializedName}
+             * value. Instead, each key/value pair is serialized as if the key is a root-level field
+             * (serialized) name in this param object. Effectively, this map is flattened to its
+             * parent instance.
+             */
+            @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+            Map<String, Object> extraParams;
+
+            /**
+             * <strong>Required.</strong> To request a new Capability for an account, pass true.
+             * There can be a delay before the requested Capability becomes active.
+             */
+            @SerializedName("requested")
+            Boolean requested;
+
+            private BankAccounts(Map<String, Object> extraParams, Boolean requested) {
+              this.extraParams = extraParams;
+              this.requested = requested;
+            }
+
+            public static Builder builder() {
+              return new Builder();
+            }
+
+            public static class Builder {
+              private Map<String, Object> extraParams;
+
+              private Boolean requested;
+
+              /** Finalize and obtain parameter instance from this builder. */
+              public AccountCreateParams.Configuration.Storer.Capabilities.InboundTransfers
+                      .BankAccounts
+                  build() {
+                return new AccountCreateParams.Configuration.Storer.Capabilities.InboundTransfers
+                    .BankAccounts(this.extraParams, this.requested);
+              }
+
+              /**
+               * Add a key/value pair to `extraParams` map. A map is initialized for the first
+               * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+               * original map. See {@link
+               * AccountCreateParams.Configuration.Storer.Capabilities.InboundTransfers.BankAccounts#extraParams}
+               * for the field documentation.
+               */
+              public Builder putExtraParam(String key, Object value) {
+                if (this.extraParams == null) {
+                  this.extraParams = new HashMap<>();
+                }
+                this.extraParams.put(key, value);
+                return this;
+              }
+
+              /**
+               * Add all map key/value pairs to `extraParams` map. A map is initialized for the
+               * first `put/putAll` call, and subsequent calls add additional key/value pairs to the
+               * original map. See {@link
+               * AccountCreateParams.Configuration.Storer.Capabilities.InboundTransfers.BankAccounts#extraParams}
+               * for the field documentation.
+               */
+              public Builder putAllExtraParam(Map<String, Object> map) {
+                if (this.extraParams == null) {
+                  this.extraParams = new HashMap<>();
+                }
+                this.extraParams.putAll(map);
+                return this;
+              }
+
+              /**
+               * <strong>Required.</strong> To request a new Capability for an account, pass true.
+               * There can be a delay before the requested Capability becomes active.
+               */
+              public Builder setRequested(Boolean requested) {
+                this.requested = requested;
+                return this;
+              }
+            }
+          }
+        }
+
+        @Getter
+        @EqualsAndHashCode(callSuper = false)
+        public static class OutboundPayments {
+          /** Can send funds from a FinancialAccount to a bank account owned by someone else. */
+          @SerializedName("bank_accounts")
+          BankAccounts bankAccounts;
+
+          /** Can send funds from a FinancialAccount to a debit card owned by someone else. */
+          @SerializedName("cards")
+          Cards cards;
+
+          /**
+           * Map of extra parameters for custom features not available in this client library. The
+           * content in this map is not serialized under this field's {@code @SerializedName} value.
+           * Instead, each key/value pair is serialized as if the key is a root-level field
+           * (serialized) name in this param object. Effectively, this map is flattened to its
+           * parent instance.
+           */
+          @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+          Map<String, Object> extraParams;
+
+          /**
+           * Can send funds from a FinancialAccount to another FinancialAccount owned by someone
+           * else.
+           */
+          @SerializedName("financial_accounts")
+          FinancialAccounts financialAccounts;
+
+          private OutboundPayments(
+              BankAccounts bankAccounts,
+              Cards cards,
+              Map<String, Object> extraParams,
+              FinancialAccounts financialAccounts) {
+            this.bankAccounts = bankAccounts;
+            this.cards = cards;
+            this.extraParams = extraParams;
+            this.financialAccounts = financialAccounts;
+          }
+
+          public static Builder builder() {
+            return new Builder();
+          }
+
+          public static class Builder {
+            private BankAccounts bankAccounts;
+
+            private Cards cards;
+
+            private Map<String, Object> extraParams;
+
+            private FinancialAccounts financialAccounts;
+
+            /** Finalize and obtain parameter instance from this builder. */
+            public AccountCreateParams.Configuration.Storer.Capabilities.OutboundPayments build() {
+              return new AccountCreateParams.Configuration.Storer.Capabilities.OutboundPayments(
+                  this.bankAccounts, this.cards, this.extraParams, this.financialAccounts);
+            }
+
+            /** Can send funds from a FinancialAccount to a bank account owned by someone else. */
+            public Builder setBankAccounts(
+                AccountCreateParams.Configuration.Storer.Capabilities.OutboundPayments.BankAccounts
+                    bankAccounts) {
+              this.bankAccounts = bankAccounts;
+              return this;
+            }
+
+            /** Can send funds from a FinancialAccount to a debit card owned by someone else. */
+            public Builder setCards(
+                AccountCreateParams.Configuration.Storer.Capabilities.OutboundPayments.Cards
+                    cards) {
+              this.cards = cards;
+              return this;
+            }
+
+            /**
+             * Add a key/value pair to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * AccountCreateParams.Configuration.Storer.Capabilities.OutboundPayments#extraParams}
+             * for the field documentation.
+             */
+            public Builder putExtraParam(String key, Object value) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.put(key, value);
+              return this;
+            }
+
+            /**
+             * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * AccountCreateParams.Configuration.Storer.Capabilities.OutboundPayments#extraParams}
+             * for the field documentation.
+             */
+            public Builder putAllExtraParam(Map<String, Object> map) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.putAll(map);
+              return this;
+            }
+
+            /**
+             * Can send funds from a FinancialAccount to another FinancialAccount owned by someone
+             * else.
+             */
+            public Builder setFinancialAccounts(
+                AccountCreateParams.Configuration.Storer.Capabilities.OutboundPayments
+                        .FinancialAccounts
+                    financialAccounts) {
+              this.financialAccounts = financialAccounts;
+              return this;
+            }
+          }
+
+          @Getter
+          @EqualsAndHashCode(callSuper = false)
+          public static class BankAccounts {
+            /**
+             * Map of extra parameters for custom features not available in this client library. The
+             * content in this map is not serialized under this field's {@code @SerializedName}
+             * value. Instead, each key/value pair is serialized as if the key is a root-level field
+             * (serialized) name in this param object. Effectively, this map is flattened to its
+             * parent instance.
+             */
+            @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+            Map<String, Object> extraParams;
+
+            /**
+             * <strong>Required.</strong> To request a new Capability for an account, pass true.
+             * There can be a delay before the requested Capability becomes active.
+             */
+            @SerializedName("requested")
+            Boolean requested;
+
+            private BankAccounts(Map<String, Object> extraParams, Boolean requested) {
+              this.extraParams = extraParams;
+              this.requested = requested;
+            }
+
+            public static Builder builder() {
+              return new Builder();
+            }
+
+            public static class Builder {
+              private Map<String, Object> extraParams;
+
+              private Boolean requested;
+
+              /** Finalize and obtain parameter instance from this builder. */
+              public AccountCreateParams.Configuration.Storer.Capabilities.OutboundPayments
+                      .BankAccounts
+                  build() {
+                return new AccountCreateParams.Configuration.Storer.Capabilities.OutboundPayments
+                    .BankAccounts(this.extraParams, this.requested);
+              }
+
+              /**
+               * Add a key/value pair to `extraParams` map. A map is initialized for the first
+               * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+               * original map. See {@link
+               * AccountCreateParams.Configuration.Storer.Capabilities.OutboundPayments.BankAccounts#extraParams}
+               * for the field documentation.
+               */
+              public Builder putExtraParam(String key, Object value) {
+                if (this.extraParams == null) {
+                  this.extraParams = new HashMap<>();
+                }
+                this.extraParams.put(key, value);
+                return this;
+              }
+
+              /**
+               * Add all map key/value pairs to `extraParams` map. A map is initialized for the
+               * first `put/putAll` call, and subsequent calls add additional key/value pairs to the
+               * original map. See {@link
+               * AccountCreateParams.Configuration.Storer.Capabilities.OutboundPayments.BankAccounts#extraParams}
+               * for the field documentation.
+               */
+              public Builder putAllExtraParam(Map<String, Object> map) {
+                if (this.extraParams == null) {
+                  this.extraParams = new HashMap<>();
+                }
+                this.extraParams.putAll(map);
+                return this;
+              }
+
+              /**
+               * <strong>Required.</strong> To request a new Capability for an account, pass true.
+               * There can be a delay before the requested Capability becomes active.
+               */
+              public Builder setRequested(Boolean requested) {
+                this.requested = requested;
+                return this;
+              }
+            }
+          }
+
+          @Getter
+          @EqualsAndHashCode(callSuper = false)
+          public static class Cards {
+            /**
+             * Map of extra parameters for custom features not available in this client library. The
+             * content in this map is not serialized under this field's {@code @SerializedName}
+             * value. Instead, each key/value pair is serialized as if the key is a root-level field
+             * (serialized) name in this param object. Effectively, this map is flattened to its
+             * parent instance.
+             */
+            @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+            Map<String, Object> extraParams;
+
+            /**
+             * <strong>Required.</strong> To request a new Capability for an account, pass true.
+             * There can be a delay before the requested Capability becomes active.
+             */
+            @SerializedName("requested")
+            Boolean requested;
+
+            private Cards(Map<String, Object> extraParams, Boolean requested) {
+              this.extraParams = extraParams;
+              this.requested = requested;
+            }
+
+            public static Builder builder() {
+              return new Builder();
+            }
+
+            public static class Builder {
+              private Map<String, Object> extraParams;
+
+              private Boolean requested;
+
+              /** Finalize and obtain parameter instance from this builder. */
+              public AccountCreateParams.Configuration.Storer.Capabilities.OutboundPayments.Cards
+                  build() {
+                return new AccountCreateParams.Configuration.Storer.Capabilities.OutboundPayments
+                    .Cards(this.extraParams, this.requested);
+              }
+
+              /**
+               * Add a key/value pair to `extraParams` map. A map is initialized for the first
+               * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+               * original map. See {@link
+               * AccountCreateParams.Configuration.Storer.Capabilities.OutboundPayments.Cards#extraParams}
+               * for the field documentation.
+               */
+              public Builder putExtraParam(String key, Object value) {
+                if (this.extraParams == null) {
+                  this.extraParams = new HashMap<>();
+                }
+                this.extraParams.put(key, value);
+                return this;
+              }
+
+              /**
+               * Add all map key/value pairs to `extraParams` map. A map is initialized for the
+               * first `put/putAll` call, and subsequent calls add additional key/value pairs to the
+               * original map. See {@link
+               * AccountCreateParams.Configuration.Storer.Capabilities.OutboundPayments.Cards#extraParams}
+               * for the field documentation.
+               */
+              public Builder putAllExtraParam(Map<String, Object> map) {
+                if (this.extraParams == null) {
+                  this.extraParams = new HashMap<>();
+                }
+                this.extraParams.putAll(map);
+                return this;
+              }
+
+              /**
+               * <strong>Required.</strong> To request a new Capability for an account, pass true.
+               * There can be a delay before the requested Capability becomes active.
+               */
+              public Builder setRequested(Boolean requested) {
+                this.requested = requested;
+                return this;
+              }
+            }
+          }
+
+          @Getter
+          @EqualsAndHashCode(callSuper = false)
+          public static class FinancialAccounts {
+            /**
+             * Map of extra parameters for custom features not available in this client library. The
+             * content in this map is not serialized under this field's {@code @SerializedName}
+             * value. Instead, each key/value pair is serialized as if the key is a root-level field
+             * (serialized) name in this param object. Effectively, this map is flattened to its
+             * parent instance.
+             */
+            @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+            Map<String, Object> extraParams;
+
+            /**
+             * <strong>Required.</strong> To request a new Capability for an account, pass true.
+             * There can be a delay before the requested Capability becomes active.
+             */
+            @SerializedName("requested")
+            Boolean requested;
+
+            private FinancialAccounts(Map<String, Object> extraParams, Boolean requested) {
+              this.extraParams = extraParams;
+              this.requested = requested;
+            }
+
+            public static Builder builder() {
+              return new Builder();
+            }
+
+            public static class Builder {
+              private Map<String, Object> extraParams;
+
+              private Boolean requested;
+
+              /** Finalize and obtain parameter instance from this builder. */
+              public AccountCreateParams.Configuration.Storer.Capabilities.OutboundPayments
+                      .FinancialAccounts
+                  build() {
+                return new AccountCreateParams.Configuration.Storer.Capabilities.OutboundPayments
+                    .FinancialAccounts(this.extraParams, this.requested);
+              }
+
+              /**
+               * Add a key/value pair to `extraParams` map. A map is initialized for the first
+               * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+               * original map. See {@link
+               * AccountCreateParams.Configuration.Storer.Capabilities.OutboundPayments.FinancialAccounts#extraParams}
+               * for the field documentation.
+               */
+              public Builder putExtraParam(String key, Object value) {
+                if (this.extraParams == null) {
+                  this.extraParams = new HashMap<>();
+                }
+                this.extraParams.put(key, value);
+                return this;
+              }
+
+              /**
+               * Add all map key/value pairs to `extraParams` map. A map is initialized for the
+               * first `put/putAll` call, and subsequent calls add additional key/value pairs to the
+               * original map. See {@link
+               * AccountCreateParams.Configuration.Storer.Capabilities.OutboundPayments.FinancialAccounts#extraParams}
+               * for the field documentation.
+               */
+              public Builder putAllExtraParam(Map<String, Object> map) {
+                if (this.extraParams == null) {
+                  this.extraParams = new HashMap<>();
+                }
+                this.extraParams.putAll(map);
+                return this;
+              }
+
+              /**
+               * <strong>Required.</strong> To request a new Capability for an account, pass true.
+               * There can be a delay before the requested Capability becomes active.
+               */
+              public Builder setRequested(Boolean requested) {
+                this.requested = requested;
+                return this;
+              }
+            }
+          }
+        }
+
+        @Getter
+        @EqualsAndHashCode(callSuper = false)
+        public static class OutboundTransfers {
+          /** Can send funds from a FinancialAccount to a bank account owned by yourself. */
+          @SerializedName("bank_accounts")
+          BankAccounts bankAccounts;
+
+          /**
+           * Map of extra parameters for custom features not available in this client library. The
+           * content in this map is not serialized under this field's {@code @SerializedName} value.
+           * Instead, each key/value pair is serialized as if the key is a root-level field
+           * (serialized) name in this param object. Effectively, this map is flattened to its
+           * parent instance.
+           */
+          @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+          Map<String, Object> extraParams;
+
+          /**
+           * Can send funds from a FinancialAccount to another FinancialAccount owned by yourself.
+           */
+          @SerializedName("financial_accounts")
+          FinancialAccounts financialAccounts;
+
+          private OutboundTransfers(
+              BankAccounts bankAccounts,
+              Map<String, Object> extraParams,
+              FinancialAccounts financialAccounts) {
+            this.bankAccounts = bankAccounts;
+            this.extraParams = extraParams;
+            this.financialAccounts = financialAccounts;
+          }
+
+          public static Builder builder() {
+            return new Builder();
+          }
+
+          public static class Builder {
+            private BankAccounts bankAccounts;
+
+            private Map<String, Object> extraParams;
+
+            private FinancialAccounts financialAccounts;
+
+            /** Finalize and obtain parameter instance from this builder. */
+            public AccountCreateParams.Configuration.Storer.Capabilities.OutboundTransfers build() {
+              return new AccountCreateParams.Configuration.Storer.Capabilities.OutboundTransfers(
+                  this.bankAccounts, this.extraParams, this.financialAccounts);
+            }
+
+            /** Can send funds from a FinancialAccount to a bank account owned by yourself. */
+            public Builder setBankAccounts(
+                AccountCreateParams.Configuration.Storer.Capabilities.OutboundTransfers.BankAccounts
+                    bankAccounts) {
+              this.bankAccounts = bankAccounts;
+              return this;
+            }
+
+            /**
+             * Add a key/value pair to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * AccountCreateParams.Configuration.Storer.Capabilities.OutboundTransfers#extraParams}
+             * for the field documentation.
+             */
+            public Builder putExtraParam(String key, Object value) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.put(key, value);
+              return this;
+            }
+
+            /**
+             * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * AccountCreateParams.Configuration.Storer.Capabilities.OutboundTransfers#extraParams}
+             * for the field documentation.
+             */
+            public Builder putAllExtraParam(Map<String, Object> map) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.putAll(map);
+              return this;
+            }
+
+            /**
+             * Can send funds from a FinancialAccount to another FinancialAccount owned by yourself.
+             */
+            public Builder setFinancialAccounts(
+                AccountCreateParams.Configuration.Storer.Capabilities.OutboundTransfers
+                        .FinancialAccounts
+                    financialAccounts) {
+              this.financialAccounts = financialAccounts;
+              return this;
+            }
+          }
+
+          @Getter
+          @EqualsAndHashCode(callSuper = false)
+          public static class BankAccounts {
+            /**
+             * Map of extra parameters for custom features not available in this client library. The
+             * content in this map is not serialized under this field's {@code @SerializedName}
+             * value. Instead, each key/value pair is serialized as if the key is a root-level field
+             * (serialized) name in this param object. Effectively, this map is flattened to its
+             * parent instance.
+             */
+            @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+            Map<String, Object> extraParams;
+
+            /**
+             * <strong>Required.</strong> To request a new Capability for an account, pass true.
+             * There can be a delay before the requested Capability becomes active.
+             */
+            @SerializedName("requested")
+            Boolean requested;
+
+            private BankAccounts(Map<String, Object> extraParams, Boolean requested) {
+              this.extraParams = extraParams;
+              this.requested = requested;
+            }
+
+            public static Builder builder() {
+              return new Builder();
+            }
+
+            public static class Builder {
+              private Map<String, Object> extraParams;
+
+              private Boolean requested;
+
+              /** Finalize and obtain parameter instance from this builder. */
+              public AccountCreateParams.Configuration.Storer.Capabilities.OutboundTransfers
+                      .BankAccounts
+                  build() {
+                return new AccountCreateParams.Configuration.Storer.Capabilities.OutboundTransfers
+                    .BankAccounts(this.extraParams, this.requested);
+              }
+
+              /**
+               * Add a key/value pair to `extraParams` map. A map is initialized for the first
+               * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+               * original map. See {@link
+               * AccountCreateParams.Configuration.Storer.Capabilities.OutboundTransfers.BankAccounts#extraParams}
+               * for the field documentation.
+               */
+              public Builder putExtraParam(String key, Object value) {
+                if (this.extraParams == null) {
+                  this.extraParams = new HashMap<>();
+                }
+                this.extraParams.put(key, value);
+                return this;
+              }
+
+              /**
+               * Add all map key/value pairs to `extraParams` map. A map is initialized for the
+               * first `put/putAll` call, and subsequent calls add additional key/value pairs to the
+               * original map. See {@link
+               * AccountCreateParams.Configuration.Storer.Capabilities.OutboundTransfers.BankAccounts#extraParams}
+               * for the field documentation.
+               */
+              public Builder putAllExtraParam(Map<String, Object> map) {
+                if (this.extraParams == null) {
+                  this.extraParams = new HashMap<>();
+                }
+                this.extraParams.putAll(map);
+                return this;
+              }
+
+              /**
+               * <strong>Required.</strong> To request a new Capability for an account, pass true.
+               * There can be a delay before the requested Capability becomes active.
+               */
+              public Builder setRequested(Boolean requested) {
+                this.requested = requested;
+                return this;
+              }
+            }
+          }
+
+          @Getter
+          @EqualsAndHashCode(callSuper = false)
+          public static class FinancialAccounts {
+            /**
+             * Map of extra parameters for custom features not available in this client library. The
+             * content in this map is not serialized under this field's {@code @SerializedName}
+             * value. Instead, each key/value pair is serialized as if the key is a root-level field
+             * (serialized) name in this param object. Effectively, this map is flattened to its
+             * parent instance.
+             */
+            @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+            Map<String, Object> extraParams;
+
+            /**
+             * <strong>Required.</strong> To request a new Capability for an account, pass true.
+             * There can be a delay before the requested Capability becomes active.
+             */
+            @SerializedName("requested")
+            Boolean requested;
+
+            private FinancialAccounts(Map<String, Object> extraParams, Boolean requested) {
+              this.extraParams = extraParams;
+              this.requested = requested;
+            }
+
+            public static Builder builder() {
+              return new Builder();
+            }
+
+            public static class Builder {
+              private Map<String, Object> extraParams;
+
+              private Boolean requested;
+
+              /** Finalize and obtain parameter instance from this builder. */
+              public AccountCreateParams.Configuration.Storer.Capabilities.OutboundTransfers
+                      .FinancialAccounts
+                  build() {
+                return new AccountCreateParams.Configuration.Storer.Capabilities.OutboundTransfers
+                    .FinancialAccounts(this.extraParams, this.requested);
+              }
+
+              /**
+               * Add a key/value pair to `extraParams` map. A map is initialized for the first
+               * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+               * original map. See {@link
+               * AccountCreateParams.Configuration.Storer.Capabilities.OutboundTransfers.FinancialAccounts#extraParams}
+               * for the field documentation.
+               */
+              public Builder putExtraParam(String key, Object value) {
+                if (this.extraParams == null) {
+                  this.extraParams = new HashMap<>();
+                }
+                this.extraParams.put(key, value);
+                return this;
+              }
+
+              /**
+               * Add all map key/value pairs to `extraParams` map. A map is initialized for the
+               * first `put/putAll` call, and subsequent calls add additional key/value pairs to the
+               * original map. See {@link
+               * AccountCreateParams.Configuration.Storer.Capabilities.OutboundTransfers.FinancialAccounts#extraParams}
                * for the field documentation.
                */
               public Builder putAllExtraParam(Map<String, Object> map) {
@@ -24538,6 +25898,9 @@ public class AccountCreateParams extends ApiRequestParams {
 
     @SerializedName("configuration.recipient")
     CONFIGURATION__RECIPIENT("configuration.recipient"),
+
+    @SerializedName("configuration.storer")
+    CONFIGURATION__STORER("configuration.storer"),
 
     @SerializedName("defaults")
     DEFAULTS("defaults"),

--- a/src/main/java/com/stripe/param/v2/core/AccountRetrieveParams.java
+++ b/src/main/java/com/stripe/param/v2/core/AccountRetrieveParams.java
@@ -109,6 +109,9 @@ public class AccountRetrieveParams extends ApiRequestParams {
     @SerializedName("configuration.recipient")
     CONFIGURATION__RECIPIENT("configuration.recipient"),
 
+    @SerializedName("configuration.storer")
+    CONFIGURATION__STORER("configuration.storer"),
+
     @SerializedName("defaults")
     DEFAULTS("defaults"),
 

--- a/src/main/java/com/stripe/param/v2/core/AccountUpdateParams.java
+++ b/src/main/java/com/stripe/param/v2/core/AccountUpdateParams.java
@@ -321,15 +321,24 @@ public class AccountUpdateParams extends ApiRequestParams {
     @SerializedName("recipient")
     Recipient recipient;
 
+    /**
+     * The Storer Configuration allows the Account to store and move funds using stored-value
+     * FinancialAccounts.
+     */
+    @SerializedName("storer")
+    Storer storer;
+
     private Configuration(
         Customer customer,
         Map<String, Object> extraParams,
         Merchant merchant,
-        Recipient recipient) {
+        Recipient recipient,
+        Storer storer) {
       this.customer = customer;
       this.extraParams = extraParams;
       this.merchant = merchant;
       this.recipient = recipient;
+      this.storer = storer;
     }
 
     public static Builder builder() {
@@ -345,10 +354,12 @@ public class AccountUpdateParams extends ApiRequestParams {
 
       private Recipient recipient;
 
+      private Storer storer;
+
       /** Finalize and obtain parameter instance from this builder. */
       public AccountUpdateParams.Configuration build() {
         return new AccountUpdateParams.Configuration(
-            this.customer, this.extraParams, this.merchant, this.recipient);
+            this.customer, this.extraParams, this.merchant, this.recipient, this.storer);
       }
 
       /** The Customer Configuration allows the Account to be charged. */
@@ -396,6 +407,15 @@ public class AccountUpdateParams extends ApiRequestParams {
       /** The Recipient Configuration allows the Account to receive funds. */
       public Builder setRecipient(AccountUpdateParams.Configuration.Recipient recipient) {
         this.recipient = recipient;
+        return this;
+      }
+
+      /**
+       * The Storer Configuration allows the Account to store and move funds using stored-value
+       * FinancialAccounts.
+       */
+      public Builder setStorer(AccountUpdateParams.Configuration.Storer storer) {
+        this.storer = storer;
         return this;
       }
     }
@@ -9521,6 +9541,1346 @@ public class AccountUpdateParams extends ApiRequestParams {
                * first `put/putAll` call, and subsequent calls add additional key/value pairs to the
                * original map. See {@link
                * AccountUpdateParams.Configuration.Recipient.Capabilities.StripeBalance.StripeTransfers#extraParams}
+               * for the field documentation.
+               */
+              public Builder putAllExtraParam(Map<String, Object> map) {
+                if (this.extraParams == null) {
+                  this.extraParams = new HashMap<>();
+                }
+                this.extraParams.putAll(map);
+                return this;
+              }
+
+              /**
+               * To request a new Capability for an account, pass true. There can be a delay before
+               * the requested Capability becomes active.
+               */
+              public Builder setRequested(Boolean requested) {
+                this.requested = requested;
+                return this;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    @Getter
+    @EqualsAndHashCode(callSuper = false)
+    public static class Storer {
+      /** Capabilities to request on the Storer Configuration. */
+      @SerializedName("capabilities")
+      Capabilities capabilities;
+
+      /**
+       * Map of extra parameters for custom features not available in this client library. The
+       * content in this map is not serialized under this field's {@code @SerializedName} value.
+       * Instead, each key/value pair is serialized as if the key is a root-level field (serialized)
+       * name in this param object. Effectively, this map is flattened to its parent instance.
+       */
+      @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+      Map<String, Object> extraParams;
+
+      private Storer(Capabilities capabilities, Map<String, Object> extraParams) {
+        this.capabilities = capabilities;
+        this.extraParams = extraParams;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
+      public static class Builder {
+        private Capabilities capabilities;
+
+        private Map<String, Object> extraParams;
+
+        /** Finalize and obtain parameter instance from this builder. */
+        public AccountUpdateParams.Configuration.Storer build() {
+          return new AccountUpdateParams.Configuration.Storer(this.capabilities, this.extraParams);
+        }
+
+        /** Capabilities to request on the Storer Configuration. */
+        public Builder setCapabilities(
+            AccountUpdateParams.Configuration.Storer.Capabilities capabilities) {
+          this.capabilities = capabilities;
+          return this;
+        }
+
+        /**
+         * Add a key/value pair to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link AccountUpdateParams.Configuration.Storer#extraParams} for the field
+         * documentation.
+         */
+        public Builder putExtraParam(String key, Object value) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.put(key, value);
+          return this;
+        }
+
+        /**
+         * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+         * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+         * map. See {@link AccountUpdateParams.Configuration.Storer#extraParams} for the field
+         * documentation.
+         */
+        public Builder putAllExtraParam(Map<String, Object> map) {
+          if (this.extraParams == null) {
+            this.extraParams = new HashMap<>();
+          }
+          this.extraParams.putAll(map);
+          return this;
+        }
+      }
+
+      @Getter
+      @EqualsAndHashCode(callSuper = false)
+      public static class Capabilities {
+        /**
+         * Map of extra parameters for custom features not available in this client library. The
+         * content in this map is not serialized under this field's {@code @SerializedName} value.
+         * Instead, each key/value pair is serialized as if the key is a root-level field
+         * (serialized) name in this param object. Effectively, this map is flattened to its parent
+         * instance.
+         */
+        @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+        Map<String, Object> extraParams;
+
+        /** Can provision a financial address to credit/debit a FinancialAccount. */
+        @SerializedName("financial_addresses")
+        FinancialAddresses financialAddresses;
+
+        /** Can hold storage-type funds on Stripe. */
+        @SerializedName("holds_currencies")
+        HoldsCurrencies holdsCurrencies;
+
+        /** Can pull funds from an external source, owned by yourself, to a FinancialAccount. */
+        @SerializedName("inbound_transfers")
+        InboundTransfers inboundTransfers;
+
+        /** Can send funds from a FinancialAccount to a destination owned by someone else. */
+        @SerializedName("outbound_payments")
+        OutboundPayments outboundPayments;
+
+        /** Can send funds from a FinancialAccount to a destination owned by yourself. */
+        @SerializedName("outbound_transfers")
+        OutboundTransfers outboundTransfers;
+
+        private Capabilities(
+            Map<String, Object> extraParams,
+            FinancialAddresses financialAddresses,
+            HoldsCurrencies holdsCurrencies,
+            InboundTransfers inboundTransfers,
+            OutboundPayments outboundPayments,
+            OutboundTransfers outboundTransfers) {
+          this.extraParams = extraParams;
+          this.financialAddresses = financialAddresses;
+          this.holdsCurrencies = holdsCurrencies;
+          this.inboundTransfers = inboundTransfers;
+          this.outboundPayments = outboundPayments;
+          this.outboundTransfers = outboundTransfers;
+        }
+
+        public static Builder builder() {
+          return new Builder();
+        }
+
+        public static class Builder {
+          private Map<String, Object> extraParams;
+
+          private FinancialAddresses financialAddresses;
+
+          private HoldsCurrencies holdsCurrencies;
+
+          private InboundTransfers inboundTransfers;
+
+          private OutboundPayments outboundPayments;
+
+          private OutboundTransfers outboundTransfers;
+
+          /** Finalize and obtain parameter instance from this builder. */
+          public AccountUpdateParams.Configuration.Storer.Capabilities build() {
+            return new AccountUpdateParams.Configuration.Storer.Capabilities(
+                this.extraParams,
+                this.financialAddresses,
+                this.holdsCurrencies,
+                this.inboundTransfers,
+                this.outboundPayments,
+                this.outboundTransfers);
+          }
+
+          /**
+           * Add a key/value pair to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link AccountUpdateParams.Configuration.Storer.Capabilities#extraParams} for
+           * the field documentation.
+           */
+          public Builder putExtraParam(String key, Object value) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.put(key, value);
+            return this;
+          }
+
+          /**
+           * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+           * `put/putAll` call, and subsequent calls add additional key/value pairs to the original
+           * map. See {@link AccountUpdateParams.Configuration.Storer.Capabilities#extraParams} for
+           * the field documentation.
+           */
+          public Builder putAllExtraParam(Map<String, Object> map) {
+            if (this.extraParams == null) {
+              this.extraParams = new HashMap<>();
+            }
+            this.extraParams.putAll(map);
+            return this;
+          }
+
+          /** Can provision a financial address to credit/debit a FinancialAccount. */
+          public Builder setFinancialAddresses(
+              AccountUpdateParams.Configuration.Storer.Capabilities.FinancialAddresses
+                  financialAddresses) {
+            this.financialAddresses = financialAddresses;
+            return this;
+          }
+
+          /** Can hold storage-type funds on Stripe. */
+          public Builder setHoldsCurrencies(
+              AccountUpdateParams.Configuration.Storer.Capabilities.HoldsCurrencies
+                  holdsCurrencies) {
+            this.holdsCurrencies = holdsCurrencies;
+            return this;
+          }
+
+          /** Can pull funds from an external source, owned by yourself, to a FinancialAccount. */
+          public Builder setInboundTransfers(
+              AccountUpdateParams.Configuration.Storer.Capabilities.InboundTransfers
+                  inboundTransfers) {
+            this.inboundTransfers = inboundTransfers;
+            return this;
+          }
+
+          /** Can send funds from a FinancialAccount to a destination owned by someone else. */
+          public Builder setOutboundPayments(
+              AccountUpdateParams.Configuration.Storer.Capabilities.OutboundPayments
+                  outboundPayments) {
+            this.outboundPayments = outboundPayments;
+            return this;
+          }
+
+          /** Can send funds from a FinancialAccount to a destination owned by yourself. */
+          public Builder setOutboundTransfers(
+              AccountUpdateParams.Configuration.Storer.Capabilities.OutboundTransfers
+                  outboundTransfers) {
+            this.outboundTransfers = outboundTransfers;
+            return this;
+          }
+        }
+
+        @Getter
+        @EqualsAndHashCode(callSuper = false)
+        public static class FinancialAddresses {
+          /**
+           * Can provision a bank-account-like financial address (VBAN) to credit/debit a
+           * FinancialAccount.
+           */
+          @SerializedName("bank_accounts")
+          BankAccounts bankAccounts;
+
+          /**
+           * Map of extra parameters for custom features not available in this client library. The
+           * content in this map is not serialized under this field's {@code @SerializedName} value.
+           * Instead, each key/value pair is serialized as if the key is a root-level field
+           * (serialized) name in this param object. Effectively, this map is flattened to its
+           * parent instance.
+           */
+          @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+          Map<String, Object> extraParams;
+
+          private FinancialAddresses(BankAccounts bankAccounts, Map<String, Object> extraParams) {
+            this.bankAccounts = bankAccounts;
+            this.extraParams = extraParams;
+          }
+
+          public static Builder builder() {
+            return new Builder();
+          }
+
+          public static class Builder {
+            private BankAccounts bankAccounts;
+
+            private Map<String, Object> extraParams;
+
+            /** Finalize and obtain parameter instance from this builder. */
+            public AccountUpdateParams.Configuration.Storer.Capabilities.FinancialAddresses
+                build() {
+              return new AccountUpdateParams.Configuration.Storer.Capabilities.FinancialAddresses(
+                  this.bankAccounts, this.extraParams);
+            }
+
+            /**
+             * Can provision a bank-account-like financial address (VBAN) to credit/debit a
+             * FinancialAccount.
+             */
+            public Builder setBankAccounts(
+                AccountUpdateParams.Configuration.Storer.Capabilities.FinancialAddresses
+                        .BankAccounts
+                    bankAccounts) {
+              this.bankAccounts = bankAccounts;
+              return this;
+            }
+
+            /**
+             * Add a key/value pair to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * AccountUpdateParams.Configuration.Storer.Capabilities.FinancialAddresses#extraParams}
+             * for the field documentation.
+             */
+            public Builder putExtraParam(String key, Object value) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.put(key, value);
+              return this;
+            }
+
+            /**
+             * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * AccountUpdateParams.Configuration.Storer.Capabilities.FinancialAddresses#extraParams}
+             * for the field documentation.
+             */
+            public Builder putAllExtraParam(Map<String, Object> map) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.putAll(map);
+              return this;
+            }
+          }
+
+          @Getter
+          @EqualsAndHashCode(callSuper = false)
+          public static class BankAccounts {
+            /**
+             * Map of extra parameters for custom features not available in this client library. The
+             * content in this map is not serialized under this field's {@code @SerializedName}
+             * value. Instead, each key/value pair is serialized as if the key is a root-level field
+             * (serialized) name in this param object. Effectively, this map is flattened to its
+             * parent instance.
+             */
+            @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+            Map<String, Object> extraParams;
+
+            /**
+             * To request a new Capability for an account, pass true. There can be a delay before
+             * the requested Capability becomes active.
+             */
+            @SerializedName("requested")
+            Boolean requested;
+
+            private BankAccounts(Map<String, Object> extraParams, Boolean requested) {
+              this.extraParams = extraParams;
+              this.requested = requested;
+            }
+
+            public static Builder builder() {
+              return new Builder();
+            }
+
+            public static class Builder {
+              private Map<String, Object> extraParams;
+
+              private Boolean requested;
+
+              /** Finalize and obtain parameter instance from this builder. */
+              public AccountUpdateParams.Configuration.Storer.Capabilities.FinancialAddresses
+                      .BankAccounts
+                  build() {
+                return new AccountUpdateParams.Configuration.Storer.Capabilities.FinancialAddresses
+                    .BankAccounts(this.extraParams, this.requested);
+              }
+
+              /**
+               * Add a key/value pair to `extraParams` map. A map is initialized for the first
+               * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+               * original map. See {@link
+               * AccountUpdateParams.Configuration.Storer.Capabilities.FinancialAddresses.BankAccounts#extraParams}
+               * for the field documentation.
+               */
+              public Builder putExtraParam(String key, Object value) {
+                if (this.extraParams == null) {
+                  this.extraParams = new HashMap<>();
+                }
+                this.extraParams.put(key, value);
+                return this;
+              }
+
+              /**
+               * Add all map key/value pairs to `extraParams` map. A map is initialized for the
+               * first `put/putAll` call, and subsequent calls add additional key/value pairs to the
+               * original map. See {@link
+               * AccountUpdateParams.Configuration.Storer.Capabilities.FinancialAddresses.BankAccounts#extraParams}
+               * for the field documentation.
+               */
+              public Builder putAllExtraParam(Map<String, Object> map) {
+                if (this.extraParams == null) {
+                  this.extraParams = new HashMap<>();
+                }
+                this.extraParams.putAll(map);
+                return this;
+              }
+
+              /**
+               * To request a new Capability for an account, pass true. There can be a delay before
+               * the requested Capability becomes active.
+               */
+              public Builder setRequested(Boolean requested) {
+                this.requested = requested;
+                return this;
+              }
+            }
+          }
+        }
+
+        @Getter
+        @EqualsAndHashCode(callSuper = false)
+        public static class HoldsCurrencies {
+          /**
+           * Map of extra parameters for custom features not available in this client library. The
+           * content in this map is not serialized under this field's {@code @SerializedName} value.
+           * Instead, each key/value pair is serialized as if the key is a root-level field
+           * (serialized) name in this param object. Effectively, this map is flattened to its
+           * parent instance.
+           */
+          @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+          Map<String, Object> extraParams;
+
+          /** Can hold storage-type funds on Stripe in GBP. */
+          @SerializedName("gbp")
+          Gbp gbp;
+
+          private HoldsCurrencies(Map<String, Object> extraParams, Gbp gbp) {
+            this.extraParams = extraParams;
+            this.gbp = gbp;
+          }
+
+          public static Builder builder() {
+            return new Builder();
+          }
+
+          public static class Builder {
+            private Map<String, Object> extraParams;
+
+            private Gbp gbp;
+
+            /** Finalize and obtain parameter instance from this builder. */
+            public AccountUpdateParams.Configuration.Storer.Capabilities.HoldsCurrencies build() {
+              return new AccountUpdateParams.Configuration.Storer.Capabilities.HoldsCurrencies(
+                  this.extraParams, this.gbp);
+            }
+
+            /**
+             * Add a key/value pair to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * AccountUpdateParams.Configuration.Storer.Capabilities.HoldsCurrencies#extraParams}
+             * for the field documentation.
+             */
+            public Builder putExtraParam(String key, Object value) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.put(key, value);
+              return this;
+            }
+
+            /**
+             * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * AccountUpdateParams.Configuration.Storer.Capabilities.HoldsCurrencies#extraParams}
+             * for the field documentation.
+             */
+            public Builder putAllExtraParam(Map<String, Object> map) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.putAll(map);
+              return this;
+            }
+
+            /** Can hold storage-type funds on Stripe in GBP. */
+            public Builder setGbp(
+                AccountUpdateParams.Configuration.Storer.Capabilities.HoldsCurrencies.Gbp gbp) {
+              this.gbp = gbp;
+              return this;
+            }
+          }
+
+          @Getter
+          @EqualsAndHashCode(callSuper = false)
+          public static class Gbp {
+            /**
+             * Map of extra parameters for custom features not available in this client library. The
+             * content in this map is not serialized under this field's {@code @SerializedName}
+             * value. Instead, each key/value pair is serialized as if the key is a root-level field
+             * (serialized) name in this param object. Effectively, this map is flattened to its
+             * parent instance.
+             */
+            @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+            Map<String, Object> extraParams;
+
+            /**
+             * To request a new Capability for an account, pass true. There can be a delay before
+             * the requested Capability becomes active.
+             */
+            @SerializedName("requested")
+            Boolean requested;
+
+            private Gbp(Map<String, Object> extraParams, Boolean requested) {
+              this.extraParams = extraParams;
+              this.requested = requested;
+            }
+
+            public static Builder builder() {
+              return new Builder();
+            }
+
+            public static class Builder {
+              private Map<String, Object> extraParams;
+
+              private Boolean requested;
+
+              /** Finalize and obtain parameter instance from this builder. */
+              public AccountUpdateParams.Configuration.Storer.Capabilities.HoldsCurrencies.Gbp
+                  build() {
+                return new AccountUpdateParams.Configuration.Storer.Capabilities.HoldsCurrencies
+                    .Gbp(this.extraParams, this.requested);
+              }
+
+              /**
+               * Add a key/value pair to `extraParams` map. A map is initialized for the first
+               * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+               * original map. See {@link
+               * AccountUpdateParams.Configuration.Storer.Capabilities.HoldsCurrencies.Gbp#extraParams}
+               * for the field documentation.
+               */
+              public Builder putExtraParam(String key, Object value) {
+                if (this.extraParams == null) {
+                  this.extraParams = new HashMap<>();
+                }
+                this.extraParams.put(key, value);
+                return this;
+              }
+
+              /**
+               * Add all map key/value pairs to `extraParams` map. A map is initialized for the
+               * first `put/putAll` call, and subsequent calls add additional key/value pairs to the
+               * original map. See {@link
+               * AccountUpdateParams.Configuration.Storer.Capabilities.HoldsCurrencies.Gbp#extraParams}
+               * for the field documentation.
+               */
+              public Builder putAllExtraParam(Map<String, Object> map) {
+                if (this.extraParams == null) {
+                  this.extraParams = new HashMap<>();
+                }
+                this.extraParams.putAll(map);
+                return this;
+              }
+
+              /**
+               * To request a new Capability for an account, pass true. There can be a delay before
+               * the requested Capability becomes active.
+               */
+              public Builder setRequested(Boolean requested) {
+                this.requested = requested;
+                return this;
+              }
+            }
+          }
+        }
+
+        @Getter
+        @EqualsAndHashCode(callSuper = false)
+        public static class InboundTransfers {
+          /**
+           * Can pull funds from an external bank account owned by yourself to a FinancialAccount.
+           */
+          @SerializedName("bank_accounts")
+          BankAccounts bankAccounts;
+
+          /**
+           * Map of extra parameters for custom features not available in this client library. The
+           * content in this map is not serialized under this field's {@code @SerializedName} value.
+           * Instead, each key/value pair is serialized as if the key is a root-level field
+           * (serialized) name in this param object. Effectively, this map is flattened to its
+           * parent instance.
+           */
+          @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+          Map<String, Object> extraParams;
+
+          private InboundTransfers(BankAccounts bankAccounts, Map<String, Object> extraParams) {
+            this.bankAccounts = bankAccounts;
+            this.extraParams = extraParams;
+          }
+
+          public static Builder builder() {
+            return new Builder();
+          }
+
+          public static class Builder {
+            private BankAccounts bankAccounts;
+
+            private Map<String, Object> extraParams;
+
+            /** Finalize and obtain parameter instance from this builder. */
+            public AccountUpdateParams.Configuration.Storer.Capabilities.InboundTransfers build() {
+              return new AccountUpdateParams.Configuration.Storer.Capabilities.InboundTransfers(
+                  this.bankAccounts, this.extraParams);
+            }
+
+            /**
+             * Can pull funds from an external bank account owned by yourself to a FinancialAccount.
+             */
+            public Builder setBankAccounts(
+                AccountUpdateParams.Configuration.Storer.Capabilities.InboundTransfers.BankAccounts
+                    bankAccounts) {
+              this.bankAccounts = bankAccounts;
+              return this;
+            }
+
+            /**
+             * Add a key/value pair to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * AccountUpdateParams.Configuration.Storer.Capabilities.InboundTransfers#extraParams}
+             * for the field documentation.
+             */
+            public Builder putExtraParam(String key, Object value) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.put(key, value);
+              return this;
+            }
+
+            /**
+             * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * AccountUpdateParams.Configuration.Storer.Capabilities.InboundTransfers#extraParams}
+             * for the field documentation.
+             */
+            public Builder putAllExtraParam(Map<String, Object> map) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.putAll(map);
+              return this;
+            }
+          }
+
+          @Getter
+          @EqualsAndHashCode(callSuper = false)
+          public static class BankAccounts {
+            /**
+             * Map of extra parameters for custom features not available in this client library. The
+             * content in this map is not serialized under this field's {@code @SerializedName}
+             * value. Instead, each key/value pair is serialized as if the key is a root-level field
+             * (serialized) name in this param object. Effectively, this map is flattened to its
+             * parent instance.
+             */
+            @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+            Map<String, Object> extraParams;
+
+            /**
+             * To request a new Capability for an account, pass true. There can be a delay before
+             * the requested Capability becomes active.
+             */
+            @SerializedName("requested")
+            Boolean requested;
+
+            private BankAccounts(Map<String, Object> extraParams, Boolean requested) {
+              this.extraParams = extraParams;
+              this.requested = requested;
+            }
+
+            public static Builder builder() {
+              return new Builder();
+            }
+
+            public static class Builder {
+              private Map<String, Object> extraParams;
+
+              private Boolean requested;
+
+              /** Finalize and obtain parameter instance from this builder. */
+              public AccountUpdateParams.Configuration.Storer.Capabilities.InboundTransfers
+                      .BankAccounts
+                  build() {
+                return new AccountUpdateParams.Configuration.Storer.Capabilities.InboundTransfers
+                    .BankAccounts(this.extraParams, this.requested);
+              }
+
+              /**
+               * Add a key/value pair to `extraParams` map. A map is initialized for the first
+               * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+               * original map. See {@link
+               * AccountUpdateParams.Configuration.Storer.Capabilities.InboundTransfers.BankAccounts#extraParams}
+               * for the field documentation.
+               */
+              public Builder putExtraParam(String key, Object value) {
+                if (this.extraParams == null) {
+                  this.extraParams = new HashMap<>();
+                }
+                this.extraParams.put(key, value);
+                return this;
+              }
+
+              /**
+               * Add all map key/value pairs to `extraParams` map. A map is initialized for the
+               * first `put/putAll` call, and subsequent calls add additional key/value pairs to the
+               * original map. See {@link
+               * AccountUpdateParams.Configuration.Storer.Capabilities.InboundTransfers.BankAccounts#extraParams}
+               * for the field documentation.
+               */
+              public Builder putAllExtraParam(Map<String, Object> map) {
+                if (this.extraParams == null) {
+                  this.extraParams = new HashMap<>();
+                }
+                this.extraParams.putAll(map);
+                return this;
+              }
+
+              /**
+               * To request a new Capability for an account, pass true. There can be a delay before
+               * the requested Capability becomes active.
+               */
+              public Builder setRequested(Boolean requested) {
+                this.requested = requested;
+                return this;
+              }
+            }
+          }
+        }
+
+        @Getter
+        @EqualsAndHashCode(callSuper = false)
+        public static class OutboundPayments {
+          /** Can send funds from a FinancialAccount to a bank account owned by someone else. */
+          @SerializedName("bank_accounts")
+          BankAccounts bankAccounts;
+
+          /** Can send funds from a FinancialAccount to a debit card owned by someone else. */
+          @SerializedName("cards")
+          Cards cards;
+
+          /**
+           * Map of extra parameters for custom features not available in this client library. The
+           * content in this map is not serialized under this field's {@code @SerializedName} value.
+           * Instead, each key/value pair is serialized as if the key is a root-level field
+           * (serialized) name in this param object. Effectively, this map is flattened to its
+           * parent instance.
+           */
+          @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+          Map<String, Object> extraParams;
+
+          /**
+           * Can send funds from a FinancialAccount to another FinancialAccount owned by someone
+           * else.
+           */
+          @SerializedName("financial_accounts")
+          FinancialAccounts financialAccounts;
+
+          private OutboundPayments(
+              BankAccounts bankAccounts,
+              Cards cards,
+              Map<String, Object> extraParams,
+              FinancialAccounts financialAccounts) {
+            this.bankAccounts = bankAccounts;
+            this.cards = cards;
+            this.extraParams = extraParams;
+            this.financialAccounts = financialAccounts;
+          }
+
+          public static Builder builder() {
+            return new Builder();
+          }
+
+          public static class Builder {
+            private BankAccounts bankAccounts;
+
+            private Cards cards;
+
+            private Map<String, Object> extraParams;
+
+            private FinancialAccounts financialAccounts;
+
+            /** Finalize and obtain parameter instance from this builder. */
+            public AccountUpdateParams.Configuration.Storer.Capabilities.OutboundPayments build() {
+              return new AccountUpdateParams.Configuration.Storer.Capabilities.OutboundPayments(
+                  this.bankAccounts, this.cards, this.extraParams, this.financialAccounts);
+            }
+
+            /** Can send funds from a FinancialAccount to a bank account owned by someone else. */
+            public Builder setBankAccounts(
+                AccountUpdateParams.Configuration.Storer.Capabilities.OutboundPayments.BankAccounts
+                    bankAccounts) {
+              this.bankAccounts = bankAccounts;
+              return this;
+            }
+
+            /** Can send funds from a FinancialAccount to a debit card owned by someone else. */
+            public Builder setCards(
+                AccountUpdateParams.Configuration.Storer.Capabilities.OutboundPayments.Cards
+                    cards) {
+              this.cards = cards;
+              return this;
+            }
+
+            /**
+             * Add a key/value pair to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * AccountUpdateParams.Configuration.Storer.Capabilities.OutboundPayments#extraParams}
+             * for the field documentation.
+             */
+            public Builder putExtraParam(String key, Object value) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.put(key, value);
+              return this;
+            }
+
+            /**
+             * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * AccountUpdateParams.Configuration.Storer.Capabilities.OutboundPayments#extraParams}
+             * for the field documentation.
+             */
+            public Builder putAllExtraParam(Map<String, Object> map) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.putAll(map);
+              return this;
+            }
+
+            /**
+             * Can send funds from a FinancialAccount to another FinancialAccount owned by someone
+             * else.
+             */
+            public Builder setFinancialAccounts(
+                AccountUpdateParams.Configuration.Storer.Capabilities.OutboundPayments
+                        .FinancialAccounts
+                    financialAccounts) {
+              this.financialAccounts = financialAccounts;
+              return this;
+            }
+          }
+
+          @Getter
+          @EqualsAndHashCode(callSuper = false)
+          public static class BankAccounts {
+            /**
+             * Map of extra parameters for custom features not available in this client library. The
+             * content in this map is not serialized under this field's {@code @SerializedName}
+             * value. Instead, each key/value pair is serialized as if the key is a root-level field
+             * (serialized) name in this param object. Effectively, this map is flattened to its
+             * parent instance.
+             */
+            @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+            Map<String, Object> extraParams;
+
+            /**
+             * To request a new Capability for an account, pass true. There can be a delay before
+             * the requested Capability becomes active.
+             */
+            @SerializedName("requested")
+            Boolean requested;
+
+            private BankAccounts(Map<String, Object> extraParams, Boolean requested) {
+              this.extraParams = extraParams;
+              this.requested = requested;
+            }
+
+            public static Builder builder() {
+              return new Builder();
+            }
+
+            public static class Builder {
+              private Map<String, Object> extraParams;
+
+              private Boolean requested;
+
+              /** Finalize and obtain parameter instance from this builder. */
+              public AccountUpdateParams.Configuration.Storer.Capabilities.OutboundPayments
+                      .BankAccounts
+                  build() {
+                return new AccountUpdateParams.Configuration.Storer.Capabilities.OutboundPayments
+                    .BankAccounts(this.extraParams, this.requested);
+              }
+
+              /**
+               * Add a key/value pair to `extraParams` map. A map is initialized for the first
+               * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+               * original map. See {@link
+               * AccountUpdateParams.Configuration.Storer.Capabilities.OutboundPayments.BankAccounts#extraParams}
+               * for the field documentation.
+               */
+              public Builder putExtraParam(String key, Object value) {
+                if (this.extraParams == null) {
+                  this.extraParams = new HashMap<>();
+                }
+                this.extraParams.put(key, value);
+                return this;
+              }
+
+              /**
+               * Add all map key/value pairs to `extraParams` map. A map is initialized for the
+               * first `put/putAll` call, and subsequent calls add additional key/value pairs to the
+               * original map. See {@link
+               * AccountUpdateParams.Configuration.Storer.Capabilities.OutboundPayments.BankAccounts#extraParams}
+               * for the field documentation.
+               */
+              public Builder putAllExtraParam(Map<String, Object> map) {
+                if (this.extraParams == null) {
+                  this.extraParams = new HashMap<>();
+                }
+                this.extraParams.putAll(map);
+                return this;
+              }
+
+              /**
+               * To request a new Capability for an account, pass true. There can be a delay before
+               * the requested Capability becomes active.
+               */
+              public Builder setRequested(Boolean requested) {
+                this.requested = requested;
+                return this;
+              }
+            }
+          }
+
+          @Getter
+          @EqualsAndHashCode(callSuper = false)
+          public static class Cards {
+            /**
+             * Map of extra parameters for custom features not available in this client library. The
+             * content in this map is not serialized under this field's {@code @SerializedName}
+             * value. Instead, each key/value pair is serialized as if the key is a root-level field
+             * (serialized) name in this param object. Effectively, this map is flattened to its
+             * parent instance.
+             */
+            @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+            Map<String, Object> extraParams;
+
+            /**
+             * To request a new Capability for an account, pass true. There can be a delay before
+             * the requested Capability becomes active.
+             */
+            @SerializedName("requested")
+            Boolean requested;
+
+            private Cards(Map<String, Object> extraParams, Boolean requested) {
+              this.extraParams = extraParams;
+              this.requested = requested;
+            }
+
+            public static Builder builder() {
+              return new Builder();
+            }
+
+            public static class Builder {
+              private Map<String, Object> extraParams;
+
+              private Boolean requested;
+
+              /** Finalize and obtain parameter instance from this builder. */
+              public AccountUpdateParams.Configuration.Storer.Capabilities.OutboundPayments.Cards
+                  build() {
+                return new AccountUpdateParams.Configuration.Storer.Capabilities.OutboundPayments
+                    .Cards(this.extraParams, this.requested);
+              }
+
+              /**
+               * Add a key/value pair to `extraParams` map. A map is initialized for the first
+               * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+               * original map. See {@link
+               * AccountUpdateParams.Configuration.Storer.Capabilities.OutboundPayments.Cards#extraParams}
+               * for the field documentation.
+               */
+              public Builder putExtraParam(String key, Object value) {
+                if (this.extraParams == null) {
+                  this.extraParams = new HashMap<>();
+                }
+                this.extraParams.put(key, value);
+                return this;
+              }
+
+              /**
+               * Add all map key/value pairs to `extraParams` map. A map is initialized for the
+               * first `put/putAll` call, and subsequent calls add additional key/value pairs to the
+               * original map. See {@link
+               * AccountUpdateParams.Configuration.Storer.Capabilities.OutboundPayments.Cards#extraParams}
+               * for the field documentation.
+               */
+              public Builder putAllExtraParam(Map<String, Object> map) {
+                if (this.extraParams == null) {
+                  this.extraParams = new HashMap<>();
+                }
+                this.extraParams.putAll(map);
+                return this;
+              }
+
+              /**
+               * To request a new Capability for an account, pass true. There can be a delay before
+               * the requested Capability becomes active.
+               */
+              public Builder setRequested(Boolean requested) {
+                this.requested = requested;
+                return this;
+              }
+            }
+          }
+
+          @Getter
+          @EqualsAndHashCode(callSuper = false)
+          public static class FinancialAccounts {
+            /**
+             * Map of extra parameters for custom features not available in this client library. The
+             * content in this map is not serialized under this field's {@code @SerializedName}
+             * value. Instead, each key/value pair is serialized as if the key is a root-level field
+             * (serialized) name in this param object. Effectively, this map is flattened to its
+             * parent instance.
+             */
+            @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+            Map<String, Object> extraParams;
+
+            /**
+             * To request a new Capability for an account, pass true. There can be a delay before
+             * the requested Capability becomes active.
+             */
+            @SerializedName("requested")
+            Boolean requested;
+
+            private FinancialAccounts(Map<String, Object> extraParams, Boolean requested) {
+              this.extraParams = extraParams;
+              this.requested = requested;
+            }
+
+            public static Builder builder() {
+              return new Builder();
+            }
+
+            public static class Builder {
+              private Map<String, Object> extraParams;
+
+              private Boolean requested;
+
+              /** Finalize and obtain parameter instance from this builder. */
+              public AccountUpdateParams.Configuration.Storer.Capabilities.OutboundPayments
+                      .FinancialAccounts
+                  build() {
+                return new AccountUpdateParams.Configuration.Storer.Capabilities.OutboundPayments
+                    .FinancialAccounts(this.extraParams, this.requested);
+              }
+
+              /**
+               * Add a key/value pair to `extraParams` map. A map is initialized for the first
+               * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+               * original map. See {@link
+               * AccountUpdateParams.Configuration.Storer.Capabilities.OutboundPayments.FinancialAccounts#extraParams}
+               * for the field documentation.
+               */
+              public Builder putExtraParam(String key, Object value) {
+                if (this.extraParams == null) {
+                  this.extraParams = new HashMap<>();
+                }
+                this.extraParams.put(key, value);
+                return this;
+              }
+
+              /**
+               * Add all map key/value pairs to `extraParams` map. A map is initialized for the
+               * first `put/putAll` call, and subsequent calls add additional key/value pairs to the
+               * original map. See {@link
+               * AccountUpdateParams.Configuration.Storer.Capabilities.OutboundPayments.FinancialAccounts#extraParams}
+               * for the field documentation.
+               */
+              public Builder putAllExtraParam(Map<String, Object> map) {
+                if (this.extraParams == null) {
+                  this.extraParams = new HashMap<>();
+                }
+                this.extraParams.putAll(map);
+                return this;
+              }
+
+              /**
+               * To request a new Capability for an account, pass true. There can be a delay before
+               * the requested Capability becomes active.
+               */
+              public Builder setRequested(Boolean requested) {
+                this.requested = requested;
+                return this;
+              }
+            }
+          }
+        }
+
+        @Getter
+        @EqualsAndHashCode(callSuper = false)
+        public static class OutboundTransfers {
+          /** Can send funds from a FinancialAccount to a bank account owned by yourself. */
+          @SerializedName("bank_accounts")
+          BankAccounts bankAccounts;
+
+          /**
+           * Map of extra parameters for custom features not available in this client library. The
+           * content in this map is not serialized under this field's {@code @SerializedName} value.
+           * Instead, each key/value pair is serialized as if the key is a root-level field
+           * (serialized) name in this param object. Effectively, this map is flattened to its
+           * parent instance.
+           */
+          @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+          Map<String, Object> extraParams;
+
+          /**
+           * Can send funds from a FinancialAccount to another FinancialAccount owned by yourself.
+           */
+          @SerializedName("financial_accounts")
+          FinancialAccounts financialAccounts;
+
+          private OutboundTransfers(
+              BankAccounts bankAccounts,
+              Map<String, Object> extraParams,
+              FinancialAccounts financialAccounts) {
+            this.bankAccounts = bankAccounts;
+            this.extraParams = extraParams;
+            this.financialAccounts = financialAccounts;
+          }
+
+          public static Builder builder() {
+            return new Builder();
+          }
+
+          public static class Builder {
+            private BankAccounts bankAccounts;
+
+            private Map<String, Object> extraParams;
+
+            private FinancialAccounts financialAccounts;
+
+            /** Finalize and obtain parameter instance from this builder. */
+            public AccountUpdateParams.Configuration.Storer.Capabilities.OutboundTransfers build() {
+              return new AccountUpdateParams.Configuration.Storer.Capabilities.OutboundTransfers(
+                  this.bankAccounts, this.extraParams, this.financialAccounts);
+            }
+
+            /** Can send funds from a FinancialAccount to a bank account owned by yourself. */
+            public Builder setBankAccounts(
+                AccountUpdateParams.Configuration.Storer.Capabilities.OutboundTransfers.BankAccounts
+                    bankAccounts) {
+              this.bankAccounts = bankAccounts;
+              return this;
+            }
+
+            /**
+             * Add a key/value pair to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * AccountUpdateParams.Configuration.Storer.Capabilities.OutboundTransfers#extraParams}
+             * for the field documentation.
+             */
+            public Builder putExtraParam(String key, Object value) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.put(key, value);
+              return this;
+            }
+
+            /**
+             * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+             * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+             * original map. See {@link
+             * AccountUpdateParams.Configuration.Storer.Capabilities.OutboundTransfers#extraParams}
+             * for the field documentation.
+             */
+            public Builder putAllExtraParam(Map<String, Object> map) {
+              if (this.extraParams == null) {
+                this.extraParams = new HashMap<>();
+              }
+              this.extraParams.putAll(map);
+              return this;
+            }
+
+            /**
+             * Can send funds from a FinancialAccount to another FinancialAccount owned by yourself.
+             */
+            public Builder setFinancialAccounts(
+                AccountUpdateParams.Configuration.Storer.Capabilities.OutboundTransfers
+                        .FinancialAccounts
+                    financialAccounts) {
+              this.financialAccounts = financialAccounts;
+              return this;
+            }
+          }
+
+          @Getter
+          @EqualsAndHashCode(callSuper = false)
+          public static class BankAccounts {
+            /**
+             * Map of extra parameters for custom features not available in this client library. The
+             * content in this map is not serialized under this field's {@code @SerializedName}
+             * value. Instead, each key/value pair is serialized as if the key is a root-level field
+             * (serialized) name in this param object. Effectively, this map is flattened to its
+             * parent instance.
+             */
+            @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+            Map<String, Object> extraParams;
+
+            /**
+             * To request a new Capability for an account, pass true. There can be a delay before
+             * the requested Capability becomes active.
+             */
+            @SerializedName("requested")
+            Boolean requested;
+
+            private BankAccounts(Map<String, Object> extraParams, Boolean requested) {
+              this.extraParams = extraParams;
+              this.requested = requested;
+            }
+
+            public static Builder builder() {
+              return new Builder();
+            }
+
+            public static class Builder {
+              private Map<String, Object> extraParams;
+
+              private Boolean requested;
+
+              /** Finalize and obtain parameter instance from this builder. */
+              public AccountUpdateParams.Configuration.Storer.Capabilities.OutboundTransfers
+                      .BankAccounts
+                  build() {
+                return new AccountUpdateParams.Configuration.Storer.Capabilities.OutboundTransfers
+                    .BankAccounts(this.extraParams, this.requested);
+              }
+
+              /**
+               * Add a key/value pair to `extraParams` map. A map is initialized for the first
+               * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+               * original map. See {@link
+               * AccountUpdateParams.Configuration.Storer.Capabilities.OutboundTransfers.BankAccounts#extraParams}
+               * for the field documentation.
+               */
+              public Builder putExtraParam(String key, Object value) {
+                if (this.extraParams == null) {
+                  this.extraParams = new HashMap<>();
+                }
+                this.extraParams.put(key, value);
+                return this;
+              }
+
+              /**
+               * Add all map key/value pairs to `extraParams` map. A map is initialized for the
+               * first `put/putAll` call, and subsequent calls add additional key/value pairs to the
+               * original map. See {@link
+               * AccountUpdateParams.Configuration.Storer.Capabilities.OutboundTransfers.BankAccounts#extraParams}
+               * for the field documentation.
+               */
+              public Builder putAllExtraParam(Map<String, Object> map) {
+                if (this.extraParams == null) {
+                  this.extraParams = new HashMap<>();
+                }
+                this.extraParams.putAll(map);
+                return this;
+              }
+
+              /**
+               * To request a new Capability for an account, pass true. There can be a delay before
+               * the requested Capability becomes active.
+               */
+              public Builder setRequested(Boolean requested) {
+                this.requested = requested;
+                return this;
+              }
+            }
+          }
+
+          @Getter
+          @EqualsAndHashCode(callSuper = false)
+          public static class FinancialAccounts {
+            /**
+             * Map of extra parameters for custom features not available in this client library. The
+             * content in this map is not serialized under this field's {@code @SerializedName}
+             * value. Instead, each key/value pair is serialized as if the key is a root-level field
+             * (serialized) name in this param object. Effectively, this map is flattened to its
+             * parent instance.
+             */
+            @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+            Map<String, Object> extraParams;
+
+            /**
+             * To request a new Capability for an account, pass true. There can be a delay before
+             * the requested Capability becomes active.
+             */
+            @SerializedName("requested")
+            Boolean requested;
+
+            private FinancialAccounts(Map<String, Object> extraParams, Boolean requested) {
+              this.extraParams = extraParams;
+              this.requested = requested;
+            }
+
+            public static Builder builder() {
+              return new Builder();
+            }
+
+            public static class Builder {
+              private Map<String, Object> extraParams;
+
+              private Boolean requested;
+
+              /** Finalize and obtain parameter instance from this builder. */
+              public AccountUpdateParams.Configuration.Storer.Capabilities.OutboundTransfers
+                      .FinancialAccounts
+                  build() {
+                return new AccountUpdateParams.Configuration.Storer.Capabilities.OutboundTransfers
+                    .FinancialAccounts(this.extraParams, this.requested);
+              }
+
+              /**
+               * Add a key/value pair to `extraParams` map. A map is initialized for the first
+               * `put/putAll` call, and subsequent calls add additional key/value pairs to the
+               * original map. See {@link
+               * AccountUpdateParams.Configuration.Storer.Capabilities.OutboundTransfers.FinancialAccounts#extraParams}
+               * for the field documentation.
+               */
+              public Builder putExtraParam(String key, Object value) {
+                if (this.extraParams == null) {
+                  this.extraParams = new HashMap<>();
+                }
+                this.extraParams.put(key, value);
+                return this;
+              }
+
+              /**
+               * Add all map key/value pairs to `extraParams` map. A map is initialized for the
+               * first `put/putAll` call, and subsequent calls add additional key/value pairs to the
+               * original map. See {@link
+               * AccountUpdateParams.Configuration.Storer.Capabilities.OutboundTransfers.FinancialAccounts#extraParams}
                * for the field documentation.
                */
               public Builder putAllExtraParam(Map<String, Object> map) {
@@ -25846,6 +27206,9 @@ public class AccountUpdateParams extends ApiRequestParams {
 
     @SerializedName("configuration.recipient")
     CONFIGURATION__RECIPIENT("configuration.recipient"),
+
+    @SerializedName("configuration.storer")
+    CONFIGURATION__STORER("configuration.storer"),
 
     @SerializedName("defaults")
     DEFAULTS("defaults"),

--- a/src/main/java/com/stripe/param/v2/moneymanagement/FinancialAccountCloseParams.java
+++ b/src/main/java/com/stripe/param/v2/moneymanagement/FinancialAccountCloseParams.java
@@ -1,0 +1,165 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.v2.moneymanagement;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@EqualsAndHashCode(callSuper = false)
+public class FinancialAccountCloseParams extends ApiRequestParams {
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  /** The addresses to forward any incoming transactions to. */
+  @SerializedName("forwarding_settings")
+  ForwardingSettings forwardingSettings;
+
+  private FinancialAccountCloseParams(
+      Map<String, Object> extraParams, ForwardingSettings forwardingSettings) {
+    this.extraParams = extraParams;
+    this.forwardingSettings = forwardingSettings;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Map<String, Object> extraParams;
+
+    private ForwardingSettings forwardingSettings;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public FinancialAccountCloseParams build() {
+      return new FinancialAccountCloseParams(this.extraParams, this.forwardingSettings);
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * FinancialAccountCloseParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link FinancialAccountCloseParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /** The addresses to forward any incoming transactions to. */
+    public Builder setForwardingSettings(
+        FinancialAccountCloseParams.ForwardingSettings forwardingSettings) {
+      this.forwardingSettings = forwardingSettings;
+      return this;
+    }
+  }
+
+  @Getter
+  @EqualsAndHashCode(callSuper = false)
+  public static class ForwardingSettings {
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /** The address to send forwarded payments to. */
+    @SerializedName("payment_method")
+    String paymentMethod;
+
+    /** The address to send forwarded payouts to. */
+    @SerializedName("payout_method")
+    String payoutMethod;
+
+    private ForwardingSettings(
+        Map<String, Object> extraParams, String paymentMethod, String payoutMethod) {
+      this.extraParams = extraParams;
+      this.paymentMethod = paymentMethod;
+      this.payoutMethod = payoutMethod;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Map<String, Object> extraParams;
+
+      private String paymentMethod;
+
+      private String payoutMethod;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public FinancialAccountCloseParams.ForwardingSettings build() {
+        return new FinancialAccountCloseParams.ForwardingSettings(
+            this.extraParams, this.paymentMethod, this.payoutMethod);
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * FinancialAccountCloseParams.ForwardingSettings#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link FinancialAccountCloseParams.ForwardingSettings#extraParams} for the field
+       * documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /** The address to send forwarded payments to. */
+      public Builder setPaymentMethod(String paymentMethod) {
+        this.paymentMethod = paymentMethod;
+        return this;
+      }
+
+      /** The address to send forwarded payouts to. */
+      public Builder setPayoutMethod(String payoutMethod) {
+        this.payoutMethod = payoutMethod;
+        return this;
+      }
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/v2/moneymanagement/FinancialAccountCreateParams.java
+++ b/src/main/java/com/stripe/param/v2/moneymanagement/FinancialAccountCreateParams.java
@@ -1,0 +1,781 @@
+// File generated from our OpenAPI spec
+package com.stripe.param.v2.moneymanagement;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.net.ApiRequestParams;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@EqualsAndHashCode(callSuper = false)
+public class FinancialAccountCreateParams extends ApiRequestParams {
+  /**
+   * Map of extra parameters for custom features not available in this client library. The content
+   * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+   * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+   * param object. Effectively, this map is flattened to its parent instance.
+   */
+  @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+  Map<String, Object> extraParams;
+
+  /** Metadata associated with the FinancialAccount. */
+  @SerializedName("metadata")
+  Map<String, String> metadata;
+
+  /** Parameters specific to creating {@code storage} type FinancialAccounts. */
+  @SerializedName("storage")
+  Storage storage;
+
+  /** <strong>Required.</strong> The type of FinancialAccount to create. */
+  @SerializedName("type")
+  Type type;
+
+  private FinancialAccountCreateParams(
+      Map<String, Object> extraParams, Map<String, String> metadata, Storage storage, Type type) {
+    this.extraParams = extraParams;
+    this.metadata = metadata;
+    this.storage = storage;
+    this.type = type;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Map<String, Object> extraParams;
+
+    private Map<String, String> metadata;
+
+    private Storage storage;
+
+    private Type type;
+
+    /** Finalize and obtain parameter instance from this builder. */
+    public FinancialAccountCreateParams build() {
+      return new FinancialAccountCreateParams(
+          this.extraParams, this.metadata, this.storage, this.type);
+    }
+
+    /**
+     * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+     * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+     * FinancialAccountCreateParams#extraParams} for the field documentation.
+     */
+    public Builder putExtraParam(String key, Object value) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link FinancialAccountCreateParams#extraParams} for the field documentation.
+     */
+    public Builder putAllExtraParam(Map<String, Object> map) {
+      if (this.extraParams == null) {
+        this.extraParams = new HashMap<>();
+      }
+      this.extraParams.putAll(map);
+      return this;
+    }
+
+    /**
+     * Add a key/value pair to `metadata` map. A map is initialized for the first `put/putAll` call,
+     * and subsequent calls add additional key/value pairs to the original map. See {@link
+     * FinancialAccountCreateParams#metadata} for the field documentation.
+     */
+    public Builder putMetadata(String key, String value) {
+      if (this.metadata == null) {
+        this.metadata = new HashMap<>();
+      }
+      this.metadata.put(key, value);
+      return this;
+    }
+
+    /**
+     * Add all map key/value pairs to `metadata` map. A map is initialized for the first
+     * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+     * See {@link FinancialAccountCreateParams#metadata} for the field documentation.
+     */
+    public Builder putAllMetadata(Map<String, String> map) {
+      if (this.metadata == null) {
+        this.metadata = new HashMap<>();
+      }
+      this.metadata.putAll(map);
+      return this;
+    }
+
+    /** Parameters specific to creating {@code storage} type FinancialAccounts. */
+    public Builder setStorage(FinancialAccountCreateParams.Storage storage) {
+      this.storage = storage;
+      return this;
+    }
+
+    /** <strong>Required.</strong> The type of FinancialAccount to create. */
+    public Builder setType(FinancialAccountCreateParams.Type type) {
+      this.type = type;
+      return this;
+    }
+  }
+
+  @Getter
+  @EqualsAndHashCode(callSuper = false)
+  public static class Storage {
+    /**
+     * Map of extra parameters for custom features not available in this client library. The content
+     * in this map is not serialized under this field's {@code @SerializedName} value. Instead, each
+     * key/value pair is serialized as if the key is a root-level field (serialized) name in this
+     * param object. Effectively, this map is flattened to its parent instance.
+     */
+    @SerializedName(ApiRequestParams.EXTRA_PARAMS_KEY)
+    Map<String, Object> extraParams;
+
+    /** <strong>Required.</strong> The currencies that this FinancialAccount can hold. */
+    @SerializedName("holds_currencies")
+    List<FinancialAccountCreateParams.Storage.HoldsCurrency> holdsCurrencies;
+
+    private Storage(
+        Map<String, Object> extraParams,
+        List<FinancialAccountCreateParams.Storage.HoldsCurrency> holdsCurrencies) {
+      this.extraParams = extraParams;
+      this.holdsCurrencies = holdsCurrencies;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private Map<String, Object> extraParams;
+
+      private List<FinancialAccountCreateParams.Storage.HoldsCurrency> holdsCurrencies;
+
+      /** Finalize and obtain parameter instance from this builder. */
+      public FinancialAccountCreateParams.Storage build() {
+        return new FinancialAccountCreateParams.Storage(this.extraParams, this.holdsCurrencies);
+      }
+
+      /**
+       * Add a key/value pair to `extraParams` map. A map is initialized for the first `put/putAll`
+       * call, and subsequent calls add additional key/value pairs to the original map. See {@link
+       * FinancialAccountCreateParams.Storage#extraParams} for the field documentation.
+       */
+      public Builder putExtraParam(String key, Object value) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.put(key, value);
+        return this;
+      }
+
+      /**
+       * Add all map key/value pairs to `extraParams` map. A map is initialized for the first
+       * `put/putAll` call, and subsequent calls add additional key/value pairs to the original map.
+       * See {@link FinancialAccountCreateParams.Storage#extraParams} for the field documentation.
+       */
+      public Builder putAllExtraParam(Map<String, Object> map) {
+        if (this.extraParams == null) {
+          this.extraParams = new HashMap<>();
+        }
+        this.extraParams.putAll(map);
+        return this;
+      }
+
+      /**
+       * Add an element to `holdsCurrencies` list. A list is initialized for the first `add/addAll`
+       * call, and subsequent calls adds additional elements to the original list. See {@link
+       * FinancialAccountCreateParams.Storage#holdsCurrencies} for the field documentation.
+       */
+      public Builder addHoldsCurrency(FinancialAccountCreateParams.Storage.HoldsCurrency element) {
+        if (this.holdsCurrencies == null) {
+          this.holdsCurrencies = new ArrayList<>();
+        }
+        this.holdsCurrencies.add(element);
+        return this;
+      }
+
+      /**
+       * Add all elements to `holdsCurrencies` list. A list is initialized for the first
+       * `add/addAll` call, and subsequent calls adds additional elements to the original list. See
+       * {@link FinancialAccountCreateParams.Storage#holdsCurrencies} for the field documentation.
+       */
+      public Builder addAllHoldsCurrency(
+          List<FinancialAccountCreateParams.Storage.HoldsCurrency> elements) {
+        if (this.holdsCurrencies == null) {
+          this.holdsCurrencies = new ArrayList<>();
+        }
+        this.holdsCurrencies.addAll(elements);
+        return this;
+      }
+    }
+
+    public enum HoldsCurrency implements ApiRequestParams.EnumParam {
+      @SerializedName("aed")
+      AED("aed"),
+
+      @SerializedName("afn")
+      AFN("afn"),
+
+      @SerializedName("all")
+      ALL("all"),
+
+      @SerializedName("amd")
+      AMD("amd"),
+
+      @SerializedName("ang")
+      ANG("ang"),
+
+      @SerializedName("aoa")
+      AOA("aoa"),
+
+      @SerializedName("ars")
+      ARS("ars"),
+
+      @SerializedName("aud")
+      AUD("aud"),
+
+      @SerializedName("awg")
+      AWG("awg"),
+
+      @SerializedName("azn")
+      AZN("azn"),
+
+      @SerializedName("bam")
+      BAM("bam"),
+
+      @SerializedName("bbd")
+      BBD("bbd"),
+
+      @SerializedName("bdt")
+      BDT("bdt"),
+
+      @SerializedName("bgn")
+      BGN("bgn"),
+
+      @SerializedName("bhd")
+      BHD("bhd"),
+
+      @SerializedName("bif")
+      BIF("bif"),
+
+      @SerializedName("bmd")
+      BMD("bmd"),
+
+      @SerializedName("bnd")
+      BND("bnd"),
+
+      @SerializedName("bob")
+      BOB("bob"),
+
+      @SerializedName("bov")
+      BOV("bov"),
+
+      @SerializedName("brl")
+      BRL("brl"),
+
+      @SerializedName("bsd")
+      BSD("bsd"),
+
+      @SerializedName("btn")
+      BTN("btn"),
+
+      @SerializedName("bwp")
+      BWP("bwp"),
+
+      @SerializedName("byn")
+      BYN("byn"),
+
+      @SerializedName("byr")
+      BYR("byr"),
+
+      @SerializedName("bzd")
+      BZD("bzd"),
+
+      @SerializedName("cad")
+      CAD("cad"),
+
+      @SerializedName("cdf")
+      CDF("cdf"),
+
+      @SerializedName("che")
+      CHE("che"),
+
+      @SerializedName("chf")
+      CHF("chf"),
+
+      @SerializedName("chw")
+      CHW("chw"),
+
+      @SerializedName("clf")
+      CLF("clf"),
+
+      @SerializedName("clp")
+      CLP("clp"),
+
+      @SerializedName("cny")
+      CNY("cny"),
+
+      @SerializedName("cop")
+      COP("cop"),
+
+      @SerializedName("cou")
+      COU("cou"),
+
+      @SerializedName("crc")
+      CRC("crc"),
+
+      @SerializedName("cuc")
+      CUC("cuc"),
+
+      @SerializedName("cup")
+      CUP("cup"),
+
+      @SerializedName("cve")
+      CVE("cve"),
+
+      @SerializedName("czk")
+      CZK("czk"),
+
+      @SerializedName("djf")
+      DJF("djf"),
+
+      @SerializedName("dkk")
+      DKK("dkk"),
+
+      @SerializedName("dop")
+      DOP("dop"),
+
+      @SerializedName("dzd")
+      DZD("dzd"),
+
+      @SerializedName("eek")
+      EEK("eek"),
+
+      @SerializedName("egp")
+      EGP("egp"),
+
+      @SerializedName("ern")
+      ERN("ern"),
+
+      @SerializedName("etb")
+      ETB("etb"),
+
+      @SerializedName("eur")
+      EUR("eur"),
+
+      @SerializedName("fjd")
+      FJD("fjd"),
+
+      @SerializedName("fkp")
+      FKP("fkp"),
+
+      @SerializedName("gbp")
+      GBP("gbp"),
+
+      @SerializedName("gel")
+      GEL("gel"),
+
+      @SerializedName("ghc")
+      GHC("ghc"),
+
+      @SerializedName("ghs")
+      GHS("ghs"),
+
+      @SerializedName("gip")
+      GIP("gip"),
+
+      @SerializedName("gmd")
+      GMD("gmd"),
+
+      @SerializedName("gnf")
+      GNF("gnf"),
+
+      @SerializedName("gtq")
+      GTQ("gtq"),
+
+      @SerializedName("gyd")
+      GYD("gyd"),
+
+      @SerializedName("hkd")
+      HKD("hkd"),
+
+      @SerializedName("hnl")
+      HNL("hnl"),
+
+      @SerializedName("hrk")
+      HRK("hrk"),
+
+      @SerializedName("htg")
+      HTG("htg"),
+
+      @SerializedName("huf")
+      HUF("huf"),
+
+      @SerializedName("idr")
+      IDR("idr"),
+
+      @SerializedName("ils")
+      ILS("ils"),
+
+      @SerializedName("inr")
+      INR("inr"),
+
+      @SerializedName("iqd")
+      IQD("iqd"),
+
+      @SerializedName("irr")
+      IRR("irr"),
+
+      @SerializedName("isk")
+      ISK("isk"),
+
+      @SerializedName("jmd")
+      JMD("jmd"),
+
+      @SerializedName("jod")
+      JOD("jod"),
+
+      @SerializedName("jpy")
+      JPY("jpy"),
+
+      @SerializedName("kes")
+      KES("kes"),
+
+      @SerializedName("kgs")
+      KGS("kgs"),
+
+      @SerializedName("khr")
+      KHR("khr"),
+
+      @SerializedName("kmf")
+      KMF("kmf"),
+
+      @SerializedName("kpw")
+      KPW("kpw"),
+
+      @SerializedName("krw")
+      KRW("krw"),
+
+      @SerializedName("kwd")
+      KWD("kwd"),
+
+      @SerializedName("kyd")
+      KYD("kyd"),
+
+      @SerializedName("kzt")
+      KZT("kzt"),
+
+      @SerializedName("lak")
+      LAK("lak"),
+
+      @SerializedName("lbp")
+      LBP("lbp"),
+
+      @SerializedName("lkr")
+      LKR("lkr"),
+
+      @SerializedName("lrd")
+      LRD("lrd"),
+
+      @SerializedName("lsl")
+      LSL("lsl"),
+
+      @SerializedName("ltl")
+      LTL("ltl"),
+
+      @SerializedName("lvl")
+      LVL("lvl"),
+
+      @SerializedName("lyd")
+      LYD("lyd"),
+
+      @SerializedName("mad")
+      MAD("mad"),
+
+      @SerializedName("mdl")
+      MDL("mdl"),
+
+      @SerializedName("mga")
+      MGA("mga"),
+
+      @SerializedName("mkd")
+      MKD("mkd"),
+
+      @SerializedName("mmk")
+      MMK("mmk"),
+
+      @SerializedName("mnt")
+      MNT("mnt"),
+
+      @SerializedName("mop")
+      MOP("mop"),
+
+      @SerializedName("mro")
+      MRO("mro"),
+
+      @SerializedName("mru")
+      MRU("mru"),
+
+      @SerializedName("mur")
+      MUR("mur"),
+
+      @SerializedName("mvr")
+      MVR("mvr"),
+
+      @SerializedName("mwk")
+      MWK("mwk"),
+
+      @SerializedName("mxn")
+      MXN("mxn"),
+
+      @SerializedName("mxv")
+      MXV("mxv"),
+
+      @SerializedName("myr")
+      MYR("myr"),
+
+      @SerializedName("mzn")
+      MZN("mzn"),
+
+      @SerializedName("nad")
+      NAD("nad"),
+
+      @SerializedName("ngn")
+      NGN("ngn"),
+
+      @SerializedName("nio")
+      NIO("nio"),
+
+      @SerializedName("nok")
+      NOK("nok"),
+
+      @SerializedName("npr")
+      NPR("npr"),
+
+      @SerializedName("nzd")
+      NZD("nzd"),
+
+      @SerializedName("omr")
+      OMR("omr"),
+
+      @SerializedName("pab")
+      PAB("pab"),
+
+      @SerializedName("pen")
+      PEN("pen"),
+
+      @SerializedName("pgk")
+      PGK("pgk"),
+
+      @SerializedName("php")
+      PHP("php"),
+
+      @SerializedName("pkr")
+      PKR("pkr"),
+
+      @SerializedName("pln")
+      PLN("pln"),
+
+      @SerializedName("pyg")
+      PYG("pyg"),
+
+      @SerializedName("qar")
+      QAR("qar"),
+
+      @SerializedName("ron")
+      RON("ron"),
+
+      @SerializedName("rsd")
+      RSD("rsd"),
+
+      @SerializedName("rub")
+      RUB("rub"),
+
+      @SerializedName("rwf")
+      RWF("rwf"),
+
+      @SerializedName("sar")
+      SAR("sar"),
+
+      @SerializedName("sbd")
+      SBD("sbd"),
+
+      @SerializedName("scr")
+      SCR("scr"),
+
+      @SerializedName("sdg")
+      SDG("sdg"),
+
+      @SerializedName("sek")
+      SEK("sek"),
+
+      @SerializedName("sgd")
+      SGD("sgd"),
+
+      @SerializedName("shp")
+      SHP("shp"),
+
+      @SerializedName("sle")
+      SLE("sle"),
+
+      @SerializedName("sll")
+      SLL("sll"),
+
+      @SerializedName("sos")
+      SOS("sos"),
+
+      @SerializedName("srd")
+      SRD("srd"),
+
+      @SerializedName("ssp")
+      SSP("ssp"),
+
+      @SerializedName("std")
+      STD("std"),
+
+      @SerializedName("stn")
+      STN("stn"),
+
+      @SerializedName("svc")
+      SVC("svc"),
+
+      @SerializedName("syp")
+      SYP("syp"),
+
+      @SerializedName("szl")
+      SZL("szl"),
+
+      @SerializedName("thb")
+      THB("thb"),
+
+      @SerializedName("tjs")
+      TJS("tjs"),
+
+      @SerializedName("tmt")
+      TMT("tmt"),
+
+      @SerializedName("tnd")
+      TND("tnd"),
+
+      @SerializedName("top")
+      TOP("top"),
+
+      @SerializedName("try")
+      TRY("try"),
+
+      @SerializedName("ttd")
+      TTD("ttd"),
+
+      @SerializedName("twd")
+      TWD("twd"),
+
+      @SerializedName("tzs")
+      TZS("tzs"),
+
+      @SerializedName("uah")
+      UAH("uah"),
+
+      @SerializedName("ugx")
+      UGX("ugx"),
+
+      @SerializedName("usd")
+      USD("usd"),
+
+      @SerializedName("usdb")
+      USDB("usdb"),
+
+      @SerializedName("usdc")
+      USDC("usdc"),
+
+      @SerializedName("usn")
+      USN("usn"),
+
+      @SerializedName("uyi")
+      UYI("uyi"),
+
+      @SerializedName("uyu")
+      UYU("uyu"),
+
+      @SerializedName("uzs")
+      UZS("uzs"),
+
+      @SerializedName("vef")
+      VEF("vef"),
+
+      @SerializedName("ves")
+      VES("ves"),
+
+      @SerializedName("vnd")
+      VND("vnd"),
+
+      @SerializedName("vuv")
+      VUV("vuv"),
+
+      @SerializedName("wst")
+      WST("wst"),
+
+      @SerializedName("xaf")
+      XAF("xaf"),
+
+      @SerializedName("xcd")
+      XCD("xcd"),
+
+      @SerializedName("xcg")
+      XCG("xcg"),
+
+      @SerializedName("xof")
+      XOF("xof"),
+
+      @SerializedName("xpf")
+      XPF("xpf"),
+
+      @SerializedName("yer")
+      YER("yer"),
+
+      @SerializedName("zar")
+      ZAR("zar"),
+
+      @SerializedName("zmk")
+      ZMK("zmk"),
+
+      @SerializedName("zmw")
+      ZMW("zmw"),
+
+      @SerializedName("zwd")
+      ZWD("zwd"),
+
+      @SerializedName("zwg")
+      ZWG("zwg"),
+
+      @SerializedName("zwl")
+      ZWL("zwl");
+
+      @Getter(onMethod_ = {@Override})
+      private final String value;
+
+      HoldsCurrency(String value) {
+        this.value = value;
+      }
+    }
+  }
+
+  public enum Type implements ApiRequestParams.EnumParam {
+    @SerializedName("storage")
+    STORAGE("storage");
+
+    @Getter(onMethod_ = {@Override})
+    private final String value;
+
+    Type(String value) {
+      this.value = value;
+    }
+  }
+}

--- a/src/main/java/com/stripe/param/v2/moneymanagement/FinancialAccountListParams.java
+++ b/src/main/java/com/stripe/param/v2/moneymanagement/FinancialAccountListParams.java
@@ -24,9 +24,18 @@ public class FinancialAccountListParams extends ApiRequestParams {
   @SerializedName("limit")
   Integer limit;
 
-  private FinancialAccountListParams(Map<String, Object> extraParams, Integer limit) {
+  /**
+   * The status of the FinancialAccount to filter by. By default, closed FinancialAccounts are not
+   * returned.
+   */
+  @SerializedName("status")
+  Status status;
+
+  private FinancialAccountListParams(
+      Map<String, Object> extraParams, Integer limit, Status status) {
     this.extraParams = extraParams;
     this.limit = limit;
+    this.status = status;
   }
 
   public static Builder builder() {
@@ -38,9 +47,11 @@ public class FinancialAccountListParams extends ApiRequestParams {
 
     private Integer limit;
 
+    private Status status;
+
     /** Finalize and obtain parameter instance from this builder. */
     public FinancialAccountListParams build() {
-      return new FinancialAccountListParams(this.extraParams, this.limit);
+      return new FinancialAccountListParams(this.extraParams, this.limit, this.status);
     }
 
     /**
@@ -73,6 +84,33 @@ public class FinancialAccountListParams extends ApiRequestParams {
     public Builder setLimit(Integer limit) {
       this.limit = limit;
       return this;
+    }
+
+    /**
+     * The status of the FinancialAccount to filter by. By default, closed FinancialAccounts are not
+     * returned.
+     */
+    public Builder setStatus(FinancialAccountListParams.Status status) {
+      this.status = status;
+      return this;
+    }
+  }
+
+  public enum Status implements ApiRequestParams.EnumParam {
+    @SerializedName("closed")
+    CLOSED("closed"),
+
+    @SerializedName("open")
+    OPEN("open"),
+
+    @SerializedName("pending")
+    PENDING("pending");
+
+    @Getter(onMethod_ = {@Override})
+    private final String value;
+
+    Status(String value) {
+      this.value = value;
     }
   }
 }

--- a/src/main/java/com/stripe/service/v2/moneymanagement/FinancialAccountService.java
+++ b/src/main/java/com/stripe/service/v2/moneymanagement/FinancialAccountService.java
@@ -2,6 +2,9 @@
 package com.stripe.service.v2.moneymanagement;
 
 import com.google.gson.reflect.TypeToken;
+import com.stripe.exception.AlreadyExistsException;
+import com.stripe.exception.FeatureNotEnabledException;
+import com.stripe.exception.NonZeroBalanceException;
 import com.stripe.exception.StripeException;
 import com.stripe.model.v2.StripeCollection;
 import com.stripe.model.v2.moneymanagement.FinancialAccount;
@@ -12,6 +15,8 @@ import com.stripe.net.ApiService;
 import com.stripe.net.BaseAddress;
 import com.stripe.net.RequestOptions;
 import com.stripe.net.StripeResponseGetter;
+import com.stripe.param.v2.moneymanagement.FinancialAccountCloseParams;
+import com.stripe.param.v2.moneymanagement.FinancialAccountCreateParams;
 import com.stripe.param.v2.moneymanagement.FinancialAccountListParams;
 
 public final class FinancialAccountService extends ApiService {
@@ -45,6 +50,24 @@ public final class FinancialAccountService extends ApiService {
             options);
     return this.request(request, new TypeToken<StripeCollection<FinancialAccount>>() {}.getType());
   }
+  /** Creates a new FinancialAccount. */
+  public FinancialAccount create(FinancialAccountCreateParams params)
+      throws StripeException, AlreadyExistsException, FeatureNotEnabledException {
+    return create(params, (RequestOptions) null);
+  }
+  /** Creates a new FinancialAccount. */
+  public FinancialAccount create(FinancialAccountCreateParams params, RequestOptions options)
+      throws StripeException, AlreadyExistsException, FeatureNotEnabledException {
+    String path = "/v2/money_management/financial_accounts";
+    ApiRequest request =
+        new ApiRequest(
+            BaseAddress.API,
+            ApiResource.RequestMethod.POST,
+            path,
+            ApiRequestParams.paramsToMap(params),
+            options);
+    return this.request(request, FinancialAccount.class);
+  }
   /** Retrieves the details of an existing FinancialAccount. */
   public FinancialAccount retrieve(String id) throws StripeException {
     return retrieve(id, (RequestOptions) null);
@@ -55,6 +78,36 @@ public final class FinancialAccountService extends ApiService {
         String.format("/v2/money_management/financial_accounts/%s", ApiResource.urlEncodeId(id));
     ApiRequest request =
         new ApiRequest(BaseAddress.API, ApiResource.RequestMethod.GET, path, null, options);
+    return this.request(request, FinancialAccount.class);
+  }
+  /** Closes a FinancialAccount with or without forwarding settings. */
+  public FinancialAccount close(String id, FinancialAccountCloseParams params)
+      throws StripeException, NonZeroBalanceException {
+    return close(id, params, (RequestOptions) null);
+  }
+  /** Closes a FinancialAccount with or without forwarding settings. */
+  public FinancialAccount close(String id, RequestOptions options)
+      throws StripeException, NonZeroBalanceException {
+    return close(id, (FinancialAccountCloseParams) null, options);
+  }
+  /** Closes a FinancialAccount with or without forwarding settings. */
+  public FinancialAccount close(String id) throws StripeException, NonZeroBalanceException {
+    return close(id, (FinancialAccountCloseParams) null, (RequestOptions) null);
+  }
+  /** Closes a FinancialAccount with or without forwarding settings. */
+  public FinancialAccount close(
+      String id, FinancialAccountCloseParams params, RequestOptions options)
+      throws StripeException, NonZeroBalanceException {
+    String path =
+        String.format(
+            "/v2/money_management/financial_accounts/%s/close", ApiResource.urlEncodeId(id));
+    ApiRequest request =
+        new ApiRequest(
+            BaseAddress.API,
+            ApiResource.RequestMethod.POST,
+            path,
+            ApiRequestParams.paramsToMap(params),
+            options);
     return this.request(request, FinancialAccount.class);
   }
 }

--- a/src/test/java/com/stripe/functional/GeneratedExamples.java
+++ b/src/test/java/com/stripe/functional/GeneratedExamples.java
@@ -15813,7 +15813,7 @@ class GeneratedExamples extends BaseStripeTest {
         null,
         new TypeToken<
             com.stripe.model.v2.StripeCollection<com.stripe.model.v2.core.Account>>() {}.getType(),
-        "{\"data\":[{\"applied_configurations\":[\"recipient\"],\"configuration\":null,\"contact_email\":null,\"created\":\"1970-01-12T21:42:34.472Z\",\"dashboard\":null,\"defaults\":null,\"display_name\":null,\"id\":\"obj_123\",\"identity\":null,\"metadata\":null,\"object\":\"v2.core.account\",\"requirements\":null,\"livemode\":true}],\"next_page_url\":null,\"previous_page_url\":null}");
+        "{\"data\":[{\"applied_configurations\":[\"storer\"],\"configuration\":null,\"contact_email\":null,\"created\":\"1970-01-12T21:42:34.472Z\",\"dashboard\":null,\"defaults\":null,\"display_name\":null,\"id\":\"obj_123\",\"identity\":null,\"metadata\":null,\"object\":\"v2.core.account\",\"requirements\":null,\"livemode\":true}],\"next_page_url\":null,\"previous_page_url\":null}");
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.v2.core.AccountListParams params =
@@ -15835,7 +15835,7 @@ class GeneratedExamples extends BaseStripeTest {
         null,
         null,
         com.stripe.model.v2.core.Account.class,
-        "{\"applied_configurations\":[\"recipient\"],\"configuration\":null,\"contact_email\":null,\"created\":\"1970-01-12T21:42:34.472Z\",\"dashboard\":null,\"defaults\":null,\"display_name\":null,\"id\":\"obj_123\",\"identity\":null,\"metadata\":null,\"object\":\"v2.core.account\",\"requirements\":null,\"livemode\":true}");
+        "{\"applied_configurations\":[\"storer\"],\"configuration\":null,\"contact_email\":null,\"created\":\"1970-01-12T21:42:34.472Z\",\"dashboard\":null,\"defaults\":null,\"display_name\":null,\"id\":\"obj_123\",\"identity\":null,\"metadata\":null,\"object\":\"v2.core.account\",\"requirements\":null,\"livemode\":true}");
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.v2.core.AccountCreateParams params =
@@ -15856,7 +15856,7 @@ class GeneratedExamples extends BaseStripeTest {
         null,
         null,
         com.stripe.model.v2.core.Account.class,
-        "{\"applied_configurations\":[\"recipient\"],\"configuration\":null,\"contact_email\":null,\"created\":\"1970-01-12T21:42:34.472Z\",\"dashboard\":null,\"defaults\":null,\"display_name\":null,\"id\":\"obj_123\",\"identity\":null,\"metadata\":null,\"object\":\"v2.core.account\",\"requirements\":null,\"livemode\":true}");
+        "{\"applied_configurations\":[\"storer\"],\"configuration\":null,\"contact_email\":null,\"created\":\"1970-01-12T21:42:34.472Z\",\"dashboard\":null,\"defaults\":null,\"display_name\":null,\"id\":\"obj_123\",\"identity\":null,\"metadata\":null,\"object\":\"v2.core.account\",\"requirements\":null,\"livemode\":true}");
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.v2.core.AccountRetrieveParams params =
@@ -15882,7 +15882,7 @@ class GeneratedExamples extends BaseStripeTest {
         null,
         null,
         com.stripe.model.v2.core.Account.class,
-        "{\"applied_configurations\":[\"recipient\"],\"configuration\":null,\"contact_email\":null,\"created\":\"1970-01-12T21:42:34.472Z\",\"dashboard\":null,\"defaults\":null,\"display_name\":null,\"id\":\"obj_123\",\"identity\":null,\"metadata\":null,\"object\":\"v2.core.account\",\"requirements\":null,\"livemode\":true}");
+        "{\"applied_configurations\":[\"storer\"],\"configuration\":null,\"contact_email\":null,\"created\":\"1970-01-12T21:42:34.472Z\",\"dashboard\":null,\"defaults\":null,\"display_name\":null,\"id\":\"obj_123\",\"identity\":null,\"metadata\":null,\"object\":\"v2.core.account\",\"requirements\":null,\"livemode\":true}");
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.v2.core.AccountUpdateParams params =
@@ -15908,7 +15908,7 @@ class GeneratedExamples extends BaseStripeTest {
         null,
         null,
         com.stripe.model.v2.core.Account.class,
-        "{\"applied_configurations\":[\"recipient\"],\"configuration\":null,\"contact_email\":null,\"created\":\"1970-01-12T21:42:34.472Z\",\"dashboard\":null,\"defaults\":null,\"display_name\":null,\"id\":\"obj_123\",\"identity\":null,\"metadata\":null,\"object\":\"v2.core.account\",\"requirements\":null,\"livemode\":true}");
+        "{\"applied_configurations\":[\"storer\"],\"configuration\":null,\"contact_email\":null,\"created\":\"1970-01-12T21:42:34.472Z\",\"dashboard\":null,\"defaults\":null,\"display_name\":null,\"id\":\"obj_123\",\"identity\":null,\"metadata\":null,\"object\":\"v2.core.account\",\"requirements\":null,\"livemode\":true}");
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.v2.core.AccountCloseParams params =
@@ -16581,7 +16581,7 @@ class GeneratedExamples extends BaseStripeTest {
         new TypeToken<
             com.stripe.model.v2.StripeCollection<
                 com.stripe.model.v2.moneymanagement.FinancialAccount>>() {}.getType(),
-        "{\"data\":[{\"balance\":{\"available\":{\"undefined\":{\"currency\":\"USD\",\"value\":35}},\"inbound_pending\":{\"undefined\":{\"currency\":\"USD\",\"value\":11}},\"outbound_pending\":{\"undefined\":{\"currency\":\"USD\",\"value\":60}}},\"country\":\"af\",\"created\":\"1970-01-12T21:42:34.472Z\",\"id\":\"obj_123\",\"metadata\":null,\"object\":\"v2.money_management.financial_account\",\"other\":null,\"status\":\"closed\",\"storage\":null,\"type\":\"other\",\"livemode\":true}],\"next_page_url\":null,\"previous_page_url\":null}");
+        "{\"data\":[{\"balance\":{\"available\":{\"undefined\":{\"currency\":\"USD\",\"value\":35}},\"inbound_pending\":{\"undefined\":{\"currency\":\"USD\",\"value\":11}},\"outbound_pending\":{\"undefined\":{\"currency\":\"USD\",\"value\":60}}},\"country\":\"af\",\"created\":\"1970-01-12T21:42:34.472Z\",\"id\":\"obj_123\",\"metadata\":null,\"object\":\"v2.money_management.financial_account\",\"other\":null,\"status\":\"closed\",\"status_details\":null,\"storage\":null,\"type\":\"other\",\"livemode\":true}],\"next_page_url\":null,\"previous_page_url\":null}");
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.v2.moneymanagement.FinancialAccountListParams params =
@@ -16599,6 +16599,34 @@ class GeneratedExamples extends BaseStripeTest {
   }
 
   @Test
+  public void testV2MoneyManagementFinancialAccountPostServices() throws StripeException {
+    stubRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v2/money_management/financial_accounts",
+        null,
+        null,
+        com.stripe.model.v2.moneymanagement.FinancialAccount.class,
+        "{\"balance\":{\"available\":{\"undefined\":{\"currency\":\"USD\",\"value\":35}},\"inbound_pending\":{\"undefined\":{\"currency\":\"USD\",\"value\":11}},\"outbound_pending\":{\"undefined\":{\"currency\":\"USD\",\"value\":60}}},\"country\":\"af\",\"created\":\"1970-01-12T21:42:34.472Z\",\"id\":\"obj_123\",\"metadata\":null,\"object\":\"v2.money_management.financial_account\",\"other\":null,\"status\":\"closed\",\"status_details\":null,\"storage\":null,\"type\":\"other\",\"livemode\":true}");
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.v2.moneymanagement.FinancialAccountCreateParams params =
+        com.stripe.param.v2.moneymanagement.FinancialAccountCreateParams.builder()
+            .setType(com.stripe.param.v2.moneymanagement.FinancialAccountCreateParams.Type.STORAGE)
+            .build();
+
+    com.stripe.model.v2.moneymanagement.FinancialAccount financialAccount =
+        client.v2().moneyManagement().financialAccounts().create(params);
+    assertNotNull(financialAccount);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v2/money_management/financial_accounts",
+        params.toMap(),
+        null);
+  }
+
+  @Test
   public void testV2MoneyManagementFinancialAccountGet2Services() throws StripeException {
     stubRequest(
         BaseAddress.API,
@@ -16607,7 +16635,7 @@ class GeneratedExamples extends BaseStripeTest {
         null,
         null,
         com.stripe.model.v2.moneymanagement.FinancialAccount.class,
-        "{\"balance\":{\"available\":{\"undefined\":{\"currency\":\"USD\",\"value\":35}},\"inbound_pending\":{\"undefined\":{\"currency\":\"USD\",\"value\":11}},\"outbound_pending\":{\"undefined\":{\"currency\":\"USD\",\"value\":60}}},\"country\":\"af\",\"created\":\"1970-01-12T21:42:34.472Z\",\"id\":\"obj_123\",\"metadata\":null,\"object\":\"v2.money_management.financial_account\",\"other\":null,\"status\":\"closed\",\"storage\":null,\"type\":\"other\",\"livemode\":true}");
+        "{\"balance\":{\"available\":{\"undefined\":{\"currency\":\"USD\",\"value\":35}},\"inbound_pending\":{\"undefined\":{\"currency\":\"USD\",\"value\":11}},\"outbound_pending\":{\"undefined\":{\"currency\":\"USD\",\"value\":60}}},\"country\":\"af\",\"created\":\"1970-01-12T21:42:34.472Z\",\"id\":\"obj_123\",\"metadata\":null,\"object\":\"v2.money_management.financial_account\",\"other\":null,\"status\":\"closed\",\"status_details\":null,\"storage\":null,\"type\":\"other\",\"livemode\":true}");
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.model.v2.moneymanagement.FinancialAccount financialAccount =
@@ -16618,6 +16646,32 @@ class GeneratedExamples extends BaseStripeTest {
         ApiResource.RequestMethod.GET,
         "/v2/money_management/financial_accounts/id_123",
         null,
+        null);
+  }
+
+  @Test
+  public void testV2MoneyManagementFinancialAccountPost2Services() throws StripeException {
+    stubRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v2/money_management/financial_accounts/id_123/close",
+        null,
+        null,
+        com.stripe.model.v2.moneymanagement.FinancialAccount.class,
+        "{\"balance\":{\"available\":{\"undefined\":{\"currency\":\"USD\",\"value\":35}},\"inbound_pending\":{\"undefined\":{\"currency\":\"USD\",\"value\":11}},\"outbound_pending\":{\"undefined\":{\"currency\":\"USD\",\"value\":60}}},\"country\":\"af\",\"created\":\"1970-01-12T21:42:34.472Z\",\"id\":\"obj_123\",\"metadata\":null,\"object\":\"v2.money_management.financial_account\",\"other\":null,\"status\":\"closed\",\"status_details\":null,\"storage\":null,\"type\":\"other\",\"livemode\":true}");
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.v2.moneymanagement.FinancialAccountCloseParams params =
+        com.stripe.param.v2.moneymanagement.FinancialAccountCloseParams.builder().build();
+
+    com.stripe.model.v2.moneymanagement.FinancialAccount financialAccount =
+        client.v2().moneyManagement().financialAccounts().close("id_123", params);
+    assertNotNull(financialAccount);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v2/money_management/financial_accounts/id_123/close",
+        params.toMap(),
         null);
   }
 
@@ -17732,6 +17786,97 @@ class GeneratedExamples extends BaseStripeTest {
   }
 
   @Test
+  public void testNonZeroBalanceErrorServices() throws StripeException {
+    stubRequestReturnError(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v2/money_management/financial_accounts/id_123/close",
+        null,
+        null,
+        "{\"error\":{\"type\":\"non_zero_balance\",\"code\":\"closing_financial_account_with_non_zero_balances\"}}",
+        400);
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.v2.moneymanagement.FinancialAccountCloseParams params =
+        com.stripe.param.v2.moneymanagement.FinancialAccountCloseParams.builder().build();
+
+    try {
+      client.v2().moneyManagement().financialAccounts().close("id_123", params);
+    } catch (NonZeroBalanceException e) {
+
+    }
+    ;
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v2/money_management/financial_accounts/id_123/close",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testAlreadyExistsErrorServices() throws StripeException {
+    stubRequestReturnError(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v2/money_management/financial_accounts",
+        null,
+        null,
+        "{\"error\":{\"type\":\"already_exists\",\"code\":\"already_exists\"}}",
+        400);
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.v2.moneymanagement.FinancialAccountCreateParams params =
+        com.stripe.param.v2.moneymanagement.FinancialAccountCreateParams.builder()
+            .setType(com.stripe.param.v2.moneymanagement.FinancialAccountCreateParams.Type.STORAGE)
+            .build();
+
+    try {
+      client.v2().moneyManagement().financialAccounts().create(params);
+    } catch (AlreadyExistsException e) {
+
+    }
+    ;
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v2/money_management/financial_accounts",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testFeatureNotEnabledErrorServices() throws StripeException {
+    stubRequestReturnError(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v2/money_management/financial_accounts",
+        null,
+        null,
+        "{\"error\":{\"type\":\"feature_not_enabled\",\"code\":\"storer_capability_missing\"}}",
+        400);
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.v2.moneymanagement.FinancialAccountCreateParams params =
+        com.stripe.param.v2.moneymanagement.FinancialAccountCreateParams.builder()
+            .setType(com.stripe.param.v2.moneymanagement.FinancialAccountCreateParams.Type.STORAGE)
+            .build();
+
+    try {
+      client.v2().moneyManagement().financialAccounts().create(params);
+    } catch (FeatureNotEnabledException e) {
+
+    }
+    ;
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v2/money_management/financial_accounts",
+        params.toMap(),
+        null);
+  }
+
+  @Test
   public void testFinancialAccountNotOpenErrorServices() throws StripeException {
     stubRequestReturnError(
         BaseAddress.API,
@@ -17753,39 +17898,6 @@ class GeneratedExamples extends BaseStripeTest {
     try {
       client.v2().moneyManagement().financialAddresses().create(params);
     } catch (FinancialAccountNotOpenException e) {
-
-    }
-    ;
-    verifyRequest(
-        BaseAddress.API,
-        ApiResource.RequestMethod.POST,
-        "/v2/money_management/financial_addresses",
-        params.toMap(),
-        null);
-  }
-
-  @Test
-  public void testFeatureNotEnabledErrorServices() throws StripeException {
-    stubRequestReturnError(
-        BaseAddress.API,
-        ApiResource.RequestMethod.POST,
-        "/v2/money_management/financial_addresses",
-        null,
-        null,
-        "{\"error\":{\"type\":\"feature_not_enabled\",\"code\":\"storer_capability_missing\"}}",
-        400);
-    StripeClient client = new StripeClient(networkSpy);
-
-    com.stripe.param.v2.moneymanagement.FinancialAddressCreateParams params =
-        com.stripe.param.v2.moneymanagement.FinancialAddressCreateParams.builder()
-            .setCurrency(
-                com.stripe.param.v2.moneymanagement.FinancialAddressCreateParams.Currency.STN)
-            .setFinancialAccount("financial_account")
-            .build();
-
-    try {
-      client.v2().moneyManagement().financialAddresses().create(params);
-    } catch (FeatureNotEnabledException e) {
 
     }
     ;


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Changes were done to V2 FinancialAccount API in the June release which did not make it to the SDKs. Pulling those changes in now and making another SDK release for the 2025-06-30.preview API version

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

* Pull protos in codegen for 2025-06-30.preview
* Generate the SDK

### See Also
<!-- Include any links or additional information that help explain this change. -->

## Changelog
* Add support for `close` and `create` methods on resource `v2.moneymanagement.FinancialAccount`
* Add support for `storer` on `v2.core.Account.configuration`, `v2.core.AccountCreateParams.configuration`, and `v2.core.AccountUpdateParams.configuration`
* Add support for `statusDetails` on `v2.moneymanagement.FinancialAccount`
* Add support for `status` on `v2.moneymanagement.FinancialAccountListParams`
* Add support for new value `configuration.storer` on enums `v2.core.AccountCreateParams.include`, `v2.core.AccountRetrieveParams.include`, and `v2.core.AccountUpdateParams.include`
* Add support for new value `storer` on enum `v2.core.AccountCloseParams.appliedConfigurations`
* Add support for thin events `V2CoreAccountIncludingConfigurationStorerCapabilityStatusUpdatedEvent` and `V2CoreAccountIncludingConfigurationStorerUpdatedEvent` with related object `v2.core.Account`
* Add support for error types `AlreadyExistsException` and `NonZeroBalanceException`