### PR TITLE
Introduce V1 namespaces in StripeClient

### DIFF
--- a/src/main/java/com/stripe/StripeClient.java
+++ b/src/main/java/com/stripe/StripeClient.java
@@ -117,282 +117,645 @@ public class StripeClient {
   }
 
   // The beginning of the section generated from our OpenAPI spec
-  public com.stripe.service.AccountLinkService accountLinks() {
-    return new com.stripe.service.AccountLinkService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.AccountSessionService accountSessions() {
-    return new com.stripe.service.AccountSessionService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.AccountService accounts() {
-    return new com.stripe.service.AccountService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.ApplePayDomainService applePayDomains() {
-    return new com.stripe.service.ApplePayDomainService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.ApplicationFeeService applicationFees() {
-    return new com.stripe.service.ApplicationFeeService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.AppsService apps() {
-    return new com.stripe.service.AppsService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.BalanceService balance() {
-    return new com.stripe.service.BalanceService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.BalanceTransactionService balanceTransactions() {
-    return new com.stripe.service.BalanceTransactionService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.BillingService billing() {
-    return new com.stripe.service.BillingService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.BillingPortalService billingPortal() {
-    return new com.stripe.service.BillingPortalService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.ChargeService charges() {
-    return new com.stripe.service.ChargeService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.CheckoutService checkout() {
-    return new com.stripe.service.CheckoutService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.ClimateService climate() {
-    return new com.stripe.service.ClimateService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.ConfirmationTokenService confirmationTokens() {
-    return new com.stripe.service.ConfirmationTokenService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.CountrySpecService countrySpecs() {
-    return new com.stripe.service.CountrySpecService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.CouponService coupons() {
-    return new com.stripe.service.CouponService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.CreditNoteService creditNotes() {
-    return new com.stripe.service.CreditNoteService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.CustomerSessionService customerSessions() {
-    return new com.stripe.service.CustomerSessionService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.CustomerService customers() {
-    return new com.stripe.service.CustomerService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.DisputeService disputes() {
-    return new com.stripe.service.DisputeService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.EntitlementsService entitlements() {
-    return new com.stripe.service.EntitlementsService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.EphemeralKeyService ephemeralKeys() {
-    return new com.stripe.service.EphemeralKeyService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.EventService events() {
-    return new com.stripe.service.EventService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.ExchangeRateService exchangeRates() {
-    return new com.stripe.service.ExchangeRateService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.FileLinkService fileLinks() {
-    return new com.stripe.service.FileLinkService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.FileService files() {
-    return new com.stripe.service.FileService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.FinancialConnectionsService financialConnections() {
-    return new com.stripe.service.FinancialConnectionsService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.ForwardingService forwarding() {
-    return new com.stripe.service.ForwardingService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.IdentityService identity() {
-    return new com.stripe.service.IdentityService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.InvoiceItemService invoiceItems() {
-    return new com.stripe.service.InvoiceItemService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.InvoicePaymentService invoicePayments() {
-    return new com.stripe.service.InvoicePaymentService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.InvoiceRenderingTemplateService invoiceRenderingTemplates() {
-    return new com.stripe.service.InvoiceRenderingTemplateService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.InvoiceService invoices() {
-    return new com.stripe.service.InvoiceService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.IssuingService issuing() {
-    return new com.stripe.service.IssuingService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.MandateService mandates() {
-    return new com.stripe.service.MandateService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.PaymentIntentService paymentIntents() {
-    return new com.stripe.service.PaymentIntentService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.PaymentLinkService paymentLinks() {
-    return new com.stripe.service.PaymentLinkService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.PaymentMethodConfigurationService paymentMethodConfigurations() {
-    return new com.stripe.service.PaymentMethodConfigurationService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.PaymentMethodDomainService paymentMethodDomains() {
-    return new com.stripe.service.PaymentMethodDomainService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.PaymentMethodService paymentMethods() {
-    return new com.stripe.service.PaymentMethodService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.PayoutService payouts() {
-    return new com.stripe.service.PayoutService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.PlanService plans() {
-    return new com.stripe.service.PlanService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.PriceService prices() {
-    return new com.stripe.service.PriceService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.ProductService products() {
-    return new com.stripe.service.ProductService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.PromotionCodeService promotionCodes() {
-    return new com.stripe.service.PromotionCodeService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.QuoteService quotes() {
-    return new com.stripe.service.QuoteService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.RadarService radar() {
-    return new com.stripe.service.RadarService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.RefundService refunds() {
-    return new com.stripe.service.RefundService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.ReportingService reporting() {
-    return new com.stripe.service.ReportingService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.ReviewService reviews() {
-    return new com.stripe.service.ReviewService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.SetupAttemptService setupAttempts() {
-    return new com.stripe.service.SetupAttemptService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.SetupIntentService setupIntents() {
-    return new com.stripe.service.SetupIntentService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.ShippingRateService shippingRates() {
-    return new com.stripe.service.ShippingRateService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.SigmaService sigma() {
-    return new com.stripe.service.SigmaService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.SourceService sources() {
-    return new com.stripe.service.SourceService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.SubscriptionItemService subscriptionItems() {
-    return new com.stripe.service.SubscriptionItemService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.SubscriptionScheduleService subscriptionSchedules() {
-    return new com.stripe.service.SubscriptionScheduleService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.SubscriptionService subscriptions() {
-    return new com.stripe.service.SubscriptionService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.TaxService tax() {
-    return new com.stripe.service.TaxService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.TaxCodeService taxCodes() {
-    return new com.stripe.service.TaxCodeService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.TaxIdService taxIds() {
-    return new com.stripe.service.TaxIdService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.TaxRateService taxRates() {
-    return new com.stripe.service.TaxRateService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.TerminalService terminal() {
-    return new com.stripe.service.TerminalService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.TestHelpersService testHelpers() {
-    return new com.stripe.service.TestHelpersService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.TokenService tokens() {
-    return new com.stripe.service.TokenService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.TopupService topups() {
-    return new com.stripe.service.TopupService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.TransferService transfers() {
-    return new com.stripe.service.TransferService(this.getResponseGetter());
-  }
-
-  public com.stripe.service.TreasuryService treasury() {
-    return new com.stripe.service.TreasuryService(this.getResponseGetter());
+  public com.stripe.service.V1Services v1() {
+    return new com.stripe.service.V1Services(this.getResponseGetter());
   }
 
   public com.stripe.service.V2Services v2() {
     return new com.stripe.service.V2Services(this.getResponseGetter());
   }
 
+  /**
+   * Deprecation Warning: StripeClient.accountLinks() will be deprecated in the next major release.
+   * All functionality under it has been copied over to StripeClient.v1().accountLinks(). See [link
+   * TKTK] for more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.AccountLinkService accountLinks() {
+    return new com.stripe.service.AccountLinkService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.accountSessions() will be deprecated in the next major
+   * release. All functionality under it has been copied over to
+   * StripeClient.v1().accountSessions(). See [link TKTK] for more on this and tips on migrating to
+   * the new v1 namespace.
+   */
+  public com.stripe.service.AccountSessionService accountSessions() {
+    return new com.stripe.service.AccountSessionService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.accounts() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().accounts(). See [link TKTK]
+   * for more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.AccountService accounts() {
+    return new com.stripe.service.AccountService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.applePayDomains() will be deprecated in the next major
+   * release. All functionality under it has been copied over to
+   * StripeClient.v1().applePayDomains(). See [link TKTK] for more on this and tips on migrating to
+   * the new v1 namespace.
+   */
+  public com.stripe.service.ApplePayDomainService applePayDomains() {
+    return new com.stripe.service.ApplePayDomainService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.applicationFees() will be deprecated in the next major
+   * release. All functionality under it has been copied over to
+   * StripeClient.v1().applicationFees(). See [link TKTK] for more on this and tips on migrating to
+   * the new v1 namespace.
+   */
+  public com.stripe.service.ApplicationFeeService applicationFees() {
+    return new com.stripe.service.ApplicationFeeService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.apps() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().apps(). See [link TKTK] for
+   * more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.AppsService apps() {
+    return new com.stripe.service.AppsService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.balance() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().balance(). See [link TKTK] for
+   * more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.BalanceService balance() {
+    return new com.stripe.service.BalanceService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.balanceTransactions() will be deprecated in the next major
+   * release. All functionality under it has been copied over to
+   * StripeClient.v1().balanceTransactions(). See [link TKTK] for more on this and tips on migrating
+   * to the new v1 namespace.
+   */
+  public com.stripe.service.BalanceTransactionService balanceTransactions() {
+    return new com.stripe.service.BalanceTransactionService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.billing() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().billing(). See [link TKTK] for
+   * more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.BillingService billing() {
+    return new com.stripe.service.BillingService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.billingPortal() will be deprecated in the next major release.
+   * All functionality under it has been copied over to StripeClient.v1().billingPortal(). See [link
+   * TKTK] for more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.BillingPortalService billingPortal() {
+    return new com.stripe.service.BillingPortalService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.charges() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().charges(). See [link TKTK] for
+   * more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.ChargeService charges() {
+    return new com.stripe.service.ChargeService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.checkout() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().checkout(). See [link TKTK]
+   * for more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.CheckoutService checkout() {
+    return new com.stripe.service.CheckoutService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.climate() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().climate(). See [link TKTK] for
+   * more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.ClimateService climate() {
+    return new com.stripe.service.ClimateService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.confirmationTokens() will be deprecated in the next major
+   * release. All functionality under it has been copied over to
+   * StripeClient.v1().confirmationTokens(). See [link TKTK] for more on this and tips on migrating
+   * to the new v1 namespace.
+   */
+  public com.stripe.service.ConfirmationTokenService confirmationTokens() {
+    return new com.stripe.service.ConfirmationTokenService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.countrySpecs() will be deprecated in the next major release.
+   * All functionality under it has been copied over to StripeClient.v1().countrySpecs(). See [link
+   * TKTK] for more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.CountrySpecService countrySpecs() {
+    return new com.stripe.service.CountrySpecService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.coupons() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().coupons(). See [link TKTK] for
+   * more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.CouponService coupons() {
+    return new com.stripe.service.CouponService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.creditNotes() will be deprecated in the next major release.
+   * All functionality under it has been copied over to StripeClient.v1().creditNotes(). See [link
+   * TKTK] for more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.CreditNoteService creditNotes() {
+    return new com.stripe.service.CreditNoteService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.customerSessions() will be deprecated in the next major
+   * release. All functionality under it has been copied over to
+   * StripeClient.v1().customerSessions(). See [link TKTK] for more on this and tips on migrating to
+   * the new v1 namespace.
+   */
+  public com.stripe.service.CustomerSessionService customerSessions() {
+    return new com.stripe.service.CustomerSessionService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.customers() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().customers(). See [link TKTK]
+   * for more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.CustomerService customers() {
+    return new com.stripe.service.CustomerService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.disputes() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().disputes(). See [link TKTK]
+   * for more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.DisputeService disputes() {
+    return new com.stripe.service.DisputeService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.entitlements() will be deprecated in the next major release.
+   * All functionality under it has been copied over to StripeClient.v1().entitlements(). See [link
+   * TKTK] for more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.EntitlementsService entitlements() {
+    return new com.stripe.service.EntitlementsService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.ephemeralKeys() will be deprecated in the next major release.
+   * All functionality under it has been copied over to StripeClient.v1().ephemeralKeys(). See [link
+   * TKTK] for more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.EphemeralKeyService ephemeralKeys() {
+    return new com.stripe.service.EphemeralKeyService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.events() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().events(). See [link TKTK] for
+   * more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.EventService events() {
+    return new com.stripe.service.EventService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.exchangeRates() will be deprecated in the next major release.
+   * All functionality under it has been copied over to StripeClient.v1().exchangeRates(). See [link
+   * TKTK] for more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.ExchangeRateService exchangeRates() {
+    return new com.stripe.service.ExchangeRateService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.fileLinks() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().fileLinks(). See [link TKTK]
+   * for more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.FileLinkService fileLinks() {
+    return new com.stripe.service.FileLinkService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.files() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().files(). See [link TKTK] for
+   * more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.FileService files() {
+    return new com.stripe.service.FileService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.financialConnections() will be deprecated in the next major
+   * release. All functionality under it has been copied over to
+   * StripeClient.v1().financialConnections(). See [link TKTK] for more on this and tips on
+   * migrating to the new v1 namespace.
+   */
+  public com.stripe.service.FinancialConnectionsService financialConnections() {
+    return new com.stripe.service.FinancialConnectionsService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.forwarding() will be deprecated in the next major release.
+   * All functionality under it has been copied over to StripeClient.v1().forwarding(). See [link
+   * TKTK] for more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.ForwardingService forwarding() {
+    return new com.stripe.service.ForwardingService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.identity() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().identity(). See [link TKTK]
+   * for more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.IdentityService identity() {
+    return new com.stripe.service.IdentityService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.invoiceItems() will be deprecated in the next major release.
+   * All functionality under it has been copied over to StripeClient.v1().invoiceItems(). See [link
+   * TKTK] for more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.InvoiceItemService invoiceItems() {
+    return new com.stripe.service.InvoiceItemService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.invoicePayments() will be deprecated in the next major
+   * release. All functionality under it has been copied over to
+   * StripeClient.v1().invoicePayments(). See [link TKTK] for more on this and tips on migrating to
+   * the new v1 namespace.
+   */
+  public com.stripe.service.InvoicePaymentService invoicePayments() {
+    return new com.stripe.service.InvoicePaymentService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.invoiceRenderingTemplates() will be deprecated in the next
+   * major release. All functionality under it has been copied over to
+   * StripeClient.v1().invoiceRenderingTemplates(). See [link TKTK] for more on this and tips on
+   * migrating to the new v1 namespace.
+   */
+  public com.stripe.service.InvoiceRenderingTemplateService invoiceRenderingTemplates() {
+    return new com.stripe.service.InvoiceRenderingTemplateService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.invoices() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().invoices(). See [link TKTK]
+   * for more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.InvoiceService invoices() {
+    return new com.stripe.service.InvoiceService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.issuing() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().issuing(). See [link TKTK] for
+   * more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.IssuingService issuing() {
+    return new com.stripe.service.IssuingService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.mandates() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().mandates(). See [link TKTK]
+   * for more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.MandateService mandates() {
+    return new com.stripe.service.MandateService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.paymentIntents() will be deprecated in the next major
+   * release. All functionality under it has been copied over to StripeClient.v1().paymentIntents().
+   * See [link TKTK] for more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.PaymentIntentService paymentIntents() {
+    return new com.stripe.service.PaymentIntentService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.paymentLinks() will be deprecated in the next major release.
+   * All functionality under it has been copied over to StripeClient.v1().paymentLinks(). See [link
+   * TKTK] for more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.PaymentLinkService paymentLinks() {
+    return new com.stripe.service.PaymentLinkService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.paymentMethodConfigurations() will be deprecated in the next
+   * major release. All functionality under it has been copied over to
+   * StripeClient.v1().paymentMethodConfigurations(). See [link TKTK] for more on this and tips on
+   * migrating to the new v1 namespace.
+   */
+  public com.stripe.service.PaymentMethodConfigurationService paymentMethodConfigurations() {
+    return new com.stripe.service.PaymentMethodConfigurationService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.paymentMethodDomains() will be deprecated in the next major
+   * release. All functionality under it has been copied over to
+   * StripeClient.v1().paymentMethodDomains(). See [link TKTK] for more on this and tips on
+   * migrating to the new v1 namespace.
+   */
+  public com.stripe.service.PaymentMethodDomainService paymentMethodDomains() {
+    return new com.stripe.service.PaymentMethodDomainService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.paymentMethods() will be deprecated in the next major
+   * release. All functionality under it has been copied over to StripeClient.v1().paymentMethods().
+   * See [link TKTK] for more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.PaymentMethodService paymentMethods() {
+    return new com.stripe.service.PaymentMethodService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.payouts() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().payouts(). See [link TKTK] for
+   * more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.PayoutService payouts() {
+    return new com.stripe.service.PayoutService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.plans() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().plans(). See [link TKTK] for
+   * more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.PlanService plans() {
+    return new com.stripe.service.PlanService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.prices() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().prices(). See [link TKTK] for
+   * more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.PriceService prices() {
+    return new com.stripe.service.PriceService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.products() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().products(). See [link TKTK]
+   * for more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.ProductService products() {
+    return new com.stripe.service.ProductService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.promotionCodes() will be deprecated in the next major
+   * release. All functionality under it has been copied over to StripeClient.v1().promotionCodes().
+   * See [link TKTK] for more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.PromotionCodeService promotionCodes() {
+    return new com.stripe.service.PromotionCodeService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.quotes() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().quotes(). See [link TKTK] for
+   * more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.QuoteService quotes() {
+    return new com.stripe.service.QuoteService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.radar() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().radar(). See [link TKTK] for
+   * more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.RadarService radar() {
+    return new com.stripe.service.RadarService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.refunds() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().refunds(). See [link TKTK] for
+   * more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.RefundService refunds() {
+    return new com.stripe.service.RefundService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.reporting() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().reporting(). See [link TKTK]
+   * for more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.ReportingService reporting() {
+    return new com.stripe.service.ReportingService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.reviews() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().reviews(). See [link TKTK] for
+   * more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.ReviewService reviews() {
+    return new com.stripe.service.ReviewService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.setupAttempts() will be deprecated in the next major release.
+   * All functionality under it has been copied over to StripeClient.v1().setupAttempts(). See [link
+   * TKTK] for more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.SetupAttemptService setupAttempts() {
+    return new com.stripe.service.SetupAttemptService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.setupIntents() will be deprecated in the next major release.
+   * All functionality under it has been copied over to StripeClient.v1().setupIntents(). See [link
+   * TKTK] for more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.SetupIntentService setupIntents() {
+    return new com.stripe.service.SetupIntentService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.shippingRates() will be deprecated in the next major release.
+   * All functionality under it has been copied over to StripeClient.v1().shippingRates(). See [link
+   * TKTK] for more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.ShippingRateService shippingRates() {
+    return new com.stripe.service.ShippingRateService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.sigma() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().sigma(). See [link TKTK] for
+   * more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.SigmaService sigma() {
+    return new com.stripe.service.SigmaService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.sources() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().sources(). See [link TKTK] for
+   * more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.SourceService sources() {
+    return new com.stripe.service.SourceService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.subscriptionItems() will be deprecated in the next major
+   * release. All functionality under it has been copied over to
+   * StripeClient.v1().subscriptionItems(). See [link TKTK] for more on this and tips on migrating
+   * to the new v1 namespace.
+   */
+  public com.stripe.service.SubscriptionItemService subscriptionItems() {
+    return new com.stripe.service.SubscriptionItemService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.subscriptionSchedules() will be deprecated in the next major
+   * release. All functionality under it has been copied over to
+   * StripeClient.v1().subscriptionSchedules(). See [link TKTK] for more on this and tips on
+   * migrating to the new v1 namespace.
+   */
+  public com.stripe.service.SubscriptionScheduleService subscriptionSchedules() {
+    return new com.stripe.service.SubscriptionScheduleService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.subscriptions() will be deprecated in the next major release.
+   * All functionality under it has been copied over to StripeClient.v1().subscriptions(). See [link
+   * TKTK] for more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.SubscriptionService subscriptions() {
+    return new com.stripe.service.SubscriptionService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.tax() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().tax(). See [link TKTK] for
+   * more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.TaxService tax() {
+    return new com.stripe.service.TaxService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.taxCodes() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().taxCodes(). See [link TKTK]
+   * for more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.TaxCodeService taxCodes() {
+    return new com.stripe.service.TaxCodeService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.taxIds() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().taxIds(). See [link TKTK] for
+   * more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.TaxIdService taxIds() {
+    return new com.stripe.service.TaxIdService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.taxRates() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().taxRates(). See [link TKTK]
+   * for more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.TaxRateService taxRates() {
+    return new com.stripe.service.TaxRateService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.terminal() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().terminal(). See [link TKTK]
+   * for more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.TerminalService terminal() {
+    return new com.stripe.service.TerminalService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.testHelpers() will be deprecated in the next major release.
+   * All functionality under it has been copied over to StripeClient.v1().testHelpers(). See [link
+   * TKTK] for more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.TestHelpersService testHelpers() {
+    return new com.stripe.service.TestHelpersService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.tokens() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().tokens(). See [link TKTK] for
+   * more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.TokenService tokens() {
+    return new com.stripe.service.TokenService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.topups() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().topups(). See [link TKTK] for
+   * more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.TopupService topups() {
+    return new com.stripe.service.TopupService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.transfers() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().transfers(). See [link TKTK]
+   * for more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.TransferService transfers() {
+    return new com.stripe.service.TransferService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.treasury() will be deprecated in the next major release. All
+   * functionality under it has been copied over to StripeClient.v1().treasury(). See [link TKTK]
+   * for more on this and tips on migrating to the new v1 namespace.
+   */
+  public com.stripe.service.TreasuryService treasury() {
+    return new com.stripe.service.TreasuryService(this.getResponseGetter());
+  }
+
+  /**
+   * Deprecation Warning: StripeClient.webhookEndpoints() will be deprecated in the next major
+   * release. All functionality under it has been copied over to
+   * StripeClient.v1().webhookEndpoints(). See [link TKTK] for more on this and tips on migrating to
+   * the new v1 namespace.
+   */
   public com.stripe.service.WebhookEndpointService webhookEndpoints() {
     return new com.stripe.service.WebhookEndpointService(this.getResponseGetter());
   }

--- a/src/main/java/com/stripe/StripeClient.java
+++ b/src/main/java/com/stripe/StripeClient.java
@@ -127,8 +127,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.accountLinks() will be deprecated in the next major release.
-   * All functionality under it has been copied over to StripeClient.v1().accountLinks(). See [link
-   * TKTK] for more on this and tips on migrating to the new v1 namespace.
+   * All functionality under it has been copied over to StripeClient.v1().accountLinks(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.AccountLinkService accountLinks() {
     return new com.stripe.service.AccountLinkService(this.getResponseGetter());
@@ -137,8 +138,9 @@ public class StripeClient {
   /**
    * Deprecation Warning: StripeClient.accountSessions() will be deprecated in the next major
    * release. All functionality under it has been copied over to
-   * StripeClient.v1().accountSessions(). See [link TKTK] for more on this and tips on migrating to
-   * the new v1 namespace.
+   * StripeClient.v1().accountSessions(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.AccountSessionService accountSessions() {
     return new com.stripe.service.AccountSessionService(this.getResponseGetter());
@@ -146,8 +148,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.accounts() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().accounts(). See [link TKTK]
-   * for more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().accounts(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.AccountService accounts() {
     return new com.stripe.service.AccountService(this.getResponseGetter());
@@ -156,8 +159,9 @@ public class StripeClient {
   /**
    * Deprecation Warning: StripeClient.applePayDomains() will be deprecated in the next major
    * release. All functionality under it has been copied over to
-   * StripeClient.v1().applePayDomains(). See [link TKTK] for more on this and tips on migrating to
-   * the new v1 namespace.
+   * StripeClient.v1().applePayDomains(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.ApplePayDomainService applePayDomains() {
     return new com.stripe.service.ApplePayDomainService(this.getResponseGetter());
@@ -166,8 +170,9 @@ public class StripeClient {
   /**
    * Deprecation Warning: StripeClient.applicationFees() will be deprecated in the next major
    * release. All functionality under it has been copied over to
-   * StripeClient.v1().applicationFees(). See [link TKTK] for more on this and tips on migrating to
-   * the new v1 namespace.
+   * StripeClient.v1().applicationFees(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.ApplicationFeeService applicationFees() {
     return new com.stripe.service.ApplicationFeeService(this.getResponseGetter());
@@ -175,8 +180,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.apps() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().apps(). See [link TKTK] for
-   * more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().apps(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.AppsService apps() {
     return new com.stripe.service.AppsService(this.getResponseGetter());
@@ -184,8 +190,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.balance() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().balance(). See [link TKTK] for
-   * more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().balance(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.BalanceService balance() {
     return new com.stripe.service.BalanceService(this.getResponseGetter());
@@ -194,8 +201,9 @@ public class StripeClient {
   /**
    * Deprecation Warning: StripeClient.balanceTransactions() will be deprecated in the next major
    * release. All functionality under it has been copied over to
-   * StripeClient.v1().balanceTransactions(). See [link TKTK] for more on this and tips on migrating
-   * to the new v1 namespace.
+   * StripeClient.v1().balanceTransactions(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.BalanceTransactionService balanceTransactions() {
     return new com.stripe.service.BalanceTransactionService(this.getResponseGetter());
@@ -203,8 +211,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.billing() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().billing(). See [link TKTK] for
-   * more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().billing(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.BillingService billing() {
     return new com.stripe.service.BillingService(this.getResponseGetter());
@@ -212,8 +221,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.billingPortal() will be deprecated in the next major release.
-   * All functionality under it has been copied over to StripeClient.v1().billingPortal(). See [link
-   * TKTK] for more on this and tips on migrating to the new v1 namespace.
+   * All functionality under it has been copied over to StripeClient.v1().billingPortal(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.BillingPortalService billingPortal() {
     return new com.stripe.service.BillingPortalService(this.getResponseGetter());
@@ -221,8 +231,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.charges() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().charges(). See [link TKTK] for
-   * more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().charges(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.ChargeService charges() {
     return new com.stripe.service.ChargeService(this.getResponseGetter());
@@ -230,8 +241,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.checkout() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().checkout(). See [link TKTK]
-   * for more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().checkout(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.CheckoutService checkout() {
     return new com.stripe.service.CheckoutService(this.getResponseGetter());
@@ -239,8 +251,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.climate() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().climate(). See [link TKTK] for
-   * more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().climate(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.ClimateService climate() {
     return new com.stripe.service.ClimateService(this.getResponseGetter());
@@ -249,8 +262,9 @@ public class StripeClient {
   /**
    * Deprecation Warning: StripeClient.confirmationTokens() will be deprecated in the next major
    * release. All functionality under it has been copied over to
-   * StripeClient.v1().confirmationTokens(). See [link TKTK] for more on this and tips on migrating
-   * to the new v1 namespace.
+   * StripeClient.v1().confirmationTokens(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.ConfirmationTokenService confirmationTokens() {
     return new com.stripe.service.ConfirmationTokenService(this.getResponseGetter());
@@ -258,8 +272,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.countrySpecs() will be deprecated in the next major release.
-   * All functionality under it has been copied over to StripeClient.v1().countrySpecs(). See [link
-   * TKTK] for more on this and tips on migrating to the new v1 namespace.
+   * All functionality under it has been copied over to StripeClient.v1().countrySpecs(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.CountrySpecService countrySpecs() {
     return new com.stripe.service.CountrySpecService(this.getResponseGetter());
@@ -267,8 +282,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.coupons() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().coupons(). See [link TKTK] for
-   * more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().coupons(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.CouponService coupons() {
     return new com.stripe.service.CouponService(this.getResponseGetter());
@@ -276,8 +292,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.creditNotes() will be deprecated in the next major release.
-   * All functionality under it has been copied over to StripeClient.v1().creditNotes(). See [link
-   * TKTK] for more on this and tips on migrating to the new v1 namespace.
+   * All functionality under it has been copied over to StripeClient.v1().creditNotes(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.CreditNoteService creditNotes() {
     return new com.stripe.service.CreditNoteService(this.getResponseGetter());
@@ -286,8 +303,9 @@ public class StripeClient {
   /**
    * Deprecation Warning: StripeClient.customerSessions() will be deprecated in the next major
    * release. All functionality under it has been copied over to
-   * StripeClient.v1().customerSessions(). See [link TKTK] for more on this and tips on migrating to
-   * the new v1 namespace.
+   * StripeClient.v1().customerSessions(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.CustomerSessionService customerSessions() {
     return new com.stripe.service.CustomerSessionService(this.getResponseGetter());
@@ -295,8 +313,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.customers() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().customers(). See [link TKTK]
-   * for more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().customers(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.CustomerService customers() {
     return new com.stripe.service.CustomerService(this.getResponseGetter());
@@ -304,8 +323,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.disputes() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().disputes(). See [link TKTK]
-   * for more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().disputes(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.DisputeService disputes() {
     return new com.stripe.service.DisputeService(this.getResponseGetter());
@@ -313,8 +333,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.entitlements() will be deprecated in the next major release.
-   * All functionality under it has been copied over to StripeClient.v1().entitlements(). See [link
-   * TKTK] for more on this and tips on migrating to the new v1 namespace.
+   * All functionality under it has been copied over to StripeClient.v1().entitlements(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.EntitlementsService entitlements() {
     return new com.stripe.service.EntitlementsService(this.getResponseGetter());
@@ -322,8 +343,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.ephemeralKeys() will be deprecated in the next major release.
-   * All functionality under it has been copied over to StripeClient.v1().ephemeralKeys(). See [link
-   * TKTK] for more on this and tips on migrating to the new v1 namespace.
+   * All functionality under it has been copied over to StripeClient.v1().ephemeralKeys(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.EphemeralKeyService ephemeralKeys() {
     return new com.stripe.service.EphemeralKeyService(this.getResponseGetter());
@@ -331,8 +353,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.events() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().events(). See [link TKTK] for
-   * more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().events(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.EventService events() {
     return new com.stripe.service.EventService(this.getResponseGetter());
@@ -340,8 +363,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.exchangeRates() will be deprecated in the next major release.
-   * All functionality under it has been copied over to StripeClient.v1().exchangeRates(). See [link
-   * TKTK] for more on this and tips on migrating to the new v1 namespace.
+   * All functionality under it has been copied over to StripeClient.v1().exchangeRates(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.ExchangeRateService exchangeRates() {
     return new com.stripe.service.ExchangeRateService(this.getResponseGetter());
@@ -349,8 +373,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.fileLinks() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().fileLinks(). See [link TKTK]
-   * for more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().fileLinks(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.FileLinkService fileLinks() {
     return new com.stripe.service.FileLinkService(this.getResponseGetter());
@@ -358,8 +383,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.files() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().files(). See [link TKTK] for
-   * more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().files(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.FileService files() {
     return new com.stripe.service.FileService(this.getResponseGetter());
@@ -368,8 +394,9 @@ public class StripeClient {
   /**
    * Deprecation Warning: StripeClient.financialConnections() will be deprecated in the next major
    * release. All functionality under it has been copied over to
-   * StripeClient.v1().financialConnections(). See [link TKTK] for more on this and tips on
-   * migrating to the new v1 namespace.
+   * StripeClient.v1().financialConnections(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.FinancialConnectionsService financialConnections() {
     return new com.stripe.service.FinancialConnectionsService(this.getResponseGetter());
@@ -377,8 +404,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.forwarding() will be deprecated in the next major release.
-   * All functionality under it has been copied over to StripeClient.v1().forwarding(). See [link
-   * TKTK] for more on this and tips on migrating to the new v1 namespace.
+   * All functionality under it has been copied over to StripeClient.v1().forwarding(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.ForwardingService forwarding() {
     return new com.stripe.service.ForwardingService(this.getResponseGetter());
@@ -386,8 +414,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.identity() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().identity(). See [link TKTK]
-   * for more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().identity(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.IdentityService identity() {
     return new com.stripe.service.IdentityService(this.getResponseGetter());
@@ -395,8 +424,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.invoiceItems() will be deprecated in the next major release.
-   * All functionality under it has been copied over to StripeClient.v1().invoiceItems(). See [link
-   * TKTK] for more on this and tips on migrating to the new v1 namespace.
+   * All functionality under it has been copied over to StripeClient.v1().invoiceItems(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.InvoiceItemService invoiceItems() {
     return new com.stripe.service.InvoiceItemService(this.getResponseGetter());
@@ -405,8 +435,9 @@ public class StripeClient {
   /**
    * Deprecation Warning: StripeClient.invoicePayments() will be deprecated in the next major
    * release. All functionality under it has been copied over to
-   * StripeClient.v1().invoicePayments(). See [link TKTK] for more on this and tips on migrating to
-   * the new v1 namespace.
+   * StripeClient.v1().invoicePayments(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.InvoicePaymentService invoicePayments() {
     return new com.stripe.service.InvoicePaymentService(this.getResponseGetter());
@@ -415,8 +446,9 @@ public class StripeClient {
   /**
    * Deprecation Warning: StripeClient.invoiceRenderingTemplates() will be deprecated in the next
    * major release. All functionality under it has been copied over to
-   * StripeClient.v1().invoiceRenderingTemplates(). See [link TKTK] for more on this and tips on
-   * migrating to the new v1 namespace.
+   * StripeClient.v1().invoiceRenderingTemplates(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.InvoiceRenderingTemplateService invoiceRenderingTemplates() {
     return new com.stripe.service.InvoiceRenderingTemplateService(this.getResponseGetter());
@@ -424,8 +456,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.invoices() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().invoices(). See [link TKTK]
-   * for more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().invoices(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.InvoiceService invoices() {
     return new com.stripe.service.InvoiceService(this.getResponseGetter());
@@ -433,8 +466,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.issuing() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().issuing(). See [link TKTK] for
-   * more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().issuing(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.IssuingService issuing() {
     return new com.stripe.service.IssuingService(this.getResponseGetter());
@@ -442,8 +476,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.mandates() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().mandates(). See [link TKTK]
-   * for more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().mandates(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.MandateService mandates() {
     return new com.stripe.service.MandateService(this.getResponseGetter());
@@ -452,7 +487,8 @@ public class StripeClient {
   /**
    * Deprecation Warning: StripeClient.paymentIntents() will be deprecated in the next major
    * release. All functionality under it has been copied over to StripeClient.v1().paymentIntents().
-   * See [link TKTK] for more on this and tips on migrating to the new v1 namespace.
+   * See <a href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.PaymentIntentService paymentIntents() {
     return new com.stripe.service.PaymentIntentService(this.getResponseGetter());
@@ -460,8 +496,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.paymentLinks() will be deprecated in the next major release.
-   * All functionality under it has been copied over to StripeClient.v1().paymentLinks(). See [link
-   * TKTK] for more on this and tips on migrating to the new v1 namespace.
+   * All functionality under it has been copied over to StripeClient.v1().paymentLinks(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.PaymentLinkService paymentLinks() {
     return new com.stripe.service.PaymentLinkService(this.getResponseGetter());
@@ -470,8 +507,9 @@ public class StripeClient {
   /**
    * Deprecation Warning: StripeClient.paymentMethodConfigurations() will be deprecated in the next
    * major release. All functionality under it has been copied over to
-   * StripeClient.v1().paymentMethodConfigurations(). See [link TKTK] for more on this and tips on
-   * migrating to the new v1 namespace.
+   * StripeClient.v1().paymentMethodConfigurations(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.PaymentMethodConfigurationService paymentMethodConfigurations() {
     return new com.stripe.service.PaymentMethodConfigurationService(this.getResponseGetter());
@@ -480,8 +518,9 @@ public class StripeClient {
   /**
    * Deprecation Warning: StripeClient.paymentMethodDomains() will be deprecated in the next major
    * release. All functionality under it has been copied over to
-   * StripeClient.v1().paymentMethodDomains(). See [link TKTK] for more on this and tips on
-   * migrating to the new v1 namespace.
+   * StripeClient.v1().paymentMethodDomains(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.PaymentMethodDomainService paymentMethodDomains() {
     return new com.stripe.service.PaymentMethodDomainService(this.getResponseGetter());
@@ -490,7 +529,8 @@ public class StripeClient {
   /**
    * Deprecation Warning: StripeClient.paymentMethods() will be deprecated in the next major
    * release. All functionality under it has been copied over to StripeClient.v1().paymentMethods().
-   * See [link TKTK] for more on this and tips on migrating to the new v1 namespace.
+   * See <a href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.PaymentMethodService paymentMethods() {
     return new com.stripe.service.PaymentMethodService(this.getResponseGetter());
@@ -498,8 +538,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.payouts() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().payouts(). See [link TKTK] for
-   * more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().payouts(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.PayoutService payouts() {
     return new com.stripe.service.PayoutService(this.getResponseGetter());
@@ -507,8 +548,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.plans() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().plans(). See [link TKTK] for
-   * more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().plans(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.PlanService plans() {
     return new com.stripe.service.PlanService(this.getResponseGetter());
@@ -516,8 +558,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.prices() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().prices(). See [link TKTK] for
-   * more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().prices(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.PriceService prices() {
     return new com.stripe.service.PriceService(this.getResponseGetter());
@@ -525,8 +568,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.products() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().products(). See [link TKTK]
-   * for more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().products(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.ProductService products() {
     return new com.stripe.service.ProductService(this.getResponseGetter());
@@ -535,7 +579,8 @@ public class StripeClient {
   /**
    * Deprecation Warning: StripeClient.promotionCodes() will be deprecated in the next major
    * release. All functionality under it has been copied over to StripeClient.v1().promotionCodes().
-   * See [link TKTK] for more on this and tips on migrating to the new v1 namespace.
+   * See <a href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.PromotionCodeService promotionCodes() {
     return new com.stripe.service.PromotionCodeService(this.getResponseGetter());
@@ -543,8 +588,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.quotes() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().quotes(). See [link TKTK] for
-   * more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().quotes(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.QuoteService quotes() {
     return new com.stripe.service.QuoteService(this.getResponseGetter());
@@ -552,8 +598,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.radar() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().radar(). See [link TKTK] for
-   * more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().radar(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.RadarService radar() {
     return new com.stripe.service.RadarService(this.getResponseGetter());
@@ -561,8 +608,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.refunds() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().refunds(). See [link TKTK] for
-   * more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().refunds(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.RefundService refunds() {
     return new com.stripe.service.RefundService(this.getResponseGetter());
@@ -570,8 +618,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.reporting() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().reporting(). See [link TKTK]
-   * for more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().reporting(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.ReportingService reporting() {
     return new com.stripe.service.ReportingService(this.getResponseGetter());
@@ -579,8 +628,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.reviews() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().reviews(). See [link TKTK] for
-   * more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().reviews(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.ReviewService reviews() {
     return new com.stripe.service.ReviewService(this.getResponseGetter());
@@ -588,8 +638,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.setupAttempts() will be deprecated in the next major release.
-   * All functionality under it has been copied over to StripeClient.v1().setupAttempts(). See [link
-   * TKTK] for more on this and tips on migrating to the new v1 namespace.
+   * All functionality under it has been copied over to StripeClient.v1().setupAttempts(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.SetupAttemptService setupAttempts() {
     return new com.stripe.service.SetupAttemptService(this.getResponseGetter());
@@ -597,8 +648,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.setupIntents() will be deprecated in the next major release.
-   * All functionality under it has been copied over to StripeClient.v1().setupIntents(). See [link
-   * TKTK] for more on this and tips on migrating to the new v1 namespace.
+   * All functionality under it has been copied over to StripeClient.v1().setupIntents(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.SetupIntentService setupIntents() {
     return new com.stripe.service.SetupIntentService(this.getResponseGetter());
@@ -606,8 +658,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.shippingRates() will be deprecated in the next major release.
-   * All functionality under it has been copied over to StripeClient.v1().shippingRates(). See [link
-   * TKTK] for more on this and tips on migrating to the new v1 namespace.
+   * All functionality under it has been copied over to StripeClient.v1().shippingRates(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.ShippingRateService shippingRates() {
     return new com.stripe.service.ShippingRateService(this.getResponseGetter());
@@ -615,8 +668,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.sigma() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().sigma(). See [link TKTK] for
-   * more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().sigma(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.SigmaService sigma() {
     return new com.stripe.service.SigmaService(this.getResponseGetter());
@@ -624,8 +678,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.sources() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().sources(). See [link TKTK] for
-   * more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().sources(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.SourceService sources() {
     return new com.stripe.service.SourceService(this.getResponseGetter());
@@ -634,8 +689,9 @@ public class StripeClient {
   /**
    * Deprecation Warning: StripeClient.subscriptionItems() will be deprecated in the next major
    * release. All functionality under it has been copied over to
-   * StripeClient.v1().subscriptionItems(). See [link TKTK] for more on this and tips on migrating
-   * to the new v1 namespace.
+   * StripeClient.v1().subscriptionItems(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.SubscriptionItemService subscriptionItems() {
     return new com.stripe.service.SubscriptionItemService(this.getResponseGetter());
@@ -644,8 +700,9 @@ public class StripeClient {
   /**
    * Deprecation Warning: StripeClient.subscriptionSchedules() will be deprecated in the next major
    * release. All functionality under it has been copied over to
-   * StripeClient.v1().subscriptionSchedules(). See [link TKTK] for more on this and tips on
-   * migrating to the new v1 namespace.
+   * StripeClient.v1().subscriptionSchedules(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.SubscriptionScheduleService subscriptionSchedules() {
     return new com.stripe.service.SubscriptionScheduleService(this.getResponseGetter());
@@ -653,8 +710,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.subscriptions() will be deprecated in the next major release.
-   * All functionality under it has been copied over to StripeClient.v1().subscriptions(). See [link
-   * TKTK] for more on this and tips on migrating to the new v1 namespace.
+   * All functionality under it has been copied over to StripeClient.v1().subscriptions(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.SubscriptionService subscriptions() {
     return new com.stripe.service.SubscriptionService(this.getResponseGetter());
@@ -662,8 +720,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.tax() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().tax(). See [link TKTK] for
-   * more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().tax(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.TaxService tax() {
     return new com.stripe.service.TaxService(this.getResponseGetter());
@@ -671,8 +730,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.taxCodes() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().taxCodes(). See [link TKTK]
-   * for more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().taxCodes(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.TaxCodeService taxCodes() {
     return new com.stripe.service.TaxCodeService(this.getResponseGetter());
@@ -680,8 +740,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.taxIds() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().taxIds(). See [link TKTK] for
-   * more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().taxIds(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.TaxIdService taxIds() {
     return new com.stripe.service.TaxIdService(this.getResponseGetter());
@@ -689,8 +750,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.taxRates() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().taxRates(). See [link TKTK]
-   * for more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().taxRates(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.TaxRateService taxRates() {
     return new com.stripe.service.TaxRateService(this.getResponseGetter());
@@ -698,8 +760,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.terminal() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().terminal(). See [link TKTK]
-   * for more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().terminal(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.TerminalService terminal() {
     return new com.stripe.service.TerminalService(this.getResponseGetter());
@@ -707,8 +770,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.testHelpers() will be deprecated in the next major release.
-   * All functionality under it has been copied over to StripeClient.v1().testHelpers(). See [link
-   * TKTK] for more on this and tips on migrating to the new v1 namespace.
+   * All functionality under it has been copied over to StripeClient.v1().testHelpers(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.TestHelpersService testHelpers() {
     return new com.stripe.service.TestHelpersService(this.getResponseGetter());
@@ -716,8 +780,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.tokens() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().tokens(). See [link TKTK] for
-   * more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().tokens(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.TokenService tokens() {
     return new com.stripe.service.TokenService(this.getResponseGetter());
@@ -725,8 +790,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.topups() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().topups(). See [link TKTK] for
-   * more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().topups(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.TopupService topups() {
     return new com.stripe.service.TopupService(this.getResponseGetter());
@@ -734,8 +800,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.transfers() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().transfers(). See [link TKTK]
-   * for more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().transfers(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.TransferService transfers() {
     return new com.stripe.service.TransferService(this.getResponseGetter());
@@ -743,8 +810,9 @@ public class StripeClient {
 
   /**
    * Deprecation Warning: StripeClient.treasury() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().treasury(). See [link TKTK]
-   * for more on this and tips on migrating to the new v1 namespace.
+   * functionality under it has been copied over to StripeClient.v1().treasury(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.TreasuryService treasury() {
     return new com.stripe.service.TreasuryService(this.getResponseGetter());
@@ -753,8 +821,9 @@ public class StripeClient {
   /**
    * Deprecation Warning: StripeClient.webhookEndpoints() will be deprecated in the next major
    * release. All functionality under it has been copied over to
-   * StripeClient.v1().webhookEndpoints(). See [link TKTK] for more on this and tips on migrating to
-   * the new v1 namespace.
+   * StripeClient.v1().webhookEndpoints(). See <a
+   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   * guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
   public com.stripe.service.WebhookEndpointService webhookEndpoints() {
     return new com.stripe.service.WebhookEndpointService(this.getResponseGetter());

--- a/src/main/java/com/stripe/service/V1Services.java
+++ b/src/main/java/com/stripe/service/V1Services.java
@@ -1,0 +1,287 @@
+// File generated from our OpenAPI spec
+package com.stripe.service;
+
+import com.stripe.net.ApiService;
+import com.stripe.net.StripeResponseGetter;
+
+public final class V1Services extends ApiService {
+  public V1Services(StripeResponseGetter responseGetter) {
+    super(responseGetter);
+  }
+
+  public com.stripe.service.AccountLinkService accountLinks() {
+    return new com.stripe.service.AccountLinkService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.AccountSessionService accountSessions() {
+    return new com.stripe.service.AccountSessionService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.AccountService accounts() {
+    return new com.stripe.service.AccountService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.ApplePayDomainService applePayDomains() {
+    return new com.stripe.service.ApplePayDomainService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.ApplicationFeeService applicationFees() {
+    return new com.stripe.service.ApplicationFeeService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.AppsService apps() {
+    return new com.stripe.service.AppsService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.BalanceService balance() {
+    return new com.stripe.service.BalanceService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.BalanceTransactionService balanceTransactions() {
+    return new com.stripe.service.BalanceTransactionService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.BillingService billing() {
+    return new com.stripe.service.BillingService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.BillingPortalService billingPortal() {
+    return new com.stripe.service.BillingPortalService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.ChargeService charges() {
+    return new com.stripe.service.ChargeService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.CheckoutService checkout() {
+    return new com.stripe.service.CheckoutService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.ClimateService climate() {
+    return new com.stripe.service.ClimateService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.ConfirmationTokenService confirmationTokens() {
+    return new com.stripe.service.ConfirmationTokenService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.CountrySpecService countrySpecs() {
+    return new com.stripe.service.CountrySpecService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.CouponService coupons() {
+    return new com.stripe.service.CouponService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.CreditNoteService creditNotes() {
+    return new com.stripe.service.CreditNoteService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.CustomerSessionService customerSessions() {
+    return new com.stripe.service.CustomerSessionService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.CustomerService customers() {
+    return new com.stripe.service.CustomerService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.DisputeService disputes() {
+    return new com.stripe.service.DisputeService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.EntitlementsService entitlements() {
+    return new com.stripe.service.EntitlementsService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.EphemeralKeyService ephemeralKeys() {
+    return new com.stripe.service.EphemeralKeyService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.EventService events() {
+    return new com.stripe.service.EventService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.ExchangeRateService exchangeRates() {
+    return new com.stripe.service.ExchangeRateService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.FileLinkService fileLinks() {
+    return new com.stripe.service.FileLinkService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.FileService files() {
+    return new com.stripe.service.FileService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.FinancialConnectionsService financialConnections() {
+    return new com.stripe.service.FinancialConnectionsService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.ForwardingService forwarding() {
+    return new com.stripe.service.ForwardingService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.IdentityService identity() {
+    return new com.stripe.service.IdentityService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.InvoiceItemService invoiceItems() {
+    return new com.stripe.service.InvoiceItemService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.InvoicePaymentService invoicePayments() {
+    return new com.stripe.service.InvoicePaymentService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.InvoiceRenderingTemplateService invoiceRenderingTemplates() {
+    return new com.stripe.service.InvoiceRenderingTemplateService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.InvoiceService invoices() {
+    return new com.stripe.service.InvoiceService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.IssuingService issuing() {
+    return new com.stripe.service.IssuingService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.MandateService mandates() {
+    return new com.stripe.service.MandateService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.PaymentIntentService paymentIntents() {
+    return new com.stripe.service.PaymentIntentService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.PaymentLinkService paymentLinks() {
+    return new com.stripe.service.PaymentLinkService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.PaymentMethodConfigurationService paymentMethodConfigurations() {
+    return new com.stripe.service.PaymentMethodConfigurationService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.PaymentMethodDomainService paymentMethodDomains() {
+    return new com.stripe.service.PaymentMethodDomainService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.PaymentMethodService paymentMethods() {
+    return new com.stripe.service.PaymentMethodService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.PayoutService payouts() {
+    return new com.stripe.service.PayoutService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.PlanService plans() {
+    return new com.stripe.service.PlanService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.PriceService prices() {
+    return new com.stripe.service.PriceService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.ProductService products() {
+    return new com.stripe.service.ProductService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.PromotionCodeService promotionCodes() {
+    return new com.stripe.service.PromotionCodeService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.QuoteService quotes() {
+    return new com.stripe.service.QuoteService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.RadarService radar() {
+    return new com.stripe.service.RadarService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.RefundService refunds() {
+    return new com.stripe.service.RefundService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.ReportingService reporting() {
+    return new com.stripe.service.ReportingService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.ReviewService reviews() {
+    return new com.stripe.service.ReviewService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.SetupAttemptService setupAttempts() {
+    return new com.stripe.service.SetupAttemptService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.SetupIntentService setupIntents() {
+    return new com.stripe.service.SetupIntentService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.ShippingRateService shippingRates() {
+    return new com.stripe.service.ShippingRateService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.SigmaService sigma() {
+    return new com.stripe.service.SigmaService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.SourceService sources() {
+    return new com.stripe.service.SourceService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.SubscriptionItemService subscriptionItems() {
+    return new com.stripe.service.SubscriptionItemService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.SubscriptionScheduleService subscriptionSchedules() {
+    return new com.stripe.service.SubscriptionScheduleService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.SubscriptionService subscriptions() {
+    return new com.stripe.service.SubscriptionService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.TaxService tax() {
+    return new com.stripe.service.TaxService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.TaxCodeService taxCodes() {
+    return new com.stripe.service.TaxCodeService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.TaxIdService taxIds() {
+    return new com.stripe.service.TaxIdService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.TaxRateService taxRates() {
+    return new com.stripe.service.TaxRateService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.TerminalService terminal() {
+    return new com.stripe.service.TerminalService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.TestHelpersService testHelpers() {
+    return new com.stripe.service.TestHelpersService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.TokenService tokens() {
+    return new com.stripe.service.TokenService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.TopupService topups() {
+    return new com.stripe.service.TopupService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.TransferService transfers() {
+    return new com.stripe.service.TransferService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.TreasuryService treasury() {
+    return new com.stripe.service.TreasuryService(this.getResponseGetter());
+  }
+
+  public com.stripe.service.WebhookEndpointService webhookEndpoints() {
+    return new com.stripe.service.WebhookEndpointService(this.getResponseGetter());
+  }
+}

--- a/src/test/java/com/stripe/functional/GeneratedExamples.java
+++ b/src/test/java/com/stripe/functional/GeneratedExamples.java
@@ -44,6 +44,24 @@ class GeneratedExamples extends BaseStripeTest {
             .setType(com.stripe.param.AccountLinkCreateParams.Type.ACCOUNT_ONBOARDING)
             .build();
 
+    com.stripe.model.AccountLink accountLink = client.v1().accountLinks().create(params);
+    assertNotNull(accountLink);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.POST, "/v1/account_links", params.toMap(), null);
+  }
+
+  @Test
+  public void testAccountLinksPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.AccountLinkCreateParams params =
+        com.stripe.param.AccountLinkCreateParams.builder()
+            .setAccount("acct_xxxxxxxxxxxxx")
+            .setRefreshUrl("https://example.com/reauth")
+            .setReturnUrl("https://example.com/return")
+            .setType(com.stripe.param.AccountLinkCreateParams.Type.ACCOUNT_ONBOARDING)
+            .build();
+
     com.stripe.model.AccountLink accountLink = client.accountLinks().create(params);
     assertNotNull(accountLink);
     verifyRequest(
@@ -68,6 +86,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testAccountsCapabilitiesGetServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.AccountCapabilityListParams params =
+        com.stripe.param.AccountCapabilityListParams.builder().build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.Capability> stripeCollection =
+        client.v1().accounts().capabilities().list("acct_xxxxxxxxxxxxx", params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/accounts/acct_xxxxxxxxxxxxx/capabilities",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testAccountsCapabilitiesGetServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.AccountCapabilityListParams params =
@@ -100,6 +136,28 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testAccountsCapabilitiesGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.AccountCapabilityRetrieveParams params =
+        com.stripe.param.AccountCapabilityRetrieveParams.builder().build();
+
+    com.stripe.model.Capability capability =
+        client
+            .v1()
+            .accounts()
+            .capabilities()
+            .retrieve("acct_xxxxxxxxxxxxx", "card_payments", params);
+    assertNotNull(capability);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/accounts/acct_xxxxxxxxxxxxx/capabilities/card_payments",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testAccountsCapabilitiesGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.AccountCapabilityRetrieveParams params =
@@ -142,6 +200,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.AccountCapabilityUpdateParams.builder().setRequested(true).build();
 
     com.stripe.model.Capability capability =
+        client.v1().accounts().capabilities().update("acct_xxxxxxxxxxxxx", "card_payments", params);
+    assertNotNull(capability);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/accounts/acct_xxxxxxxxxxxxx/capabilities/card_payments",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testAccountsCapabilitiesPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.AccountCapabilityUpdateParams params =
+        com.stripe.param.AccountCapabilityUpdateParams.builder().setRequested(true).build();
+
+    com.stripe.model.Capability capability =
         client.accounts().capabilities().update("acct_xxxxxxxxxxxxx", "card_payments", params);
     assertNotNull(capability);
     verifyRequest(
@@ -170,6 +246,20 @@ class GeneratedExamples extends BaseStripeTest {
   public void testAccountsDeleteServices() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
+    com.stripe.model.Account account = client.v1().accounts().delete("acct_xxxxxxxxxxxxx");
+    assertNotNull(account);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.DELETE,
+        "/v1/accounts/acct_xxxxxxxxxxxxx",
+        null,
+        null);
+  }
+
+  @Test
+  public void testAccountsDeleteServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
     com.stripe.model.Account account = client.accounts().delete("acct_xxxxxxxxxxxxx");
     assertNotNull(account);
     verifyRequest(
@@ -185,6 +275,21 @@ class GeneratedExamples extends BaseStripeTest {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.model.ExternalAccount externalAccount =
+        client.v1().accounts().externalAccounts().delete("acct_xxxxxxxxxxxxx", "ba_xxxxxxxxxxxxx");
+    assertNotNull(externalAccount);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.DELETE,
+        "/v1/accounts/acct_xxxxxxxxxxxxx/external_accounts/ba_xxxxxxxxxxxxx",
+        null,
+        null);
+  }
+
+  @Test
+  public void testAccountsExternalAccountsDeleteServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.model.ExternalAccount externalAccount =
         client.accounts().externalAccounts().delete("acct_xxxxxxxxxxxxx", "ba_xxxxxxxxxxxxx");
     assertNotNull(externalAccount);
     verifyRequest(
@@ -197,6 +302,25 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testAccountsExternalAccountsDelete2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.model.ExternalAccount externalAccount =
+        client
+            .v1()
+            .accounts()
+            .externalAccounts()
+            .delete("acct_xxxxxxxxxxxxx", "card_xxxxxxxxxxxxx");
+    assertNotNull(externalAccount);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.DELETE,
+        "/v1/accounts/acct_xxxxxxxxxxxxx/external_accounts/card_xxxxxxxxxxxxx",
+        null,
+        null);
+  }
+
+  @Test
+  public void testAccountsExternalAccountsDelete2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.model.ExternalAccount externalAccount =
@@ -218,6 +342,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.AccountExternalAccountListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.ExternalAccount> stripeCollection =
+        client.v1().accounts().externalAccounts().list("acct_xxxxxxxxxxxxx", params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/accounts/acct_xxxxxxxxxxxxx/external_accounts",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testAccountsExternalAccountsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.AccountExternalAccountListParams params =
+        com.stripe.param.AccountExternalAccountListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.ExternalAccount> stripeCollection =
         client.accounts().externalAccounts().list("acct_xxxxxxxxxxxxx", params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -230,6 +372,27 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testAccountsExternalAccountsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.AccountExternalAccountListParams params =
+        com.stripe.param.AccountExternalAccountListParams.builder()
+            .setObject("bank_account")
+            .setLimit(3L)
+            .build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.ExternalAccount> stripeCollection =
+        client.v1().accounts().externalAccounts().list("acct_xxxxxxxxxxxxx", params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/accounts/acct_xxxxxxxxxxxxx/external_accounts",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testAccountsExternalAccountsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.AccountExternalAccountListParams params =
@@ -260,6 +423,27 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.StripeCollection<com.stripe.model.ExternalAccount> stripeCollection =
+        client.v1().accounts().externalAccounts().list("acct_xxxxxxxxxxxxx", params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/accounts/acct_xxxxxxxxxxxxx/external_accounts",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testAccountsExternalAccountsGet3ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.AccountExternalAccountListParams params =
+        com.stripe.param.AccountExternalAccountListParams.builder()
+            .setObject("card")
+            .setLimit(3L)
+            .build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.ExternalAccount> stripeCollection =
         client.accounts().externalAccounts().list("acct_xxxxxxxxxxxxx", params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -272,6 +456,28 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testAccountsExternalAccountsGet4Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.AccountExternalAccountRetrieveParams params =
+        com.stripe.param.AccountExternalAccountRetrieveParams.builder().build();
+
+    com.stripe.model.ExternalAccount externalAccount =
+        client
+            .v1()
+            .accounts()
+            .externalAccounts()
+            .retrieve("acct_xxxxxxxxxxxxx", "ba_xxxxxxxxxxxxx", params);
+    assertNotNull(externalAccount);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/accounts/acct_xxxxxxxxxxxxx/external_accounts/ba_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testAccountsExternalAccountsGet4ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.AccountExternalAccountRetrieveParams params =
@@ -293,6 +499,28 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testAccountsExternalAccountsGet5Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.AccountExternalAccountRetrieveParams params =
+        com.stripe.param.AccountExternalAccountRetrieveParams.builder().build();
+
+    com.stripe.model.ExternalAccount externalAccount =
+        client
+            .v1()
+            .accounts()
+            .externalAccounts()
+            .retrieve("acct_xxxxxxxxxxxxx", "card_xxxxxxxxxxxxx", params);
+    assertNotNull(externalAccount);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/accounts/acct_xxxxxxxxxxxxx/external_accounts/card_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testAccountsExternalAccountsGet5ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.AccountExternalAccountRetrieveParams params =
@@ -322,6 +550,26 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.ExternalAccount externalAccount =
+        client.v1().accounts().externalAccounts().create("acct_xxxxxxxxxxxxx", params);
+    assertNotNull(externalAccount);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/accounts/acct_xxxxxxxxxxxxx/external_accounts",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testAccountsExternalAccountsPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.AccountExternalAccountCreateParams params =
+        com.stripe.param.AccountExternalAccountCreateParams.builder()
+            .setExternalAccount("btok_xxxxxxxxxxxxx")
+            .build();
+
+    com.stripe.model.ExternalAccount externalAccount =
         client.accounts().externalAccounts().create("acct_xxxxxxxxxxxxx", params);
     assertNotNull(externalAccount);
     verifyRequest(
@@ -334,6 +582,26 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testAccountsExternalAccountsPost2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.AccountExternalAccountCreateParams params =
+        com.stripe.param.AccountExternalAccountCreateParams.builder()
+            .setExternalAccount("tok_xxxx_debit")
+            .build();
+
+    com.stripe.model.ExternalAccount externalAccount =
+        client.v1().accounts().externalAccounts().create("acct_xxxxxxxxxxxxx", params);
+    assertNotNull(externalAccount);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/accounts/acct_xxxxxxxxxxxxx/external_accounts",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testAccountsExternalAccountsPost2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.AccountExternalAccountCreateParams params =
@@ -363,6 +631,30 @@ class GeneratedExamples extends BaseStripeTest {
 
     com.stripe.model.ExternalAccount externalAccount =
         client
+            .v1()
+            .accounts()
+            .externalAccounts()
+            .update("acct_xxxxxxxxxxxxx", "ba_xxxxxxxxxxxxx", params);
+    assertNotNull(externalAccount);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/accounts/acct_xxxxxxxxxxxxx/external_accounts/ba_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testAccountsExternalAccountsPost3ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.AccountExternalAccountUpdateParams params =
+        com.stripe.param.AccountExternalAccountUpdateParams.builder()
+            .putMetadata("order_id", "6735")
+            .build();
+
+    com.stripe.model.ExternalAccount externalAccount =
+        client
             .accounts()
             .externalAccounts()
             .update("acct_xxxxxxxxxxxxx", "ba_xxxxxxxxxxxxx", params);
@@ -377,6 +669,30 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testAccountsExternalAccountsPost4Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.AccountExternalAccountUpdateParams params =
+        com.stripe.param.AccountExternalAccountUpdateParams.builder()
+            .putMetadata("order_id", "6735")
+            .build();
+
+    com.stripe.model.ExternalAccount externalAccount =
+        client
+            .v1()
+            .accounts()
+            .externalAccounts()
+            .update("acct_xxxxxxxxxxxxx", "card_xxxxxxxxxxxxx", params);
+    assertNotNull(externalAccount);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/accounts/acct_xxxxxxxxxxxxx/external_accounts/card_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testAccountsExternalAccountsPost4ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.AccountExternalAccountUpdateParams params =
@@ -416,6 +732,20 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.AccountListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.Account> stripeCollection =
+        client.v1().accounts().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/accounts", params.toMap(), null);
+  }
+
+  @Test
+  public void testAccountsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.AccountListParams params =
+        com.stripe.param.AccountListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.Account> stripeCollection =
         client.accounts().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -441,6 +771,24 @@ class GeneratedExamples extends BaseStripeTest {
     com.stripe.param.AccountRetrieveParams params =
         com.stripe.param.AccountRetrieveParams.builder().build();
 
+    com.stripe.model.Account account =
+        client.v1().accounts().retrieve("acct_xxxxxxxxxxxxx", params);
+    assertNotNull(account);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/accounts/acct_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testAccountsGet2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.AccountRetrieveParams params =
+        com.stripe.param.AccountRetrieveParams.builder().build();
+
     com.stripe.model.Account account = client.accounts().retrieve("acct_xxxxxxxxxxxxx", params);
     assertNotNull(account);
     verifyRequest(
@@ -453,6 +801,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testAccountsLoginLinksPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.AccountLoginLinkCreateParams params =
+        com.stripe.param.AccountLoginLinkCreateParams.builder().build();
+
+    com.stripe.model.LoginLink loginLink =
+        client.v1().accounts().loginLinks().create("acct_xxxxxxxxxxxxx", params);
+    assertNotNull(loginLink);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/accounts/acct_xxxxxxxxxxxxx/login_links",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testAccountsLoginLinksPostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.AccountLoginLinkCreateParams params =
@@ -490,6 +856,21 @@ class GeneratedExamples extends BaseStripeTest {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.model.Person person =
+        client.v1().accounts().persons().delete("acct_xxxxxxxxxxxxx", "person_xxxxxxxxxxxxx");
+    assertNotNull(person);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.DELETE,
+        "/v1/accounts/acct_xxxxxxxxxxxxx/persons/person_xxxxxxxxxxxxx",
+        null,
+        null);
+  }
+
+  @Test
+  public void testAccountsPersonsDeleteServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.model.Person person =
         client.accounts().persons().delete("acct_xxxxxxxxxxxxx", "person_xxxxxxxxxxxxx");
     assertNotNull(person);
     verifyRequest(
@@ -524,6 +905,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.AccountPersonListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.Person> stripeCollection =
+        client.v1().accounts().persons().list("acct_xxxxxxxxxxxxx", params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/accounts/acct_xxxxxxxxxxxxx/persons",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testAccountsPersonsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.AccountPersonListParams params =
+        com.stripe.param.AccountPersonListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.Person> stripeCollection =
         client.accounts().persons().list("acct_xxxxxxxxxxxxx", params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -550,6 +949,28 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testAccountsPersonsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.AccountPersonRetrieveParams params =
+        com.stripe.param.AccountPersonRetrieveParams.builder().build();
+
+    com.stripe.model.Person person =
+        client
+            .v1()
+            .accounts()
+            .persons()
+            .retrieve("acct_xxxxxxxxxxxxx", "person_xxxxxxxxxxxxx", params);
+    assertNotNull(person);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/accounts/acct_xxxxxxxxxxxxx/persons/person_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testAccountsPersonsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.AccountPersonRetrieveParams params =
@@ -594,6 +1015,27 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.Person person =
+        client.v1().accounts().persons().create("acct_xxxxxxxxxxxxx", params);
+    assertNotNull(person);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/accounts/acct_xxxxxxxxxxxxx/persons",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testAccountsPersonsPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.AccountPersonCreateParams params =
+        com.stripe.param.AccountPersonCreateParams.builder()
+            .setFirstName("Jane")
+            .setLastName("Diaz")
+            .build();
+
+    com.stripe.model.Person person =
         client.accounts().persons().create("acct_xxxxxxxxxxxxx", params);
     assertNotNull(person);
     verifyRequest(
@@ -625,6 +1067,30 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testAccountsPersonsPost2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.AccountPersonUpdateParams params =
+        com.stripe.param.AccountPersonUpdateParams.builder()
+            .putMetadata("order_id", "6735")
+            .build();
+
+    com.stripe.model.Person person =
+        client
+            .v1()
+            .accounts()
+            .persons()
+            .update("acct_xxxxxxxxxxxxx", "person_xxxxxxxxxxxxx", params);
+    assertNotNull(person);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/accounts/acct_xxxxxxxxxxxxx/persons/person_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testAccountsPersonsPost2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.AccountPersonUpdateParams params =
@@ -691,6 +1157,34 @@ class GeneratedExamples extends BaseStripeTest {
                     .build())
             .build();
 
+    com.stripe.model.Account account = client.v1().accounts().create(params);
+    assertNotNull(account);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.POST, "/v1/accounts", params.toMap(), null);
+  }
+
+  @Test
+  public void testAccountsPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.AccountCreateParams params =
+        com.stripe.param.AccountCreateParams.builder()
+            .setType(com.stripe.param.AccountCreateParams.Type.CUSTOM)
+            .setCountry("US")
+            .setEmail("jenny.rosen@example.com")
+            .setCapabilities(
+                com.stripe.param.AccountCreateParams.Capabilities.builder()
+                    .setCardPayments(
+                        com.stripe.param.AccountCreateParams.Capabilities.CardPayments.builder()
+                            .setRequested(true)
+                            .build())
+                    .setTransfers(
+                        com.stripe.param.AccountCreateParams.Capabilities.Transfers.builder()
+                            .setRequested(true)
+                            .build())
+                    .build())
+            .build();
+
     com.stripe.model.Account account = client.accounts().create(params);
     assertNotNull(account);
     verifyRequest(
@@ -716,6 +1210,23 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testAccountsPost2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.AccountUpdateParams params =
+        com.stripe.param.AccountUpdateParams.builder().putMetadata("order_id", "6735").build();
+
+    com.stripe.model.Account account = client.v1().accounts().update("acct_xxxxxxxxxxxxx", params);
+    assertNotNull(account);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/accounts/acct_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testAccountsPost2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.AccountUpdateParams params =
@@ -754,6 +1265,23 @@ class GeneratedExamples extends BaseStripeTest {
     com.stripe.param.AccountRejectParams params =
         com.stripe.param.AccountRejectParams.builder().setReason("fraud").build();
 
+    com.stripe.model.Account account = client.v1().accounts().reject("acct_xxxxxxxxxxxxx", params);
+    assertNotNull(account);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/accounts/acct_xxxxxxxxxxxxx/reject",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testAccountsRejectPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.AccountRejectParams params =
+        com.stripe.param.AccountRejectParams.builder().setReason("fraud").build();
+
     com.stripe.model.Account account = client.accounts().reject("acct_xxxxxxxxxxxxx", params);
     assertNotNull(account);
     verifyRequest(
@@ -786,6 +1314,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.ApplicationFeeListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.ApplicationFee> stripeCollection =
+        client.v1().applicationFees().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/application_fees",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testApplicationFeesGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.ApplicationFeeListParams params =
+        com.stripe.param.ApplicationFeeListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.ApplicationFee> stripeCollection =
         client.applicationFees().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -810,6 +1356,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testApplicationFeesGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.ApplicationFeeRetrieveParams params =
+        com.stripe.param.ApplicationFeeRetrieveParams.builder().build();
+
+    com.stripe.model.ApplicationFee applicationFee =
+        client.v1().applicationFees().retrieve("fee_xxxxxxxxxxxxx", params);
+    assertNotNull(applicationFee);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/application_fees/fee_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testApplicationFeesGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.ApplicationFeeRetrieveParams params =
@@ -851,6 +1415,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.ApplicationFeeRefundListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.FeeRefund> stripeCollection =
+        client.v1().applicationFees().refunds().list("fee_xxxxxxxxxxxxx", params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/application_fees/fee_xxxxxxxxxxxxx/refunds",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testApplicationFeesRefundsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.ApplicationFeeRefundListParams params =
+        com.stripe.param.ApplicationFeeRefundListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.FeeRefund> stripeCollection =
         client.applicationFees().refunds().list("fee_xxxxxxxxxxxxx", params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -877,6 +1459,28 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testApplicationFeesRefundsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.ApplicationFeeRefundRetrieveParams params =
+        com.stripe.param.ApplicationFeeRefundRetrieveParams.builder().build();
+
+    com.stripe.model.FeeRefund feeRefund =
+        client
+            .v1()
+            .applicationFees()
+            .refunds()
+            .retrieve("fee_xxxxxxxxxxxxx", "fr_xxxxxxxxxxxxx", params);
+    assertNotNull(feeRefund);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/application_fees/fee_xxxxxxxxxxxxx/refunds/fr_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testApplicationFeesRefundsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.ApplicationFeeRefundRetrieveParams params =
@@ -914,6 +1518,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testApplicationFeesRefundsPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.ApplicationFeeRefundCreateParams params =
+        com.stripe.param.ApplicationFeeRefundCreateParams.builder().build();
+
+    com.stripe.model.FeeRefund feeRefund =
+        client.v1().applicationFees().refunds().create("fee_xxxxxxxxxxxxx", params);
+    assertNotNull(feeRefund);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/application_fees/fee_xxxxxxxxxxxxx/refunds",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testApplicationFeesRefundsPostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.ApplicationFeeRefundCreateParams params =
@@ -959,6 +1581,30 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.FeeRefund feeRefund =
+        client
+            .v1()
+            .applicationFees()
+            .refunds()
+            .update("fee_xxxxxxxxxxxxx", "fr_xxxxxxxxxxxxx", params);
+    assertNotNull(feeRefund);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/application_fees/fee_xxxxxxxxxxxxx/refunds/fr_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testApplicationFeesRefundsPost2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.ApplicationFeeRefundUpdateParams params =
+        com.stripe.param.ApplicationFeeRefundUpdateParams.builder()
+            .putMetadata("order_id", "6735")
+            .build();
+
+    com.stripe.model.FeeRefund feeRefund =
         client.applicationFees().refunds().update("fee_xxxxxxxxxxxxx", "fr_xxxxxxxxxxxxx", params);
     assertNotNull(feeRefund);
     verifyRequest(
@@ -992,6 +1638,29 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testAppsSecretsDeletePostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.apps.SecretDeleteWhereParams params =
+        com.stripe.param.apps.SecretDeleteWhereParams.builder()
+            .setName("my-api-key")
+            .setScope(
+                com.stripe.param.apps.SecretDeleteWhereParams.Scope.builder()
+                    .setType(com.stripe.param.apps.SecretDeleteWhereParams.Scope.Type.ACCOUNT)
+                    .build())
+            .build();
+
+    com.stripe.model.apps.Secret secret = client.v1().apps().secrets().deleteWhere(params);
+    assertNotNull(secret);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/apps/secrets/delete",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testAppsSecretsDeletePostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.apps.SecretDeleteWhereParams params =
@@ -1047,6 +1716,29 @@ class GeneratedExamples extends BaseStripeTest {
                     .build())
             .build();
 
+    com.stripe.model.apps.Secret secret = client.v1().apps().secrets().find(params);
+    assertNotNull(secret);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/apps/secrets/find",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testAppsSecretsFindGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.apps.SecretFindParams params =
+        com.stripe.param.apps.SecretFindParams.builder()
+            .setName("sec_123")
+            .setScope(
+                com.stripe.param.apps.SecretFindParams.Scope.builder()
+                    .setType(com.stripe.param.apps.SecretFindParams.Scope.Type.ACCOUNT)
+                    .build())
+            .build();
+
     com.stripe.model.apps.Secret secret = client.apps().secrets().find(params);
     assertNotNull(secret);
     verifyRequest(
@@ -1088,6 +1780,26 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.StripeCollection<com.stripe.model.apps.Secret> stripeCollection =
+        client.v1().apps().secrets().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/apps/secrets", params.toMap(), null);
+  }
+
+  @Test
+  public void testAppsSecretsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.apps.SecretListParams params =
+        com.stripe.param.apps.SecretListParams.builder()
+            .setScope(
+                com.stripe.param.apps.SecretListParams.Scope.builder()
+                    .setType(com.stripe.param.apps.SecretListParams.Scope.Type.ACCOUNT)
+                    .build())
+            .setLimit(2L)
+            .build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.apps.Secret> stripeCollection =
         client.apps().secrets().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -1113,6 +1825,26 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testAppsSecretsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.apps.SecretListParams params =
+        com.stripe.param.apps.SecretListParams.builder()
+            .setScope(
+                com.stripe.param.apps.SecretListParams.Scope.builder()
+                    .setType(com.stripe.param.apps.SecretListParams.Scope.Type.ACCOUNT)
+                    .build())
+            .setLimit(2L)
+            .build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.apps.Secret> stripeCollection =
+        client.v1().apps().secrets().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/apps/secrets", params.toMap(), null);
+  }
+
+  @Test
+  public void testAppsSecretsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.apps.SecretListParams params =
@@ -1163,6 +1895,26 @@ class GeneratedExamples extends BaseStripeTest {
                     .build())
             .build();
 
+    com.stripe.model.apps.Secret secret = client.v1().apps().secrets().create(params);
+    assertNotNull(secret);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.POST, "/v1/apps/secrets", params.toMap(), null);
+  }
+
+  @Test
+  public void testAppsSecretsPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.apps.SecretCreateParams params =
+        com.stripe.param.apps.SecretCreateParams.builder()
+            .setName("sec_123")
+            .setPayload("very secret string")
+            .setScope(
+                com.stripe.param.apps.SecretCreateParams.Scope.builder()
+                    .setType(com.stripe.param.apps.SecretCreateParams.Scope.Type.ACCOUNT)
+                    .build())
+            .build();
+
     com.stripe.model.apps.Secret secret = client.apps().secrets().create(params);
     assertNotNull(secret);
     verifyRequest(
@@ -1189,6 +1941,26 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testAppsSecretsPost2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.apps.SecretCreateParams params =
+        com.stripe.param.apps.SecretCreateParams.builder()
+            .setName("my-api-key")
+            .setPayload("secret_key_xxxxxx")
+            .setScope(
+                com.stripe.param.apps.SecretCreateParams.Scope.builder()
+                    .setType(com.stripe.param.apps.SecretCreateParams.Scope.Type.ACCOUNT)
+                    .build())
+            .build();
+
+    com.stripe.model.apps.Secret secret = client.v1().apps().secrets().create(params);
+    assertNotNull(secret);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.POST, "/v1/apps/secrets", params.toMap(), null);
+  }
+
+  @Test
+  public void testAppsSecretsPost2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.apps.SecretCreateParams params =
@@ -1230,6 +2002,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.BalanceTransactionListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.BalanceTransaction> stripeCollection =
+        client.v1().balanceTransactions().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/balance_transactions",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testBalanceTransactionsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.BalanceTransactionListParams params =
+        com.stripe.param.BalanceTransactionListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.BalanceTransaction> stripeCollection =
         client.balanceTransactions().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -1254,6 +2044,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testBalanceTransactionsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.BalanceTransactionRetrieveParams params =
+        com.stripe.param.BalanceTransactionRetrieveParams.builder().build();
+
+    com.stripe.model.BalanceTransaction balanceTransaction =
+        client.v1().balanceTransactions().retrieve("txn_xxxxxxxxxxxxx", params);
+    assertNotNull(balanceTransaction);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/balance_transactions/txn_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testBalanceTransactionsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.BalanceTransactionRetrieveParams params =
@@ -1294,6 +2102,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.billingportal.ConfigurationListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.billingportal.Configuration>
+        stripeCollection = client.v1().billingPortal().configurations().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/billing_portal/configurations",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testBillingPortalConfigurationsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.billingportal.ConfigurationListParams params =
+        com.stripe.param.billingportal.ConfigurationListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.billingportal.Configuration>
         stripeCollection = client.billingPortal().configurations().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -1319,6 +2145,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testBillingPortalConfigurationsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.billingportal.ConfigurationRetrieveParams params =
+        com.stripe.param.billingportal.ConfigurationRetrieveParams.builder().build();
+
+    com.stripe.model.billingportal.Configuration configuration =
+        client.v1().billingPortal().configurations().retrieve("bpc_xxxxxxxxxxxxx", params);
+    assertNotNull(configuration);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/billing_portal/configurations/bpc_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testBillingPortalConfigurationsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.billingportal.ConfigurationRetrieveParams params =
@@ -1409,6 +2253,49 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.billingportal.Configuration configuration =
+        client.v1().billingPortal().configurations().create(params);
+    assertNotNull(configuration);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/billing_portal/configurations",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testBillingPortalConfigurationsPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.billingportal.ConfigurationCreateParams params =
+        com.stripe.param.billingportal.ConfigurationCreateParams.builder()
+            .setFeatures(
+                com.stripe.param.billingportal.ConfigurationCreateParams.Features.builder()
+                    .setCustomerUpdate(
+                        com.stripe.param.billingportal.ConfigurationCreateParams.Features
+                            .CustomerUpdate.builder()
+                            .addAllowedUpdate(
+                                com.stripe.param.billingportal.ConfigurationCreateParams.Features
+                                    .CustomerUpdate.AllowedUpdate.EMAIL)
+                            .addAllowedUpdate(
+                                com.stripe.param.billingportal.ConfigurationCreateParams.Features
+                                    .CustomerUpdate.AllowedUpdate.TAX_ID)
+                            .setEnabled(true)
+                            .build())
+                    .setInvoiceHistory(
+                        com.stripe.param.billingportal.ConfigurationCreateParams.Features
+                            .InvoiceHistory.builder()
+                            .setEnabled(true)
+                            .build())
+                    .build())
+            .setBusinessProfile(
+                com.stripe.param.billingportal.ConfigurationCreateParams.BusinessProfile.builder()
+                    .setPrivacyPolicyUrl("https://example.com/privacy")
+                    .setTermsOfServiceUrl("https://example.com/terms")
+                    .build())
+            .build();
+
+    com.stripe.model.billingportal.Configuration configuration =
         client.billingPortal().configurations().create(params);
     assertNotNull(configuration);
     verifyRequest(
@@ -1445,6 +2332,30 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testBillingPortalConfigurationsPost2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.billingportal.ConfigurationUpdateParams params =
+        com.stripe.param.billingportal.ConfigurationUpdateParams.builder()
+            .setBusinessProfile(
+                com.stripe.param.billingportal.ConfigurationUpdateParams.BusinessProfile.builder()
+                    .setPrivacyPolicyUrl("https://example.com/privacy")
+                    .setTermsOfServiceUrl("https://example.com/terms")
+                    .build())
+            .build();
+
+    com.stripe.model.billingportal.Configuration configuration =
+        client.v1().billingPortal().configurations().update("bpc_xxxxxxxxxxxxx", params);
+    assertNotNull(configuration);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/billing_portal/configurations/bpc_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testBillingPortalConfigurationsPost2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.billingportal.ConfigurationUpdateParams params =
@@ -1497,6 +2408,27 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.billingportal.Session session =
+        client.v1().billingPortal().sessions().create(params);
+    assertNotNull(session);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/billing_portal/sessions",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testBillingPortalSessionsPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.billingportal.SessionCreateParams params =
+        com.stripe.param.billingportal.SessionCreateParams.builder()
+            .setCustomer("cus_xxxxxxxxxxxxx")
+            .setReturnUrl("https://example.com/account")
+            .build();
+
+    com.stripe.model.billingportal.Session session =
         client.billingPortal().sessions().create(params);
     assertNotNull(session);
     verifyRequest(
@@ -1530,6 +2462,23 @@ class GeneratedExamples extends BaseStripeTest {
     com.stripe.param.ChargeCaptureParams params =
         com.stripe.param.ChargeCaptureParams.builder().build();
 
+    com.stripe.model.Charge charge = client.v1().charges().capture("ch_xxxxxxxxxxxxx", params);
+    assertNotNull(charge);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/charges/ch_xxxxxxxxxxxxx/capture",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testChargesCapturePostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.ChargeCaptureParams params =
+        com.stripe.param.ChargeCaptureParams.builder().build();
+
     com.stripe.model.Charge charge = client.charges().capture("ch_xxxxxxxxxxxxx", params);
     assertNotNull(charge);
     verifyRequest(
@@ -1558,6 +2507,20 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.ChargeListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.Charge> stripeCollection =
+        client.v1().charges().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/charges", params.toMap(), null);
+  }
+
+  @Test
+  public void testChargesGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.ChargeListParams params =
+        com.stripe.param.ChargeListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.Charge> stripeCollection =
         client.charges().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -1574,6 +2537,23 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testChargesGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.ChargeRetrieveParams params =
+        com.stripe.param.ChargeRetrieveParams.builder().build();
+
+    com.stripe.model.Charge charge = client.v1().charges().retrieve("ch_xxxxxxxxxxxxx", params);
+    assertNotNull(charge);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/charges/ch_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testChargesGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.ChargeRetrieveParams params =
@@ -1619,6 +2599,25 @@ class GeneratedExamples extends BaseStripeTest {
                 "My First Test Charge (created for API docs at https://www.stripe.com/docs/api)")
             .build();
 
+    com.stripe.model.Charge charge = client.v1().charges().create(params);
+    assertNotNull(charge);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.POST, "/v1/charges", params.toMap(), null);
+  }
+
+  @Test
+  public void testChargesPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.ChargeCreateParams params =
+        com.stripe.param.ChargeCreateParams.builder()
+            .setAmount(2000L)
+            .setCurrency("usd")
+            .setSource("tok_xxxx")
+            .setDescription(
+                "My First Test Charge (created for API docs at https://www.stripe.com/docs/api)")
+            .build();
+
     com.stripe.model.Charge charge = client.charges().create(params);
     assertNotNull(charge);
     verifyRequest(
@@ -1644,6 +2643,23 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testChargesPost2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.ChargeUpdateParams params =
+        com.stripe.param.ChargeUpdateParams.builder().putMetadata("order_id", "6735").build();
+
+    com.stripe.model.Charge charge = client.v1().charges().update("ch_xxxxxxxxxxxxx", params);
+    assertNotNull(charge);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/charges/ch_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testChargesPost2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.ChargeUpdateParams params =
@@ -1680,6 +2696,22 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.StripeSearchResult<com.stripe.model.Charge> stripeSearchResult =
+        client.v1().charges().search(params);
+    assertNotNull(stripeSearchResult);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/charges/search", params.toMap(), null);
+  }
+
+  @Test
+  public void testChargesSearchGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.ChargeSearchParams params =
+        com.stripe.param.ChargeSearchParams.builder()
+            .setQuery("amount>999 AND metadata['order_id']:'6735'")
+            .build();
+
+    com.stripe.model.StripeSearchResult<com.stripe.model.Charge> stripeSearchResult =
         client.charges().search(params);
     assertNotNull(stripeSearchResult);
     verifyRequest(
@@ -1706,6 +2738,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testCheckoutSessionsExpirePostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.checkout.SessionExpireParams params =
+        com.stripe.param.checkout.SessionExpireParams.builder().build();
+
+    com.stripe.model.checkout.Session session =
+        client.v1().checkout().sessions().expire("sess_xyz", params);
+    assertNotNull(session);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/checkout/sessions/sess_xyz/expire",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCheckoutSessionsExpirePostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.checkout.SessionExpireParams params =
@@ -1748,6 +2798,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.checkout.SessionExpireParams.builder().build();
 
     com.stripe.model.checkout.Session session =
+        client.v1().checkout().sessions().expire("cs_test_xxxxxxxxxxxxx", params);
+    assertNotNull(session);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/checkout/sessions/cs_test_xxxxxxxxxxxxx/expire",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCheckoutSessionsExpirePost2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.checkout.SessionExpireParams params =
+        com.stripe.param.checkout.SessionExpireParams.builder().build();
+
+    com.stripe.model.checkout.Session session =
         client.checkout().sessions().expire("cs_test_xxxxxxxxxxxxx", params);
     assertNotNull(session);
     verifyRequest(
@@ -1776,6 +2844,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testCheckoutSessionsGetServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.checkout.SessionListParams params =
+        com.stripe.param.checkout.SessionListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.checkout.Session> stripeCollection =
+        client.v1().checkout().sessions().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/checkout/sessions",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCheckoutSessionsGetServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.checkout.SessionListParams params =
@@ -1813,6 +2899,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.checkout.SessionRetrieveParams.builder().build();
 
     com.stripe.model.checkout.Session session =
+        client.v1().checkout().sessions().retrieve("cs_test_xxxxxxxxxxxxx", params);
+    assertNotNull(session);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/checkout/sessions/cs_test_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCheckoutSessionsGet2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.checkout.SessionRetrieveParams params =
+        com.stripe.param.checkout.SessionRetrieveParams.builder().build();
+
+    com.stripe.model.checkout.Session session =
         client.checkout().sessions().retrieve("cs_test_xxxxxxxxxxxxx", params);
     assertNotNull(session);
     verifyRequest(
@@ -1825,6 +2929,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testCheckoutSessionsLineItemsGetServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.checkout.SessionLineItemListParams params =
+        com.stripe.param.checkout.SessionLineItemListParams.builder().build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.LineItem> stripeCollection =
+        client.v1().checkout().sessions().lineItems().list("sess_xyz", params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/checkout/sessions/sess_xyz/line_items",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCheckoutSessionsLineItemsGetServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.checkout.SessionLineItemListParams params =
@@ -1939,6 +3061,61 @@ class GeneratedExamples extends BaseStripeTest {
                     .build())
             .build();
 
+    com.stripe.model.checkout.Session session = client.v1().checkout().sessions().create(params);
+    assertNotNull(session);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/checkout/sessions",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCheckoutSessionsPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.checkout.SessionCreateParams params =
+        com.stripe.param.checkout.SessionCreateParams.builder()
+            .setSuccessUrl("https://example.com/success")
+            .setCancelUrl("https://example.com/cancel")
+            .setMode(com.stripe.param.checkout.SessionCreateParams.Mode.PAYMENT)
+            .addShippingOption(
+                com.stripe.param.checkout.SessionCreateParams.ShippingOption.builder()
+                    .setShippingRate("shr_standard")
+                    .build())
+            .addShippingOption(
+                com.stripe.param.checkout.SessionCreateParams.ShippingOption.builder()
+                    .setShippingRateData(
+                        com.stripe.param.checkout.SessionCreateParams.ShippingOption
+                            .ShippingRateData.builder()
+                            .setDisplayName("Standard")
+                            .setDeliveryEstimate(
+                                com.stripe.param.checkout.SessionCreateParams.ShippingOption
+                                    .ShippingRateData.DeliveryEstimate.builder()
+                                    .setMinimum(
+                                        com.stripe.param.checkout.SessionCreateParams.ShippingOption
+                                            .ShippingRateData.DeliveryEstimate.Minimum.builder()
+                                            .setUnit(
+                                                com.stripe.param.checkout.SessionCreateParams
+                                                    .ShippingOption.ShippingRateData
+                                                    .DeliveryEstimate.Minimum.Unit.DAY)
+                                            .setValue(5L)
+                                            .build())
+                                    .setMaximum(
+                                        com.stripe.param.checkout.SessionCreateParams.ShippingOption
+                                            .ShippingRateData.DeliveryEstimate.Maximum.builder()
+                                            .setUnit(
+                                                com.stripe.param.checkout.SessionCreateParams
+                                                    .ShippingOption.ShippingRateData
+                                                    .DeliveryEstimate.Maximum.Unit.DAY)
+                                            .setValue(7L)
+                                            .build())
+                                    .build())
+                            .build())
+                    .build())
+            .build();
+
     com.stripe.model.checkout.Session session = client.checkout().sessions().create(params);
     assertNotNull(session);
     verifyRequest(
@@ -1974,6 +3151,31 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testCheckoutSessionsPost2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.checkout.SessionCreateParams params =
+        com.stripe.param.checkout.SessionCreateParams.builder()
+            .setSuccessUrl("https://example.com/success")
+            .addLineItem(
+                com.stripe.param.checkout.SessionCreateParams.LineItem.builder()
+                    .setPrice("price_xxxxxxxxxxxxx")
+                    .setQuantity(2L)
+                    .build())
+            .setMode(com.stripe.param.checkout.SessionCreateParams.Mode.PAYMENT)
+            .build();
+
+    com.stripe.model.checkout.Session session = client.v1().checkout().sessions().create(params);
+    assertNotNull(session);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/checkout/sessions",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCheckoutSessionsPost2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.checkout.SessionCreateParams params =
@@ -2033,6 +3235,20 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.CountrySpecListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.CountrySpec> stripeCollection =
+        client.v1().countrySpecs().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/country_specs", params.toMap(), null);
+  }
+
+  @Test
+  public void testCountrySpecsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CountrySpecListParams params =
+        com.stripe.param.CountrySpecListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.CountrySpec> stripeCollection =
         client.countrySpecs().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -2049,6 +3265,23 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testCountrySpecsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CountrySpecRetrieveParams params =
+        com.stripe.param.CountrySpecRetrieveParams.builder().build();
+
+    com.stripe.model.CountrySpec countrySpec = client.v1().countrySpecs().retrieve("US", params);
+    assertNotNull(countrySpec);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/country_specs/US",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCountrySpecsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.CountrySpecRetrieveParams params =
@@ -2078,6 +3311,16 @@ class GeneratedExamples extends BaseStripeTest {
   public void testCouponsDeleteServices() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
+    com.stripe.model.Coupon coupon = client.v1().coupons().delete("Z4OV52SU");
+    assertNotNull(coupon);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.DELETE, "/v1/coupons/Z4OV52SU", null, null);
+  }
+
+  @Test
+  public void testCouponsDeleteServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
     com.stripe.model.Coupon coupon = client.coupons().delete("Z4OV52SU");
     assertNotNull(coupon);
     verifyRequest(
@@ -2102,6 +3345,20 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.CouponListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.Coupon> stripeCollection =
+        client.v1().coupons().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/coupons", params.toMap(), null);
+  }
+
+  @Test
+  public void testCouponsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CouponListParams params =
+        com.stripe.param.CouponListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.Coupon> stripeCollection =
         client.coupons().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -2118,6 +3375,23 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testCouponsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CouponRetrieveParams params =
+        com.stripe.param.CouponRetrieveParams.builder().build();
+
+    com.stripe.model.Coupon coupon = client.v1().coupons().retrieve("Z4OV52SU", params);
+    assertNotNull(coupon);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/coupons/Z4OV52SU",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCouponsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.CouponRetrieveParams params =
@@ -2157,6 +3431,22 @@ class GeneratedExamples extends BaseStripeTest {
             .setDuration(com.stripe.param.CouponCreateParams.Duration.ONCE)
             .build();
 
+    com.stripe.model.Coupon coupon = client.v1().coupons().create(params);
+    assertNotNull(coupon);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.POST, "/v1/coupons", params.toMap(), null);
+  }
+
+  @Test
+  public void testCouponsPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CouponCreateParams params =
+        com.stripe.param.CouponCreateParams.builder()
+            .setPercentOff(new BigDecimal(25.5))
+            .setDuration(com.stripe.param.CouponCreateParams.Duration.ONCE)
+            .build();
+
     com.stripe.model.Coupon coupon = client.coupons().create(params);
     assertNotNull(coupon);
     verifyRequest(
@@ -2187,6 +3477,23 @@ class GeneratedExamples extends BaseStripeTest {
     com.stripe.param.CouponUpdateParams params =
         com.stripe.param.CouponUpdateParams.builder().putMetadata("order_id", "6735").build();
 
+    com.stripe.model.Coupon coupon = client.v1().coupons().update("Z4OV52SU", params);
+    assertNotNull(coupon);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/coupons/Z4OV52SU",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCouponsPost2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CouponUpdateParams params =
+        com.stripe.param.CouponUpdateParams.builder().putMetadata("order_id", "6735").build();
+
     com.stripe.model.Coupon coupon = client.coupons().update("Z4OV52SU", params);
     assertNotNull(coupon);
     verifyRequest(
@@ -2209,6 +3516,20 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testCreditNotesGetServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CreditNoteListParams params =
+        com.stripe.param.CreditNoteListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.CreditNote> stripeCollection =
+        client.v1().creditNotes().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/credit_notes", params.toMap(), null);
+  }
+
+  @Test
+  public void testCreditNotesGetServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.CreditNoteListParams params =
@@ -2246,6 +3567,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.CreditNoteLineItemListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.CreditNoteLineItem> stripeCollection =
+        client.v1().creditNotes().lineItems().list("cn_xxxxxxxxxxxxx", params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/credit_notes/cn_xxxxxxxxxxxxx/lines",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCreditNotesLinesGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CreditNoteLineItemListParams params =
+        com.stripe.param.CreditNoteLineItemListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.CreditNoteLineItem> stripeCollection =
         client.creditNotes().lineItems().list("cn_xxxxxxxxxxxxx", params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -2277,6 +3616,27 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testCreditNotesPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CreditNoteCreateParams params =
+        com.stripe.param.CreditNoteCreateParams.builder()
+            .setInvoice("in_xxxxxxxxxxxxx")
+            .addLine(
+                com.stripe.param.CreditNoteCreateParams.Line.builder()
+                    .setType(com.stripe.param.CreditNoteCreateParams.Line.Type.INVOICE_LINE_ITEM)
+                    .setInvoiceLineItem("il_xxxxxxxxxxxxx")
+                    .setQuantity(1L)
+                    .build())
+            .build();
+
+    com.stripe.model.CreditNote creditNote = client.v1().creditNotes().create(params);
+    assertNotNull(creditNote);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.POST, "/v1/credit_notes", params.toMap(), null);
+  }
+
+  @Test
+  public void testCreditNotesPostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.CreditNoteCreateParams params =
@@ -2334,6 +3694,31 @@ class GeneratedExamples extends BaseStripeTest {
                     .build())
             .build();
 
+    com.stripe.model.CreditNote creditNote = client.v1().creditNotes().preview(params);
+    assertNotNull(creditNote);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/credit_notes/preview",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCreditNotesPreviewGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CreditNotePreviewParams params =
+        com.stripe.param.CreditNotePreviewParams.builder()
+            .setInvoice("in_xxxxxxxxxxxxx")
+            .addLine(
+                com.stripe.param.CreditNotePreviewParams.Line.builder()
+                    .setType(com.stripe.param.CreditNotePreviewParams.Line.Type.INVOICE_LINE_ITEM)
+                    .setInvoiceLineItem("il_xxxxxxxxxxxxx")
+                    .setQuantity(1L)
+                    .build())
+            .build();
+
     com.stripe.model.CreditNote creditNote = client.creditNotes().preview(params);
     assertNotNull(creditNote);
     verifyRequest(
@@ -2346,6 +3731,27 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testCreditNotesPreviewLinesGetServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CreditNotePreviewLinesListParams params =
+        com.stripe.param.CreditNotePreviewLinesListParams.builder()
+            .setLimit(3L)
+            .setInvoice("in_xxxxxxxxxxxxx")
+            .build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.CreditNoteLineItem> stripeCollection =
+        client.v1().creditNotes().previewLines().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/credit_notes/preview/lines",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCreditNotesPreviewLinesGetServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.CreditNotePreviewLinesListParams params =
@@ -2383,6 +3789,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testCreditNotesVoidPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CreditNoteVoidCreditNoteParams params =
+        com.stripe.param.CreditNoteVoidCreditNoteParams.builder().build();
+
+    com.stripe.model.CreditNote creditNote =
+        client.v1().creditNotes().voidCreditNote("cn_xxxxxxxxxxxxx", params);
+    assertNotNull(creditNote);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/credit_notes/cn_xxxxxxxxxxxxx/void",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCreditNotesVoidPostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.CreditNoteVoidCreditNoteParams params =
@@ -2439,6 +3863,33 @@ class GeneratedExamples extends BaseStripeTest {
                     .build())
             .build();
 
+    com.stripe.model.CustomerSession customerSession =
+        client.v1().customerSessions().create(params);
+    assertNotNull(customerSession);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/customer_sessions",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCustomerSessionsPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CustomerSessionCreateParams params =
+        com.stripe.param.CustomerSessionCreateParams.builder()
+            .setCustomer("cus_123")
+            .setComponents(
+                com.stripe.param.CustomerSessionCreateParams.Components.builder()
+                    .setBuyButton(
+                        com.stripe.param.CustomerSessionCreateParams.Components.BuyButton.builder()
+                            .setEnabled(true)
+                            .build())
+                    .build())
+            .build();
+
     com.stripe.model.CustomerSession customerSession = client.customerSessions().create(params);
     assertNotNull(customerSession);
     verifyRequest(
@@ -2476,6 +3927,25 @@ class GeneratedExamples extends BaseStripeTest {
 
     com.stripe.model.StripeCollection<com.stripe.model.CustomerBalanceTransaction>
         stripeCollection =
+            client.v1().customers().balanceTransactions().list("cus_xxxxxxxxxxxxx", params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/customers/cus_xxxxxxxxxxxxx/balance_transactions",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCustomersBalanceTransactionsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CustomerBalanceTransactionListParams params =
+        com.stripe.param.CustomerBalanceTransactionListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.CustomerBalanceTransaction>
+        stripeCollection =
             client.customers().balanceTransactions().list("cus_xxxxxxxxxxxxx", params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -2503,6 +3973,28 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testCustomersBalanceTransactionsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CustomerBalanceTransactionRetrieveParams params =
+        com.stripe.param.CustomerBalanceTransactionRetrieveParams.builder().build();
+
+    com.stripe.model.CustomerBalanceTransaction customerBalanceTransaction =
+        client
+            .v1()
+            .customers()
+            .balanceTransactions()
+            .retrieve("cus_xxxxxxxxxxxxx", "cbtxn_xxxxxxxxxxxxx", params);
+    assertNotNull(customerBalanceTransaction);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/customers/cus_xxxxxxxxxxxxx/balance_transactions/cbtxn_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCustomersBalanceTransactionsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.CustomerBalanceTransactionRetrieveParams params =
@@ -2554,6 +4046,27 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.CustomerBalanceTransaction customerBalanceTransaction =
+        client.v1().customers().balanceTransactions().create("cus_xxxxxxxxxxxxx", params);
+    assertNotNull(customerBalanceTransaction);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/customers/cus_xxxxxxxxxxxxx/balance_transactions",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCustomersBalanceTransactionsPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CustomerBalanceTransactionCreateParams params =
+        com.stripe.param.CustomerBalanceTransactionCreateParams.builder()
+            .setAmount(-500L)
+            .setCurrency("usd")
+            .build();
+
+    com.stripe.model.CustomerBalanceTransaction customerBalanceTransaction =
         client.customers().balanceTransactions().create("cus_xxxxxxxxxxxxx", params);
     assertNotNull(customerBalanceTransaction);
     verifyRequest(
@@ -2595,6 +4108,30 @@ class GeneratedExamples extends BaseStripeTest {
 
     com.stripe.model.CustomerBalanceTransaction customerBalanceTransaction =
         client
+            .v1()
+            .customers()
+            .balanceTransactions()
+            .update("cus_xxxxxxxxxxxxx", "cbtxn_xxxxxxxxxxxxx", params);
+    assertNotNull(customerBalanceTransaction);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/customers/cus_xxxxxxxxxxxxx/balance_transactions/cbtxn_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCustomersBalanceTransactionsPost2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CustomerBalanceTransactionUpdateParams params =
+        com.stripe.param.CustomerBalanceTransactionUpdateParams.builder()
+            .putMetadata("order_id", "6735")
+            .build();
+
+    com.stripe.model.CustomerBalanceTransaction customerBalanceTransaction =
+        client
             .customers()
             .balanceTransactions()
             .update("cus_xxxxxxxxxxxxx", "cbtxn_xxxxxxxxxxxxx", params);
@@ -2615,6 +4152,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.CustomerCashBalanceRetrieveParams.builder().build();
 
     com.stripe.model.CashBalance cashBalance =
+        client.v1().customers().cashBalance().retrieve("cus_123", params);
+    assertNotNull(cashBalance);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/customers/cus_123/cash_balance",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCustomersCashBalanceGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CustomerCashBalanceRetrieveParams params =
+        com.stripe.param.CustomerCashBalanceRetrieveParams.builder().build();
+
+    com.stripe.model.CashBalance cashBalance =
         client.customers().cashBalance().retrieve("cus_123", params);
     assertNotNull(cashBalance);
     verifyRequest(
@@ -2627,6 +4182,31 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testCustomersCashBalancePostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CustomerCashBalanceUpdateParams params =
+        com.stripe.param.CustomerCashBalanceUpdateParams.builder()
+            .setSettings(
+                com.stripe.param.CustomerCashBalanceUpdateParams.Settings.builder()
+                    .setReconciliationMode(
+                        com.stripe.param.CustomerCashBalanceUpdateParams.Settings.ReconciliationMode
+                            .MANUAL)
+                    .build())
+            .build();
+
+    com.stripe.model.CashBalance cashBalance =
+        client.v1().customers().cashBalance().update("cus_123", params);
+    assertNotNull(cashBalance);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/customers/cus_123/cash_balance",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCustomersCashBalancePostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.CustomerCashBalanceUpdateParams params =
@@ -2676,6 +4256,26 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.CustomerCashBalanceTransactionListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.CustomerCashBalanceTransaction>
+        stripeCollection =
+            client.v1().customers().cashBalanceTransactions().list("cus_123", params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/customers/cus_123/cash_balance_transactions",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCustomersCashBalanceTransactionsGetServicesNonNamespaced()
+      throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CustomerCashBalanceTransactionListParams params =
+        com.stripe.param.CustomerCashBalanceTransactionListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.CustomerCashBalanceTransaction>
         stripeCollection = client.customers().cashBalanceTransactions().list("cus_123", params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -2702,6 +4302,20 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testCustomersDeleteServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.model.Customer customer = client.v1().customers().delete("cus_xxxxxxxxxxxxx");
+    assertNotNull(customer);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.DELETE,
+        "/v1/customers/cus_xxxxxxxxxxxxx",
+        null,
+        null);
+  }
+
+  @Test
+  public void testCustomersDeleteServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.model.Customer customer = client.customers().delete("cus_xxxxxxxxxxxxx");
@@ -2763,6 +4377,37 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.FundingInstructions fundingInstructions =
+        client.v1().customers().fundingInstructions().create("cus_123", params);
+    assertNotNull(fundingInstructions);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/customers/cus_123/funding_instructions",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCustomersFundingInstructionsPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CustomerFundingInstructionsCreateParams params =
+        com.stripe.param.CustomerFundingInstructionsCreateParams.builder()
+            .setBankTransfer(
+                com.stripe.param.CustomerFundingInstructionsCreateParams.BankTransfer.builder()
+                    .addRequestedAddressType(
+                        com.stripe.param.CustomerFundingInstructionsCreateParams.BankTransfer
+                            .RequestedAddressType.ZENGIN)
+                    .setType(
+                        com.stripe.param.CustomerFundingInstructionsCreateParams.BankTransfer.Type
+                            .JP_BANK_TRANSFER)
+                    .build())
+            .setCurrency("usd")
+            .setFundingType(
+                com.stripe.param.CustomerFundingInstructionsCreateParams.FundingType.BANK_TRANSFER)
+            .build();
+
+    com.stripe.model.FundingInstructions fundingInstructions =
         client.customers().fundingInstructions().create("cus_123", params);
     assertNotNull(fundingInstructions);
     verifyRequest(
@@ -2785,6 +4430,20 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testCustomersGetServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CustomerListParams params =
+        com.stripe.param.CustomerListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.Customer> stripeCollection =
+        client.v1().customers().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/customers", params.toMap(), null);
+  }
+
+  @Test
+  public void testCustomersGetServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.CustomerListParams params =
@@ -2815,6 +4474,20 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.CustomerListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.Customer> stripeCollection =
+        client.v1().customers().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/customers", params.toMap(), null);
+  }
+
+  @Test
+  public void testCustomersGet2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CustomerListParams params =
+        com.stripe.param.CustomerListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.Customer> stripeCollection =
         client.customers().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -2835,6 +4508,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testCustomersGet3Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CustomerRetrieveParams params =
+        com.stripe.param.CustomerRetrieveParams.builder().build();
+
+    com.stripe.model.Customer customer =
+        client.v1().customers().retrieve("cus_xxxxxxxxxxxxx", params);
+    assertNotNull(customer);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/customers/cus_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCustomersGet3ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.CustomerRetrieveParams params =
@@ -2871,6 +4562,26 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testCustomersPaymentMethodsGetServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CustomerPaymentMethodListParams params =
+        com.stripe.param.CustomerPaymentMethodListParams.builder()
+            .setType(com.stripe.param.CustomerPaymentMethodListParams.Type.CARD)
+            .build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.PaymentMethod> stripeCollection =
+        client.v1().customers().paymentMethods().list("cus_xyz", params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/customers/cus_xyz/payment_methods",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCustomersPaymentMethodsGetServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.CustomerPaymentMethodListParams params =
@@ -2918,6 +4629,26 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.StripeCollection<com.stripe.model.PaymentMethod> stripeCollection =
+        client.v1().customers().paymentMethods().list("cus_xxxxxxxxxxxxx", params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/customers/cus_xxxxxxxxxxxxx/payment_methods",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCustomersPaymentMethodsGet2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CustomerPaymentMethodListParams params =
+        com.stripe.param.CustomerPaymentMethodListParams.builder()
+            .setType(com.stripe.param.CustomerPaymentMethodListParams.Type.CARD)
+            .build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.PaymentMethod> stripeCollection =
         client.customers().paymentMethods().list("cus_xxxxxxxxxxxxx", params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -2944,6 +4675,22 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testCustomersPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CustomerCreateParams params =
+        com.stripe.param.CustomerCreateParams.builder()
+            .setDescription(
+                "My First Test Customer (created for API docs at https://www.stripe.com/docs/api)")
+            .build();
+
+    com.stripe.model.Customer customer = client.v1().customers().create(params);
+    assertNotNull(customer);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.POST, "/v1/customers", params.toMap(), null);
+  }
+
+  @Test
+  public void testCustomersPostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.CustomerCreateParams params =
@@ -2982,6 +4729,24 @@ class GeneratedExamples extends BaseStripeTest {
     com.stripe.param.CustomerUpdateParams params =
         com.stripe.param.CustomerUpdateParams.builder().putMetadata("order_id", "6735").build();
 
+    com.stripe.model.Customer customer =
+        client.v1().customers().update("cus_xxxxxxxxxxxxx", params);
+    assertNotNull(customer);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/customers/cus_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCustomersPost2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CustomerUpdateParams params =
+        com.stripe.param.CustomerUpdateParams.builder().putMetadata("order_id", "6735").build();
+
     com.stripe.model.Customer customer = client.customers().update("cus_xxxxxxxxxxxxx", params);
     assertNotNull(customer);
     verifyRequest(
@@ -3011,6 +4776,26 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testCustomersSearchGetServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CustomerSearchParams params =
+        com.stripe.param.CustomerSearchParams.builder()
+            .setQuery("name:'fakename' AND metadata['foo']:'bar'")
+            .build();
+
+    com.stripe.model.StripeSearchResult<com.stripe.model.Customer> stripeSearchResult =
+        client.v1().customers().search(params);
+    assertNotNull(stripeSearchResult);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/customers/search",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCustomersSearchGetServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.CustomerSearchParams params =
@@ -3056,6 +4841,26 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.StripeSearchResult<com.stripe.model.Customer> stripeSearchResult =
+        client.v1().customers().search(params);
+    assertNotNull(stripeSearchResult);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/customers/search",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCustomersSearchGet2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CustomerSearchParams params =
+        com.stripe.param.CustomerSearchParams.builder()
+            .setQuery("name:'fakename' AND metadata['foo']:'bar'")
+            .build();
+
+    com.stripe.model.StripeSearchResult<com.stripe.model.Customer> stripeSearchResult =
         client.customers().search(params);
     assertNotNull(stripeSearchResult);
     verifyRequest(
@@ -3068,6 +4873,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testCustomersSourcesDeleteServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.SourceDetachParams params =
+        com.stripe.param.SourceDetachParams.builder().build();
+
+    com.stripe.model.PaymentSource paymentSource =
+        client.v1().sources().detach("cus_xxxxxxxxxxxxx", "ba_xxxxxxxxxxxxx", params);
+    assertNotNull(paymentSource);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.DELETE,
+        "/v1/customers/cus_xxxxxxxxxxxxx/sources/ba_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCustomersSourcesDeleteServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.SourceDetachParams params =
@@ -3092,6 +4915,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.SourceDetachParams.builder().build();
 
     com.stripe.model.PaymentSource paymentSource =
+        client.v1().sources().detach("cus_xxxxxxxxxxxxx", "card_xxxxxxxxxxxxx", params);
+    assertNotNull(paymentSource);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.DELETE,
+        "/v1/customers/cus_xxxxxxxxxxxxx/sources/card_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCustomersSourcesDelete2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.SourceDetachParams params =
+        com.stripe.param.SourceDetachParams.builder().build();
+
+    com.stripe.model.PaymentSource paymentSource =
         client.sources().detach("cus_xxxxxxxxxxxxx", "card_xxxxxxxxxxxxx", params);
     assertNotNull(paymentSource);
     verifyRequest(
@@ -3104,6 +4945,27 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testCustomersSourcesGetServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CustomerPaymentSourceListParams params =
+        com.stripe.param.CustomerPaymentSourceListParams.builder()
+            .setObject("bank_account")
+            .setLimit(3L)
+            .build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.PaymentSource> stripeCollection =
+        client.v1().customers().paymentSources().list("cus_xxxxxxxxxxxxx", params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/customers/cus_xxxxxxxxxxxxx/sources",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCustomersSourcesGetServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.CustomerPaymentSourceListParams params =
@@ -3134,6 +4996,27 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.StripeCollection<com.stripe.model.PaymentSource> stripeCollection =
+        client.v1().customers().paymentSources().list("cus_xxxxxxxxxxxxx", params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/customers/cus_xxxxxxxxxxxxx/sources",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCustomersSourcesGet2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CustomerPaymentSourceListParams params =
+        com.stripe.param.CustomerPaymentSourceListParams.builder()
+            .setObject("card")
+            .setLimit(3L)
+            .build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.PaymentSource> stripeCollection =
         client.customers().paymentSources().list("cus_xxxxxxxxxxxxx", params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -3146,6 +5029,28 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testCustomersSourcesGet3Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CustomerPaymentSourceRetrieveParams params =
+        com.stripe.param.CustomerPaymentSourceRetrieveParams.builder().build();
+
+    com.stripe.model.PaymentSource paymentSource =
+        client
+            .v1()
+            .customers()
+            .paymentSources()
+            .retrieve("cus_xxxxxxxxxxxxx", "ba_xxxxxxxxxxxxx", params);
+    assertNotNull(paymentSource);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/customers/cus_xxxxxxxxxxxxx/sources/ba_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCustomersSourcesGet3ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.CustomerPaymentSourceRetrieveParams params =
@@ -3167,6 +5072,28 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testCustomersSourcesGet4Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CustomerPaymentSourceRetrieveParams params =
+        com.stripe.param.CustomerPaymentSourceRetrieveParams.builder().build();
+
+    com.stripe.model.PaymentSource paymentSource =
+        client
+            .v1()
+            .customers()
+            .paymentSources()
+            .retrieve("cus_xxxxxxxxxxxxx", "card_xxxxxxxxxxxxx", params);
+    assertNotNull(paymentSource);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/customers/cus_xxxxxxxxxxxxx/sources/card_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCustomersSourcesGet4ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.CustomerPaymentSourceRetrieveParams params =
@@ -3196,6 +5123,26 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.PaymentSource paymentSource =
+        client.v1().customers().paymentSources().update("cus_123", "card_123", params);
+    assertNotNull(paymentSource);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/customers/cus_123/sources/card_123",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCustomersSourcesPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CustomerPaymentSourceUpdateParams params =
+        com.stripe.param.CustomerPaymentSourceUpdateParams.builder()
+            .setAccountHolderName("Kamil")
+            .build();
+
+    com.stripe.model.PaymentSource paymentSource =
         client.customers().paymentSources().update("cus_123", "card_123", params);
     assertNotNull(paymentSource);
     verifyRequest(
@@ -3208,6 +5155,26 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testCustomersSourcesPost2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CustomerPaymentSourceCreateParams params =
+        com.stripe.param.CustomerPaymentSourceCreateParams.builder()
+            .setSource("btok_xxxxxxxxxxxxx")
+            .build();
+
+    com.stripe.model.PaymentSource paymentSource =
+        client.v1().customers().paymentSources().create("cus_xxxxxxxxxxxxx", params);
+    assertNotNull(paymentSource);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/customers/cus_xxxxxxxxxxxxx/sources",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCustomersSourcesPost2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.CustomerPaymentSourceCreateParams params =
@@ -3234,6 +5201,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.CustomerPaymentSourceCreateParams.builder().setSource("tok_xxxx").build();
 
     com.stripe.model.PaymentSource paymentSource =
+        client.v1().customers().paymentSources().create("cus_xxxxxxxxxxxxx", params);
+    assertNotNull(paymentSource);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/customers/cus_xxxxxxxxxxxxx/sources",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCustomersSourcesPost3ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CustomerPaymentSourceCreateParams params =
+        com.stripe.param.CustomerPaymentSourceCreateParams.builder().setSource("tok_xxxx").build();
+
+    com.stripe.model.PaymentSource paymentSource =
         client.customers().paymentSources().create("cus_xxxxxxxxxxxxx", params);
     assertNotNull(paymentSource);
     verifyRequest(
@@ -3254,6 +5239,30 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.PaymentSource paymentSource =
+        client
+            .v1()
+            .customers()
+            .paymentSources()
+            .update("cus_xxxxxxxxxxxxx", "ba_xxxxxxxxxxxxx", params);
+    assertNotNull(paymentSource);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/customers/cus_xxxxxxxxxxxxx/sources/ba_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCustomersSourcesPost4ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CustomerPaymentSourceUpdateParams params =
+        com.stripe.param.CustomerPaymentSourceUpdateParams.builder()
+            .putMetadata("order_id", "6735")
+            .build();
+
+    com.stripe.model.PaymentSource paymentSource =
         client.customers().paymentSources().update("cus_xxxxxxxxxxxxx", "ba_xxxxxxxxxxxxx", params);
     assertNotNull(paymentSource);
     verifyRequest(
@@ -3266,6 +5275,28 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testCustomersSourcesPost5Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CustomerPaymentSourceUpdateParams params =
+        com.stripe.param.CustomerPaymentSourceUpdateParams.builder().setName("Jenny Rosen").build();
+
+    com.stripe.model.PaymentSource paymentSource =
+        client
+            .v1()
+            .customers()
+            .paymentSources()
+            .update("cus_xxxxxxxxxxxxx", "card_xxxxxxxxxxxxx", params);
+    assertNotNull(paymentSource);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/customers/cus_xxxxxxxxxxxxx/sources/card_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCustomersSourcesPost5ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.CustomerPaymentSourceUpdateParams params =
@@ -3296,6 +5327,31 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.BankAccount bankAccount =
+        client
+            .v1()
+            .customers()
+            .paymentSources()
+            .verify("cus_xxxxxxxxxxxxx", "ba_xxxxxxxxxxxxx", params);
+    assertNotNull(bankAccount);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/customers/cus_xxxxxxxxxxxxx/sources/ba_xxxxxxxxxxxxx/verify",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCustomersSourcesVerifyPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CustomerPaymentSourceVerifyParams params =
+        com.stripe.param.CustomerPaymentSourceVerifyParams.builder()
+            .addAmount(32L)
+            .addAmount(45L)
+            .build();
+
+    com.stripe.model.BankAccount bankAccount =
         client.customers().paymentSources().verify("cus_xxxxxxxxxxxxx", "ba_xxxxxxxxxxxxx", params);
     assertNotNull(bankAccount);
     verifyRequest(
@@ -3311,6 +5367,21 @@ class GeneratedExamples extends BaseStripeTest {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.model.TaxId taxId =
+        client.v1().customers().taxIds().delete("cus_xxxxxxxxxxxxx", "txi_xxxxxxxxxxxxx");
+    assertNotNull(taxId);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.DELETE,
+        "/v1/customers/cus_xxxxxxxxxxxxx/tax_ids/txi_xxxxxxxxxxxxx",
+        null,
+        null);
+  }
+
+  @Test
+  public void testCustomersTaxIdsDeleteServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.model.TaxId taxId =
         client.customers().taxIds().delete("cus_xxxxxxxxxxxxx", "txi_xxxxxxxxxxxxx");
     assertNotNull(taxId);
     verifyRequest(
@@ -3323,6 +5394,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testCustomersTaxIdsGetServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CustomerTaxIdListParams params =
+        com.stripe.param.CustomerTaxIdListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.TaxId> stripeCollection =
+        client.v1().customers().taxIds().list("cus_xxxxxxxxxxxxx", params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/customers/cus_xxxxxxxxxxxxx/tax_ids",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCustomersTaxIdsGetServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.CustomerTaxIdListParams params =
@@ -3347,6 +5436,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.CustomerTaxIdRetrieveParams.builder().build();
 
     com.stripe.model.TaxId taxId =
+        client.v1().customers().taxIds().retrieve("cus_xxxxxxxxxxxxx", "txi_xxxxxxxxxxxxx", params);
+    assertNotNull(taxId);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/customers/cus_xxxxxxxxxxxxx/tax_ids/txi_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCustomersTaxIdsGet2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CustomerTaxIdRetrieveParams params =
+        com.stripe.param.CustomerTaxIdRetrieveParams.builder().build();
+
+    com.stripe.model.TaxId taxId =
         client.customers().taxIds().retrieve("cus_xxxxxxxxxxxxx", "txi_xxxxxxxxxxxxx", params);
     assertNotNull(taxId);
     verifyRequest(
@@ -3359,6 +5466,27 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testCustomersTaxIdsPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CustomerTaxIdCreateParams params =
+        com.stripe.param.CustomerTaxIdCreateParams.builder()
+            .setType(com.stripe.param.CustomerTaxIdCreateParams.Type.EU_VAT)
+            .setValue("DE123456789")
+            .build();
+
+    com.stripe.model.TaxId taxId =
+        client.v1().customers().taxIds().create("cus_xxxxxxxxxxxxx", params);
+    assertNotNull(taxId);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/customers/cus_xxxxxxxxxxxxx/tax_ids",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testCustomersTaxIdsPostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.CustomerTaxIdCreateParams params =
@@ -3400,6 +5528,23 @@ class GeneratedExamples extends BaseStripeTest {
     com.stripe.param.DisputeCloseParams params =
         com.stripe.param.DisputeCloseParams.builder().build();
 
+    com.stripe.model.Dispute dispute = client.v1().disputes().close("dp_xxxxxxxxxxxxx", params);
+    assertNotNull(dispute);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/disputes/dp_xxxxxxxxxxxxx/close",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testDisputesClosePostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.DisputeCloseParams params =
+        com.stripe.param.DisputeCloseParams.builder().build();
+
     com.stripe.model.Dispute dispute = client.disputes().close("dp_xxxxxxxxxxxxx", params);
     assertNotNull(dispute);
     verifyRequest(
@@ -3428,6 +5573,20 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.DisputeListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.Dispute> stripeCollection =
+        client.v1().disputes().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/disputes", params.toMap(), null);
+  }
+
+  @Test
+  public void testDisputesGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.DisputeListParams params =
+        com.stripe.param.DisputeListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.Dispute> stripeCollection =
         client.disputes().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -3448,6 +5607,23 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testDisputesGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.DisputeRetrieveParams params =
+        com.stripe.param.DisputeRetrieveParams.builder().build();
+
+    com.stripe.model.Dispute dispute = client.v1().disputes().retrieve("dp_xxxxxxxxxxxxx", params);
+    assertNotNull(dispute);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/disputes/dp_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testDisputesGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.DisputeRetrieveParams params =
@@ -3487,6 +5663,23 @@ class GeneratedExamples extends BaseStripeTest {
     com.stripe.param.DisputeUpdateParams params =
         com.stripe.param.DisputeUpdateParams.builder().putMetadata("order_id", "6735").build();
 
+    com.stripe.model.Dispute dispute = client.v1().disputes().update("dp_xxxxxxxxxxxxx", params);
+    assertNotNull(dispute);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/disputes/dp_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testDisputesPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.DisputeUpdateParams params =
+        com.stripe.param.DisputeUpdateParams.builder().putMetadata("order_id", "6735").build();
+
     com.stripe.model.Dispute dispute = client.disputes().update("dp_xxxxxxxxxxxxx", params);
     assertNotNull(dispute);
     verifyRequest(
@@ -3515,6 +5708,20 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.EventListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.Event> stripeCollection =
+        client.v1().events().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/events", params.toMap(), null);
+  }
+
+  @Test
+  public void testEventsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.EventListParams params =
+        com.stripe.param.EventListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.Event> stripeCollection =
         client.events().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -3531,6 +5738,23 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testEventsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.EventRetrieveParams params =
+        com.stripe.param.EventRetrieveParams.builder().build();
+
+    com.stripe.model.Event event = client.v1().events().retrieve("evt_xxxxxxxxxxxxx", params);
+    assertNotNull(event);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/events/evt_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testEventsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.EventRetrieveParams params =
@@ -3564,6 +5788,20 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.FileLinkListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.FileLink> stripeCollection =
+        client.v1().fileLinks().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/file_links", params.toMap(), null);
+  }
+
+  @Test
+  public void testFileLinksGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.FileLinkListParams params =
+        com.stripe.param.FileLinkListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.FileLink> stripeCollection =
         client.fileLinks().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -3584,6 +5822,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testFileLinksGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.FileLinkRetrieveParams params =
+        com.stripe.param.FileLinkRetrieveParams.builder().build();
+
+    com.stripe.model.FileLink fileLink =
+        client.v1().fileLinks().retrieve("link_xxxxxxxxxxxxx", params);
+    assertNotNull(fileLink);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/file_links/link_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testFileLinksGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.FileLinkRetrieveParams params =
@@ -3612,6 +5868,19 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testFileLinksPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.FileLinkCreateParams params =
+        com.stripe.param.FileLinkCreateParams.builder().setFile("file_xxxxxxxxxxxxx").build();
+
+    com.stripe.model.FileLink fileLink = client.v1().fileLinks().create(params);
+    assertNotNull(fileLink);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.POST, "/v1/file_links", params.toMap(), null);
+  }
+
+  @Test
+  public void testFileLinksPostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.FileLinkCreateParams params =
@@ -3647,6 +5916,24 @@ class GeneratedExamples extends BaseStripeTest {
     com.stripe.param.FileLinkUpdateParams params =
         com.stripe.param.FileLinkUpdateParams.builder().putMetadata("order_id", "6735").build();
 
+    com.stripe.model.FileLink fileLink =
+        client.v1().fileLinks().update("link_xxxxxxxxxxxxx", params);
+    assertNotNull(fileLink);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/file_links/link_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testFileLinksPost2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.FileLinkUpdateParams params =
+        com.stripe.param.FileLinkUpdateParams.builder().putMetadata("order_id", "6735").build();
+
     com.stripe.model.FileLink fileLink = client.fileLinks().update("link_xxxxxxxxxxxxx", params);
     assertNotNull(fileLink);
     verifyRequest(
@@ -3675,6 +5962,20 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.FileListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.File> stripeCollection =
+        client.v1().files().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/files", params.toMap(), null);
+  }
+
+  @Test
+  public void testFilesGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.FileListParams params =
+        com.stripe.param.FileListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.File> stripeCollection =
         client.files().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -3691,6 +5992,23 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testFilesGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.FileRetrieveParams params =
+        com.stripe.param.FileRetrieveParams.builder().build();
+
+    com.stripe.model.File file = client.v1().files().retrieve("file_xxxxxxxxxxxxx", params);
+    assertNotNull(file);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/files/file_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testFilesGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.FileRetrieveParams params =
@@ -3734,6 +6052,24 @@ class GeneratedExamples extends BaseStripeTest {
                     "Hello world".getBytes(java.nio.charset.Charset.defaultCharset())))
             .build();
 
+    com.stripe.model.File file = client.v1().files().create(params);
+    assertNotNull(file);
+    verifyRequest(
+        BaseAddress.FILES, ApiResource.RequestMethod.POST, "/v1/files", params.toMap(), null);
+  }
+
+  @Test
+  public void testFilesPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.FileCreateParams params =
+        com.stripe.param.FileCreateParams.builder()
+            .setPurpose(com.stripe.param.FileCreateParams.Purpose.ACCOUNT_REQUIREMENT)
+            .setFile(
+                new java.io.ByteArrayInputStream(
+                    "Hello world".getBytes(java.nio.charset.Charset.defaultCharset())))
+            .build();
+
     com.stripe.model.File file = client.files().create(params);
     assertNotNull(file);
     verifyRequest(
@@ -3760,6 +6096,25 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testFinancialConnectionsAccountsDisconnectPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.financialconnections.AccountDisconnectParams params =
+        com.stripe.param.financialconnections.AccountDisconnectParams.builder().build();
+
+    com.stripe.model.financialconnections.Account account =
+        client.v1().financialConnections().accounts().disconnect("fca_xyz", params);
+    assertNotNull(account);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/financial_connections/accounts/fca_xyz/disconnect",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testFinancialConnectionsAccountsDisconnectPostServicesNonNamespaced()
+      throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.financialconnections.AccountDisconnectParams params =
@@ -3802,6 +6157,25 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.financialconnections.AccountDisconnectParams.builder().build();
 
     com.stripe.model.financialconnections.Account account =
+        client.v1().financialConnections().accounts().disconnect("fca_xxxxxxxxxxxxx", params);
+    assertNotNull(account);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/financial_connections/accounts/fca_xxxxxxxxxxxxx/disconnect",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testFinancialConnectionsAccountsDisconnectPost2ServicesNonNamespaced()
+      throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.financialconnections.AccountDisconnectParams params =
+        com.stripe.param.financialconnections.AccountDisconnectParams.builder().build();
+
+    com.stripe.model.financialconnections.Account account =
         client.financialConnections().accounts().disconnect("fca_xxxxxxxxxxxxx", params);
     assertNotNull(account);
     verifyRequest(
@@ -3836,6 +6210,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.financialconnections.AccountListParams.builder().build();
 
     com.stripe.model.StripeCollection<com.stripe.model.financialconnections.Account>
+        stripeCollection = client.v1().financialConnections().accounts().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/financial_connections/accounts",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testFinancialConnectionsAccountsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.financialconnections.AccountListParams params =
+        com.stripe.param.financialconnections.AccountListParams.builder().build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.financialconnections.Account>
         stripeCollection = client.financialConnections().accounts().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -3861,6 +6253,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testFinancialConnectionsAccountsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.financialconnections.AccountRetrieveParams params =
+        com.stripe.param.financialconnections.AccountRetrieveParams.builder().build();
+
+    com.stripe.model.financialconnections.Account account =
+        client.v1().financialConnections().accounts().retrieve("fca_xyz", params);
+    assertNotNull(account);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/financial_connections/accounts/fca_xyz",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testFinancialConnectionsAccountsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.financialconnections.AccountRetrieveParams params =
@@ -3911,6 +6321,29 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.StripeCollection<com.stripe.model.financialconnections.Account>
+        stripeCollection = client.v1().financialConnections().accounts().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/financial_connections/accounts",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testFinancialConnectionsAccountsGet3ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.financialconnections.AccountListParams params =
+        com.stripe.param.financialconnections.AccountListParams.builder()
+            .setAccountHolder(
+                com.stripe.param.financialconnections.AccountListParams.AccountHolder.builder()
+                    .setCustomer("cus_xxxxxxxxxxxxx")
+                    .build())
+            .build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.financialconnections.Account>
         stripeCollection = client.financialConnections().accounts().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -3936,6 +6369,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testFinancialConnectionsAccountsGet4Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.financialconnections.AccountRetrieveParams params =
+        com.stripe.param.financialconnections.AccountRetrieveParams.builder().build();
+
+    com.stripe.model.financialconnections.Account account =
+        client.v1().financialConnections().accounts().retrieve("fca_xxxxxxxxxxxxx", params);
+    assertNotNull(account);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/financial_connections/accounts/fca_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testFinancialConnectionsAccountsGet4ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.financialconnections.AccountRetrieveParams params =
@@ -3975,6 +6426,28 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testFinancialConnectionsAccountsOwnersGetServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.financialconnections.AccountOwnerListParams params =
+        com.stripe.param.financialconnections.AccountOwnerListParams.builder()
+            .setOwnership("fcaowns_xyz")
+            .build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.financialconnections.AccountOwner>
+        stripeCollection =
+            client.v1().financialConnections().accounts().owners().list("fca_xyz", params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/financial_connections/accounts/fca_xyz/owners",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testFinancialConnectionsAccountsOwnersGetServicesNonNamespaced()
+      throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.financialconnections.AccountOwnerListParams params =
@@ -4028,6 +6501,34 @@ class GeneratedExamples extends BaseStripeTest {
 
     com.stripe.model.StripeCollection<com.stripe.model.financialconnections.AccountOwner>
         stripeCollection =
+            client
+                .v1()
+                .financialConnections()
+                .accounts()
+                .owners()
+                .list("fca_xxxxxxxxxxxxx", params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/financial_connections/accounts/fca_xxxxxxxxxxxxx/owners",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testFinancialConnectionsAccountsOwnersGet2ServicesNonNamespaced()
+      throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.financialconnections.AccountOwnerListParams params =
+        com.stripe.param.financialconnections.AccountOwnerListParams.builder()
+            .setLimit(3L)
+            .setOwnership("fcaowns_xxxxxxxxxxxxx")
+            .build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.financialconnections.AccountOwner>
+        stripeCollection =
             client.financialConnections().accounts().owners().list("fca_xxxxxxxxxxxxx", params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -4060,6 +6561,27 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testFinancialConnectionsAccountsRefreshPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.financialconnections.AccountRefreshParams params =
+        com.stripe.param.financialconnections.AccountRefreshParams.builder()
+            .addFeature(com.stripe.param.financialconnections.AccountRefreshParams.Feature.BALANCE)
+            .build();
+
+    com.stripe.model.financialconnections.Account account =
+        client.v1().financialConnections().accounts().refresh("fca_xyz", params);
+    assertNotNull(account);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/financial_connections/accounts/fca_xyz/refresh",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testFinancialConnectionsAccountsRefreshPostServicesNonNamespaced()
+      throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.financialconnections.AccountRefreshParams params =
@@ -4101,6 +6623,28 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testFinancialConnectionsAccountsSubscribePostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.financialconnections.AccountSubscribeParams params =
+        com.stripe.param.financialconnections.AccountSubscribeParams.builder()
+            .addFeature(
+                com.stripe.param.financialconnections.AccountSubscribeParams.Feature.TRANSACTIONS)
+            .build();
+
+    com.stripe.model.financialconnections.Account account =
+        client.v1().financialConnections().accounts().subscribe("fa_123", params);
+    assertNotNull(account);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/financial_connections/accounts/fa_123/subscribe",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testFinancialConnectionsAccountsSubscribePostServicesNonNamespaced()
+      throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.financialconnections.AccountSubscribeParams params =
@@ -4152,6 +6696,28 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.financialconnections.Account account =
+        client.v1().financialConnections().accounts().unsubscribe("fa_123", params);
+    assertNotNull(account);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/financial_connections/accounts/fa_123/unsubscribe",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testFinancialConnectionsAccountsUnsubscribePostServicesNonNamespaced()
+      throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.financialconnections.AccountUnsubscribeParams params =
+        com.stripe.param.financialconnections.AccountUnsubscribeParams.builder()
+            .addFeature(
+                com.stripe.param.financialconnections.AccountUnsubscribeParams.Feature.TRANSACTIONS)
+            .build();
+
+    com.stripe.model.financialconnections.Account account =
         client.financialConnections().accounts().unsubscribe("fa_123", params);
     assertNotNull(account);
     verifyRequest(
@@ -4183,6 +6749,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.financialconnections.SessionRetrieveParams.builder().build();
 
     com.stripe.model.financialconnections.Session session =
+        client.v1().financialConnections().sessions().retrieve("fcsess_xyz", params);
+    assertNotNull(session);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/financial_connections/sessions/fcsess_xyz",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testFinancialConnectionsSessionsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.financialconnections.SessionRetrieveParams params =
+        com.stripe.param.financialconnections.SessionRetrieveParams.builder().build();
+
+    com.stripe.model.financialconnections.Session session =
         client.financialConnections().sessions().retrieve("fcsess_xyz", params);
     assertNotNull(session);
     verifyRequest(
@@ -4208,6 +6792,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testFinancialConnectionsSessionsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.financialconnections.SessionRetrieveParams params =
+        com.stripe.param.financialconnections.SessionRetrieveParams.builder().build();
+
+    com.stripe.model.financialconnections.Session session =
+        client.v1().financialConnections().sessions().retrieve("fcsess_xxxxxxxxxxxxx", params);
+    assertNotNull(session);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/financial_connections/sessions/fcsess_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testFinancialConnectionsSessionsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.financialconnections.SessionRetrieveParams params =
@@ -4252,6 +6854,34 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testFinancialConnectionsSessionsPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.financialconnections.SessionCreateParams params =
+        com.stripe.param.financialconnections.SessionCreateParams.builder()
+            .setAccountHolder(
+                com.stripe.param.financialconnections.SessionCreateParams.AccountHolder.builder()
+                    .setType(
+                        com.stripe.param.financialconnections.SessionCreateParams.AccountHolder.Type
+                            .CUSTOMER)
+                    .setCustomer("cus_123")
+                    .build())
+            .addPermission(
+                com.stripe.param.financialconnections.SessionCreateParams.Permission.BALANCES)
+            .build();
+
+    com.stripe.model.financialconnections.Session session =
+        client.v1().financialConnections().sessions().create(params);
+    assertNotNull(session);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/financial_connections/sessions",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testFinancialConnectionsSessionsPostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.financialconnections.SessionCreateParams params =
@@ -4334,6 +6964,40 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.financialconnections.Session session =
+        client.v1().financialConnections().sessions().create(params);
+    assertNotNull(session);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/financial_connections/sessions",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testFinancialConnectionsSessionsPost2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.financialconnections.SessionCreateParams params =
+        com.stripe.param.financialconnections.SessionCreateParams.builder()
+            .setAccountHolder(
+                com.stripe.param.financialconnections.SessionCreateParams.AccountHolder.builder()
+                    .setType(
+                        com.stripe.param.financialconnections.SessionCreateParams.AccountHolder.Type
+                            .CUSTOMER)
+                    .setCustomer("cus_xxxxxxxxxxxxx")
+                    .build())
+            .addPermission(
+                com.stripe.param.financialconnections.SessionCreateParams.Permission.PAYMENT_METHOD)
+            .addPermission(
+                com.stripe.param.financialconnections.SessionCreateParams.Permission.BALANCES)
+            .setFilters(
+                com.stripe.param.financialconnections.SessionCreateParams.Filters.builder()
+                    .addCountry("US")
+                    .build())
+            .build();
+
+    com.stripe.model.financialconnections.Session session =
         client.financialConnections().sessions().create(params);
     assertNotNull(session);
     verifyRequest(
@@ -4359,6 +7023,25 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testFinancialConnectionsTransactionsGetServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.financialconnections.TransactionRetrieveParams params =
+        com.stripe.param.financialconnections.TransactionRetrieveParams.builder().build();
+
+    com.stripe.model.financialconnections.Transaction transaction =
+        client.v1().financialConnections().transactions().retrieve("tr_123", params);
+    assertNotNull(transaction);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/financial_connections/transactions/tr_123",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testFinancialConnectionsTransactionsGetServicesNonNamespaced()
+      throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.financialconnections.TransactionRetrieveParams params =
@@ -4403,6 +7086,27 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.StripeCollection<com.stripe.model.financialconnections.Transaction>
+        stripeCollection = client.v1().financialConnections().transactions().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/financial_connections/transactions",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testFinancialConnectionsTransactionsGet2ServicesNonNamespaced()
+      throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.financialconnections.TransactionListParams params =
+        com.stripe.param.financialconnections.TransactionListParams.builder()
+            .setAccount("fca_xyz")
+            .build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.financialconnections.Transaction>
         stripeCollection = client.financialConnections().transactions().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -4437,6 +7141,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.identity.VerificationReportListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.identity.VerificationReport>
+        stripeCollection = client.v1().identity().verificationReports().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/identity/verification_reports",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testIdentityVerificationReportsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.identity.VerificationReportListParams params =
+        com.stripe.param.identity.VerificationReportListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.identity.VerificationReport>
         stripeCollection = client.identity().verificationReports().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -4462,6 +7184,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testIdentityVerificationReportsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.identity.VerificationReportRetrieveParams params =
+        com.stripe.param.identity.VerificationReportRetrieveParams.builder().build();
+
+    com.stripe.model.identity.VerificationReport verificationReport =
+        client.v1().identity().verificationReports().retrieve("vr_xxxxxxxxxxxxx", params);
+    assertNotNull(verificationReport);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/identity/verification_reports/vr_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testIdentityVerificationReportsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.identity.VerificationReportRetrieveParams params =
@@ -4504,6 +7244,25 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.identity.VerificationSessionCancelParams.builder().build();
 
     com.stripe.model.identity.VerificationSession verificationSession =
+        client.v1().identity().verificationSessions().cancel("vs_xxxxxxxxxxxxx", params);
+    assertNotNull(verificationSession);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/identity/verification_sessions/vs_xxxxxxxxxxxxx/cancel",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testIdentityVerificationSessionsCancelPostServicesNonNamespaced()
+      throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.identity.VerificationSessionCancelParams params =
+        com.stripe.param.identity.VerificationSessionCancelParams.builder().build();
+
+    com.stripe.model.identity.VerificationSession verificationSession =
         client.identity().verificationSessions().cancel("vs_xxxxxxxxxxxxx", params);
     assertNotNull(verificationSession);
     verifyRequest(
@@ -4532,6 +7291,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testIdentityVerificationSessionsGetServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.identity.VerificationSessionListParams params =
+        com.stripe.param.identity.VerificationSessionListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.identity.VerificationSession>
+        stripeCollection = client.v1().identity().verificationSessions().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/identity/verification_sessions",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testIdentityVerificationSessionsGetServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.identity.VerificationSessionListParams params =
@@ -4569,6 +7346,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.identity.VerificationSessionRetrieveParams.builder().build();
 
     com.stripe.model.identity.VerificationSession verificationSession =
+        client.v1().identity().verificationSessions().retrieve("vs_xxxxxxxxxxxxx", params);
+    assertNotNull(verificationSession);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/identity/verification_sessions/vs_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testIdentityVerificationSessionsGet2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.identity.VerificationSessionRetrieveParams params =
+        com.stripe.param.identity.VerificationSessionRetrieveParams.builder().build();
+
+    com.stripe.model.identity.VerificationSession verificationSession =
         client.identity().verificationSessions().retrieve("vs_xxxxxxxxxxxxx", params);
     assertNotNull(verificationSession);
     verifyRequest(
@@ -4599,6 +7394,26 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testIdentityVerificationSessionsPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.identity.VerificationSessionCreateParams params =
+        com.stripe.param.identity.VerificationSessionCreateParams.builder()
+            .setType(com.stripe.param.identity.VerificationSessionCreateParams.Type.DOCUMENT)
+            .build();
+
+    com.stripe.model.identity.VerificationSession verificationSession =
+        client.v1().identity().verificationSessions().create(params);
+    assertNotNull(verificationSession);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/identity/verification_sessions",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testIdentityVerificationSessionsPostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.identity.VerificationSessionCreateParams params =
@@ -4647,6 +7462,26 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.identity.VerificationSession verificationSession =
+        client.v1().identity().verificationSessions().update("vs_xxxxxxxxxxxxx", params);
+    assertNotNull(verificationSession);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/identity/verification_sessions/vs_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testIdentityVerificationSessionsPost2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.identity.VerificationSessionUpdateParams params =
+        com.stripe.param.identity.VerificationSessionUpdateParams.builder()
+            .setType(com.stripe.param.identity.VerificationSessionUpdateParams.Type.ID_NUMBER)
+            .build();
+
+    com.stripe.model.identity.VerificationSession verificationSession =
         client.identity().verificationSessions().update("vs_xxxxxxxxxxxxx", params);
     assertNotNull(verificationSession);
     verifyRequest(
@@ -4683,6 +7518,25 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.identity.VerificationSessionRedactParams.builder().build();
 
     com.stripe.model.identity.VerificationSession verificationSession =
+        client.v1().identity().verificationSessions().redact("vs_xxxxxxxxxxxxx", params);
+    assertNotNull(verificationSession);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/identity/verification_sessions/vs_xxxxxxxxxxxxx/redact",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testIdentityVerificationSessionsRedactPostServicesNonNamespaced()
+      throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.identity.VerificationSessionRedactParams params =
+        com.stripe.param.identity.VerificationSessionRedactParams.builder().build();
+
+    com.stripe.model.identity.VerificationSession verificationSession =
         client.identity().verificationSessions().redact("vs_xxxxxxxxxxxxx", params);
     assertNotNull(verificationSession);
     verifyRequest(
@@ -4711,6 +7565,21 @@ class GeneratedExamples extends BaseStripeTest {
   public void testInvoiceitemsDeleteServices() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
+    com.stripe.model.InvoiceItem invoiceItem =
+        client.v1().invoiceItems().delete("ii_xxxxxxxxxxxxx");
+    assertNotNull(invoiceItem);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.DELETE,
+        "/v1/invoiceitems/ii_xxxxxxxxxxxxx",
+        null,
+        null);
+  }
+
+  @Test
+  public void testInvoiceitemsDeleteServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
     com.stripe.model.InvoiceItem invoiceItem = client.invoiceItems().delete("ii_xxxxxxxxxxxxx");
     assertNotNull(invoiceItem);
     verifyRequest(
@@ -4733,6 +7602,20 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testInvoiceitemsGetServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.InvoiceItemListParams params =
+        com.stripe.param.InvoiceItemListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.InvoiceItem> stripeCollection =
+        client.v1().invoiceItems().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/invoiceitems", params.toMap(), null);
+  }
+
+  @Test
+  public void testInvoiceitemsGetServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.InvoiceItemListParams params =
@@ -4765,6 +7648,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.InvoiceItemRetrieveParams.builder().build();
 
     com.stripe.model.InvoiceItem invoiceItem =
+        client.v1().invoiceItems().retrieve("ii_xxxxxxxxxxxxx", params);
+    assertNotNull(invoiceItem);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/invoiceitems/ii_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testInvoiceitemsGet2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.InvoiceItemRetrieveParams params =
+        com.stripe.param.InvoiceItemRetrieveParams.builder().build();
+
+    com.stripe.model.InvoiceItem invoiceItem =
         client.invoiceItems().retrieve("ii_xxxxxxxxxxxxx", params);
     assertNotNull(invoiceItem);
     verifyRequest(
@@ -4788,6 +7689,19 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testInvoiceitemsPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.InvoiceItemCreateParams params =
+        com.stripe.param.InvoiceItemCreateParams.builder().setCustomer("cus_xxxxxxxxxxxxx").build();
+
+    com.stripe.model.InvoiceItem invoiceItem = client.v1().invoiceItems().create(params);
+    assertNotNull(invoiceItem);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.POST, "/v1/invoiceitems", params.toMap(), null);
+  }
+
+  @Test
+  public void testInvoiceitemsPostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.InvoiceItemCreateParams params =
@@ -4824,6 +7738,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.InvoiceItemUpdateParams.builder().putMetadata("order_id", "6735").build();
 
     com.stripe.model.InvoiceItem invoiceItem =
+        client.v1().invoiceItems().update("ii_xxxxxxxxxxxxx", params);
+    assertNotNull(invoiceItem);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/invoiceitems/ii_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testInvoiceitemsPost2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.InvoiceItemUpdateParams params =
+        com.stripe.param.InvoiceItemUpdateParams.builder().putMetadata("order_id", "6735").build();
+
+    com.stripe.model.InvoiceItem invoiceItem =
         client.invoiceItems().update("ii_xxxxxxxxxxxxx", params);
     assertNotNull(invoiceItem);
     verifyRequest(
@@ -4850,6 +7782,20 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testInvoicesDeleteServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.model.Invoice invoice = client.v1().invoices().delete("in_xxxxxxxxxxxxx");
+    assertNotNull(invoice);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.DELETE,
+        "/v1/invoices/in_xxxxxxxxxxxxx",
+        null,
+        null);
+  }
+
+  @Test
+  public void testInvoicesDeleteServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.model.Invoice invoice = client.invoices().delete("in_xxxxxxxxxxxxx");
@@ -4886,6 +7832,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.InvoiceFinalizeInvoiceParams.builder().build();
 
     com.stripe.model.Invoice invoice =
+        client.v1().invoices().finalizeInvoice("in_xxxxxxxxxxxxx", params);
+    assertNotNull(invoice);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/invoices/in_xxxxxxxxxxxxx/finalize",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testInvoicesFinalizePostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.InvoiceFinalizeInvoiceParams params =
+        com.stripe.param.InvoiceFinalizeInvoiceParams.builder().build();
+
+    com.stripe.model.Invoice invoice =
         client.invoices().finalizeInvoice("in_xxxxxxxxxxxxx", params);
     assertNotNull(invoice);
     verifyRequest(
@@ -4908,6 +7872,20 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testInvoicesGetServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.InvoiceListParams params =
+        com.stripe.param.InvoiceListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.Invoice> stripeCollection =
+        client.v1().invoices().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/invoices", params.toMap(), null);
+  }
+
+  @Test
+  public void testInvoicesGetServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.InvoiceListParams params =
@@ -4939,6 +7917,23 @@ class GeneratedExamples extends BaseStripeTest {
     com.stripe.param.InvoiceRetrieveParams params =
         com.stripe.param.InvoiceRetrieveParams.builder().build();
 
+    com.stripe.model.Invoice invoice = client.v1().invoices().retrieve("in_xxxxxxxxxxxxx", params);
+    assertNotNull(invoice);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/invoices/in_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testInvoicesGet2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.InvoiceRetrieveParams params =
+        com.stripe.param.InvoiceRetrieveParams.builder().build();
+
     com.stripe.model.Invoice invoice = client.invoices().retrieve("in_xxxxxxxxxxxxx", params);
     assertNotNull(invoice);
     verifyRequest(
@@ -4965,6 +7960,23 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testInvoicesGet3Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.InvoiceRetrieveParams params =
+        com.stripe.param.InvoiceRetrieveParams.builder().addExpand("customer").build();
+
+    com.stripe.model.Invoice invoice = client.v1().invoices().retrieve("in_xxxxxxxxxxxxx", params);
+    assertNotNull(invoice);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/invoices/in_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testInvoicesGet3ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.InvoiceRetrieveParams params =
@@ -5004,6 +8016,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.InvoiceMarkUncollectibleParams.builder().build();
 
     com.stripe.model.Invoice invoice =
+        client.v1().invoices().markUncollectible("in_xxxxxxxxxxxxx", params);
+    assertNotNull(invoice);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/invoices/in_xxxxxxxxxxxxx/mark_uncollectible",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testInvoicesMarkUncollectiblePostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.InvoiceMarkUncollectibleParams params =
+        com.stripe.param.InvoiceMarkUncollectibleParams.builder().build();
+
+    com.stripe.model.Invoice invoice =
         client.invoices().markUncollectible("in_xxxxxxxxxxxxx", params);
     assertNotNull(invoice);
     verifyRequest(
@@ -5036,6 +8066,22 @@ class GeneratedExamples extends BaseStripeTest {
 
     com.stripe.param.InvoicePayParams params = com.stripe.param.InvoicePayParams.builder().build();
 
+    com.stripe.model.Invoice invoice = client.v1().invoices().pay("in_xxxxxxxxxxxxx", params);
+    assertNotNull(invoice);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/invoices/in_xxxxxxxxxxxxx/pay",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testInvoicesPayPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.InvoicePayParams params = com.stripe.param.InvoicePayParams.builder().build();
+
     com.stripe.model.Invoice invoice = client.invoices().pay("in_xxxxxxxxxxxxx", params);
     assertNotNull(invoice);
     verifyRequest(
@@ -5059,6 +8105,19 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testInvoicesPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.InvoiceCreateParams params =
+        com.stripe.param.InvoiceCreateParams.builder().setCustomer("cus_xxxxxxxxxxxxx").build();
+
+    com.stripe.model.Invoice invoice = client.v1().invoices().create(params);
+    assertNotNull(invoice);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.POST, "/v1/invoices", params.toMap(), null);
+  }
+
+  @Test
+  public void testInvoicesPostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.InvoiceCreateParams params =
@@ -5094,6 +8153,23 @@ class GeneratedExamples extends BaseStripeTest {
     com.stripe.param.InvoiceUpdateParams params =
         com.stripe.param.InvoiceUpdateParams.builder().putMetadata("order_id", "6735").build();
 
+    com.stripe.model.Invoice invoice = client.v1().invoices().update("in_xxxxxxxxxxxxx", params);
+    assertNotNull(invoice);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/invoices/in_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testInvoicesPost2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.InvoiceUpdateParams params =
+        com.stripe.param.InvoiceUpdateParams.builder().putMetadata("order_id", "6735").build();
+
     com.stripe.model.Invoice invoice = client.invoices().update("in_xxxxxxxxxxxxx", params);
     assertNotNull(invoice);
     verifyRequest(
@@ -5121,6 +8197,26 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testInvoicesSearchGetServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.InvoiceSearchParams params =
+        com.stripe.param.InvoiceSearchParams.builder()
+            .setQuery("total>999 AND metadata['order_id']:'6735'")
+            .build();
+
+    com.stripe.model.StripeSearchResult<com.stripe.model.Invoice> stripeSearchResult =
+        client.v1().invoices().search(params);
+    assertNotNull(stripeSearchResult);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/invoices/search",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testInvoicesSearchGetServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.InvoiceSearchParams params =
@@ -5162,6 +8258,24 @@ class GeneratedExamples extends BaseStripeTest {
     com.stripe.param.InvoiceSendInvoiceParams params =
         com.stripe.param.InvoiceSendInvoiceParams.builder().build();
 
+    com.stripe.model.Invoice invoice =
+        client.v1().invoices().sendInvoice("in_xxxxxxxxxxxxx", params);
+    assertNotNull(invoice);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/invoices/in_xxxxxxxxxxxxx/send",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testInvoicesSendPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.InvoiceSendInvoiceParams params =
+        com.stripe.param.InvoiceSendInvoiceParams.builder().build();
+
     com.stripe.model.Invoice invoice = client.invoices().sendInvoice("in_xxxxxxxxxxxxx", params);
     assertNotNull(invoice);
     verifyRequest(
@@ -5190,6 +8304,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testInvoicesVoidPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.InvoiceVoidInvoiceParams params =
+        com.stripe.param.InvoiceVoidInvoiceParams.builder().build();
+
+    com.stripe.model.Invoice invoice =
+        client.v1().invoices().voidInvoice("in_xxxxxxxxxxxxx", params);
+    assertNotNull(invoice);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/invoices/in_xxxxxxxxxxxxx/void",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testInvoicesVoidPostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.InvoiceVoidInvoiceParams params =
@@ -5225,6 +8357,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testIssuingAuthorizationsApprovePostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.AuthorizationApproveParams params =
+        com.stripe.param.issuing.AuthorizationApproveParams.builder().build();
+
+    com.stripe.model.issuing.Authorization authorization =
+        client.v1().issuing().authorizations().approve("iauth_xxxxxxxxxxxxx", params);
+    assertNotNull(authorization);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/issuing/authorizations/iauth_xxxxxxxxxxxxx/approve",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testIssuingAuthorizationsApprovePostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.issuing.AuthorizationApproveParams params =
@@ -5267,6 +8417,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.issuing.AuthorizationDeclineParams.builder().build();
 
     com.stripe.model.issuing.Authorization authorization =
+        client.v1().issuing().authorizations().decline("iauth_xxxxxxxxxxxxx", params);
+    assertNotNull(authorization);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/issuing/authorizations/iauth_xxxxxxxxxxxxx/decline",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testIssuingAuthorizationsDeclinePostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.AuthorizationDeclineParams params =
+        com.stripe.param.issuing.AuthorizationDeclineParams.builder().build();
+
+    com.stripe.model.issuing.Authorization authorization =
         client.issuing().authorizations().decline("iauth_xxxxxxxxxxxxx", params);
     assertNotNull(authorization);
     verifyRequest(
@@ -5301,6 +8469,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.issuing.AuthorizationListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.issuing.Authorization> stripeCollection =
+        client.v1().issuing().authorizations().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/issuing/authorizations",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testIssuingAuthorizationsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.AuthorizationListParams params =
+        com.stripe.param.issuing.AuthorizationListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.issuing.Authorization> stripeCollection =
         client.issuing().authorizations().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -5326,6 +8512,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testIssuingAuthorizationsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.AuthorizationRetrieveParams params =
+        com.stripe.param.issuing.AuthorizationRetrieveParams.builder().build();
+
+    com.stripe.model.issuing.Authorization authorization =
+        client.v1().issuing().authorizations().retrieve("iauth_xxxxxxxxxxxxx", params);
+    assertNotNull(authorization);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/issuing/authorizations/iauth_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testIssuingAuthorizationsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.issuing.AuthorizationRetrieveParams params =
@@ -5372,6 +8576,26 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.issuing.Authorization authorization =
+        client.v1().issuing().authorizations().update("iauth_xxxxxxxxxxxxx", params);
+    assertNotNull(authorization);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/issuing/authorizations/iauth_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testIssuingAuthorizationsPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.AuthorizationUpdateParams params =
+        com.stripe.param.issuing.AuthorizationUpdateParams.builder()
+            .putMetadata("order_id", "6735")
+            .build();
+
+    com.stripe.model.issuing.Authorization authorization =
         client.issuing().authorizations().update("iauth_xxxxxxxxxxxxx", params);
     assertNotNull(authorization);
     verifyRequest(
@@ -5406,6 +8630,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.issuing.CardholderListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.issuing.Cardholder> stripeCollection =
+        client.v1().issuing().cardholders().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/issuing/cardholders",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testIssuingCardholdersGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.CardholderListParams params =
+        com.stripe.param.issuing.CardholderListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.issuing.Cardholder> stripeCollection =
         client.issuing().cardholders().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -5431,6 +8673,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testIssuingCardholdersGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.CardholderRetrieveParams params =
+        com.stripe.param.issuing.CardholderRetrieveParams.builder().build();
+
+    com.stripe.model.issuing.Cardholder cardholder =
+        client.v1().issuing().cardholders().retrieve("ich_xxxxxxxxxxxxx", params);
+    assertNotNull(cardholder);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/issuing/cardholders/ich_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testIssuingCardholdersGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.issuing.CardholderRetrieveParams params =
@@ -5502,6 +8762,40 @@ class GeneratedExamples extends BaseStripeTest {
                     .build())
             .build();
 
+    com.stripe.model.issuing.Cardholder cardholder =
+        client.v1().issuing().cardholders().create(params);
+    assertNotNull(cardholder);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/issuing/cardholders",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testIssuingCardholdersPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.CardholderCreateParams params =
+        com.stripe.param.issuing.CardholderCreateParams.builder()
+            .setType(com.stripe.param.issuing.CardholderCreateParams.Type.INDIVIDUAL)
+            .setName("Jenny Rosen")
+            .setEmail("jenny.rosen@example.com")
+            .setPhoneNumber("+18888675309")
+            .setBilling(
+                com.stripe.param.issuing.CardholderCreateParams.Billing.builder()
+                    .setAddress(
+                        com.stripe.param.issuing.CardholderCreateParams.Billing.Address.builder()
+                            .setLine1("1234 Main Street")
+                            .setCity("San Francisco")
+                            .setState("CA")
+                            .setCountry("US")
+                            .setPostalCode("94111")
+                            .build())
+                    .build())
+            .build();
+
     com.stripe.model.issuing.Cardholder cardholder = client.issuing().cardholders().create(params);
     assertNotNull(cardholder);
     verifyRequest(
@@ -5542,6 +8836,26 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.issuing.Cardholder cardholder =
+        client.v1().issuing().cardholders().update("ich_xxxxxxxxxxxxx", params);
+    assertNotNull(cardholder);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/issuing/cardholders/ich_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testIssuingCardholdersPost2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.CardholderUpdateParams params =
+        com.stripe.param.issuing.CardholderUpdateParams.builder()
+            .putMetadata("order_id", "6735")
+            .build();
+
+    com.stripe.model.issuing.Cardholder cardholder =
         client.issuing().cardholders().update("ich_xxxxxxxxxxxxx", params);
     assertNotNull(cardholder);
     verifyRequest(
@@ -5571,6 +8885,20 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.issuing.CardListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.issuing.Card> stripeCollection =
+        client.v1().issuing().cards().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/issuing/cards", params.toMap(), null);
+  }
+
+  @Test
+  public void testIssuingCardsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.CardListParams params =
+        com.stripe.param.issuing.CardListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.issuing.Card> stripeCollection =
         client.issuing().cards().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -5591,6 +8919,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testIssuingCardsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.CardRetrieveParams params =
+        com.stripe.param.issuing.CardRetrieveParams.builder().build();
+
+    com.stripe.model.issuing.Card card =
+        client.v1().issuing().cards().retrieve("ic_xxxxxxxxxxxxx", params);
+    assertNotNull(card);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/issuing/cards/ic_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testIssuingCardsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.issuing.CardRetrieveParams params =
@@ -5633,6 +8979,23 @@ class GeneratedExamples extends BaseStripeTest {
             .setType(com.stripe.param.issuing.CardCreateParams.Type.VIRTUAL)
             .build();
 
+    com.stripe.model.issuing.Card card = client.v1().issuing().cards().create(params);
+    assertNotNull(card);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.POST, "/v1/issuing/cards", params.toMap(), null);
+  }
+
+  @Test
+  public void testIssuingCardsPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.CardCreateParams params =
+        com.stripe.param.issuing.CardCreateParams.builder()
+            .setCardholder("ich_xxxxxxxxxxxxx")
+            .setCurrency("usd")
+            .setType(com.stripe.param.issuing.CardCreateParams.Type.VIRTUAL)
+            .build();
+
     com.stripe.model.issuing.Card card = client.issuing().cards().create(params);
     assertNotNull(card);
     verifyRequest(
@@ -5659,6 +9022,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testIssuingCardsPost2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.CardUpdateParams params =
+        com.stripe.param.issuing.CardUpdateParams.builder().putMetadata("order_id", "6735").build();
+
+    com.stripe.model.issuing.Card card =
+        client.v1().issuing().cards().update("ic_xxxxxxxxxxxxx", params);
+    assertNotNull(card);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/issuing/cards/ic_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testIssuingCardsPost2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.issuing.CardUpdateParams params =
@@ -5699,6 +9080,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.issuing.DisputeListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.issuing.Dispute> stripeCollection =
+        client.v1().issuing().disputes().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/issuing/disputes",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testIssuingDisputesGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.DisputeListParams params =
+        com.stripe.param.issuing.DisputeListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.issuing.Dispute> stripeCollection =
         client.issuing().disputes().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -5724,6 +9123,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testIssuingDisputesGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.DisputeRetrieveParams params =
+        com.stripe.param.issuing.DisputeRetrieveParams.builder().build();
+
+    com.stripe.model.issuing.Dispute dispute =
+        client.v1().issuing().disputes().retrieve("idp_xxxxxxxxxxxxx", params);
+    assertNotNull(dispute);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/issuing/disputes/idp_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testIssuingDisputesGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.issuing.DisputeRetrieveParams params =
@@ -5784,6 +9201,34 @@ class GeneratedExamples extends BaseStripeTest {
                     .build())
             .build();
 
+    com.stripe.model.issuing.Dispute dispute = client.v1().issuing().disputes().create(params);
+    assertNotNull(dispute);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/issuing/disputes",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testIssuingDisputesPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.DisputeCreateParams params =
+        com.stripe.param.issuing.DisputeCreateParams.builder()
+            .setTransaction("ipi_xxxxxxxxxxxxx")
+            .setEvidence(
+                com.stripe.param.issuing.DisputeCreateParams.Evidence.builder()
+                    .setReason(
+                        com.stripe.param.issuing.DisputeCreateParams.Evidence.Reason.FRAUDULENT)
+                    .setFraudulent(
+                        com.stripe.param.issuing.DisputeCreateParams.Evidence.Fraudulent.builder()
+                            .setExplanation("Purchase was unrecognized.")
+                            .build())
+                    .build())
+            .build();
+
     com.stripe.model.issuing.Dispute dispute = client.issuing().disputes().create(params);
     assertNotNull(dispute);
     verifyRequest(
@@ -5814,6 +9259,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testIssuingDisputesSubmitPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.DisputeSubmitParams params =
+        com.stripe.param.issuing.DisputeSubmitParams.builder().build();
+
+    com.stripe.model.issuing.Dispute dispute =
+        client.v1().issuing().disputes().submit("idp_xxxxxxxxxxxxx", params);
+    assertNotNull(dispute);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/issuing/disputes/idp_xxxxxxxxxxxxx/submit",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testIssuingDisputesSubmitPostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.issuing.DisputeSubmitParams params =
@@ -5854,6 +9317,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.issuing.PersonalizationDesignListParams.builder().build();
 
     com.stripe.model.StripeCollection<com.stripe.model.issuing.PersonalizationDesign>
+        stripeCollection = client.v1().issuing().personalizationDesigns().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/issuing/personalization_designs",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testIssuingPersonalizationDesignsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.PersonalizationDesignListParams params =
+        com.stripe.param.issuing.PersonalizationDesignListParams.builder().build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.issuing.PersonalizationDesign>
         stripeCollection = client.issuing().personalizationDesigns().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -5879,6 +9360,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testIssuingPersonalizationDesignsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.PersonalizationDesignRetrieveParams params =
+        com.stripe.param.issuing.PersonalizationDesignRetrieveParams.builder().build();
+
+    com.stripe.model.issuing.PersonalizationDesign personalizationDesign =
+        client.v1().issuing().personalizationDesigns().retrieve("pd_xyz", params);
+    assertNotNull(personalizationDesign);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/issuing/personalization_designs/pd_xyz",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testIssuingPersonalizationDesignsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.issuing.PersonalizationDesignRetrieveParams params =
@@ -5923,6 +9422,26 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.issuing.PersonalizationDesign personalizationDesign =
+        client.v1().issuing().personalizationDesigns().create(params);
+    assertNotNull(personalizationDesign);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/issuing/personalization_designs",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testIssuingPersonalizationDesignsPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.PersonalizationDesignCreateParams params =
+        com.stripe.param.issuing.PersonalizationDesignCreateParams.builder()
+            .setPhysicalBundle("pb_xyz")
+            .build();
+
+    com.stripe.model.issuing.PersonalizationDesign personalizationDesign =
         client.issuing().personalizationDesigns().create(params);
     assertNotNull(personalizationDesign);
     verifyRequest(
@@ -5953,6 +9472,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testIssuingPersonalizationDesignsPost2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.PersonalizationDesignUpdateParams params =
+        com.stripe.param.issuing.PersonalizationDesignUpdateParams.builder().build();
+
+    com.stripe.model.issuing.PersonalizationDesign personalizationDesign =
+        client.v1().issuing().personalizationDesigns().update("pd_xyz", params);
+    assertNotNull(personalizationDesign);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/issuing/personalization_designs/pd_xyz",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testIssuingPersonalizationDesignsPost2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.issuing.PersonalizationDesignUpdateParams params =
@@ -5993,6 +9530,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.issuing.PhysicalBundleListParams.builder().build();
 
     com.stripe.model.StripeCollection<com.stripe.model.issuing.PhysicalBundle> stripeCollection =
+        client.v1().issuing().physicalBundles().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/issuing/physical_bundles",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testIssuingPhysicalBundlesGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.PhysicalBundleListParams params =
+        com.stripe.param.issuing.PhysicalBundleListParams.builder().build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.issuing.PhysicalBundle> stripeCollection =
         client.issuing().physicalBundles().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -6018,6 +9573,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testIssuingPhysicalBundlesGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.PhysicalBundleRetrieveParams params =
+        com.stripe.param.issuing.PhysicalBundleRetrieveParams.builder().build();
+
+    com.stripe.model.issuing.PhysicalBundle physicalBundle =
+        client.v1().issuing().physicalBundles().retrieve("pb_xyz", params);
+    assertNotNull(physicalBundle);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/issuing/physical_bundles/pb_xyz",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testIssuingPhysicalBundlesGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.issuing.PhysicalBundleRetrieveParams params =
@@ -6058,6 +9631,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.issuing.TransactionListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.issuing.Transaction> stripeCollection =
+        client.v1().issuing().transactions().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/issuing/transactions",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testIssuingTransactionsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.TransactionListParams params =
+        com.stripe.param.issuing.TransactionListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.issuing.Transaction> stripeCollection =
         client.issuing().transactions().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -6083,6 +9674,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testIssuingTransactionsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.TransactionRetrieveParams params =
+        com.stripe.param.issuing.TransactionRetrieveParams.builder().build();
+
+    com.stripe.model.issuing.Transaction transaction =
+        client.v1().issuing().transactions().retrieve("ipi_xxxxxxxxxxxxx", params);
+    assertNotNull(transaction);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/issuing/transactions/ipi_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testIssuingTransactionsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.issuing.TransactionRetrieveParams params =
@@ -6129,6 +9738,26 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.issuing.Transaction transaction =
+        client.v1().issuing().transactions().update("ipi_xxxxxxxxxxxxx", params);
+    assertNotNull(transaction);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/issuing/transactions/ipi_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testIssuingTransactionsPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.TransactionUpdateParams params =
+        com.stripe.param.issuing.TransactionUpdateParams.builder()
+            .putMetadata("order_id", "6735")
+            .build();
+
+    com.stripe.model.issuing.Transaction transaction =
         client.issuing().transactions().update("ipi_xxxxxxxxxxxxx", params);
     assertNotNull(transaction);
     verifyRequest(
@@ -6153,6 +9782,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testMandatesGetServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.MandateRetrieveParams params =
+        com.stripe.param.MandateRetrieveParams.builder().build();
+
+    com.stripe.model.Mandate mandate =
+        client.v1().mandates().retrieve("mandate_xxxxxxxxxxxxx", params);
+    assertNotNull(mandate);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/mandates/mandate_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testMandatesGetServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.MandateRetrieveParams params =
@@ -6193,6 +9840,25 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.PaymentIntentApplyCustomerBalanceParams.builder().build();
 
     com.stripe.model.PaymentIntent paymentIntent =
+        client.v1().paymentIntents().applyCustomerBalance("pi_xxxxxxxxxxxxx", params);
+    assertNotNull(paymentIntent);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/payment_intents/pi_xxxxxxxxxxxxx/apply_customer_balance",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPaymentIntentsApplyCustomerBalancePostServicesNonNamespaced()
+      throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PaymentIntentApplyCustomerBalanceParams params =
+        com.stripe.param.PaymentIntentApplyCustomerBalanceParams.builder().build();
+
+    com.stripe.model.PaymentIntent paymentIntent =
         client.paymentIntents().applyCustomerBalance("pi_xxxxxxxxxxxxx", params);
     assertNotNull(paymentIntent);
     verifyRequest(
@@ -6227,6 +9893,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.PaymentIntentCancelParams.builder().build();
 
     com.stripe.model.PaymentIntent paymentIntent =
+        client.v1().paymentIntents().cancel("pi_xxxxxxxxxxxxx", params);
+    assertNotNull(paymentIntent);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/payment_intents/pi_xxxxxxxxxxxxx/cancel",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPaymentIntentsCancelPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PaymentIntentCancelParams params =
+        com.stripe.param.PaymentIntentCancelParams.builder().build();
+
+    com.stripe.model.PaymentIntent paymentIntent =
         client.paymentIntents().cancel("pi_xxxxxxxxxxxxx", params);
     assertNotNull(paymentIntent);
     verifyRequest(
@@ -6255,6 +9939,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testPaymentIntentsCapturePostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PaymentIntentCaptureParams params =
+        com.stripe.param.PaymentIntentCaptureParams.builder().build();
+
+    com.stripe.model.PaymentIntent paymentIntent =
+        client.v1().paymentIntents().capture("pi_xxxxxxxxxxxxx", params);
+    assertNotNull(paymentIntent);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/payment_intents/pi_xxxxxxxxxxxxx/capture",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPaymentIntentsCapturePostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.PaymentIntentCaptureParams params =
@@ -6298,6 +10000,26 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.PaymentIntent paymentIntent =
+        client.v1().paymentIntents().confirm("pi_xxxxxxxxxxxxx", params);
+    assertNotNull(paymentIntent);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/payment_intents/pi_xxxxxxxxxxxxx/confirm",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPaymentIntentsConfirmPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PaymentIntentConfirmParams params =
+        com.stripe.param.PaymentIntentConfirmParams.builder()
+            .setPaymentMethod("pm_card_visa")
+            .build();
+
+    com.stripe.model.PaymentIntent paymentIntent =
         client.paymentIntents().confirm("pi_xxxxxxxxxxxxx", params);
     assertNotNull(paymentIntent);
     verifyRequest(
@@ -6330,6 +10052,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.PaymentIntentListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.PaymentIntent> stripeCollection =
+        client.v1().paymentIntents().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/payment_intents",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPaymentIntentsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PaymentIntentListParams params =
+        com.stripe.param.PaymentIntentListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.PaymentIntent> stripeCollection =
         client.paymentIntents().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -6354,6 +10094,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testPaymentIntentsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PaymentIntentRetrieveParams params =
+        com.stripe.param.PaymentIntentRetrieveParams.builder().build();
+
+    com.stripe.model.PaymentIntent paymentIntent =
+        client.v1().paymentIntents().retrieve("pi_xxxxxxxxxxxxx", params);
+    assertNotNull(paymentIntent);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/payment_intents/pi_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPaymentIntentsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.PaymentIntentRetrieveParams params =
@@ -6397,6 +10155,27 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.PaymentIntent paymentIntent =
+        client.v1().paymentIntents().incrementAuthorization("pi_xxxxxxxxxxxxx", params);
+    assertNotNull(paymentIntent);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/payment_intents/pi_xxxxxxxxxxxxx/increment_authorization",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPaymentIntentsIncrementAuthorizationPostServicesNonNamespaced()
+      throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PaymentIntentIncrementAuthorizationParams params =
+        com.stripe.param.PaymentIntentIncrementAuthorizationParams.builder()
+            .setAmount(2099L)
+            .build();
+
+    com.stripe.model.PaymentIntent paymentIntent =
         client.paymentIntents().incrementAuthorization("pi_xxxxxxxxxxxxx", params);
     assertNotNull(paymentIntent);
     verifyRequest(
@@ -6431,6 +10210,30 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testPaymentIntentsPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PaymentIntentCreateParams params =
+        com.stripe.param.PaymentIntentCreateParams.builder()
+            .setAmount(1099L)
+            .setCurrency("eur")
+            .setAutomaticPaymentMethods(
+                com.stripe.param.PaymentIntentCreateParams.AutomaticPaymentMethods.builder()
+                    .setEnabled(true)
+                    .build())
+            .build();
+
+    com.stripe.model.PaymentIntent paymentIntent = client.v1().paymentIntents().create(params);
+    assertNotNull(paymentIntent);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/payment_intents",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPaymentIntentsPostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.PaymentIntentCreateParams params =
@@ -6489,6 +10292,30 @@ class GeneratedExamples extends BaseStripeTest {
                     .build())
             .build();
 
+    com.stripe.model.PaymentIntent paymentIntent = client.v1().paymentIntents().create(params);
+    assertNotNull(paymentIntent);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/payment_intents",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPaymentIntentsPost2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PaymentIntentCreateParams params =
+        com.stripe.param.PaymentIntentCreateParams.builder()
+            .setAmount(2000L)
+            .setCurrency("usd")
+            .setAutomaticPaymentMethods(
+                com.stripe.param.PaymentIntentCreateParams.AutomaticPaymentMethods.builder()
+                    .setEnabled(true)
+                    .build())
+            .build();
+
     com.stripe.model.PaymentIntent paymentIntent = client.paymentIntents().create(params);
     assertNotNull(paymentIntent);
     verifyRequest(
@@ -6518,6 +10345,26 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testPaymentIntentsPost3Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PaymentIntentUpdateParams params =
+        com.stripe.param.PaymentIntentUpdateParams.builder()
+            .putMetadata("order_id", "6735")
+            .build();
+
+    com.stripe.model.PaymentIntent paymentIntent =
+        client.v1().paymentIntents().update("pi_xxxxxxxxxxxxx", params);
+    assertNotNull(paymentIntent);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/payment_intents/pi_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPaymentIntentsPost3ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.PaymentIntentUpdateParams params =
@@ -6585,6 +10432,38 @@ class GeneratedExamples extends BaseStripeTest {
                     .build())
             .build();
 
+    com.stripe.model.PaymentIntent paymentIntent = client.v1().paymentIntents().create(params);
+    assertNotNull(paymentIntent);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/payment_intents",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPaymentIntentsPost4ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PaymentIntentCreateParams params =
+        com.stripe.param.PaymentIntentCreateParams.builder()
+            .setAmount(200L)
+            .setCurrency("usd")
+            .setPaymentMethodData(
+                com.stripe.param.PaymentIntentCreateParams.PaymentMethodData.builder()
+                    .setType(com.stripe.param.PaymentIntentCreateParams.PaymentMethodData.Type.P24)
+                    .setP24(
+                        com.stripe.param.PaymentIntentCreateParams.PaymentMethodData.P24
+                            .builder()
+                            .setBank(
+                                com.stripe.param.PaymentIntentCreateParams.PaymentMethodData.P24
+                                    .Bank
+                                    .BLIK)
+                            .build())
+                    .build())
+            .build();
+
     com.stripe.model.PaymentIntent paymentIntent = client.paymentIntents().create(params);
     assertNotNull(paymentIntent);
     verifyRequest(
@@ -6622,6 +10501,26 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.StripeSearchResult<com.stripe.model.PaymentIntent> stripeSearchResult =
+        client.v1().paymentIntents().search(params);
+    assertNotNull(stripeSearchResult);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/payment_intents/search",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPaymentIntentsSearchGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PaymentIntentSearchParams params =
+        com.stripe.param.PaymentIntentSearchParams.builder()
+            .setQuery("status:'succeeded' AND metadata['order_id']:'6735'")
+            .build();
+
+    com.stripe.model.StripeSearchResult<com.stripe.model.PaymentIntent> stripeSearchResult =
         client.paymentIntents().search(params);
     assertNotNull(stripeSearchResult);
     verifyRequest(
@@ -6651,6 +10550,25 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testPaymentIntentsVerifyMicrodepositsPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PaymentIntentVerifyMicrodepositsParams params =
+        com.stripe.param.PaymentIntentVerifyMicrodepositsParams.builder().build();
+
+    com.stripe.model.PaymentIntent paymentIntent =
+        client.v1().paymentIntents().verifyMicrodeposits("pi_xxxxxxxxxxxxx", params);
+    assertNotNull(paymentIntent);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/payment_intents/pi_xxxxxxxxxxxxx/verify_microdeposits",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPaymentIntentsVerifyMicrodepositsPostServicesNonNamespaced()
+      throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.PaymentIntentVerifyMicrodepositsParams params =
@@ -6695,6 +10613,28 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.PaymentIntent paymentIntent =
+        client.v1().paymentIntents().verifyMicrodeposits("pi_xxxxxxxxxxxxx", params);
+    assertNotNull(paymentIntent);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/payment_intents/pi_xxxxxxxxxxxxx/verify_microdeposits",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPaymentIntentsVerifyMicrodepositsPost2ServicesNonNamespaced()
+      throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PaymentIntentVerifyMicrodepositsParams params =
+        com.stripe.param.PaymentIntentVerifyMicrodepositsParams.builder()
+            .addAmount(32L)
+            .addAmount(45L)
+            .build();
+
+    com.stripe.model.PaymentIntent paymentIntent =
         client.paymentIntents().verifyMicrodeposits("pi_xxxxxxxxxxxxx", params);
     assertNotNull(paymentIntent);
     verifyRequest(
@@ -6715,6 +10655,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testPaymentLinksGetServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PaymentLinkRetrieveParams params =
+        com.stripe.param.PaymentLinkRetrieveParams.builder().build();
+
+    com.stripe.model.PaymentLink paymentLink =
+        client.v1().paymentLinks().retrieve("pl_xyz", params);
+    assertNotNull(paymentLink);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/payment_links/pl_xyz",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPaymentLinksGetServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.PaymentLinkRetrieveParams params =
@@ -6748,6 +10706,20 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.PaymentLinkListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.PaymentLink> stripeCollection =
+        client.v1().paymentLinks().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/payment_links", params.toMap(), null);
+  }
+
+  @Test
+  public void testPaymentLinksGet2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PaymentLinkListParams params =
+        com.stripe.param.PaymentLinkListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.PaymentLink> stripeCollection =
         client.paymentLinks().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -6768,6 +10740,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testPaymentLinksGet3Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PaymentLinkRetrieveParams params =
+        com.stripe.param.PaymentLinkRetrieveParams.builder().build();
+
+    com.stripe.model.PaymentLink paymentLink =
+        client.v1().paymentLinks().retrieve("plink_xxxxxxxxxxxxx", params);
+    assertNotNull(paymentLink);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/payment_links/plink_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPaymentLinksGet3ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.PaymentLinkRetrieveParams params =
@@ -6808,6 +10798,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.PaymentLinkLineItemListParams.builder().build();
 
     com.stripe.model.StripeCollection<com.stripe.model.LineItem> stripeCollection =
+        client.v1().paymentLinks().lineItems().list("pl_xyz", params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/payment_links/pl_xyz/line_items",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPaymentLinksLineItemsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PaymentLinkLineItemListParams params =
+        com.stripe.param.PaymentLinkLineItemListParams.builder().build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.LineItem> stripeCollection =
         client.paymentLinks().lineItems().list("pl_xyz", params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -6837,6 +10845,25 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testPaymentLinksPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PaymentLinkCreateParams params =
+        com.stripe.param.PaymentLinkCreateParams.builder()
+            .addLineItem(
+                com.stripe.param.PaymentLinkCreateParams.LineItem.builder()
+                    .setPrice("price_xxxxxxxxxxxxx")
+                    .setQuantity(1L)
+                    .build())
+            .build();
+
+    com.stripe.model.PaymentLink paymentLink = client.v1().paymentLinks().create(params);
+    assertNotNull(paymentLink);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.POST, "/v1/payment_links", params.toMap(), null);
+  }
+
+  @Test
+  public void testPaymentLinksPostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.PaymentLinkCreateParams params =
@@ -6884,6 +10911,25 @@ class GeneratedExamples extends BaseStripeTest {
                     .build())
             .build();
 
+    com.stripe.model.PaymentLink paymentLink = client.v1().paymentLinks().create(params);
+    assertNotNull(paymentLink);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.POST, "/v1/payment_links", params.toMap(), null);
+  }
+
+  @Test
+  public void testPaymentLinksPost2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PaymentLinkCreateParams params =
+        com.stripe.param.PaymentLinkCreateParams.builder()
+            .addLineItem(
+                com.stripe.param.PaymentLinkCreateParams.LineItem.builder()
+                    .setPrice("price_xxxxxxxxxxxxx")
+                    .setQuantity(1L)
+                    .build())
+            .build();
+
     com.stripe.model.PaymentLink paymentLink = client.paymentLinks().create(params);
     assertNotNull(paymentLink);
     verifyRequest(
@@ -6908,6 +10954,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testPaymentLinksPost3Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PaymentLinkUpdateParams params =
+        com.stripe.param.PaymentLinkUpdateParams.builder().setActive(false).build();
+
+    com.stripe.model.PaymentLink paymentLink =
+        client.v1().paymentLinks().update("plink_xxxxxxxxxxxxx", params);
+    assertNotNull(paymentLink);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/payment_links/plink_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPaymentLinksPost3ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.PaymentLinkUpdateParams params =
@@ -6950,6 +11014,26 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.StripeCollection<com.stripe.model.PaymentMethodConfiguration>
+        stripeCollection = client.v1().paymentMethodConfigurations().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/payment_method_configurations",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPaymentMethodConfigurationsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PaymentMethodConfigurationListParams params =
+        com.stripe.param.PaymentMethodConfigurationListParams.builder()
+            .setApplication("foo")
+            .build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.PaymentMethodConfiguration>
         stripeCollection = client.paymentMethodConfigurations().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -6975,6 +11059,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testPaymentMethodConfigurationsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PaymentMethodConfigurationRetrieveParams params =
+        com.stripe.param.PaymentMethodConfigurationRetrieveParams.builder().build();
+
+    com.stripe.model.PaymentMethodConfiguration paymentMethodConfiguration =
+        client.v1().paymentMethodConfigurations().retrieve("foo", params);
+    assertNotNull(paymentMethodConfiguration);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/payment_method_configurations/foo",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPaymentMethodConfigurationsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.PaymentMethodConfigurationRetrieveParams params =
@@ -7028,6 +11130,45 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testPaymentMethodConfigurationsPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PaymentMethodConfigurationCreateParams params =
+        com.stripe.param.PaymentMethodConfigurationCreateParams.builder()
+            .setAcssDebit(
+                com.stripe.param.PaymentMethodConfigurationCreateParams.AcssDebit.builder()
+                    .setDisplayPreference(
+                        com.stripe.param.PaymentMethodConfigurationCreateParams.AcssDebit
+                            .DisplayPreference.builder()
+                            .setPreference(
+                                com.stripe.param.PaymentMethodConfigurationCreateParams.AcssDebit
+                                    .DisplayPreference.Preference.NONE)
+                            .build())
+                    .build())
+            .setAffirm(
+                com.stripe.param.PaymentMethodConfigurationCreateParams.Affirm.builder()
+                    .setDisplayPreference(
+                        com.stripe.param.PaymentMethodConfigurationCreateParams.Affirm
+                            .DisplayPreference.builder()
+                            .setPreference(
+                                com.stripe.param.PaymentMethodConfigurationCreateParams.Affirm
+                                    .DisplayPreference.Preference.NONE)
+                            .build())
+                    .build())
+            .build();
+
+    com.stripe.model.PaymentMethodConfiguration paymentMethodConfiguration =
+        client.v1().paymentMethodConfigurations().create(params);
+    assertNotNull(paymentMethodConfiguration);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/payment_method_configurations",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPaymentMethodConfigurationsPostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.PaymentMethodConfigurationCreateParams params =
@@ -7111,6 +11252,35 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.PaymentMethodConfiguration paymentMethodConfiguration =
+        client.v1().paymentMethodConfigurations().update("foo", params);
+    assertNotNull(paymentMethodConfiguration);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/payment_method_configurations/foo",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPaymentMethodConfigurationsPost2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PaymentMethodConfigurationUpdateParams params =
+        com.stripe.param.PaymentMethodConfigurationUpdateParams.builder()
+            .setAcssDebit(
+                com.stripe.param.PaymentMethodConfigurationUpdateParams.AcssDebit.builder()
+                    .setDisplayPreference(
+                        com.stripe.param.PaymentMethodConfigurationUpdateParams.AcssDebit
+                            .DisplayPreference.builder()
+                            .setPreference(
+                                com.stripe.param.PaymentMethodConfigurationUpdateParams.AcssDebit
+                                    .DisplayPreference.Preference.ON)
+                            .build())
+                    .build())
+            .build();
+
+    com.stripe.model.PaymentMethodConfiguration paymentMethodConfiguration =
         client.paymentMethodConfigurations().update("foo", params);
     assertNotNull(paymentMethodConfiguration);
     verifyRequest(
@@ -7148,6 +11318,26 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.PaymentMethod paymentMethod =
+        client.v1().paymentMethods().attach("pm_xxxxxxxxxxxxx", params);
+    assertNotNull(paymentMethod);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/payment_methods/pm_xxxxxxxxxxxxx/attach",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPaymentMethodsAttachPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PaymentMethodAttachParams params =
+        com.stripe.param.PaymentMethodAttachParams.builder()
+            .setCustomer("cus_xxxxxxxxxxxxx")
+            .build();
+
+    com.stripe.model.PaymentMethod paymentMethod =
         client.paymentMethods().attach("pm_xxxxxxxxxxxxx", params);
     assertNotNull(paymentMethod);
     verifyRequest(
@@ -7176,6 +11366,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testPaymentMethodsDetachPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PaymentMethodDetachParams params =
+        com.stripe.param.PaymentMethodDetachParams.builder().build();
+
+    com.stripe.model.PaymentMethod paymentMethod =
+        client.v1().paymentMethods().detach("pm_xxxxxxxxxxxxx", params);
+    assertNotNull(paymentMethod);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/payment_methods/pm_xxxxxxxxxxxxx/detach",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPaymentMethodsDetachPostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.PaymentMethodDetachParams params =
@@ -7221,6 +11429,27 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.StripeCollection<com.stripe.model.PaymentMethod> stripeCollection =
+        client.v1().paymentMethods().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/payment_methods",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPaymentMethodsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PaymentMethodListParams params =
+        com.stripe.param.PaymentMethodListParams.builder()
+            .setCustomer("cus_xxxxxxxxxxxxx")
+            .setType(com.stripe.param.PaymentMethodListParams.Type.CARD)
+            .build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.PaymentMethod> stripeCollection =
         client.paymentMethods().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -7245,6 +11474,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testPaymentMethodsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PaymentMethodRetrieveParams params =
+        com.stripe.param.PaymentMethodRetrieveParams.builder().build();
+
+    com.stripe.model.PaymentMethod paymentMethod =
+        client.v1().paymentMethods().retrieve("pm_xxxxxxxxxxxxx", params);
+    assertNotNull(paymentMethod);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/payment_methods/pm_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPaymentMethodsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.PaymentMethodRetrieveParams params =
@@ -7288,6 +11535,26 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.PaymentMethod paymentMethod =
+        client.v1().paymentMethods().update("pm_xxxxxxxxxxxxx", params);
+    assertNotNull(paymentMethod);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/payment_methods/pm_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPaymentMethodsPost2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PaymentMethodUpdateParams params =
+        com.stripe.param.PaymentMethodUpdateParams.builder()
+            .putMetadata("order_id", "6735")
+            .build();
+
+    com.stripe.model.PaymentMethod paymentMethod =
         client.paymentMethods().update("pm_xxxxxxxxxxxxx", params);
     assertNotNull(paymentMethod);
     verifyRequest(
@@ -7321,6 +11588,23 @@ class GeneratedExamples extends BaseStripeTest {
     com.stripe.param.PayoutCancelParams params =
         com.stripe.param.PayoutCancelParams.builder().build();
 
+    com.stripe.model.Payout payout = client.v1().payouts().cancel("po_xxxxxxxxxxxxx", params);
+    assertNotNull(payout);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/payouts/po_xxxxxxxxxxxxx/cancel",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPayoutsCancelPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PayoutCancelParams params =
+        com.stripe.param.PayoutCancelParams.builder().build();
+
     com.stripe.model.Payout payout = client.payouts().cancel("po_xxxxxxxxxxxxx", params);
     assertNotNull(payout);
     verifyRequest(
@@ -7349,6 +11633,20 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.PayoutListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.Payout> stripeCollection =
+        client.v1().payouts().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/payouts", params.toMap(), null);
+  }
+
+  @Test
+  public void testPayoutsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PayoutListParams params =
+        com.stripe.param.PayoutListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.Payout> stripeCollection =
         client.payouts().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -7365,6 +11663,23 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testPayoutsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PayoutRetrieveParams params =
+        com.stripe.param.PayoutRetrieveParams.builder().build();
+
+    com.stripe.model.Payout payout = client.v1().payouts().retrieve("po_xxxxxxxxxxxxx", params);
+    assertNotNull(payout);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/payouts/po_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPayoutsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.PayoutRetrieveParams params =
@@ -7398,6 +11713,19 @@ class GeneratedExamples extends BaseStripeTest {
     com.stripe.param.PayoutCreateParams params =
         com.stripe.param.PayoutCreateParams.builder().setAmount(1100L).setCurrency("usd").build();
 
+    com.stripe.model.Payout payout = client.v1().payouts().create(params);
+    assertNotNull(payout);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.POST, "/v1/payouts", params.toMap(), null);
+  }
+
+  @Test
+  public void testPayoutsPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PayoutCreateParams params =
+        com.stripe.param.PayoutCreateParams.builder().setAmount(1100L).setCurrency("usd").build();
+
     com.stripe.model.Payout payout = client.payouts().create(params);
     assertNotNull(payout);
     verifyRequest(
@@ -7423,6 +11751,23 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testPayoutsPost2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PayoutUpdateParams params =
+        com.stripe.param.PayoutUpdateParams.builder().putMetadata("order_id", "6735").build();
+
+    com.stripe.model.Payout payout = client.v1().payouts().update("po_xxxxxxxxxxxxx", params);
+    assertNotNull(payout);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/payouts/po_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPayoutsPost2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.PayoutUpdateParams params =
@@ -7461,6 +11806,23 @@ class GeneratedExamples extends BaseStripeTest {
     com.stripe.param.PayoutReverseParams params =
         com.stripe.param.PayoutReverseParams.builder().build();
 
+    com.stripe.model.Payout payout = client.v1().payouts().reverse("po_xxxxxxxxxxxxx", params);
+    assertNotNull(payout);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/payouts/po_xxxxxxxxxxxxx/reverse",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPayoutsReversePostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PayoutReverseParams params =
+        com.stripe.param.PayoutReverseParams.builder().build();
+
     com.stripe.model.Payout payout = client.payouts().reverse("po_xxxxxxxxxxxxx", params);
     assertNotNull(payout);
     verifyRequest(
@@ -7487,6 +11849,20 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testPlansDeleteServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.model.Plan plan = client.v1().plans().delete("price_xxxxxxxxxxxxx");
+    assertNotNull(plan);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.DELETE,
+        "/v1/plans/price_xxxxxxxxxxxxx",
+        null,
+        null);
+  }
+
+  @Test
+  public void testPlansDeleteServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.model.Plan plan = client.plans().delete("price_xxxxxxxxxxxxx");
@@ -7517,6 +11893,20 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.PlanListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.Plan> stripeCollection =
+        client.v1().plans().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/plans", params.toMap(), null);
+  }
+
+  @Test
+  public void testPlansGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PlanListParams params =
+        com.stripe.param.PlanListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.Plan> stripeCollection =
         client.plans().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -7537,6 +11927,23 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testPlansGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PlanRetrieveParams params =
+        com.stripe.param.PlanRetrieveParams.builder().build();
+
+    com.stripe.model.Plan plan = client.v1().plans().retrieve("price_xxxxxxxxxxxxx", params);
+    assertNotNull(plan);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/plans/price_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPlansGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.PlanRetrieveParams params =
@@ -7570,6 +11977,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testPlansPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PlanCreateParams params =
+        com.stripe.param.PlanCreateParams.builder()
+            .setAmount(2000L)
+            .setCurrency("usd")
+            .setInterval(com.stripe.param.PlanCreateParams.Interval.MONTH)
+            .setProduct("prod_xxxxxxxxxxxxx")
+            .build();
+
+    com.stripe.model.Plan plan = client.v1().plans().create(params);
+    assertNotNull(plan);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.POST, "/v1/plans", params.toMap(), null);
+  }
+
+  @Test
+  public void testPlansPostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.PlanCreateParams params =
@@ -7615,6 +12040,25 @@ class GeneratedExamples extends BaseStripeTest {
                 com.stripe.param.PlanCreateParams.Product.builder().setName("My product").build())
             .build();
 
+    com.stripe.model.Plan plan = client.v1().plans().create(params);
+    assertNotNull(plan);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.POST, "/v1/plans", params.toMap(), null);
+  }
+
+  @Test
+  public void testPlansPost2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PlanCreateParams params =
+        com.stripe.param.PlanCreateParams.builder()
+            .setAmount(2000L)
+            .setCurrency("usd")
+            .setInterval(com.stripe.param.PlanCreateParams.Interval.MONTH)
+            .setProduct(
+                com.stripe.param.PlanCreateParams.Product.builder().setName("My product").build())
+            .build();
+
     com.stripe.model.Plan plan = client.plans().create(params);
     assertNotNull(plan);
     verifyRequest(
@@ -7639,6 +12083,23 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testPlansPost3Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PlanUpdateParams params =
+        com.stripe.param.PlanUpdateParams.builder().putMetadata("order_id", "6735").build();
+
+    com.stripe.model.Plan plan = client.v1().plans().update("price_xxxxxxxxxxxxx", params);
+    assertNotNull(plan);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/plans/price_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPlansPost3ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.PlanUpdateParams params =
@@ -7672,6 +12133,20 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.PriceListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.Price> stripeCollection =
+        client.v1().prices().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/prices", params.toMap(), null);
+  }
+
+  @Test
+  public void testPricesGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PriceListParams params =
+        com.stripe.param.PriceListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.Price> stripeCollection =
         client.prices().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -7692,6 +12167,23 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testPricesGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PriceRetrieveParams params =
+        com.stripe.param.PriceRetrieveParams.builder().build();
+
+    com.stripe.model.Price price = client.v1().prices().retrieve("price_xxxxxxxxxxxxx", params);
+    assertNotNull(price);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/prices/price_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPricesGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.PriceRetrieveParams params =
@@ -7755,6 +12247,37 @@ class GeneratedExamples extends BaseStripeTest {
             .setProduct("prod_xxxxxxxxxxxxx")
             .build();
 
+    com.stripe.model.Price price = client.v1().prices().create(params);
+    assertNotNull(price);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.POST, "/v1/prices", params.toMap(), null);
+  }
+
+  @Test
+  public void testPricesPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PriceCreateParams params =
+        com.stripe.param.PriceCreateParams.builder()
+            .setUnitAmount(2000L)
+            .setCurrency("usd")
+            .putCurrencyOption(
+                "uah",
+                com.stripe.param.PriceCreateParams.CurrencyOption.builder()
+                    .setUnitAmount(5000L)
+                    .build())
+            .putCurrencyOption(
+                "eur",
+                com.stripe.param.PriceCreateParams.CurrencyOption.builder()
+                    .setUnitAmount(1800L)
+                    .build())
+            .setRecurring(
+                com.stripe.param.PriceCreateParams.Recurring.builder()
+                    .setInterval(com.stripe.param.PriceCreateParams.Recurring.Interval.MONTH)
+                    .build())
+            .setProduct("prod_xxxxxxxxxxxxx")
+            .build();
+
     com.stripe.model.Price price = client.prices().create(params);
     assertNotNull(price);
     verifyRequest(
@@ -7782,6 +12305,27 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testPricesPost2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PriceCreateParams params =
+        com.stripe.param.PriceCreateParams.builder()
+            .setUnitAmount(2000L)
+            .setCurrency("usd")
+            .setRecurring(
+                com.stripe.param.PriceCreateParams.Recurring.builder()
+                    .setInterval(com.stripe.param.PriceCreateParams.Recurring.Interval.MONTH)
+                    .build())
+            .setProduct("prod_xxxxxxxxxxxxx")
+            .build();
+
+    com.stripe.model.Price price = client.v1().prices().create(params);
+    assertNotNull(price);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.POST, "/v1/prices", params.toMap(), null);
+  }
+
+  @Test
+  public void testPricesPost2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.PriceCreateParams params =
@@ -7824,6 +12368,23 @@ class GeneratedExamples extends BaseStripeTest {
     com.stripe.param.PriceUpdateParams params =
         com.stripe.param.PriceUpdateParams.builder().putMetadata("order_id", "6735").build();
 
+    com.stripe.model.Price price = client.v1().prices().update("price_xxxxxxxxxxxxx", params);
+    assertNotNull(price);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/prices/price_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPricesPost3ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PriceUpdateParams params =
+        com.stripe.param.PriceUpdateParams.builder().putMetadata("order_id", "6735").build();
+
     com.stripe.model.Price price = client.prices().update("price_xxxxxxxxxxxxx", params);
     assertNotNull(price);
     verifyRequest(
@@ -7857,6 +12418,22 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.StripeSearchResult<com.stripe.model.Price> stripeSearchResult =
+        client.v1().prices().search(params);
+    assertNotNull(stripeSearchResult);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/prices/search", params.toMap(), null);
+  }
+
+  @Test
+  public void testPricesSearchGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PriceSearchParams params =
+        com.stripe.param.PriceSearchParams.builder()
+            .setQuery("active:'true' AND metadata['order_id']:'6735'")
+            .build();
+
+    com.stripe.model.StripeSearchResult<com.stripe.model.Price> stripeSearchResult =
         client.prices().search(params);
     assertNotNull(stripeSearchResult);
     verifyRequest(
@@ -7879,6 +12456,20 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testProductsDeleteServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.model.Product product = client.v1().products().delete("prod_xxxxxxxxxxxxx");
+    assertNotNull(product);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.DELETE,
+        "/v1/products/prod_xxxxxxxxxxxxx",
+        null,
+        null);
+  }
+
+  @Test
+  public void testProductsDeleteServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.model.Product product = client.products().delete("prod_xxxxxxxxxxxxx");
@@ -7909,6 +12500,20 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.ProductListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.Product> stripeCollection =
+        client.v1().products().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/products", params.toMap(), null);
+  }
+
+  @Test
+  public void testProductsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.ProductListParams params =
+        com.stripe.param.ProductListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.Product> stripeCollection =
         client.products().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -7929,6 +12534,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testProductsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.ProductRetrieveParams params =
+        com.stripe.param.ProductRetrieveParams.builder().build();
+
+    com.stripe.model.Product product =
+        client.v1().products().retrieve("prod_xxxxxxxxxxxxx", params);
+    assertNotNull(product);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/products/prod_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testProductsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.ProductRetrieveParams params =
@@ -7961,6 +12584,19 @@ class GeneratedExamples extends BaseStripeTest {
     com.stripe.param.ProductCreateParams params =
         com.stripe.param.ProductCreateParams.builder().setName("Gold Special").build();
 
+    com.stripe.model.Product product = client.v1().products().create(params);
+    assertNotNull(product);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.POST, "/v1/products", params.toMap(), null);
+  }
+
+  @Test
+  public void testProductsPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.ProductCreateParams params =
+        com.stripe.param.ProductCreateParams.builder().setName("Gold Special").build();
+
     com.stripe.model.Product product = client.products().create(params);
     assertNotNull(product);
     verifyRequest(
@@ -7986,6 +12622,23 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testProductsPost2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.ProductUpdateParams params =
+        com.stripe.param.ProductUpdateParams.builder().putMetadata("order_id", "6735").build();
+
+    com.stripe.model.Product product = client.v1().products().update("prod_xxxxxxxxxxxxx", params);
+    assertNotNull(product);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/products/prod_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testProductsPost2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.ProductUpdateParams params =
@@ -8028,6 +12681,26 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.StripeSearchResult<com.stripe.model.Product> stripeSearchResult =
+        client.v1().products().search(params);
+    assertNotNull(stripeSearchResult);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/products/search",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testProductsSearchGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.ProductSearchParams params =
+        com.stripe.param.ProductSearchParams.builder()
+            .setQuery("active:'true' AND metadata['order_id']:'6735'")
+            .build();
+
+    com.stripe.model.StripeSearchResult<com.stripe.model.Product> stripeSearchResult =
         client.products().search(params);
     assertNotNull(stripeSearchResult);
     verifyRequest(
@@ -8054,6 +12727,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testPromotionCodesGetServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PromotionCodeListParams params =
+        com.stripe.param.PromotionCodeListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.PromotionCode> stripeCollection =
+        client.v1().promotionCodes().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/promotion_codes",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPromotionCodesGetServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.PromotionCodeListParams params =
@@ -8090,6 +12781,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.PromotionCodeRetrieveParams.builder().build();
 
     com.stripe.model.PromotionCode promotionCode =
+        client.v1().promotionCodes().retrieve("promo_xxxxxxxxxxxxx", params);
+    assertNotNull(promotionCode);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/promotion_codes/promo_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPromotionCodesGet2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PromotionCodeRetrieveParams params =
+        com.stripe.param.PromotionCodeRetrieveParams.builder().build();
+
+    com.stripe.model.PromotionCode promotionCode =
         client.promotionCodes().retrieve("promo_xxxxxxxxxxxxx", params);
     assertNotNull(promotionCode);
     verifyRequest(
@@ -8117,6 +12826,23 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testPromotionCodesPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PromotionCodeCreateParams params =
+        com.stripe.param.PromotionCodeCreateParams.builder().setCoupon("Z4OV52SU").build();
+
+    com.stripe.model.PromotionCode promotionCode = client.v1().promotionCodes().create(params);
+    assertNotNull(promotionCode);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/promotion_codes",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPromotionCodesPostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.PromotionCodeCreateParams params =
@@ -8159,6 +12885,26 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.PromotionCode promotionCode =
+        client.v1().promotionCodes().update("promo_xxxxxxxxxxxxx", params);
+    assertNotNull(promotionCode);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/promotion_codes/promo_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testPromotionCodesPost2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.PromotionCodeUpdateParams params =
+        com.stripe.param.PromotionCodeUpdateParams.builder()
+            .putMetadata("order_id", "6735")
+            .build();
+
+    com.stripe.model.PromotionCode promotionCode =
         client.promotionCodes().update("promo_xxxxxxxxxxxxx", params);
     assertNotNull(promotionCode);
     verifyRequest(
@@ -8187,6 +12933,23 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testQuotesAcceptPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.QuoteAcceptParams params =
+        com.stripe.param.QuoteAcceptParams.builder().build();
+
+    com.stripe.model.Quote quote = client.v1().quotes().accept("qt_xxxxxxxxxxxxx", params);
+    assertNotNull(quote);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/quotes/qt_xxxxxxxxxxxxx/accept",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testQuotesAcceptPostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.QuoteAcceptParams params =
@@ -8225,6 +12988,23 @@ class GeneratedExamples extends BaseStripeTest {
     com.stripe.param.QuoteCancelParams params =
         com.stripe.param.QuoteCancelParams.builder().build();
 
+    com.stripe.model.Quote quote = client.v1().quotes().cancel("qt_xxxxxxxxxxxxx", params);
+    assertNotNull(quote);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/quotes/qt_xxxxxxxxxxxxx/cancel",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testQuotesCancelPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.QuoteCancelParams params =
+        com.stripe.param.QuoteCancelParams.builder().build();
+
     com.stripe.model.Quote quote = client.quotes().cancel("qt_xxxxxxxxxxxxx", params);
     assertNotNull(quote);
     verifyRequest(
@@ -8258,6 +13038,23 @@ class GeneratedExamples extends BaseStripeTest {
     com.stripe.param.QuoteFinalizeQuoteParams params =
         com.stripe.param.QuoteFinalizeQuoteParams.builder().build();
 
+    com.stripe.model.Quote quote = client.v1().quotes().finalizeQuote("qt_xxxxxxxxxxxxx", params);
+    assertNotNull(quote);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/quotes/qt_xxxxxxxxxxxxx/finalize",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testQuotesFinalizePostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.QuoteFinalizeQuoteParams params =
+        com.stripe.param.QuoteFinalizeQuoteParams.builder().build();
+
     com.stripe.model.Quote quote = client.quotes().finalizeQuote("qt_xxxxxxxxxxxxx", params);
     assertNotNull(quote);
     verifyRequest(
@@ -8286,6 +13083,20 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.QuoteListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.Quote> stripeCollection =
+        client.v1().quotes().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/quotes", params.toMap(), null);
+  }
+
+  @Test
+  public void testQuotesGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.QuoteListParams params =
+        com.stripe.param.QuoteListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.Quote> stripeCollection =
         client.quotes().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -8302,6 +13113,23 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testQuotesGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.QuoteRetrieveParams params =
+        com.stripe.param.QuoteRetrieveParams.builder().build();
+
+    com.stripe.model.Quote quote = client.v1().quotes().retrieve("qt_xxxxxxxxxxxxx", params);
+    assertNotNull(quote);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/quotes/qt_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testQuotesGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.QuoteRetrieveParams params =
@@ -8341,6 +13169,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.QuoteLineItemListParams.builder().build();
 
     com.stripe.model.StripeCollection<com.stripe.model.LineItem> stripeCollection =
+        client.v1().quotes().lineItems().list("qt_xxxxxxxxxxxxx", params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/quotes/qt_xxxxxxxxxxxxx/line_items",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testQuotesLineItemsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.QuoteLineItemListParams params =
+        com.stripe.param.QuoteLineItemListParams.builder().build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.LineItem> stripeCollection =
         client.quotes().lineItems().list("qt_xxxxxxxxxxxxx", params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -8369,6 +13215,22 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testQuotesPdfGetServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.QuotePdfParams params = com.stripe.param.QuotePdfParams.builder().build();
+
+    java.io.InputStream inputStream = client.v1().quotes().pdf("qt_xxxxxxxxxxxxx", params);
+    assertNotNull(inputStream);
+    verifyRequest(
+        BaseAddress.FILES,
+        ApiResource.RequestMethod.GET,
+        "/v1/quotes/qt_xxxxxxxxxxxxx/pdf",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testQuotesPdfGetServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.QuotePdfParams params = com.stripe.param.QuotePdfParams.builder().build();
@@ -8415,6 +13277,26 @@ class GeneratedExamples extends BaseStripeTest {
                     .build())
             .build();
 
+    com.stripe.model.Quote quote = client.v1().quotes().create(params);
+    assertNotNull(quote);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.POST, "/v1/quotes", params.toMap(), null);
+  }
+
+  @Test
+  public void testQuotesPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.QuoteCreateParams params =
+        com.stripe.param.QuoteCreateParams.builder()
+            .setCustomer("cus_xxxxxxxxxxxxx")
+            .addLineItem(
+                com.stripe.param.QuoteCreateParams.LineItem.builder()
+                    .setPrice("price_xxxxxxxxxxxxx")
+                    .setQuantity(2L)
+                    .build())
+            .build();
+
     com.stripe.model.Quote quote = client.quotes().create(params);
     assertNotNull(quote);
     verifyRequest(
@@ -8439,6 +13321,23 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testQuotesPost2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.QuoteUpdateParams params =
+        com.stripe.param.QuoteUpdateParams.builder().putMetadata("order_id", "6735").build();
+
+    com.stripe.model.Quote quote = client.v1().quotes().update("qt_xxxxxxxxxxxxx", params);
+    assertNotNull(quote);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/quotes/qt_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testQuotesPost2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.QuoteUpdateParams params =
@@ -8478,6 +13377,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.radar.EarlyFraudWarningListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.radar.EarlyFraudWarning> stripeCollection =
+        client.v1().radar().earlyFraudWarnings().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/radar/early_fraud_warnings",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testRadarEarlyFraudWarningsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.radar.EarlyFraudWarningListParams params =
+        com.stripe.param.radar.EarlyFraudWarningListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.radar.EarlyFraudWarning> stripeCollection =
         client.radar().earlyFraudWarnings().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -8503,6 +13420,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testRadarEarlyFraudWarningsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.radar.EarlyFraudWarningRetrieveParams params =
+        com.stripe.param.radar.EarlyFraudWarningRetrieveParams.builder().build();
+
+    com.stripe.model.radar.EarlyFraudWarning earlyFraudWarning =
+        client.v1().radar().earlyFraudWarnings().retrieve("issfr_xxxxxxxxxxxxx", params);
+    assertNotNull(earlyFraudWarning);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/radar/early_fraud_warnings/issfr_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testRadarEarlyFraudWarningsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.radar.EarlyFraudWarningRetrieveParams params =
@@ -8536,6 +13471,21 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testRadarValueListItemsDeleteServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.model.radar.ValueListItem valueListItem =
+        client.v1().radar().valueListItems().delete("rsli_xxxxxxxxxxxxx");
+    assertNotNull(valueListItem);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.DELETE,
+        "/v1/radar/value_list_items/rsli_xxxxxxxxxxxxx",
+        null,
+        null);
+  }
+
+  @Test
+  public void testRadarValueListItemsDeleteServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.model.radar.ValueListItem valueListItem =
@@ -8579,6 +13529,27 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.StripeCollection<com.stripe.model.radar.ValueListItem> stripeCollection =
+        client.v1().radar().valueListItems().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/radar/value_list_items",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testRadarValueListItemsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.radar.ValueListItemListParams params =
+        com.stripe.param.radar.ValueListItemListParams.builder()
+            .setLimit(3L)
+            .setValueList("rsl_xxxxxxxxxxxxx")
+            .build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.radar.ValueListItem> stripeCollection =
         client.radar().valueListItems().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -8604,6 +13575,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testRadarValueListItemsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.radar.ValueListItemRetrieveParams params =
+        com.stripe.param.radar.ValueListItemRetrieveParams.builder().build();
+
+    com.stripe.model.radar.ValueListItem valueListItem =
+        client.v1().radar().valueListItems().retrieve("rsli_xxxxxxxxxxxxx", params);
+    assertNotNull(valueListItem);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/radar/value_list_items/rsli_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testRadarValueListItemsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.radar.ValueListItemRetrieveParams params =
@@ -8650,6 +13639,27 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.radar.ValueListItem valueListItem =
+        client.v1().radar().valueListItems().create(params);
+    assertNotNull(valueListItem);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/radar/value_list_items",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testRadarValueListItemsPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.radar.ValueListItemCreateParams params =
+        com.stripe.param.radar.ValueListItemCreateParams.builder()
+            .setValueList("rsl_xxxxxxxxxxxxx")
+            .setValue("1.2.3.4")
+            .build();
+
+    com.stripe.model.radar.ValueListItem valueListItem =
         client.radar().valueListItems().create(params);
     assertNotNull(valueListItem);
     verifyRequest(
@@ -8677,6 +13687,21 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testRadarValueListsDeleteServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.model.radar.ValueList valueList =
+        client.v1().radar().valueLists().delete("rsl_xxxxxxxxxxxxx");
+    assertNotNull(valueList);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.DELETE,
+        "/v1/radar/value_lists/rsl_xxxxxxxxxxxxx",
+        null,
+        null);
+  }
+
+  @Test
+  public void testRadarValueListsDeleteServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.model.radar.ValueList valueList =
@@ -8714,6 +13739,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.radar.ValueListListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.radar.ValueList> stripeCollection =
+        client.v1().radar().valueLists().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/radar/value_lists",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testRadarValueListsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.radar.ValueListListParams params =
+        com.stripe.param.radar.ValueListListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.radar.ValueList> stripeCollection =
         client.radar().valueLists().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -8739,6 +13782,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testRadarValueListsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.radar.ValueListRetrieveParams params =
+        com.stripe.param.radar.ValueListRetrieveParams.builder().build();
+
+    com.stripe.model.radar.ValueList valueList =
+        client.v1().radar().valueLists().retrieve("rsl_xxxxxxxxxxxxx", params);
+    assertNotNull(valueList);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/radar/value_lists/rsl_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testRadarValueListsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.radar.ValueListRetrieveParams params =
@@ -8776,6 +13837,27 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testRadarValueListsPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.radar.ValueListCreateParams params =
+        com.stripe.param.radar.ValueListCreateParams.builder()
+            .setAlias("custom_ip_xxxxxxxxxxxxx")
+            .setName("Custom IP Blocklist")
+            .setItemType(com.stripe.param.radar.ValueListCreateParams.ItemType.IP_ADDRESS)
+            .build();
+
+    com.stripe.model.radar.ValueList valueList = client.v1().radar().valueLists().create(params);
+    assertNotNull(valueList);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/radar/value_lists",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testRadarValueListsPostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.radar.ValueListCreateParams params =
@@ -8825,6 +13907,26 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.radar.ValueList valueList =
+        client.v1().radar().valueLists().update("rsl_xxxxxxxxxxxxx", params);
+    assertNotNull(valueList);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/radar/value_lists/rsl_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testRadarValueListsPost2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.radar.ValueListUpdateParams params =
+        com.stripe.param.radar.ValueListUpdateParams.builder()
+            .setName("Updated IP Block List")
+            .build();
+
+    com.stripe.model.radar.ValueList valueList =
         client.radar().valueLists().update("rsl_xxxxxxxxxxxxx", params);
     assertNotNull(valueList);
     verifyRequest(
@@ -8858,6 +13960,23 @@ class GeneratedExamples extends BaseStripeTest {
     com.stripe.param.RefundCancelParams params =
         com.stripe.param.RefundCancelParams.builder().build();
 
+    com.stripe.model.Refund refund = client.v1().refunds().cancel("re_xxxxxxxxxxxxx", params);
+    assertNotNull(refund);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/refunds/re_xxxxxxxxxxxxx/cancel",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testRefundsCancelPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.RefundCancelParams params =
+        com.stripe.param.RefundCancelParams.builder().build();
+
     com.stripe.model.Refund refund = client.refunds().cancel("re_xxxxxxxxxxxxx", params);
     assertNotNull(refund);
     verifyRequest(
@@ -8886,6 +14005,20 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.RefundListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.Refund> stripeCollection =
+        client.v1().refunds().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/refunds", params.toMap(), null);
+  }
+
+  @Test
+  public void testRefundsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.RefundListParams params =
+        com.stripe.param.RefundListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.Refund> stripeCollection =
         client.refunds().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -8902,6 +14035,23 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testRefundsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.RefundRetrieveParams params =
+        com.stripe.param.RefundRetrieveParams.builder().build();
+
+    com.stripe.model.Refund refund = client.v1().refunds().retrieve("re_xxxxxxxxxxxxx", params);
+    assertNotNull(refund);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/refunds/re_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testRefundsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.RefundRetrieveParams params =
@@ -8934,6 +14084,19 @@ class GeneratedExamples extends BaseStripeTest {
     com.stripe.param.RefundCreateParams params =
         com.stripe.param.RefundCreateParams.builder().setCharge("ch_xxxxxxxxxxxxx").build();
 
+    com.stripe.model.Refund refund = client.v1().refunds().create(params);
+    assertNotNull(refund);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.POST, "/v1/refunds", params.toMap(), null);
+  }
+
+  @Test
+  public void testRefundsPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.RefundCreateParams params =
+        com.stripe.param.RefundCreateParams.builder().setCharge("ch_xxxxxxxxxxxxx").build();
+
     com.stripe.model.Refund refund = client.refunds().create(params);
     assertNotNull(refund);
     verifyRequest(
@@ -8959,6 +14122,23 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testRefundsPost2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.RefundUpdateParams params =
+        com.stripe.param.RefundUpdateParams.builder().putMetadata("order_id", "6735").build();
+
+    com.stripe.model.Refund refund = client.v1().refunds().update("re_xxxxxxxxxxxxx", params);
+    assertNotNull(refund);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/refunds/re_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testRefundsPost2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.RefundUpdateParams params =
@@ -8998,6 +14178,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.reporting.ReportRunListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.reporting.ReportRun> stripeCollection =
+        client.v1().reporting().reportRuns().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/reporting/report_runs",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testReportingReportRunsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.reporting.ReportRunListParams params =
+        com.stripe.param.reporting.ReportRunListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.reporting.ReportRun> stripeCollection =
         client.reporting().reportRuns().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -9023,6 +14221,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testReportingReportRunsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.reporting.ReportRunRetrieveParams params =
+        com.stripe.param.reporting.ReportRunRetrieveParams.builder().build();
+
+    com.stripe.model.reporting.ReportRun reportRun =
+        client.v1().reporting().reportRuns().retrieve("frr_xxxxxxxxxxxxx", params);
+    assertNotNull(reportRun);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/reporting/report_runs/frr_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testReportingReportRunsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.reporting.ReportRunRetrieveParams params =
@@ -9076,6 +14292,31 @@ class GeneratedExamples extends BaseStripeTest {
                     .build())
             .build();
 
+    com.stripe.model.reporting.ReportRun reportRun =
+        client.v1().reporting().reportRuns().create(params);
+    assertNotNull(reportRun);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/reporting/report_runs",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testReportingReportRunsPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.reporting.ReportRunCreateParams params =
+        com.stripe.param.reporting.ReportRunCreateParams.builder()
+            .setReportType("balance.summary.1")
+            .setParameters(
+                com.stripe.param.reporting.ReportRunCreateParams.Parameters.builder()
+                    .setIntervalStart(1522540800L)
+                    .setIntervalEnd(1525132800L)
+                    .build())
+            .build();
+
     com.stripe.model.reporting.ReportRun reportRun = client.reporting().reportRuns().create(params);
     assertNotNull(reportRun);
     verifyRequest(
@@ -9110,6 +14351,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.reporting.ReportTypeListParams.builder().build();
 
     com.stripe.model.StripeCollection<com.stripe.model.reporting.ReportType> stripeCollection =
+        client.v1().reporting().reportTypes().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/reporting/report_types",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testReportingReportTypesGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.reporting.ReportTypeListParams params =
+        com.stripe.param.reporting.ReportTypeListParams.builder().build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.reporting.ReportType> stripeCollection =
         client.reporting().reportTypes().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -9135,6 +14394,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testReportingReportTypesGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.reporting.ReportTypeRetrieveParams params =
+        com.stripe.param.reporting.ReportTypeRetrieveParams.builder().build();
+
+    com.stripe.model.reporting.ReportType reportType =
+        client.v1().reporting().reportTypes().retrieve("balance.summary.1", params);
+    assertNotNull(reportType);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/reporting/report_types/balance.summary.1",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testReportingReportTypesGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.reporting.ReportTypeRetrieveParams params =
@@ -9174,6 +14451,23 @@ class GeneratedExamples extends BaseStripeTest {
     com.stripe.param.ReviewApproveParams params =
         com.stripe.param.ReviewApproveParams.builder().build();
 
+    com.stripe.model.Review review = client.v1().reviews().approve("prv_xxxxxxxxxxxxx", params);
+    assertNotNull(review);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/reviews/prv_xxxxxxxxxxxxx/approve",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testReviewsApprovePostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.ReviewApproveParams params =
+        com.stripe.param.ReviewApproveParams.builder().build();
+
     com.stripe.model.Review review = client.reviews().approve("prv_xxxxxxxxxxxxx", params);
     assertNotNull(review);
     verifyRequest(
@@ -9202,6 +14496,20 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.ReviewListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.Review> stripeCollection =
+        client.v1().reviews().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/reviews", params.toMap(), null);
+  }
+
+  @Test
+  public void testReviewsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.ReviewListParams params =
+        com.stripe.param.ReviewListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.Review> stripeCollection =
         client.reviews().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -9222,6 +14530,23 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testReviewsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.ReviewRetrieveParams params =
+        com.stripe.param.ReviewRetrieveParams.builder().build();
+
+    com.stripe.model.Review review = client.v1().reviews().retrieve("prv_xxxxxxxxxxxxx", params);
+    assertNotNull(review);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/reviews/prv_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testReviewsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.ReviewRetrieveParams params =
@@ -9259,6 +14584,23 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.StripeCollection<com.stripe.model.SetupAttempt> stripeCollection =
+        client.v1().setupAttempts().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/setup_attempts", params.toMap(), null);
+  }
+
+  @Test
+  public void testSetupAttemptsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.SetupAttemptListParams params =
+        com.stripe.param.SetupAttemptListParams.builder()
+            .setLimit(3L)
+            .setSetupIntent("si_xyz")
+            .build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.SetupAttempt> stripeCollection =
         client.setupAttempts().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -9283,6 +14625,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testSetupIntentsCancelPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.SetupIntentCancelParams params =
+        com.stripe.param.SetupIntentCancelParams.builder().build();
+
+    com.stripe.model.SetupIntent setupIntent =
+        client.v1().setupIntents().cancel("seti_xxxxxxxxxxxxx", params);
+    assertNotNull(setupIntent);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/setup_intents/seti_xxxxxxxxxxxxx/cancel",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testSetupIntentsCancelPostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.SetupIntentCancelParams params =
@@ -9326,6 +14686,26 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.SetupIntent setupIntent =
+        client.v1().setupIntents().confirm("seti_xxxxxxxxxxxxx", params);
+    assertNotNull(setupIntent);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/setup_intents/seti_xxxxxxxxxxxxx/confirm",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testSetupIntentsConfirmPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.SetupIntentConfirmParams params =
+        com.stripe.param.SetupIntentConfirmParams.builder()
+            .setPaymentMethod("pm_card_visa")
+            .build();
+
+    com.stripe.model.SetupIntent setupIntent =
         client.setupIntents().confirm("seti_xxxxxxxxxxxxx", params);
     assertNotNull(setupIntent);
     verifyRequest(
@@ -9348,6 +14728,20 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testSetupIntentsGetServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.SetupIntentListParams params =
+        com.stripe.param.SetupIntentListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.SetupIntent> stripeCollection =
+        client.v1().setupIntents().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/setup_intents", params.toMap(), null);
+  }
+
+  @Test
+  public void testSetupIntentsGetServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.SetupIntentListParams params =
@@ -9380,6 +14774,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.SetupIntentRetrieveParams.builder().build();
 
     com.stripe.model.SetupIntent setupIntent =
+        client.v1().setupIntents().retrieve("seti_xxxxxxxxxxxxx", params);
+    assertNotNull(setupIntent);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/setup_intents/seti_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testSetupIntentsGet2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.SetupIntentRetrieveParams params =
+        com.stripe.param.SetupIntentRetrieveParams.builder().build();
+
+    com.stripe.model.SetupIntent setupIntent =
         client.setupIntents().retrieve("seti_xxxxxxxxxxxxx", params);
     assertNotNull(setupIntent);
     verifyRequest(
@@ -9403,6 +14815,19 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testSetupIntentsPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.SetupIntentCreateParams params =
+        com.stripe.param.SetupIntentCreateParams.builder().addPaymentMethodType("card").build();
+
+    com.stripe.model.SetupIntent setupIntent = client.v1().setupIntents().create(params);
+    assertNotNull(setupIntent);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.POST, "/v1/setup_intents", params.toMap(), null);
+  }
+
+  @Test
+  public void testSetupIntentsPostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.SetupIntentCreateParams params =
@@ -9441,6 +14866,26 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.SetupIntent setupIntent =
+        client.v1().setupIntents().update("seti_xxxxxxxxxxxxx", params);
+    assertNotNull(setupIntent);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/setup_intents/seti_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testSetupIntentsPost2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.SetupIntentUpdateParams params =
+        com.stripe.param.SetupIntentUpdateParams.builder()
+            .putMetadata("user_id", "3435453")
+            .build();
+
+    com.stripe.model.SetupIntent setupIntent =
         client.setupIntents().update("seti_xxxxxxxxxxxxx", params);
     assertNotNull(setupIntent);
     verifyRequest(
@@ -9470,6 +14915,25 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testSetupIntentsVerifyMicrodepositsPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.SetupIntentVerifyMicrodepositsParams params =
+        com.stripe.param.SetupIntentVerifyMicrodepositsParams.builder().build();
+
+    com.stripe.model.SetupIntent setupIntent =
+        client.v1().setupIntents().verifyMicrodeposits("seti_xxxxxxxxxxxxx", params);
+    assertNotNull(setupIntent);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/setup_intents/seti_xxxxxxxxxxxxx/verify_microdeposits",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testSetupIntentsVerifyMicrodepositsPostServicesNonNamespaced()
+      throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.SetupIntentVerifyMicrodepositsParams params =
@@ -9514,6 +14978,28 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.SetupIntent setupIntent =
+        client.v1().setupIntents().verifyMicrodeposits("seti_xxxxxxxxxxxxx", params);
+    assertNotNull(setupIntent);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/setup_intents/seti_xxxxxxxxxxxxx/verify_microdeposits",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testSetupIntentsVerifyMicrodepositsPost2ServicesNonNamespaced()
+      throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.SetupIntentVerifyMicrodepositsParams params =
+        com.stripe.param.SetupIntentVerifyMicrodepositsParams.builder()
+            .addAmount(32L)
+            .addAmount(45L)
+            .build();
+
+    com.stripe.model.SetupIntent setupIntent =
         client.setupIntents().verifyMicrodeposits("seti_xxxxxxxxxxxxx", params);
     assertNotNull(setupIntent);
     verifyRequest(
@@ -9536,6 +15022,20 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testShippingRatesGetServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.ShippingRateListParams params =
+        com.stripe.param.ShippingRateListParams.builder().build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.ShippingRate> stripeCollection =
+        client.v1().shippingRates().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/shipping_rates", params.toMap(), null);
+  }
+
+  @Test
+  public void testShippingRatesGetServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.ShippingRateListParams params =
@@ -9566,6 +15066,20 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.ShippingRateListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.ShippingRate> stripeCollection =
+        client.v1().shippingRates().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/shipping_rates", params.toMap(), null);
+  }
+
+  @Test
+  public void testShippingRatesGet2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.ShippingRateListParams params =
+        com.stripe.param.ShippingRateListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.ShippingRate> stripeCollection =
         client.shippingRates().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -9586,6 +15100,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testShippingRatesGet3Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.ShippingRateRetrieveParams params =
+        com.stripe.param.ShippingRateRetrieveParams.builder().build();
+
+    com.stripe.model.ShippingRate shippingRate =
+        client.v1().shippingRates().retrieve("shr_xxxxxxxxxxxxx", params);
+    assertNotNull(shippingRate);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/shipping_rates/shr_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testShippingRatesGet3ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.ShippingRateRetrieveParams params =
@@ -9627,6 +15159,31 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testShippingRatesPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.ShippingRateCreateParams params =
+        com.stripe.param.ShippingRateCreateParams.builder()
+            .setDisplayName("Sample Shipper")
+            .setFixedAmount(
+                com.stripe.param.ShippingRateCreateParams.FixedAmount.builder()
+                    .setCurrency("usd")
+                    .setAmount(400L)
+                    .build())
+            .setType(com.stripe.param.ShippingRateCreateParams.Type.FIXED_AMOUNT)
+            .build();
+
+    com.stripe.model.ShippingRate shippingRate = client.v1().shippingRates().create(params);
+    assertNotNull(shippingRate);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/shipping_rates",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testShippingRatesPostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.ShippingRateCreateParams params =
@@ -9688,6 +15245,31 @@ class GeneratedExamples extends BaseStripeTest {
                     .build())
             .build();
 
+    com.stripe.model.ShippingRate shippingRate = client.v1().shippingRates().create(params);
+    assertNotNull(shippingRate);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/shipping_rates",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testShippingRatesPost2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.ShippingRateCreateParams params =
+        com.stripe.param.ShippingRateCreateParams.builder()
+            .setDisplayName("Ground shipping")
+            .setType(com.stripe.param.ShippingRateCreateParams.Type.FIXED_AMOUNT)
+            .setFixedAmount(
+                com.stripe.param.ShippingRateCreateParams.FixedAmount.builder()
+                    .setAmount(500L)
+                    .setCurrency("usd")
+                    .build())
+            .build();
+
     com.stripe.model.ShippingRate shippingRate = client.shippingRates().create(params);
     assertNotNull(shippingRate);
     verifyRequest(
@@ -9717,6 +15299,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testShippingRatesPost3Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.ShippingRateUpdateParams params =
+        com.stripe.param.ShippingRateUpdateParams.builder().putMetadata("order_id", "6735").build();
+
+    com.stripe.model.ShippingRate shippingRate =
+        client.v1().shippingRates().update("shr_xxxxxxxxxxxxx", params);
+    assertNotNull(shippingRate);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/shipping_rates/shr_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testShippingRatesPost3ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.ShippingRateUpdateParams params =
@@ -9757,6 +15357,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.sigma.ScheduledQueryRunListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.sigma.ScheduledQueryRun> stripeCollection =
+        client.v1().sigma().scheduledQueryRuns().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/sigma/scheduled_query_runs",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testSigmaScheduledQueryRunsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.sigma.ScheduledQueryRunListParams params =
+        com.stripe.param.sigma.ScheduledQueryRunListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.sigma.ScheduledQueryRun> stripeCollection =
         client.sigma().scheduledQueryRuns().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -9782,6 +15400,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testSigmaScheduledQueryRunsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.sigma.ScheduledQueryRunRetrieveParams params =
+        com.stripe.param.sigma.ScheduledQueryRunRetrieveParams.builder().build();
+
+    com.stripe.model.sigma.ScheduledQueryRun scheduledQueryRun =
+        client.v1().sigma().scheduledQueryRuns().retrieve("sqr_xxxxxxxxxxxxx", params);
+    assertNotNull(scheduledQueryRun);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/sigma/scheduled_query_runs/sqr_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testSigmaScheduledQueryRunsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.sigma.ScheduledQueryRunRetrieveParams params =
@@ -9817,6 +15453,23 @@ class GeneratedExamples extends BaseStripeTest {
     com.stripe.param.SourceRetrieveParams params =
         com.stripe.param.SourceRetrieveParams.builder().build();
 
+    com.stripe.model.Source source = client.v1().sources().retrieve("src_xxxxxxxxxxxxx", params);
+    assertNotNull(source);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/sources/src_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testSourcesGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.SourceRetrieveParams params =
+        com.stripe.param.SourceRetrieveParams.builder().build();
+
     com.stripe.model.Source source = client.sources().retrieve("src_xxxxxxxxxxxxx", params);
     assertNotNull(source);
     verifyRequest(
@@ -9841,6 +15494,23 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testSourcesGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.SourceRetrieveParams params =
+        com.stripe.param.SourceRetrieveParams.builder().build();
+
+    com.stripe.model.Source source = client.v1().sources().retrieve("src_xxxxxxxxxxxxx", params);
+    assertNotNull(source);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/sources/src_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testSourcesGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.SourceRetrieveParams params =
@@ -9880,6 +15550,23 @@ class GeneratedExamples extends BaseStripeTest {
     com.stripe.param.SourceUpdateParams params =
         com.stripe.param.SourceUpdateParams.builder().putMetadata("order_id", "6735").build();
 
+    com.stripe.model.Source source = client.v1().sources().update("src_xxxxxxxxxxxxx", params);
+    assertNotNull(source);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/sources/src_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testSourcesPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.SourceUpdateParams params =
+        com.stripe.param.SourceUpdateParams.builder().putMetadata("order_id", "6735").build();
+
     com.stripe.model.Source source = client.sources().update("src_xxxxxxxxxxxxx", params);
     assertNotNull(source);
     verifyRequest(
@@ -9908,6 +15595,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testSubscriptionItemsDeleteServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.SubscriptionItemDeleteParams params =
+        com.stripe.param.SubscriptionItemDeleteParams.builder().build();
+
+    com.stripe.model.SubscriptionItem subscriptionItem =
+        client.v1().subscriptionItems().delete("si_xxxxxxxxxxxxx", params);
+    assertNotNull(subscriptionItem);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.DELETE,
+        "/v1/subscription_items/si_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testSubscriptionItemsDeleteServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.SubscriptionItemDeleteParams params =
@@ -9949,6 +15654,26 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.StripeCollection<com.stripe.model.SubscriptionItem> stripeCollection =
+        client.v1().subscriptionItems().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/subscription_items",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testSubscriptionItemsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.SubscriptionItemListParams params =
+        com.stripe.param.SubscriptionItemListParams.builder()
+            .setSubscription("sub_xxxxxxxxxxxxx")
+            .build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.SubscriptionItem> stripeCollection =
         client.subscriptionItems().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -9973,6 +15698,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testSubscriptionItemsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.SubscriptionItemRetrieveParams params =
+        com.stripe.param.SubscriptionItemRetrieveParams.builder().build();
+
+    com.stripe.model.SubscriptionItem subscriptionItem =
+        client.v1().subscriptionItems().retrieve("si_xxxxxxxxxxxxx", params);
+    assertNotNull(subscriptionItem);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/subscription_items/si_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testSubscriptionItemsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.SubscriptionItemRetrieveParams params =
@@ -10019,6 +15762,28 @@ class GeneratedExamples extends BaseStripeTest {
             .setQuantity(2L)
             .build();
 
+    com.stripe.model.SubscriptionItem subscriptionItem =
+        client.v1().subscriptionItems().create(params);
+    assertNotNull(subscriptionItem);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/subscription_items",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testSubscriptionItemsPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.SubscriptionItemCreateParams params =
+        com.stripe.param.SubscriptionItemCreateParams.builder()
+            .setSubscription("sub_xxxxxxxxxxxxx")
+            .setPrice("price_xxxxxxxxxxxxx")
+            .setQuantity(2L)
+            .build();
+
     com.stripe.model.SubscriptionItem subscriptionItem = client.subscriptionItems().create(params);
     assertNotNull(subscriptionItem);
     verifyRequest(
@@ -10048,6 +15813,26 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testSubscriptionItemsPost2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.SubscriptionItemUpdateParams params =
+        com.stripe.param.SubscriptionItemUpdateParams.builder()
+            .putMetadata("order_id", "6735")
+            .build();
+
+    com.stripe.model.SubscriptionItem subscriptionItem =
+        client.v1().subscriptionItems().update("si_xxxxxxxxxxxxx", params);
+    assertNotNull(subscriptionItem);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/subscription_items/si_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testSubscriptionItemsPost2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.SubscriptionItemUpdateParams params =
@@ -10090,6 +15875,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.SubscriptionScheduleCancelParams.builder().build();
 
     com.stripe.model.SubscriptionSchedule subscriptionSchedule =
+        client.v1().subscriptionSchedules().cancel("sub_sched_xxxxxxxxxxxxx", params);
+    assertNotNull(subscriptionSchedule);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/subscription_schedules/sub_sched_xxxxxxxxxxxxx/cancel",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testSubscriptionSchedulesCancelPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.SubscriptionScheduleCancelParams params =
+        com.stripe.param.SubscriptionScheduleCancelParams.builder().build();
+
+    com.stripe.model.SubscriptionSchedule subscriptionSchedule =
         client.subscriptionSchedules().cancel("sub_sched_xxxxxxxxxxxxx", params);
     assertNotNull(subscriptionSchedule);
     verifyRequest(
@@ -10123,6 +15926,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.SubscriptionScheduleListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.SubscriptionSchedule> stripeCollection =
+        client.v1().subscriptionSchedules().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/subscription_schedules",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testSubscriptionSchedulesGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.SubscriptionScheduleListParams params =
+        com.stripe.param.SubscriptionScheduleListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.SubscriptionSchedule> stripeCollection =
         client.subscriptionSchedules().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -10148,6 +15969,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testSubscriptionSchedulesGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.SubscriptionScheduleRetrieveParams params =
+        com.stripe.param.SubscriptionScheduleRetrieveParams.builder().build();
+
+    com.stripe.model.SubscriptionSchedule subscriptionSchedule =
+        client.v1().subscriptionSchedules().retrieve("sub_sched_xxxxxxxxxxxxx", params);
+    assertNotNull(subscriptionSchedule);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/subscription_schedules/sub_sched_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testSubscriptionSchedulesGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.SubscriptionScheduleRetrieveParams params =
@@ -10213,6 +16052,37 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.SubscriptionSchedule subscriptionSchedule =
+        client.v1().subscriptionSchedules().create(params);
+    assertNotNull(subscriptionSchedule);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/subscription_schedules",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testSubscriptionSchedulesPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.SubscriptionScheduleCreateParams params =
+        com.stripe.param.SubscriptionScheduleCreateParams.builder()
+            .setCustomer("cus_xxxxxxxxxxxxx")
+            .setStartDate(1676070661L)
+            .setEndBehavior(com.stripe.param.SubscriptionScheduleCreateParams.EndBehavior.RELEASE)
+            .addPhase(
+                com.stripe.param.SubscriptionScheduleCreateParams.Phase.builder()
+                    .addItem(
+                        com.stripe.param.SubscriptionScheduleCreateParams.Phase.Item.builder()
+                            .setPrice("price_xxxxxxxxxxxxx")
+                            .setQuantity(1L)
+                            .build())
+                    .setIterations(12L)
+                    .build())
+            .build();
+
+    com.stripe.model.SubscriptionSchedule subscriptionSchedule =
         client.subscriptionSchedules().create(params);
     assertNotNull(subscriptionSchedule);
     verifyRequest(
@@ -10244,6 +16114,26 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testSubscriptionSchedulesPost2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.SubscriptionScheduleUpdateParams params =
+        com.stripe.param.SubscriptionScheduleUpdateParams.builder()
+            .setEndBehavior(com.stripe.param.SubscriptionScheduleUpdateParams.EndBehavior.RELEASE)
+            .build();
+
+    com.stripe.model.SubscriptionSchedule subscriptionSchedule =
+        client.v1().subscriptionSchedules().update("sub_sched_xxxxxxxxxxxxx", params);
+    assertNotNull(subscriptionSchedule);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/subscription_schedules/sub_sched_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testSubscriptionSchedulesPost2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.SubscriptionScheduleUpdateParams params =
@@ -10286,6 +16176,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.SubscriptionScheduleReleaseParams.builder().build();
 
     com.stripe.model.SubscriptionSchedule subscriptionSchedule =
+        client.v1().subscriptionSchedules().release("sub_sched_xxxxxxxxxxxxx", params);
+    assertNotNull(subscriptionSchedule);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/subscription_schedules/sub_sched_xxxxxxxxxxxxx/release",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testSubscriptionSchedulesReleasePostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.SubscriptionScheduleReleaseParams params =
+        com.stripe.param.SubscriptionScheduleReleaseParams.builder().build();
+
+    com.stripe.model.SubscriptionSchedule subscriptionSchedule =
         client.subscriptionSchedules().release("sub_sched_xxxxxxxxxxxxx", params);
     assertNotNull(subscriptionSchedule);
     verifyRequest(
@@ -10320,6 +16228,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.SubscriptionCancelParams.builder().build();
 
     com.stripe.model.Subscription subscription =
+        client.v1().subscriptions().cancel("sub_xxxxxxxxxxxxx", params);
+    assertNotNull(subscription);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.DELETE,
+        "/v1/subscriptions/sub_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testSubscriptionsDeleteServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.SubscriptionCancelParams params =
+        com.stripe.param.SubscriptionCancelParams.builder().build();
+
+    com.stripe.model.Subscription subscription =
         client.subscriptions().cancel("sub_xxxxxxxxxxxxx", params);
     assertNotNull(subscription);
     verifyRequest(
@@ -10346,6 +16272,20 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testSubscriptionsDiscountDeleteServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.model.Discount discount = client.v1().subscriptions().deleteDiscount("sub_xyz");
+    assertNotNull(discount);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.DELETE,
+        "/v1/subscriptions/sub_xyz/discount",
+        null,
+        null);
+  }
+
+  @Test
+  public void testSubscriptionsDiscountDeleteServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.model.Discount discount = client.subscriptions().deleteDiscount("sub_xyz");
@@ -10376,6 +16316,20 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.SubscriptionListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.Subscription> stripeCollection =
+        client.v1().subscriptions().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/subscriptions", params.toMap(), null);
+  }
+
+  @Test
+  public void testSubscriptionsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.SubscriptionListParams params =
+        com.stripe.param.SubscriptionListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.Subscription> stripeCollection =
         client.subscriptions().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -10396,6 +16350,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testSubscriptionsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.SubscriptionRetrieveParams params =
+        com.stripe.param.SubscriptionRetrieveParams.builder().build();
+
+    com.stripe.model.Subscription subscription =
+        client.v1().subscriptions().retrieve("sub_xxxxxxxxxxxxx", params);
+    assertNotNull(subscription);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/subscriptions/sub_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testSubscriptionsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.SubscriptionRetrieveParams params =
@@ -10440,6 +16412,25 @@ class GeneratedExamples extends BaseStripeTest {
                     .build())
             .build();
 
+    com.stripe.model.Subscription subscription = client.v1().subscriptions().create(params);
+    assertNotNull(subscription);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.POST, "/v1/subscriptions", params.toMap(), null);
+  }
+
+  @Test
+  public void testSubscriptionsPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.SubscriptionCreateParams params =
+        com.stripe.param.SubscriptionCreateParams.builder()
+            .setCustomer("cus_xxxxxxxxxxxxx")
+            .addItem(
+                com.stripe.param.SubscriptionCreateParams.Item.builder()
+                    .setPrice("price_xxxxxxxxxxxxx")
+                    .build())
+            .build();
+
     com.stripe.model.Subscription subscription = client.subscriptions().create(params);
     assertNotNull(subscription);
     verifyRequest(
@@ -10465,6 +16456,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testSubscriptionsPost2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.SubscriptionUpdateParams params =
+        com.stripe.param.SubscriptionUpdateParams.builder().putMetadata("order_id", "6735").build();
+
+    com.stripe.model.Subscription subscription =
+        client.v1().subscriptions().update("sub_xxxxxxxxxxxxx", params);
+    assertNotNull(subscription);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/subscriptions/sub_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testSubscriptionsPost2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.SubscriptionUpdateParams params =
@@ -10500,6 +16509,26 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testSubscriptionsSearchGetServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.SubscriptionSearchParams params =
+        com.stripe.param.SubscriptionSearchParams.builder()
+            .setQuery("status:'active' AND metadata['order_id']:'6735'")
+            .build();
+
+    com.stripe.model.StripeSearchResult<com.stripe.model.Subscription> stripeSearchResult =
+        client.v1().subscriptions().search(params);
+    assertNotNull(stripeSearchResult);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/subscriptions/search",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testSubscriptionsSearchGetServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.SubscriptionSearchParams params =
@@ -10584,6 +16613,45 @@ class GeneratedExamples extends BaseStripeTest {
                     .build())
             .build();
 
+    com.stripe.model.tax.Calculation calculation = client.v1().tax().calculations().create(params);
+    assertNotNull(calculation);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/tax/calculations",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTaxCalculationsPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.tax.CalculationCreateParams params =
+        com.stripe.param.tax.CalculationCreateParams.builder()
+            .setCurrency("usd")
+            .addLineItem(
+                com.stripe.param.tax.CalculationCreateParams.LineItem.builder()
+                    .setAmount(1000L)
+                    .setReference("L1")
+                    .build())
+            .setCustomerDetails(
+                com.stripe.param.tax.CalculationCreateParams.CustomerDetails.builder()
+                    .setAddress(
+                        com.stripe.param.tax.CalculationCreateParams.CustomerDetails.Address
+                            .builder()
+                            .setLine1("354 Oyster Point Blvd")
+                            .setCity("South San Francisco")
+                            .setState("CA")
+                            .setPostalCode("94080")
+                            .setCountry("US")
+                            .build())
+                    .setAddressSource(
+                        com.stripe.param.tax.CalculationCreateParams.CustomerDetails.AddressSource
+                            .SHIPPING)
+                    .build())
+            .build();
+
     com.stripe.model.tax.Calculation calculation = client.tax().calculations().create(params);
     assertNotNull(calculation);
     verifyRequest(
@@ -10612,6 +16680,20 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.TaxCodeListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.TaxCode> stripeCollection =
+        client.v1().taxCodes().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/tax_codes", params.toMap(), null);
+  }
+
+  @Test
+  public void testTaxCodesGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.TaxCodeListParams params =
+        com.stripe.param.TaxCodeListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.TaxCode> stripeCollection =
         client.taxCodes().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -10632,6 +16714,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTaxCodesGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.TaxCodeRetrieveParams params =
+        com.stripe.param.TaxCodeRetrieveParams.builder().build();
+
+    com.stripe.model.TaxCode taxCode =
+        client.v1().taxCodes().retrieve("txcd_xxxxxxxxxxxxx", params);
+    assertNotNull(taxCode);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/tax_codes/txcd_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTaxCodesGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.TaxCodeRetrieveParams params =
@@ -10665,6 +16765,20 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.TaxRateListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.TaxRate> stripeCollection =
+        client.v1().taxRates().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/tax_rates", params.toMap(), null);
+  }
+
+  @Test
+  public void testTaxRatesGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.TaxRateListParams params =
+        com.stripe.param.TaxRateListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.TaxRate> stripeCollection =
         client.taxRates().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -10685,6 +16799,23 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTaxRatesGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.TaxRateRetrieveParams params =
+        com.stripe.param.TaxRateRetrieveParams.builder().build();
+
+    com.stripe.model.TaxRate taxRate = client.v1().taxRates().retrieve("txr_xxxxxxxxxxxxx", params);
+    assertNotNull(taxRate);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/tax_rates/txr_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTaxRatesGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.TaxRateRetrieveParams params =
@@ -10730,6 +16861,25 @@ class GeneratedExamples extends BaseStripeTest {
             .setInclusive(false)
             .build();
 
+    com.stripe.model.TaxRate taxRate = client.v1().taxRates().create(params);
+    assertNotNull(taxRate);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.POST, "/v1/tax_rates", params.toMap(), null);
+  }
+
+  @Test
+  public void testTaxRatesPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.TaxRateCreateParams params =
+        com.stripe.param.TaxRateCreateParams.builder()
+            .setDisplayName("VAT")
+            .setDescription("VAT Germany")
+            .setJurisdiction("DE")
+            .setPercentage(new BigDecimal(16))
+            .setInclusive(false)
+            .build();
+
     com.stripe.model.TaxRate taxRate = client.taxRates().create(params);
     assertNotNull(taxRate);
     verifyRequest(
@@ -10754,6 +16904,23 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTaxRatesPost2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.TaxRateUpdateParams params =
+        com.stripe.param.TaxRateUpdateParams.builder().setActive(false).build();
+
+    com.stripe.model.TaxRate taxRate = client.v1().taxRates().update("txr_xxxxxxxxxxxxx", params);
+    assertNotNull(taxRate);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/tax_rates/txr_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTaxRatesPost2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.TaxRateUpdateParams params =
@@ -10789,6 +16956,26 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTaxRegistrationsGetServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.tax.RegistrationListParams params =
+        com.stripe.param.tax.RegistrationListParams.builder()
+            .setStatus(com.stripe.param.tax.RegistrationListParams.Status.ALL)
+            .build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.tax.Registration> stripeCollection =
+        client.v1().tax().registrations().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/tax/registrations",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTaxRegistrationsGetServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.tax.RegistrationListParams params =
@@ -10854,6 +17041,36 @@ class GeneratedExamples extends BaseStripeTest {
             .setActiveFrom(com.stripe.param.tax.RegistrationCreateParams.ActiveFrom.NOW)
             .build();
 
+    com.stripe.model.tax.Registration registration =
+        client.v1().tax().registrations().create(params);
+    assertNotNull(registration);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/tax/registrations",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTaxRegistrationsPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.tax.RegistrationCreateParams params =
+        com.stripe.param.tax.RegistrationCreateParams.builder()
+            .setCountry("IE")
+            .setCountryOptions(
+                com.stripe.param.tax.RegistrationCreateParams.CountryOptions.builder()
+                    .setIe(
+                        com.stripe.param.tax.RegistrationCreateParams.CountryOptions.Ie.builder()
+                            .setType(
+                                com.stripe.param.tax.RegistrationCreateParams.CountryOptions.Ie.Type
+                                    .OSS_UNION)
+                            .build())
+                    .build())
+            .setActiveFrom(com.stripe.param.tax.RegistrationCreateParams.ActiveFrom.NOW)
+            .build();
+
     com.stripe.model.tax.Registration registration = client.tax().registrations().create(params);
     assertNotNull(registration);
     verifyRequest(
@@ -10873,6 +17090,19 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTaxSettingsGetServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.tax.SettingsRetrieveParams params =
+        com.stripe.param.tax.SettingsRetrieveParams.builder().build();
+
+    com.stripe.model.tax.Settings settings = client.v1().tax().settings().retrieve(params);
+    assertNotNull(settings);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/tax/settings", params.toMap(), null);
+  }
+
+  @Test
+  public void testTaxSettingsGetServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.tax.SettingsRetrieveParams params =
@@ -10902,6 +17132,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTaxSettingsPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.tax.SettingsUpdateParams params =
+        com.stripe.param.tax.SettingsUpdateParams.builder()
+            .setDefaults(
+                com.stripe.param.tax.SettingsUpdateParams.Defaults.builder()
+                    .setTaxCode("txcd_10000000")
+                    .build())
+            .build();
+
+    com.stripe.model.tax.Settings settings = client.v1().tax().settings().update(params);
+    assertNotNull(settings);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.POST, "/v1/tax/settings", params.toMap(), null);
+  }
+
+  @Test
+  public void testTaxSettingsPostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.tax.SettingsUpdateParams params =
@@ -10948,6 +17196,28 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.tax.Transaction transaction =
+        client.v1().tax().transactions().createFromCalculation(params);
+    assertNotNull(transaction);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/tax/transactions/create_from_calculation",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTaxTransactionsCreateFromCalculationPostServicesNonNamespaced()
+      throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.tax.TransactionCreateFromCalculationParams params =
+        com.stripe.param.tax.TransactionCreateFromCalculationParams.builder()
+            .setCalculation("xxx")
+            .setReference("yyy")
+            .build();
+
+    com.stripe.model.tax.Transaction transaction =
         client.tax().transactions().createFromCalculation(params);
     assertNotNull(transaction);
     verifyRequest(
@@ -10978,6 +17248,21 @@ class GeneratedExamples extends BaseStripeTest {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.model.terminal.Configuration configuration =
+        client.v1().terminal().configurations().delete("uc_123");
+    assertNotNull(configuration);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.DELETE,
+        "/v1/terminal/configurations/uc_123",
+        null,
+        null);
+  }
+
+  @Test
+  public void testTerminalConfigurationsDeleteServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.model.terminal.Configuration configuration =
         client.terminal().configurations().delete("uc_123");
     assertNotNull(configuration);
     verifyRequest(
@@ -11005,6 +17290,21 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTerminalConfigurationsDelete2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.model.terminal.Configuration configuration =
+        client.v1().terminal().configurations().delete("tmc_xxxxxxxxxxxxx");
+    assertNotNull(configuration);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.DELETE,
+        "/v1/terminal/configurations/tmc_xxxxxxxxxxxxx",
+        null,
+        null);
+  }
+
+  @Test
+  public void testTerminalConfigurationsDelete2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.model.terminal.Configuration configuration =
@@ -11042,6 +17342,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.terminal.ConfigurationListParams.builder().build();
 
     com.stripe.model.StripeCollection<com.stripe.model.terminal.Configuration> stripeCollection =
+        client.v1().terminal().configurations().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/terminal/configurations",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTerminalConfigurationsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.terminal.ConfigurationListParams params =
+        com.stripe.param.terminal.ConfigurationListParams.builder().build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.terminal.Configuration> stripeCollection =
         client.terminal().configurations().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -11067,6 +17385,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTerminalConfigurationsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.terminal.ConfigurationRetrieveParams params =
+        com.stripe.param.terminal.ConfigurationRetrieveParams.builder().build();
+
+    com.stripe.model.terminal.Configuration configuration =
+        client.v1().terminal().configurations().retrieve("uc_123", params);
+    assertNotNull(configuration);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/terminal/configurations/uc_123",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTerminalConfigurationsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.terminal.ConfigurationRetrieveParams params =
@@ -11107,6 +17443,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.terminal.ConfigurationListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.terminal.Configuration> stripeCollection =
+        client.v1().terminal().configurations().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/terminal/configurations",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTerminalConfigurationsGet3ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.terminal.ConfigurationListParams params =
+        com.stripe.param.terminal.ConfigurationListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.terminal.Configuration> stripeCollection =
         client.terminal().configurations().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -11132,6 +17486,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTerminalConfigurationsGet4Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.terminal.ConfigurationRetrieveParams params =
+        com.stripe.param.terminal.ConfigurationRetrieveParams.builder().build();
+
+    com.stripe.model.terminal.Configuration configuration =
+        client.v1().terminal().configurations().retrieve("tmc_xxxxxxxxxxxxx", params);
+    assertNotNull(configuration);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/terminal/configurations/tmc_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTerminalConfigurationsGet4ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.terminal.ConfigurationRetrieveParams params =
@@ -11166,6 +17538,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTerminalConfigurationsPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.terminal.ConfigurationCreateParams params =
+        com.stripe.param.terminal.ConfigurationCreateParams.builder().build();
+
+    com.stripe.model.terminal.Configuration configuration =
+        client.v1().terminal().configurations().create(params);
+    assertNotNull(configuration);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/terminal/configurations",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTerminalConfigurationsPostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.terminal.ConfigurationCreateParams params =
@@ -11224,6 +17614,32 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.terminal.Configuration configuration =
+        client.v1().terminal().configurations().update("uc_123", params);
+    assertNotNull(configuration);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/terminal/configurations/uc_123",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTerminalConfigurationsPost2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.terminal.ConfigurationUpdateParams params =
+        com.stripe.param.terminal.ConfigurationUpdateParams.builder()
+            .setTipping(
+                com.stripe.param.terminal.ConfigurationUpdateParams.Tipping.builder()
+                    .setUsd(
+                        com.stripe.param.terminal.ConfigurationUpdateParams.Tipping.Usd.builder()
+                            .addFixedAmount(10L)
+                            .build())
+                    .build())
+            .build();
+
+    com.stripe.model.terminal.Configuration configuration =
         client.terminal().configurations().update("uc_123", params);
     assertNotNull(configuration);
     verifyRequest(
@@ -11257,6 +17673,29 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTerminalConfigurationsPost3Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.terminal.ConfigurationCreateParams params =
+        com.stripe.param.terminal.ConfigurationCreateParams.builder()
+            .setBbposWiseposE(
+                com.stripe.param.terminal.ConfigurationCreateParams.BbposWiseposE.builder()
+                    .setSplashscreen("file_xxxxxxxxxxxxx")
+                    .build())
+            .build();
+
+    com.stripe.model.terminal.Configuration configuration =
+        client.v1().terminal().configurations().create(params);
+    assertNotNull(configuration);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/terminal/configurations",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTerminalConfigurationsPost3ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.terminal.ConfigurationCreateParams params =
@@ -11314,6 +17753,29 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.terminal.Configuration configuration =
+        client.v1().terminal().configurations().update("tmc_xxxxxxxxxxxxx", params);
+    assertNotNull(configuration);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/terminal/configurations/tmc_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTerminalConfigurationsPost4ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.terminal.ConfigurationUpdateParams params =
+        com.stripe.param.terminal.ConfigurationUpdateParams.builder()
+            .setBbposWiseposE(
+                com.stripe.param.terminal.ConfigurationUpdateParams.BbposWiseposE.builder()
+                    .setSplashscreen("file_xxxxxxxxxxxxx")
+                    .build())
+            .build();
+
+    com.stripe.model.terminal.Configuration configuration =
         client.terminal().configurations().update("tmc_xxxxxxxxxxxxx", params);
     assertNotNull(configuration);
     verifyRequest(
@@ -11348,6 +17810,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.terminal.ConnectionTokenCreateParams.builder().build();
 
     com.stripe.model.terminal.ConnectionToken connectionToken =
+        client.v1().terminal().connectionTokens().create(params);
+    assertNotNull(connectionToken);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/terminal/connection_tokens",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTerminalConnectionTokensPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.terminal.ConnectionTokenCreateParams params =
+        com.stripe.param.terminal.ConnectionTokenCreateParams.builder().build();
+
+    com.stripe.model.terminal.ConnectionToken connectionToken =
         client.terminal().connectionTokens().create(params);
     assertNotNull(connectionToken);
     verifyRequest(
@@ -11375,6 +17855,21 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTerminalLocationsDeleteServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.model.terminal.Location location =
+        client.v1().terminal().locations().delete("tml_xxxxxxxxxxxxx");
+    assertNotNull(location);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.DELETE,
+        "/v1/terminal/locations/tml_xxxxxxxxxxxxx",
+        null,
+        null);
+  }
+
+  @Test
+  public void testTerminalLocationsDeleteServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.model.terminal.Location location =
@@ -11412,6 +17907,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.terminal.LocationListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.terminal.Location> stripeCollection =
+        client.v1().terminal().locations().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/terminal/locations",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTerminalLocationsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.terminal.LocationListParams params =
+        com.stripe.param.terminal.LocationListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.terminal.Location> stripeCollection =
         client.terminal().locations().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -11437,6 +17950,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTerminalLocationsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.terminal.LocationRetrieveParams params =
+        com.stripe.param.terminal.LocationRetrieveParams.builder().build();
+
+    com.stripe.model.terminal.Location location =
+        client.v1().terminal().locations().retrieve("tml_xxxxxxxxxxxxx", params);
+    assertNotNull(location);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/terminal/locations/tml_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTerminalLocationsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.terminal.LocationRetrieveParams params =
@@ -11495,6 +18026,33 @@ class GeneratedExamples extends BaseStripeTest {
                     .build())
             .build();
 
+    com.stripe.model.terminal.Location location = client.v1().terminal().locations().create(params);
+    assertNotNull(location);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/terminal/locations",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTerminalLocationsPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.terminal.LocationCreateParams params =
+        com.stripe.param.terminal.LocationCreateParams.builder()
+            .setDisplayName("My First Store")
+            .setAddress(
+                com.stripe.param.terminal.LocationCreateParams.Address.builder()
+                    .setLine1("1234 Main Street")
+                    .setCity("San Francisco")
+                    .setPostalCode("94111")
+                    .setState("CA")
+                    .setCountry("US")
+                    .build())
+            .build();
+
     com.stripe.model.terminal.Location location = client.terminal().locations().create(params);
     assertNotNull(location);
     verifyRequest(
@@ -11527,6 +18085,26 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTerminalLocationsPost2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.terminal.LocationUpdateParams params =
+        com.stripe.param.terminal.LocationUpdateParams.builder()
+            .setDisplayName("My First Store")
+            .build();
+
+    com.stripe.model.terminal.Location location =
+        client.v1().terminal().locations().update("tml_xxxxxxxxxxxxx", params);
+    assertNotNull(location);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/terminal/locations/tml_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTerminalLocationsPost2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.terminal.LocationUpdateParams params =
@@ -11571,6 +18149,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.terminal.ReaderCancelActionParams.builder().build();
 
     com.stripe.model.terminal.Reader reader =
+        client.v1().terminal().readers().cancelAction("tmr_xxxxxxxxxxxxx", params);
+    assertNotNull(reader);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/terminal/readers/tmr_xxxxxxxxxxxxx/cancel_action",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTerminalReadersCancelActionPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.terminal.ReaderCancelActionParams params =
+        com.stripe.param.terminal.ReaderCancelActionParams.builder().build();
+
+    com.stripe.model.terminal.Reader reader =
         client.terminal().readers().cancelAction("tmr_xxxxxxxxxxxxx", params);
     assertNotNull(reader);
     verifyRequest(
@@ -11598,6 +18194,21 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTerminalReadersDeleteServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.model.terminal.Reader reader =
+        client.v1().terminal().readers().delete("tmr_xxxxxxxxxxxxx");
+    assertNotNull(reader);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.DELETE,
+        "/v1/terminal/readers/tmr_xxxxxxxxxxxxx",
+        null,
+        null);
+  }
+
+  @Test
+  public void testTerminalReadersDeleteServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.model.terminal.Reader reader =
@@ -11635,6 +18246,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.terminal.ReaderListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.terminal.Reader> stripeCollection =
+        client.v1().terminal().readers().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/terminal/readers",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTerminalReadersGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.terminal.ReaderListParams params =
+        com.stripe.param.terminal.ReaderListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.terminal.Reader> stripeCollection =
         client.terminal().readers().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -11660,6 +18289,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTerminalReadersGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.terminal.ReaderRetrieveParams params =
+        com.stripe.param.terminal.ReaderRetrieveParams.builder().build();
+
+    com.stripe.model.terminal.Reader reader =
+        client.v1().terminal().readers().retrieve("tmr_xxxxxxxxxxxxx", params);
+    assertNotNull(reader);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/terminal/readers/tmr_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTerminalReadersGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.terminal.ReaderRetrieveParams params =
@@ -11706,6 +18353,27 @@ class GeneratedExamples extends BaseStripeTest {
             .setLocation("tml_1234")
             .build();
 
+    com.stripe.model.terminal.Reader reader = client.v1().terminal().readers().create(params);
+    assertNotNull(reader);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/terminal/readers",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTerminalReadersPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.terminal.ReaderCreateParams params =
+        com.stripe.param.terminal.ReaderCreateParams.builder()
+            .setRegistrationCode("puppies-plug-could")
+            .setLabel("Blue Rabbit")
+            .setLocation("tml_1234")
+            .build();
+
     com.stripe.model.terminal.Reader reader = client.terminal().readers().create(params);
     assertNotNull(reader);
     verifyRequest(
@@ -11736,6 +18404,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTerminalReadersPost2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.terminal.ReaderUpdateParams params =
+        com.stripe.param.terminal.ReaderUpdateParams.builder().setLabel("Blue Rabbit").build();
+
+    com.stripe.model.terminal.Reader reader =
+        client.v1().terminal().readers().update("tmr_xxxxxxxxxxxxx", params);
+    assertNotNull(reader);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/terminal/readers/tmr_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTerminalReadersPost2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.terminal.ReaderUpdateParams params =
@@ -11774,6 +18460,27 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTerminalReadersProcessPaymentIntentPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.terminal.ReaderProcessPaymentIntentParams params =
+        com.stripe.param.terminal.ReaderProcessPaymentIntentParams.builder()
+            .setPaymentIntent("pi_xxxxxxxxxxxxx")
+            .build();
+
+    com.stripe.model.terminal.Reader reader =
+        client.v1().terminal().readers().processPaymentIntent("tmr_xxxxxxxxxxxxx", params);
+    assertNotNull(reader);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/terminal/readers/tmr_xxxxxxxxxxxxx/process_payment_intent",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTerminalReadersProcessPaymentIntentPostServicesNonNamespaced()
+      throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.terminal.ReaderProcessPaymentIntentParams params =
@@ -11826,6 +18533,29 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.terminal.Reader reader =
+        client.v1().terminal().readers().processSetupIntent("tmr_xxxxxxxxxxxxx", params);
+    assertNotNull(reader);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/terminal/readers/tmr_xxxxxxxxxxxxx/process_setup_intent",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTerminalReadersProcessSetupIntentPostServicesNonNamespaced()
+      throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.terminal.ReaderProcessSetupIntentParams params =
+        com.stripe.param.terminal.ReaderProcessSetupIntentParams.builder()
+            .setSetupIntent("seti_xxxxxxxxxxxxx")
+            .setAllowRedisplay(
+                com.stripe.param.terminal.ReaderProcessSetupIntentParams.AllowRedisplay.ALWAYS)
+            .build();
+
+    com.stripe.model.terminal.Reader reader =
         client.terminal().readers().processSetupIntent("tmr_xxxxxxxxxxxxx", params);
     assertNotNull(reader);
     verifyRequest(
@@ -11856,6 +18586,28 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTestHelpersCustomersFundCashBalancePostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.CustomerFundCashBalanceParams params =
+        com.stripe.param.CustomerFundCashBalanceParams.builder()
+            .setAmount(30L)
+            .setCurrency("eur")
+            .build();
+
+    com.stripe.model.CustomerCashBalanceTransaction customerCashBalanceTransaction =
+        client.v1().testHelpers().customers().fundCashBalance("cus_123", params);
+    assertNotNull(customerCashBalanceTransaction);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/customers/cus_123/fund_cash_balance",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTestHelpersCustomersFundCashBalancePostServicesNonNamespaced()
+      throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.CustomerFundCashBalanceParams params =
@@ -12004,6 +18756,81 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.issuing.Authorization authorization =
+        client
+            .v1()
+            .testHelpers()
+            .issuing()
+            .authorizations()
+            .capture("example_authorization", params);
+    assertNotNull(authorization);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/issuing/authorizations/example_authorization/capture",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTestHelpersIssuingAuthorizationsCapturePostServicesNonNamespaced()
+      throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.AuthorizationCaptureParams params =
+        com.stripe.param.issuing.AuthorizationCaptureParams.builder()
+            .setCaptureAmount(100L)
+            .setCloseAuthorization(true)
+            .setPurchaseDetails(
+                com.stripe.param.issuing.AuthorizationCaptureParams.PurchaseDetails.builder()
+                    .setFlight(
+                        com.stripe.param.issuing.AuthorizationCaptureParams.PurchaseDetails.Flight
+                            .builder()
+                            .setDepartureAt(1633651200L)
+                            .setPassengerName("John Doe")
+                            .setRefundable(true)
+                            .addSegment(
+                                com.stripe.param.issuing.AuthorizationCaptureParams.PurchaseDetails
+                                    .Flight.Segment.builder()
+                                    .setArrivalAirportCode("SFO")
+                                    .setCarrier("Delta")
+                                    .setDepartureAirportCode("LAX")
+                                    .setFlightNumber("DL100")
+                                    .setServiceClass("Economy")
+                                    .setStopoverAllowed(true)
+                                    .build())
+                            .setTravelAgency("Orbitz")
+                            .build())
+                    .setFuel(
+                        com.stripe.param.issuing.AuthorizationCaptureParams.PurchaseDetails.Fuel
+                            .builder()
+                            .setType(
+                                com.stripe.param.issuing.AuthorizationCaptureParams.PurchaseDetails
+                                    .Fuel.Type.DIESEL)
+                            .setUnit(
+                                com.stripe.param.issuing.AuthorizationCaptureParams.PurchaseDetails
+                                    .Fuel.Unit.LITER)
+                            .setUnitCostDecimal(new BigDecimal("3.5"))
+                            .setQuantityDecimal(new BigDecimal("10"))
+                            .build())
+                    .setLodging(
+                        com.stripe.param.issuing.AuthorizationCaptureParams.PurchaseDetails.Lodging
+                            .builder()
+                            .setCheckInAt(1633651200L)
+                            .setNights(2L)
+                            .build())
+                    .addReceipt(
+                        com.stripe.param.issuing.AuthorizationCaptureParams.PurchaseDetails.Receipt
+                            .builder()
+                            .setDescription("Room charge")
+                            .setQuantity(new BigDecimal("1"))
+                            .setTotal(200L)
+                            .setUnitCost(200L)
+                            .build())
+                    .setReference("foo")
+                    .build())
+            .build();
+
+    com.stripe.model.issuing.Authorization authorization =
         client.testHelpers().issuing().authorizations().capture("example_authorization", params);
     assertNotNull(authorization);
     verifyRequest(
@@ -12034,6 +18861,30 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTestHelpersIssuingAuthorizationsExpirePostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.AuthorizationExpireParams params =
+        com.stripe.param.issuing.AuthorizationExpireParams.builder().build();
+
+    com.stripe.model.issuing.Authorization authorization =
+        client
+            .v1()
+            .testHelpers()
+            .issuing()
+            .authorizations()
+            .expire("example_authorization", params);
+    assertNotNull(authorization);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/issuing/authorizations/example_authorization/expire",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTestHelpersIssuingAuthorizationsExpirePostServicesNonNamespaced()
+      throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.issuing.AuthorizationExpireParams params =
@@ -12074,6 +18925,33 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTestHelpersIssuingAuthorizationsIncrementPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.AuthorizationIncrementParams params =
+        com.stripe.param.issuing.AuthorizationIncrementParams.builder()
+            .setIncrementAmount(50L)
+            .setIsAmountControllable(true)
+            .build();
+
+    com.stripe.model.issuing.Authorization authorization =
+        client
+            .v1()
+            .testHelpers()
+            .issuing()
+            .authorizations()
+            .increment("example_authorization", params);
+    assertNotNull(authorization);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/issuing/authorizations/example_authorization/increment",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTestHelpersIssuingAuthorizationsIncrementPostServicesNonNamespaced()
+      throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.issuing.AuthorizationIncrementParams params =
@@ -12207,6 +19085,70 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.issuing.Authorization authorization =
+        client.v1().testHelpers().issuing().authorizations().create(params);
+    assertNotNull(authorization);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/issuing/authorizations",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTestHelpersIssuingAuthorizationsPostServicesNonNamespaced()
+      throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.AuthorizationCreateParams params =
+        com.stripe.param.issuing.AuthorizationCreateParams.builder()
+            .setAmount(100L)
+            .setAmountDetails(
+                com.stripe.param.issuing.AuthorizationCreateParams.AmountDetails.builder()
+                    .setAtmFee(10L)
+                    .setCashbackAmount(5L)
+                    .build())
+            .setAuthorizationMethod(
+                com.stripe.param.issuing.AuthorizationCreateParams.AuthorizationMethod.CHIP)
+            .setCard("foo")
+            .setCurrency("usd")
+            .setIsAmountControllable(true)
+            .setMerchantData(
+                com.stripe.param.issuing.AuthorizationCreateParams.MerchantData.builder()
+                    .setCategory(
+                        com.stripe.param.issuing.AuthorizationCreateParams.MerchantData.Category
+                            .AC_REFRIGERATION_REPAIR)
+                    .setCity("foo")
+                    .setCountry("bar")
+                    .setName("foo")
+                    .setNetworkId("bar")
+                    .setPostalCode("foo")
+                    .setState("bar")
+                    .setTerminalId("foo")
+                    .build())
+            .setNetworkData(
+                com.stripe.param.issuing.AuthorizationCreateParams.NetworkData.builder()
+                    .setAcquiringInstitutionId("foo")
+                    .build())
+            .setVerificationData(
+                com.stripe.param.issuing.AuthorizationCreateParams.VerificationData.builder()
+                    .setAddressLine1Check(
+                        com.stripe.param.issuing.AuthorizationCreateParams.VerificationData
+                            .AddressLine1Check.MISMATCH)
+                    .setAddressPostalCodeCheck(
+                        com.stripe.param.issuing.AuthorizationCreateParams.VerificationData
+                            .AddressPostalCodeCheck.MATCH)
+                    .setCvcCheck(
+                        com.stripe.param.issuing.AuthorizationCreateParams.VerificationData.CvcCheck
+                            .MATCH)
+                    .setExpiryCheck(
+                        com.stripe.param.issuing.AuthorizationCreateParams.VerificationData
+                            .ExpiryCheck.MISMATCH)
+                    .build())
+            .setWallet(com.stripe.param.issuing.AuthorizationCreateParams.Wallet.APPLE_PAY)
+            .build();
+
+    com.stripe.model.issuing.Authorization authorization =
         client.testHelpers().issuing().authorizations().create(params);
     assertNotNull(authorization);
     verifyRequest(
@@ -12238,6 +19180,30 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTestHelpersIssuingAuthorizationsReversePostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.AuthorizationReverseParams params =
+        com.stripe.param.issuing.AuthorizationReverseParams.builder().setReverseAmount(20L).build();
+
+    com.stripe.model.issuing.Authorization authorization =
+        client
+            .v1()
+            .testHelpers()
+            .issuing()
+            .authorizations()
+            .reverse("example_authorization", params);
+    assertNotNull(authorization);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/issuing/authorizations/example_authorization/reverse",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTestHelpersIssuingAuthorizationsReversePostServicesNonNamespaced()
+      throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.issuing.AuthorizationReverseParams params =
@@ -12279,6 +19245,25 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.issuing.CardDeliverCardParams.builder().build();
 
     com.stripe.model.issuing.Card card =
+        client.v1().testHelpers().issuing().cards().deliverCard("card_123", params);
+    assertNotNull(card);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/issuing/cards/card_123/shipping/deliver",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTestHelpersIssuingCardsShippingDeliverPostServicesNonNamespaced()
+      throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.CardDeliverCardParams params =
+        com.stripe.param.issuing.CardDeliverCardParams.builder().build();
+
+    com.stripe.model.issuing.Card card =
         client.testHelpers().issuing().cards().deliverCard("card_123", params);
     assertNotNull(card);
     verifyRequest(
@@ -12308,6 +19293,25 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTestHelpersIssuingCardsShippingFailPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.CardFailCardParams params =
+        com.stripe.param.issuing.CardFailCardParams.builder().build();
+
+    com.stripe.model.issuing.Card card =
+        client.v1().testHelpers().issuing().cards().failCard("card_123", params);
+    assertNotNull(card);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/issuing/cards/card_123/shipping/fail",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTestHelpersIssuingCardsShippingFailPostServicesNonNamespaced()
+      throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.issuing.CardFailCardParams params =
@@ -12349,6 +19353,25 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.issuing.CardReturnCardParams.builder().build();
 
     com.stripe.model.issuing.Card card =
+        client.v1().testHelpers().issuing().cards().returnCard("card_123", params);
+    assertNotNull(card);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/issuing/cards/card_123/shipping/return",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTestHelpersIssuingCardsShippingReturnPostServicesNonNamespaced()
+      throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.CardReturnCardParams params =
+        com.stripe.param.issuing.CardReturnCardParams.builder().build();
+
+    com.stripe.model.issuing.Card card =
         client.testHelpers().issuing().cards().returnCard("card_123", params);
     assertNotNull(card);
     verifyRequest(
@@ -12378,6 +19401,25 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTestHelpersIssuingCardsShippingShipPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.CardShipCardParams params =
+        com.stripe.param.issuing.CardShipCardParams.builder().build();
+
+    com.stripe.model.issuing.Card card =
+        client.v1().testHelpers().issuing().cards().shipCard("card_123", params);
+    assertNotNull(card);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/issuing/cards/card_123/shipping/ship",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTestHelpersIssuingCardsShippingShipPostServicesNonNamespaced()
+      throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.issuing.CardShipCardParams params =
@@ -12422,6 +19464,25 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.issuing.PersonalizationDesignActivateParams.builder().build();
 
     com.stripe.model.issuing.PersonalizationDesign personalizationDesign =
+        client.v1().testHelpers().issuing().personalizationDesigns().activate("pd_xyz", params);
+    assertNotNull(personalizationDesign);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/issuing/personalization_designs/pd_xyz/activate",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTestHelpersIssuingPersonalizationDesignsActivatePostServicesNonNamespaced()
+      throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.PersonalizationDesignActivateParams params =
+        com.stripe.param.issuing.PersonalizationDesignActivateParams.builder().build();
+
+    com.stripe.model.issuing.PersonalizationDesign personalizationDesign =
         client.testHelpers().issuing().personalizationDesigns().activate("pd_xyz", params);
     assertNotNull(personalizationDesign);
     verifyRequest(
@@ -12453,6 +19514,25 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTestHelpersIssuingPersonalizationDesignsDeactivatePostServices()
+      throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.PersonalizationDesignDeactivateParams params =
+        com.stripe.param.issuing.PersonalizationDesignDeactivateParams.builder().build();
+
+    com.stripe.model.issuing.PersonalizationDesign personalizationDesign =
+        client.v1().testHelpers().issuing().personalizationDesigns().deactivate("pd_xyz", params);
+    assertNotNull(personalizationDesign);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/issuing/personalization_designs/pd_xyz/deactivate",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTestHelpersIssuingPersonalizationDesignsDeactivatePostServicesNonNamespaced()
       throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
@@ -12499,6 +19579,33 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTestHelpersIssuingPersonalizationDesignsRejectPostServices()
+      throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.PersonalizationDesignRejectParams params =
+        com.stripe.param.issuing.PersonalizationDesignRejectParams.builder()
+            .setRejectionReasons(
+                com.stripe.param.issuing.PersonalizationDesignRejectParams.RejectionReasons
+                    .builder()
+                    .addCardLogo(
+                        com.stripe.param.issuing.PersonalizationDesignRejectParams.RejectionReasons
+                            .CardLogo.GEOGRAPHIC_LOCATION)
+                    .build())
+            .build();
+
+    com.stripe.model.issuing.PersonalizationDesign personalizationDesign =
+        client.v1().testHelpers().issuing().personalizationDesigns().reject("pd_xyz", params);
+    assertNotNull(personalizationDesign);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/issuing/personalization_designs/pd_xyz/reject",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTestHelpersIssuingPersonalizationDesignsRejectPostServicesNonNamespaced()
       throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
@@ -12608,6 +19715,91 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTestHelpersIssuingTransactionsCreateForceCapturePostServices()
+      throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.TransactionCreateForceCaptureParams params =
+        com.stripe.param.issuing.TransactionCreateForceCaptureParams.builder()
+            .setAmount(100L)
+            .setCard("foo")
+            .setCurrency("usd")
+            .setMerchantData(
+                com.stripe.param.issuing.TransactionCreateForceCaptureParams.MerchantData.builder()
+                    .setCategory(
+                        com.stripe.param.issuing.TransactionCreateForceCaptureParams.MerchantData
+                            .Category.AC_REFRIGERATION_REPAIR)
+                    .setCity("foo")
+                    .setCountry("US")
+                    .setName("foo")
+                    .setNetworkId("bar")
+                    .setPostalCode("10001")
+                    .setState("NY")
+                    .setTerminalId("foo")
+                    .build())
+            .setPurchaseDetails(
+                com.stripe.param.issuing.TransactionCreateForceCaptureParams.PurchaseDetails
+                    .builder()
+                    .setFlight(
+                        com.stripe.param.issuing.TransactionCreateForceCaptureParams.PurchaseDetails
+                            .Flight.builder()
+                            .setDepartureAt(1633651200L)
+                            .setPassengerName("John Doe")
+                            .setRefundable(true)
+                            .addSegment(
+                                com.stripe.param.issuing.TransactionCreateForceCaptureParams
+                                    .PurchaseDetails.Flight.Segment.builder()
+                                    .setArrivalAirportCode("SFO")
+                                    .setCarrier("Delta")
+                                    .setDepartureAirportCode("LAX")
+                                    .setFlightNumber("DL100")
+                                    .setServiceClass("Economy")
+                                    .setStopoverAllowed(true)
+                                    .build())
+                            .setTravelAgency("Orbitz")
+                            .build())
+                    .setFuel(
+                        com.stripe.param.issuing.TransactionCreateForceCaptureParams.PurchaseDetails
+                            .Fuel.builder()
+                            .setType(
+                                com.stripe.param.issuing.TransactionCreateForceCaptureParams
+                                    .PurchaseDetails.Fuel.Type.DIESEL)
+                            .setUnit(
+                                com.stripe.param.issuing.TransactionCreateForceCaptureParams
+                                    .PurchaseDetails.Fuel.Unit.LITER)
+                            .setUnitCostDecimal(new BigDecimal("3.5"))
+                            .setQuantityDecimal(new BigDecimal("10"))
+                            .build())
+                    .setLodging(
+                        com.stripe.param.issuing.TransactionCreateForceCaptureParams.PurchaseDetails
+                            .Lodging.builder()
+                            .setCheckInAt(1533651200L)
+                            .setNights(2L)
+                            .build())
+                    .addReceipt(
+                        com.stripe.param.issuing.TransactionCreateForceCaptureParams.PurchaseDetails
+                            .Receipt.builder()
+                            .setDescription("Room charge")
+                            .setQuantity(new BigDecimal("1"))
+                            .setTotal(200L)
+                            .setUnitCost(200L)
+                            .build())
+                    .setReference("foo")
+                    .build())
+            .build();
+
+    com.stripe.model.issuing.Transaction transaction =
+        client.v1().testHelpers().issuing().transactions().createForceCapture(params);
+    assertNotNull(transaction);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/issuing/transactions/create_force_capture",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTestHelpersIssuingTransactionsCreateForceCapturePostServicesNonNamespaced()
       throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
@@ -12850,6 +20042,92 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.issuing.Transaction transaction =
+        client.v1().testHelpers().issuing().transactions().createUnlinkedRefund(params);
+    assertNotNull(transaction);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/issuing/transactions/create_unlinked_refund",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTestHelpersIssuingTransactionsCreateUnlinkedRefundPostServicesNonNamespaced()
+      throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.TransactionCreateUnlinkedRefundParams params =
+        com.stripe.param.issuing.TransactionCreateUnlinkedRefundParams.builder()
+            .setAmount(100L)
+            .setCard("foo")
+            .setCurrency("usd")
+            .setMerchantData(
+                com.stripe.param.issuing.TransactionCreateUnlinkedRefundParams.MerchantData
+                    .builder()
+                    .setCategory(
+                        com.stripe.param.issuing.TransactionCreateUnlinkedRefundParams.MerchantData
+                            .Category.AC_REFRIGERATION_REPAIR)
+                    .setCity("foo")
+                    .setCountry("bar")
+                    .setName("foo")
+                    .setNetworkId("bar")
+                    .setPostalCode("foo")
+                    .setState("bar")
+                    .setTerminalId("foo")
+                    .build())
+            .setPurchaseDetails(
+                com.stripe.param.issuing.TransactionCreateUnlinkedRefundParams.PurchaseDetails
+                    .builder()
+                    .setFlight(
+                        com.stripe.param.issuing.TransactionCreateUnlinkedRefundParams
+                            .PurchaseDetails.Flight.builder()
+                            .setDepartureAt(1533651200L)
+                            .setPassengerName("John Doe")
+                            .setRefundable(true)
+                            .addSegment(
+                                com.stripe.param.issuing.TransactionCreateUnlinkedRefundParams
+                                    .PurchaseDetails.Flight.Segment.builder()
+                                    .setArrivalAirportCode("SFO")
+                                    .setCarrier("Delta")
+                                    .setDepartureAirportCode("LAX")
+                                    .setFlightNumber("DL100")
+                                    .setServiceClass("Economy")
+                                    .setStopoverAllowed(true)
+                                    .build())
+                            .setTravelAgency("Orbitz")
+                            .build())
+                    .setFuel(
+                        com.stripe.param.issuing.TransactionCreateUnlinkedRefundParams
+                            .PurchaseDetails.Fuel.builder()
+                            .setType(
+                                com.stripe.param.issuing.TransactionCreateUnlinkedRefundParams
+                                    .PurchaseDetails.Fuel.Type.DIESEL)
+                            .setUnit(
+                                com.stripe.param.issuing.TransactionCreateUnlinkedRefundParams
+                                    .PurchaseDetails.Fuel.Unit.LITER)
+                            .setUnitCostDecimal(new BigDecimal("3.5"))
+                            .setQuantityDecimal(new BigDecimal("10"))
+                            .build())
+                    .setLodging(
+                        com.stripe.param.issuing.TransactionCreateUnlinkedRefundParams
+                            .PurchaseDetails.Lodging.builder()
+                            .setCheckInAt(1533651200L)
+                            .setNights(2L)
+                            .build())
+                    .addReceipt(
+                        com.stripe.param.issuing.TransactionCreateUnlinkedRefundParams
+                            .PurchaseDetails.Receipt.builder()
+                            .setDescription("Room charge")
+                            .setQuantity(new BigDecimal("1"))
+                            .setTotal(200L)
+                            .setUnitCost(200L)
+                            .build())
+                    .setReference("foo")
+                    .build())
+            .build();
+
+    com.stripe.model.issuing.Transaction transaction =
         client.testHelpers().issuing().transactions().createUnlinkedRefund(params);
     assertNotNull(transaction);
     verifyRequest(
@@ -12880,6 +20158,25 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTestHelpersIssuingTransactionsRefundPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.issuing.TransactionRefundParams params =
+        com.stripe.param.issuing.TransactionRefundParams.builder().setRefundAmount(50L).build();
+
+    com.stripe.model.issuing.Transaction transaction =
+        client.v1().testHelpers().issuing().transactions().refund("example_transaction", params);
+    assertNotNull(transaction);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/issuing/transactions/example_transaction/refund",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTestHelpersIssuingTransactionsRefundPostServicesNonNamespaced()
+      throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.issuing.TransactionRefundParams params =
@@ -12919,6 +20216,23 @@ class GeneratedExamples extends BaseStripeTest {
     com.stripe.param.RefundExpireParams params =
         com.stripe.param.RefundExpireParams.builder().build();
 
+    com.stripe.model.Refund refund = client.v1().testHelpers().refunds().expire("re_123", params);
+    assertNotNull(refund);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/refunds/re_123/expire",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTestHelpersRefundsExpirePostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.RefundExpireParams params =
+        com.stripe.param.RefundExpireParams.builder().build();
+
     com.stripe.model.Refund refund = client.testHelpers().refunds().expire("re_123", params);
     assertNotNull(refund);
     verifyRequest(
@@ -12949,6 +20263,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTestHelpersTestClocksAdvancePostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.testhelpers.TestClockAdvanceParams params =
+        com.stripe.param.testhelpers.TestClockAdvanceParams.builder().setFrozenTime(142L).build();
+
+    com.stripe.model.testhelpers.TestClock testClock =
+        client.v1().testHelpers().testClocks().advance("clock_xyz", params);
+    assertNotNull(testClock);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/test_clocks/clock_xyz/advance",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTestHelpersTestClocksAdvancePostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.testhelpers.TestClockAdvanceParams params =
@@ -12995,6 +20327,26 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.testhelpers.TestClock testClock =
+        client.v1().testHelpers().testClocks().advance("clock_xxxxxxxxxxxxx", params);
+    assertNotNull(testClock);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/test_clocks/clock_xxxxxxxxxxxxx/advance",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTestHelpersTestClocksAdvancePost2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.testhelpers.TestClockAdvanceParams params =
+        com.stripe.param.testhelpers.TestClockAdvanceParams.builder()
+            .setFrozenTime(1675552261L)
+            .build();
+
+    com.stripe.model.testhelpers.TestClock testClock =
         client.testHelpers().testClocks().advance("clock_xxxxxxxxxxxxx", params);
     assertNotNull(testClock);
     verifyRequest(
@@ -13025,6 +20377,21 @@ class GeneratedExamples extends BaseStripeTest {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.model.testhelpers.TestClock testClock =
+        client.v1().testHelpers().testClocks().delete("clock_xyz");
+    assertNotNull(testClock);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.DELETE,
+        "/v1/test_helpers/test_clocks/clock_xyz",
+        null,
+        null);
+  }
+
+  @Test
+  public void testTestHelpersTestClocksDeleteServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.model.testhelpers.TestClock testClock =
         client.testHelpers().testClocks().delete("clock_xyz");
     assertNotNull(testClock);
     verifyRequest(
@@ -13052,6 +20419,21 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTestHelpersTestClocksDelete2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.model.testhelpers.TestClock testClock =
+        client.v1().testHelpers().testClocks().delete("clock_xxxxxxxxxxxxx");
+    assertNotNull(testClock);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.DELETE,
+        "/v1/test_helpers/test_clocks/clock_xxxxxxxxxxxxx",
+        null,
+        null);
+  }
+
+  @Test
+  public void testTestHelpersTestClocksDelete2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.model.testhelpers.TestClock testClock =
@@ -13089,6 +20471,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.testhelpers.TestClockListParams.builder().build();
 
     com.stripe.model.StripeCollection<com.stripe.model.testhelpers.TestClock> stripeCollection =
+        client.v1().testHelpers().testClocks().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/test_helpers/test_clocks",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTestHelpersTestClocksGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.testhelpers.TestClockListParams params =
+        com.stripe.param.testhelpers.TestClockListParams.builder().build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.testhelpers.TestClock> stripeCollection =
         client.testHelpers().testClocks().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -13114,6 +20514,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTestHelpersTestClocksGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.testhelpers.TestClockRetrieveParams params =
+        com.stripe.param.testhelpers.TestClockRetrieveParams.builder().build();
+
+    com.stripe.model.testhelpers.TestClock testClock =
+        client.v1().testHelpers().testClocks().retrieve("clock_xyz", params);
+    assertNotNull(testClock);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/test_helpers/test_clocks/clock_xyz",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTestHelpersTestClocksGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.testhelpers.TestClockRetrieveParams params =
@@ -13154,6 +20572,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.testhelpers.TestClockListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.testhelpers.TestClock> stripeCollection =
+        client.v1().testHelpers().testClocks().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/test_helpers/test_clocks",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTestHelpersTestClocksGet3ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.testhelpers.TestClockListParams params =
+        com.stripe.param.testhelpers.TestClockListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.testhelpers.TestClock> stripeCollection =
         client.testHelpers().testClocks().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -13179,6 +20615,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTestHelpersTestClocksGet4Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.testhelpers.TestClockRetrieveParams params =
+        com.stripe.param.testhelpers.TestClockRetrieveParams.builder().build();
+
+    com.stripe.model.testhelpers.TestClock testClock =
+        client.v1().testHelpers().testClocks().retrieve("clock_xxxxxxxxxxxxx", params);
+    assertNotNull(testClock);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/test_helpers/test_clocks/clock_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTestHelpersTestClocksGet4ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.testhelpers.TestClockRetrieveParams params =
@@ -13225,6 +20679,27 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.testhelpers.TestClock testClock =
+        client.v1().testHelpers().testClocks().create(params);
+    assertNotNull(testClock);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/test_clocks",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTestHelpersTestClocksPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.testhelpers.TestClockCreateParams params =
+        com.stripe.param.testhelpers.TestClockCreateParams.builder()
+            .setFrozenTime(123L)
+            .setName("cogsworth")
+            .build();
+
+    com.stripe.model.testhelpers.TestClock testClock =
         client.testHelpers().testClocks().create(params);
     assertNotNull(testClock);
     verifyRequest(
@@ -13255,6 +20730,26 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTestHelpersTestClocksPost2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.testhelpers.TestClockCreateParams params =
+        com.stripe.param.testhelpers.TestClockCreateParams.builder()
+            .setFrozenTime(1577836800L)
+            .build();
+
+    com.stripe.model.testhelpers.TestClock testClock =
+        client.v1().testHelpers().testClocks().create(params);
+    assertNotNull(testClock);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/test_clocks",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTestHelpersTestClocksPost2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.testhelpers.TestClockCreateParams params =
@@ -13314,6 +20809,32 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.treasury.InboundTransfer inboundTransfer =
+        client.v1().testHelpers().treasury().inboundTransfers().fail("ibt_123", params);
+    assertNotNull(inboundTransfer);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/treasury/inbound_transfers/ibt_123/fail",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTestHelpersTreasuryInboundTransfersFailPostServicesNonNamespaced()
+      throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.InboundTransferFailParams params =
+        com.stripe.param.treasury.InboundTransferFailParams.builder()
+            .setFailureDetails(
+                com.stripe.param.treasury.InboundTransferFailParams.FailureDetails.builder()
+                    .setCode(
+                        com.stripe.param.treasury.InboundTransferFailParams.FailureDetails.Code
+                            .ACCOUNT_CLOSED)
+                    .build())
+            .build();
+
+    com.stripe.model.treasury.InboundTransfer inboundTransfer =
         client.testHelpers().treasury().inboundTransfers().fail("ibt_123", params);
     assertNotNull(inboundTransfer);
     verifyRequest(
@@ -13345,6 +20866,30 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTestHelpersTreasuryInboundTransfersReturnPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.InboundTransferReturnInboundTransferParams params =
+        com.stripe.param.treasury.InboundTransferReturnInboundTransferParams.builder().build();
+
+    com.stripe.model.treasury.InboundTransfer inboundTransfer =
+        client
+            .v1()
+            .testHelpers()
+            .treasury()
+            .inboundTransfers()
+            .returnInboundTransfer("ibt_123", params);
+    assertNotNull(inboundTransfer);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/treasury/inbound_transfers/ibt_123/return",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTestHelpersTreasuryInboundTransfersReturnPostServicesNonNamespaced()
+      throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.treasury.InboundTransferReturnInboundTransferParams params =
@@ -13388,6 +20933,25 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.treasury.InboundTransferSucceedParams.builder().build();
 
     com.stripe.model.treasury.InboundTransfer inboundTransfer =
+        client.v1().testHelpers().treasury().inboundTransfers().succeed("ibt_123", params);
+    assertNotNull(inboundTransfer);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/treasury/inbound_transfers/ibt_123/succeed",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTestHelpersTreasuryInboundTransfersSucceedPostServicesNonNamespaced()
+      throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.InboundTransferSucceedParams params =
+        com.stripe.param.treasury.InboundTransferSucceedParams.builder().build();
+
+    com.stripe.model.treasury.InboundTransfer inboundTransfer =
         client.testHelpers().treasury().inboundTransfers().succeed("ibt_123", params);
     assertNotNull(inboundTransfer);
     verifyRequest(
@@ -13425,6 +20989,25 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.treasury.OutboundTransferFailParams.builder().build();
 
     com.stripe.model.treasury.OutboundTransfer outboundTransfer =
+        client.v1().testHelpers().treasury().outboundTransfers().fail("obt_123", params);
+    assertNotNull(outboundTransfer);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/treasury/outbound_transfers/obt_123/fail",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTestHelpersTreasuryOutboundTransfersFailPostServicesNonNamespaced()
+      throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.OutboundTransferFailParams params =
+        com.stripe.param.treasury.OutboundTransferFailParams.builder().build();
+
+    com.stripe.model.treasury.OutboundTransfer outboundTransfer =
         client.testHelpers().treasury().outboundTransfers().fail("obt_123", params);
     assertNotNull(outboundTransfer);
     verifyRequest(
@@ -13456,6 +21039,25 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTestHelpersTreasuryOutboundTransfersPostPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.OutboundTransferPostParams params =
+        com.stripe.param.treasury.OutboundTransferPostParams.builder().build();
+
+    com.stripe.model.treasury.OutboundTransfer outboundTransfer =
+        client.v1().testHelpers().treasury().outboundTransfers().post("obt_123", params);
+    assertNotNull(outboundTransfer);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/treasury/outbound_transfers/obt_123/post",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTestHelpersTreasuryOutboundTransfersPostPostServicesNonNamespaced()
+      throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.treasury.OutboundTransferPostParams params =
@@ -13501,6 +21103,38 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTestHelpersTreasuryOutboundTransfersReturnPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.OutboundTransferReturnOutboundTransferParams params =
+        com.stripe.param.treasury.OutboundTransferReturnOutboundTransferParams.builder()
+            .setReturnedDetails(
+                com.stripe.param.treasury.OutboundTransferReturnOutboundTransferParams
+                    .ReturnedDetails.builder()
+                    .setCode(
+                        com.stripe.param.treasury.OutboundTransferReturnOutboundTransferParams
+                            .ReturnedDetails.Code.ACCOUNT_CLOSED)
+                    .build())
+            .build();
+
+    com.stripe.model.treasury.OutboundTransfer outboundTransfer =
+        client
+            .v1()
+            .testHelpers()
+            .treasury()
+            .outboundTransfers()
+            .returnOutboundTransfer("obt_123", params);
+    assertNotNull(outboundTransfer);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/treasury/outbound_transfers/obt_123/return",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTestHelpersTreasuryOutboundTransfersReturnPostServicesNonNamespaced()
+      throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.treasury.OutboundTransferReturnOutboundTransferParams params =
@@ -13563,6 +21197,30 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.treasury.ReceivedCredit receivedCredit =
+        client.v1().testHelpers().treasury().receivedCredits().create(params);
+    assertNotNull(receivedCredit);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/treasury/received_credits",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTestHelpersTreasuryReceivedCreditsPostServicesNonNamespaced()
+      throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.ReceivedCreditCreateParams params =
+        com.stripe.param.treasury.ReceivedCreditCreateParams.builder()
+            .setFinancialAccount("fa_123")
+            .setNetwork(com.stripe.param.treasury.ReceivedCreditCreateParams.Network.ACH)
+            .setAmount(1234L)
+            .setCurrency("usd")
+            .build();
+
+    com.stripe.model.treasury.ReceivedCredit receivedCredit =
         client.testHelpers().treasury().receivedCredits().create(params);
     assertNotNull(receivedCredit);
     verifyRequest(
@@ -13607,6 +21265,30 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.treasury.ReceivedDebit receivedDebit =
+        client.v1().testHelpers().treasury().receivedDebits().create(params);
+    assertNotNull(receivedDebit);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/test_helpers/treasury/received_debits",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTestHelpersTreasuryReceivedDebitsPostServicesNonNamespaced()
+      throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.ReceivedDebitCreateParams params =
+        com.stripe.param.treasury.ReceivedDebitCreateParams.builder()
+            .setFinancialAccount("fa_123")
+            .setNetwork(com.stripe.param.treasury.ReceivedDebitCreateParams.Network.ACH)
+            .setAmount(1234L)
+            .setCurrency("usd")
+            .build();
+
+    com.stripe.model.treasury.ReceivedDebit receivedDebit =
         client.testHelpers().treasury().receivedDebits().create(params);
     assertNotNull(receivedDebit);
     verifyRequest(
@@ -13627,6 +21309,23 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTokensGetServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.TokenRetrieveParams params =
+        com.stripe.param.TokenRetrieveParams.builder().build();
+
+    com.stripe.model.Token token = client.v1().tokens().retrieve("tok_xxxx", params);
+    assertNotNull(token);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/tokens/tok_xxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTokensGetServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.TokenRetrieveParams params =
@@ -13663,6 +21362,27 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTokensPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.TokenCreateParams params =
+        com.stripe.param.TokenCreateParams.builder()
+            .setCard(
+                com.stripe.param.TokenCreateParams.Card.builder()
+                    .setNumber("4242424242424242")
+                    .setExpMonth("5")
+                    .setExpYear("2023")
+                    .setCvc("314")
+                    .build())
+            .build();
+
+    com.stripe.model.Token token = client.v1().tokens().create(params);
+    assertNotNull(token);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.POST, "/v1/tokens", params.toMap(), null);
+  }
+
+  @Test
+  public void testTokensPostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.TokenCreateParams params =
@@ -13722,6 +21442,30 @@ class GeneratedExamples extends BaseStripeTest {
                     .build())
             .build();
 
+    com.stripe.model.Token token = client.v1().tokens().create(params);
+    assertNotNull(token);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.POST, "/v1/tokens", params.toMap(), null);
+  }
+
+  @Test
+  public void testTokensPost2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.TokenCreateParams params =
+        com.stripe.param.TokenCreateParams.builder()
+            .setBankAccount(
+                com.stripe.param.TokenCreateParams.BankAccount.builder()
+                    .setCountry("US")
+                    .setCurrency("usd")
+                    .setAccountHolderName("Jenny Rosen")
+                    .setAccountHolderType(
+                        com.stripe.param.TokenCreateParams.BankAccount.AccountHolderType.INDIVIDUAL)
+                    .setRoutingNumber("110000000")
+                    .setAccountNumber("000123456789")
+                    .build())
+            .build();
+
     com.stripe.model.Token token = client.tokens().create(params);
     assertNotNull(token);
     verifyRequest(
@@ -13743,6 +21487,22 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTokensPost3Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.TokenCreateParams params =
+        com.stripe.param.TokenCreateParams.builder()
+            .setPii(
+                com.stripe.param.TokenCreateParams.Pii.builder().setIdNumber("000000000").build())
+            .build();
+
+    com.stripe.model.Token token = client.v1().tokens().create(params);
+    assertNotNull(token);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.POST, "/v1/tokens", params.toMap(), null);
+  }
+
+  @Test
+  public void testTokensPost3ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.TokenCreateParams params =
@@ -13780,6 +21540,29 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTokensPost4Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.TokenCreateParams params =
+        com.stripe.param.TokenCreateParams.builder()
+            .setAccount(
+                com.stripe.param.TokenCreateParams.Account.builder()
+                    .setIndividual(
+                        com.stripe.param.TokenCreateParams.Account.Individual.builder()
+                            .setFirstName("Jane")
+                            .setLastName("Doe")
+                            .build())
+                    .setTosShownAndAccepted(true)
+                    .build())
+            .build();
+
+    com.stripe.model.Token token = client.v1().tokens().create(params);
+    assertNotNull(token);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.POST, "/v1/tokens", params.toMap(), null);
+  }
+
+  @Test
+  public void testTokensPost4ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.TokenCreateParams params =
@@ -13837,6 +21620,29 @@ class GeneratedExamples extends BaseStripeTest {
                     .build())
             .build();
 
+    com.stripe.model.Token token = client.v1().tokens().create(params);
+    assertNotNull(token);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.POST, "/v1/tokens", params.toMap(), null);
+  }
+
+  @Test
+  public void testTokensPost5ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.TokenCreateParams params =
+        com.stripe.param.TokenCreateParams.builder()
+            .setPerson(
+                com.stripe.param.TokenCreateParams.Person.builder()
+                    .setFirstName("Jane")
+                    .setLastName("Doe")
+                    .setRelationship(
+                        com.stripe.param.TokenCreateParams.Person.Relationship.builder()
+                            .setOwner(true)
+                            .build())
+                    .build())
+            .build();
+
     com.stripe.model.Token token = client.tokens().create(params);
     assertNotNull(token);
     verifyRequest(
@@ -13858,6 +21664,22 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTokensPost6Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.TokenCreateParams params =
+        com.stripe.param.TokenCreateParams.builder()
+            .setCvcUpdate(
+                com.stripe.param.TokenCreateParams.CvcUpdate.builder().setCvc("123").build())
+            .build();
+
+    com.stripe.model.Token token = client.v1().tokens().create(params);
+    assertNotNull(token);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.POST, "/v1/tokens", params.toMap(), null);
+  }
+
+  @Test
+  public void testTokensPost6ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.TokenCreateParams params =
@@ -13895,6 +21717,23 @@ class GeneratedExamples extends BaseStripeTest {
     com.stripe.param.TopupCancelParams params =
         com.stripe.param.TopupCancelParams.builder().build();
 
+    com.stripe.model.Topup topup = client.v1().topups().cancel("tu_xxxxxxxxxxxxx", params);
+    assertNotNull(topup);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/topups/tu_xxxxxxxxxxxxx/cancel",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTopupsCancelPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.TopupCancelParams params =
+        com.stripe.param.TopupCancelParams.builder().build();
+
     com.stripe.model.Topup topup = client.topups().cancel("tu_xxxxxxxxxxxxx", params);
     assertNotNull(topup);
     verifyRequest(
@@ -13923,6 +21762,20 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.TopupListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.Topup> stripeCollection =
+        client.v1().topups().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/topups", params.toMap(), null);
+  }
+
+  @Test
+  public void testTopupsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.TopupListParams params =
+        com.stripe.param.TopupListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.Topup> stripeCollection =
         client.topups().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -13939,6 +21792,23 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTopupsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.TopupRetrieveParams params =
+        com.stripe.param.TopupRetrieveParams.builder().build();
+
+    com.stripe.model.Topup topup = client.v1().topups().retrieve("tu_xxxxxxxxxxxxx", params);
+    assertNotNull(topup);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/topups/tu_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTopupsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.TopupRetrieveParams params =
@@ -13982,6 +21852,24 @@ class GeneratedExamples extends BaseStripeTest {
             .setStatementDescriptor("Top-up")
             .build();
 
+    com.stripe.model.Topup topup = client.v1().topups().create(params);
+    assertNotNull(topup);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.POST, "/v1/topups", params.toMap(), null);
+  }
+
+  @Test
+  public void testTopupsPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.TopupCreateParams params =
+        com.stripe.param.TopupCreateParams.builder()
+            .setAmount(2000L)
+            .setCurrency("usd")
+            .setDescription("Top-up for Jenny Rosen")
+            .setStatementDescriptor("Top-up")
+            .build();
+
     com.stripe.model.Topup topup = client.topups().create(params);
     assertNotNull(topup);
     verifyRequest(
@@ -14006,6 +21894,23 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTopupsPost2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.TopupUpdateParams params =
+        com.stripe.param.TopupUpdateParams.builder().putMetadata("order_id", "6735").build();
+
+    com.stripe.model.Topup topup = client.v1().topups().update("tu_xxxxxxxxxxxxx", params);
+    assertNotNull(topup);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/topups/tu_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTopupsPost2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.TopupUpdateParams params =
@@ -14039,6 +21944,20 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.TransferListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.Transfer> stripeCollection =
+        client.v1().transfers().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.GET, "/v1/transfers", params.toMap(), null);
+  }
+
+  @Test
+  public void testTransfersGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.TransferListParams params =
+        com.stripe.param.TransferListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.Transfer> stripeCollection =
         client.transfers().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -14059,6 +21978,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTransfersGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.TransferRetrieveParams params =
+        com.stripe.param.TransferRetrieveParams.builder().build();
+
+    com.stripe.model.Transfer transfer =
+        client.v1().transfers().retrieve("tr_xxxxxxxxxxxxx", params);
+    assertNotNull(transfer);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/transfers/tr_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTransfersGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.TransferRetrieveParams params =
@@ -14102,6 +22039,24 @@ class GeneratedExamples extends BaseStripeTest {
             .setTransferGroup("ORDER_95")
             .build();
 
+    com.stripe.model.Transfer transfer = client.v1().transfers().create(params);
+    assertNotNull(transfer);
+    verifyRequest(
+        BaseAddress.API, ApiResource.RequestMethod.POST, "/v1/transfers", params.toMap(), null);
+  }
+
+  @Test
+  public void testTransfersPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.TransferCreateParams params =
+        com.stripe.param.TransferCreateParams.builder()
+            .setAmount(400L)
+            .setCurrency("usd")
+            .setDestination("acct_xxxxxxxxxxxxx")
+            .setTransferGroup("ORDER_95")
+            .build();
+
     com.stripe.model.Transfer transfer = client.transfers().create(params);
     assertNotNull(transfer);
     verifyRequest(
@@ -14127,6 +22082,23 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTransfersPost2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.TransferUpdateParams params =
+        com.stripe.param.TransferUpdateParams.builder().putMetadata("order_id", "6735").build();
+
+    com.stripe.model.Transfer transfer = client.v1().transfers().update("tr_xxxxxxxxxxxxx", params);
+    assertNotNull(transfer);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/transfers/tr_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTransfersPost2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.TransferUpdateParams params =
@@ -14167,6 +22139,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.TransferReversalListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.TransferReversal> stripeCollection =
+        client.v1().transfers().reversals().list("tr_xxxxxxxxxxxxx", params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/transfers/tr_xxxxxxxxxxxxx/reversals",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTransfersReversalsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.TransferReversalListParams params =
+        com.stripe.param.TransferReversalListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.TransferReversal> stripeCollection =
         client.transfers().reversals().list("tr_xxxxxxxxxxxxx", params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -14193,6 +22183,28 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTransfersReversalsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.TransferReversalRetrieveParams params =
+        com.stripe.param.TransferReversalRetrieveParams.builder().build();
+
+    com.stripe.model.TransferReversal transferReversal =
+        client
+            .v1()
+            .transfers()
+            .reversals()
+            .retrieve("tr_xxxxxxxxxxxxx", "trr_xxxxxxxxxxxxx", params);
+    assertNotNull(transferReversal);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/transfers/tr_xxxxxxxxxxxxx/reversals/trr_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTransfersReversalsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.TransferReversalRetrieveParams params =
@@ -14234,6 +22246,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.TransferReversalCreateParams.builder().setAmount(100L).build();
 
     com.stripe.model.TransferReversal transferReversal =
+        client.v1().transfers().reversals().create("tr_xxxxxxxxxxxxx", params);
+    assertNotNull(transferReversal);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/transfers/tr_xxxxxxxxxxxxx/reversals",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTransfersReversalsPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.TransferReversalCreateParams params =
+        com.stripe.param.TransferReversalCreateParams.builder().setAmount(100L).build();
+
+    com.stripe.model.TransferReversal transferReversal =
         client.transfers().reversals().create("tr_xxxxxxxxxxxxx", params);
     assertNotNull(transferReversal);
     verifyRequest(
@@ -14265,6 +22295,26 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTransfersReversalsPost2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.TransferReversalUpdateParams params =
+        com.stripe.param.TransferReversalUpdateParams.builder()
+            .putMetadata("order_id", "6735")
+            .build();
+
+    com.stripe.model.TransferReversal transferReversal =
+        client.v1().transfers().reversals().update("tr_xxxxxxxxxxxxx", "trr_xxxxxxxxxxxxx", params);
+    assertNotNull(transferReversal);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/transfers/tr_xxxxxxxxxxxxx/reversals/trr_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTransfersReversalsPost2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.TransferReversalUpdateParams params =
@@ -14313,6 +22363,27 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.StripeCollection<com.stripe.model.treasury.CreditReversal> stripeCollection =
+        client.v1().treasury().creditReversals().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/treasury/credit_reversals",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTreasuryCreditReversalsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.CreditReversalListParams params =
+        com.stripe.param.treasury.CreditReversalListParams.builder()
+            .setFinancialAccount("fa_xxxxxxxxxxxxx")
+            .setLimit(3L)
+            .build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.treasury.CreditReversal> stripeCollection =
         client.treasury().creditReversals().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -14338,6 +22409,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTreasuryCreditReversalsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.CreditReversalRetrieveParams params =
+        com.stripe.param.treasury.CreditReversalRetrieveParams.builder().build();
+
+    com.stripe.model.treasury.CreditReversal creditReversal =
+        client.v1().treasury().creditReversals().retrieve("credrev_xxxxxxxxxxxxx", params);
+    assertNotNull(creditReversal);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/treasury/credit_reversals/credrev_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTreasuryCreditReversalsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.treasury.CreditReversalRetrieveParams params =
@@ -14374,6 +22463,26 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTreasuryCreditReversalsPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.CreditReversalCreateParams params =
+        com.stripe.param.treasury.CreditReversalCreateParams.builder()
+            .setReceivedCredit("rc_xxxxxxxxxxxxx")
+            .build();
+
+    com.stripe.model.treasury.CreditReversal creditReversal =
+        client.v1().treasury().creditReversals().create(params);
+    assertNotNull(creditReversal);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/treasury/credit_reversals",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTreasuryCreditReversalsPostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.treasury.CreditReversalCreateParams params =
@@ -14422,6 +22531,27 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.StripeCollection<com.stripe.model.treasury.DebitReversal> stripeCollection =
+        client.v1().treasury().debitReversals().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/treasury/debit_reversals",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTreasuryDebitReversalsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.DebitReversalListParams params =
+        com.stripe.param.treasury.DebitReversalListParams.builder()
+            .setFinancialAccount("fa_xxxxxxxxxxxxx")
+            .setLimit(3L)
+            .build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.treasury.DebitReversal> stripeCollection =
         client.treasury().debitReversals().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -14447,6 +22577,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTreasuryDebitReversalsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.DebitReversalRetrieveParams params =
+        com.stripe.param.treasury.DebitReversalRetrieveParams.builder().build();
+
+    com.stripe.model.treasury.DebitReversal debitReversal =
+        client.v1().treasury().debitReversals().retrieve("debrev_xxxxxxxxxxxxx", params);
+    assertNotNull(debitReversal);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/treasury/debit_reversals/debrev_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTreasuryDebitReversalsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.treasury.DebitReversalRetrieveParams params =
@@ -14483,6 +22631,26 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTreasuryDebitReversalsPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.DebitReversalCreateParams params =
+        com.stripe.param.treasury.DebitReversalCreateParams.builder()
+            .setReceivedDebit("rd_xxxxxxxxxxxxx")
+            .build();
+
+    com.stripe.model.treasury.DebitReversal debitReversal =
+        client.v1().treasury().debitReversals().create(params);
+    assertNotNull(debitReversal);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/treasury/debit_reversals",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTreasuryDebitReversalsPostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.treasury.DebitReversalCreateParams params =
@@ -14528,6 +22696,25 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.treasury.FinancialAccountFeaturesRetrieveParams.builder().build();
 
     com.stripe.model.treasury.FinancialAccountFeatures financialAccountFeatures =
+        client.v1().treasury().financialAccounts().features().retrieve("fa_xxxxxxxxxxxxx", params);
+    assertNotNull(financialAccountFeatures);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/treasury/financial_accounts/fa_xxxxxxxxxxxxx/features",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTreasuryFinancialAccountsFeaturesGetServicesNonNamespaced()
+      throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.FinancialAccountFeaturesRetrieveParams params =
+        com.stripe.param.treasury.FinancialAccountFeaturesRetrieveParams.builder().build();
+
+    com.stripe.model.treasury.FinancialAccountFeatures financialAccountFeatures =
         client.treasury().financialAccounts().features().retrieve("fa_xxxxxxxxxxxxx", params);
     assertNotNull(financialAccountFeatures);
     verifyRequest(
@@ -14562,6 +22749,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.treasury.FinancialAccountListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.treasury.FinancialAccount> stripeCollection =
+        client.v1().treasury().financialAccounts().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/treasury/financial_accounts",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTreasuryFinancialAccountsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.FinancialAccountListParams params =
+        com.stripe.param.treasury.FinancialAccountListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.treasury.FinancialAccount> stripeCollection =
         client.treasury().financialAccounts().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -14587,6 +22792,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTreasuryFinancialAccountsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.FinancialAccountRetrieveParams params =
+        com.stripe.param.treasury.FinancialAccountRetrieveParams.builder().build();
+
+    com.stripe.model.treasury.FinancialAccount financialAccount =
+        client.v1().treasury().financialAccounts().retrieve("fa_xxxxxxxxxxxxx", params);
+    assertNotNull(financialAccount);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/treasury/financial_accounts/fa_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTreasuryFinancialAccountsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.treasury.FinancialAccountRetrieveParams params =
@@ -14625,6 +22848,28 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTreasuryFinancialAccountsPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.FinancialAccountCreateParams params =
+        com.stripe.param.treasury.FinancialAccountCreateParams.builder()
+            .addSupportedCurrency("usd")
+            .setFeatures(
+                com.stripe.param.treasury.FinancialAccountCreateParams.Features.builder().build())
+            .build();
+
+    com.stripe.model.treasury.FinancialAccount financialAccount =
+        client.v1().treasury().financialAccounts().create(params);
+    assertNotNull(financialAccount);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/treasury/financial_accounts",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTreasuryFinancialAccountsPostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.treasury.FinancialAccountCreateParams params =
@@ -14675,6 +22920,26 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.treasury.FinancialAccount financialAccount =
+        client.v1().treasury().financialAccounts().update("fa_xxxxxxxxxxxxx", params);
+    assertNotNull(financialAccount);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/treasury/financial_accounts/fa_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTreasuryFinancialAccountsPost2ServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.FinancialAccountUpdateParams params =
+        com.stripe.param.treasury.FinancialAccountUpdateParams.builder()
+            .putMetadata("order_id", "6735")
+            .build();
+
+    com.stripe.model.treasury.FinancialAccount financialAccount =
         client.treasury().financialAccounts().update("fa_xxxxxxxxxxxxx", params);
     assertNotNull(financialAccount);
     verifyRequest(
@@ -14705,6 +22970,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTreasuryInboundTransfersCancelPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.InboundTransferCancelParams params =
+        com.stripe.param.treasury.InboundTransferCancelParams.builder().build();
+
+    com.stripe.model.treasury.InboundTransfer inboundTransfer =
+        client.v1().treasury().inboundTransfers().cancel("ibt_xxxxxxxxxxxxx", params);
+    assertNotNull(inboundTransfer);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/treasury/inbound_transfers/ibt_xxxxxxxxxxxxx/cancel",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTreasuryInboundTransfersCancelPostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.treasury.InboundTransferCancelParams params =
@@ -14751,6 +23034,27 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.StripeCollection<com.stripe.model.treasury.InboundTransfer> stripeCollection =
+        client.v1().treasury().inboundTransfers().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/treasury/inbound_transfers",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTreasuryInboundTransfersGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.InboundTransferListParams params =
+        com.stripe.param.treasury.InboundTransferListParams.builder()
+            .setFinancialAccount("fa_xxxxxxxxxxxxx")
+            .setLimit(3L)
+            .build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.treasury.InboundTransfer> stripeCollection =
         client.treasury().inboundTransfers().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -14776,6 +23080,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTreasuryInboundTransfersGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.InboundTransferRetrieveParams params =
+        com.stripe.param.treasury.InboundTransferRetrieveParams.builder().build();
+
+    com.stripe.model.treasury.InboundTransfer inboundTransfer =
+        client.v1().treasury().inboundTransfers().retrieve("ibt_xxxxxxxxxxxxx", params);
+    assertNotNull(inboundTransfer);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/treasury/inbound_transfers/ibt_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTreasuryInboundTransfersGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.treasury.InboundTransferRetrieveParams params =
@@ -14828,6 +23150,30 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.treasury.InboundTransfer inboundTransfer =
+        client.v1().treasury().inboundTransfers().create(params);
+    assertNotNull(inboundTransfer);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/treasury/inbound_transfers",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTreasuryInboundTransfersPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.InboundTransferCreateParams params =
+        com.stripe.param.treasury.InboundTransferCreateParams.builder()
+            .setFinancialAccount("fa_xxxxxxxxxxxxx")
+            .setAmount(10000L)
+            .setCurrency("usd")
+            .setOriginPaymentMethod("pm_xxxxxxxxxxxxx")
+            .setDescription("InboundTransfer from my bank account")
+            .build();
+
+    com.stripe.model.treasury.InboundTransfer inboundTransfer =
         client.treasury().inboundTransfers().create(params);
     assertNotNull(inboundTransfer);
     verifyRequest(
@@ -14858,6 +23204,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTreasuryOutboundPaymentsCancelPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.OutboundPaymentCancelParams params =
+        com.stripe.param.treasury.OutboundPaymentCancelParams.builder().build();
+
+    com.stripe.model.treasury.OutboundPayment outboundPayment =
+        client.v1().treasury().outboundPayments().cancel("bot_xxxxxxxxxxxxx", params);
+    assertNotNull(outboundPayment);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/treasury/outbound_payments/bot_xxxxxxxxxxxxx/cancel",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTreasuryOutboundPaymentsCancelPostServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.treasury.OutboundPaymentCancelParams params =
@@ -14904,6 +23268,27 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.StripeCollection<com.stripe.model.treasury.OutboundPayment> stripeCollection =
+        client.v1().treasury().outboundPayments().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/treasury/outbound_payments",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTreasuryOutboundPaymentsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.OutboundPaymentListParams params =
+        com.stripe.param.treasury.OutboundPaymentListParams.builder()
+            .setFinancialAccount("fa_xxxxxxxxxxxxx")
+            .setLimit(3L)
+            .build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.treasury.OutboundPayment> stripeCollection =
         client.treasury().outboundPayments().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -14929,6 +23314,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTreasuryOutboundPaymentsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.OutboundPaymentRetrieveParams params =
+        com.stripe.param.treasury.OutboundPaymentRetrieveParams.builder().build();
+
+    com.stripe.model.treasury.OutboundPayment outboundPayment =
+        client.v1().treasury().outboundPayments().retrieve("bot_xxxxxxxxxxxxx", params);
+    assertNotNull(outboundPayment);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/treasury/outbound_payments/bot_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTreasuryOutboundPaymentsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.treasury.OutboundPaymentRetrieveParams params =
@@ -14983,6 +23386,31 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.treasury.OutboundPayment outboundPayment =
+        client.v1().treasury().outboundPayments().create(params);
+    assertNotNull(outboundPayment);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/treasury/outbound_payments",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTreasuryOutboundPaymentsPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.OutboundPaymentCreateParams params =
+        com.stripe.param.treasury.OutboundPaymentCreateParams.builder()
+            .setFinancialAccount("fa_xxxxxxxxxxxxx")
+            .setAmount(10000L)
+            .setCurrency("usd")
+            .setCustomer("cus_xxxxxxxxxxxxx")
+            .setDestinationPaymentMethod("pm_xxxxxxxxxxxxx")
+            .setDescription("OutboundPayment to a 3rd party")
+            .build();
+
+    com.stripe.model.treasury.OutboundPayment outboundPayment =
         client.treasury().outboundPayments().create(params);
     assertNotNull(outboundPayment);
     verifyRequest(
@@ -15013,6 +23441,25 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTreasuryOutboundTransfersCancelPostServices() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.OutboundTransferCancelParams params =
+        com.stripe.param.treasury.OutboundTransferCancelParams.builder().build();
+
+    com.stripe.model.treasury.OutboundTransfer outboundTransfer =
+        client.v1().treasury().outboundTransfers().cancel("obt_xxxxxxxxxxxxx", params);
+    assertNotNull(outboundTransfer);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/treasury/outbound_transfers/obt_xxxxxxxxxxxxx/cancel",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTreasuryOutboundTransfersCancelPostServicesNonNamespaced()
+      throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.treasury.OutboundTransferCancelParams params =
@@ -15059,6 +23506,27 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.StripeCollection<com.stripe.model.treasury.OutboundTransfer> stripeCollection =
+        client.v1().treasury().outboundTransfers().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/treasury/outbound_transfers",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTreasuryOutboundTransfersGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.OutboundTransferListParams params =
+        com.stripe.param.treasury.OutboundTransferListParams.builder()
+            .setFinancialAccount("fa_xxxxxxxxxxxxx")
+            .setLimit(3L)
+            .build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.treasury.OutboundTransfer> stripeCollection =
         client.treasury().outboundTransfers().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -15084,6 +23552,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTreasuryOutboundTransfersGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.OutboundTransferRetrieveParams params =
+        com.stripe.param.treasury.OutboundTransferRetrieveParams.builder().build();
+
+    com.stripe.model.treasury.OutboundTransfer outboundTransfer =
+        client.v1().treasury().outboundTransfers().retrieve("obt_xxxxxxxxxxxxx", params);
+    assertNotNull(outboundTransfer);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/treasury/outbound_transfers/obt_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTreasuryOutboundTransfersGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.treasury.OutboundTransferRetrieveParams params =
@@ -15136,6 +23622,30 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.treasury.OutboundTransfer outboundTransfer =
+        client.v1().treasury().outboundTransfers().create(params);
+    assertNotNull(outboundTransfer);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/treasury/outbound_transfers",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTreasuryOutboundTransfersPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.OutboundTransferCreateParams params =
+        com.stripe.param.treasury.OutboundTransferCreateParams.builder()
+            .setFinancialAccount("fa_xxxxxxxxxxxxx")
+            .setDestinationPaymentMethod("pm_xxxxxxxxxxxxx")
+            .setAmount(500L)
+            .setCurrency("usd")
+            .setDescription("OutboundTransfer to my external bank account")
+            .build();
+
+    com.stripe.model.treasury.OutboundTransfer outboundTransfer =
         client.treasury().outboundTransfers().create(params);
     assertNotNull(outboundTransfer);
     verifyRequest(
@@ -15176,6 +23686,27 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.StripeCollection<com.stripe.model.treasury.ReceivedCredit> stripeCollection =
+        client.v1().treasury().receivedCredits().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/treasury/received_credits",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTreasuryReceivedCreditsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.ReceivedCreditListParams params =
+        com.stripe.param.treasury.ReceivedCreditListParams.builder()
+            .setFinancialAccount("fa_xxxxxxxxxxxxx")
+            .setLimit(3L)
+            .build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.treasury.ReceivedCredit> stripeCollection =
         client.treasury().receivedCredits().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -15201,6 +23732,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTreasuryReceivedCreditsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.ReceivedCreditRetrieveParams params =
+        com.stripe.param.treasury.ReceivedCreditRetrieveParams.builder().build();
+
+    com.stripe.model.treasury.ReceivedCredit receivedCredit =
+        client.v1().treasury().receivedCredits().retrieve("rc_xxxxxxxxxxxxx", params);
+    assertNotNull(receivedCredit);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/treasury/received_credits/rc_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTreasuryReceivedCreditsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.treasury.ReceivedCreditRetrieveParams params =
@@ -15247,6 +23796,27 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.StripeCollection<com.stripe.model.treasury.ReceivedDebit> stripeCollection =
+        client.v1().treasury().receivedDebits().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/treasury/received_debits",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTreasuryReceivedDebitsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.ReceivedDebitListParams params =
+        com.stripe.param.treasury.ReceivedDebitListParams.builder()
+            .setFinancialAccount("fa_xxxxxxxxxxxxx")
+            .setLimit(3L)
+            .build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.treasury.ReceivedDebit> stripeCollection =
         client.treasury().receivedDebits().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -15272,6 +23842,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTreasuryReceivedDebitsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.ReceivedDebitRetrieveParams params =
+        com.stripe.param.treasury.ReceivedDebitRetrieveParams.builder().build();
+
+    com.stripe.model.treasury.ReceivedDebit receivedDebit =
+        client.v1().treasury().receivedDebits().retrieve("rd_xxxxxxxxxxxxx", params);
+    assertNotNull(receivedDebit);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/treasury/received_debits/rd_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTreasuryReceivedDebitsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.treasury.ReceivedDebitRetrieveParams params =
@@ -15318,6 +23906,27 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.StripeCollection<com.stripe.model.treasury.TransactionEntry> stripeCollection =
+        client.v1().treasury().transactionEntries().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/treasury/transaction_entries",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTreasuryTransactionEntriesGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.TransactionEntryListParams params =
+        com.stripe.param.treasury.TransactionEntryListParams.builder()
+            .setFinancialAccount("fa_xxxxxxxxxxxxx")
+            .setLimit(3L)
+            .build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.treasury.TransactionEntry> stripeCollection =
         client.treasury().transactionEntries().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -15343,6 +23952,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTreasuryTransactionEntriesGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.TransactionEntryRetrieveParams params =
+        com.stripe.param.treasury.TransactionEntryRetrieveParams.builder().build();
+
+    com.stripe.model.treasury.TransactionEntry transactionEntry =
+        client.v1().treasury().transactionEntries().retrieve("trxne_xxxxxxxxxxxxx", params);
+    assertNotNull(transactionEntry);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/treasury/transaction_entries/trxne_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTreasuryTransactionEntriesGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.treasury.TransactionEntryRetrieveParams params =
@@ -15389,6 +24016,27 @@ class GeneratedExamples extends BaseStripeTest {
             .build();
 
     com.stripe.model.StripeCollection<com.stripe.model.treasury.Transaction> stripeCollection =
+        client.v1().treasury().transactions().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/treasury/transactions",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTreasuryTransactionsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.TransactionListParams params =
+        com.stripe.param.treasury.TransactionListParams.builder()
+            .setFinancialAccount("fa_xxxxxxxxxxxxx")
+            .setLimit(3L)
+            .build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.treasury.Transaction> stripeCollection =
         client.treasury().transactions().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -15414,6 +24062,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testTreasuryTransactionsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.treasury.TransactionRetrieveParams params =
+        com.stripe.param.treasury.TransactionRetrieveParams.builder().build();
+
+    com.stripe.model.treasury.Transaction transaction =
+        client.v1().treasury().transactions().retrieve("trxn_xxxxxxxxxxxxx", params);
+    assertNotNull(transaction);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/treasury/transactions/trxn_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testTreasuryTransactionsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.treasury.TransactionRetrieveParams params =
@@ -15449,6 +24115,21 @@ class GeneratedExamples extends BaseStripeTest {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.model.WebhookEndpoint webhookEndpoint =
+        client.v1().webhookEndpoints().delete("we_xxxxxxxxxxxxx");
+    assertNotNull(webhookEndpoint);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.DELETE,
+        "/v1/webhook_endpoints/we_xxxxxxxxxxxxx",
+        null,
+        null);
+  }
+
+  @Test
+  public void testWebhookEndpointsDeleteServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.model.WebhookEndpoint webhookEndpoint =
         client.webhookEndpoints().delete("we_xxxxxxxxxxxxx");
     assertNotNull(webhookEndpoint);
     verifyRequest(
@@ -15481,6 +24162,24 @@ class GeneratedExamples extends BaseStripeTest {
         com.stripe.param.WebhookEndpointListParams.builder().setLimit(3L).build();
 
     com.stripe.model.StripeCollection<com.stripe.model.WebhookEndpoint> stripeCollection =
+        client.v1().webhookEndpoints().list(params);
+    assertNotNull(stripeCollection);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/webhook_endpoints",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testWebhookEndpointsGetServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.WebhookEndpointListParams params =
+        com.stripe.param.WebhookEndpointListParams.builder().setLimit(3L).build();
+
+    com.stripe.model.StripeCollection<com.stripe.model.WebhookEndpoint> stripeCollection =
         client.webhookEndpoints().list(params);
     assertNotNull(stripeCollection);
     verifyRequest(
@@ -15505,6 +24204,24 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testWebhookEndpointsGet2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.WebhookEndpointRetrieveParams params =
+        com.stripe.param.WebhookEndpointRetrieveParams.builder().build();
+
+    com.stripe.model.WebhookEndpoint webhookEndpoint =
+        client.v1().webhookEndpoints().retrieve("we_xxxxxxxxxxxxx", params);
+    assertNotNull(webhookEndpoint);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.GET,
+        "/v1/webhook_endpoints/we_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testWebhookEndpointsGet2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.WebhookEndpointRetrieveParams params =
@@ -15553,6 +24270,30 @@ class GeneratedExamples extends BaseStripeTest {
                 com.stripe.param.WebhookEndpointCreateParams.EnabledEvent.CHARGE__SUCCEEDED)
             .build();
 
+    com.stripe.model.WebhookEndpoint webhookEndpoint =
+        client.v1().webhookEndpoints().create(params);
+    assertNotNull(webhookEndpoint);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/webhook_endpoints",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testWebhookEndpointsPostServicesNonNamespaced() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.WebhookEndpointCreateParams params =
+        com.stripe.param.WebhookEndpointCreateParams.builder()
+            .setUrl("https://example.com/my/webhook/endpoint")
+            .addEnabledEvent(
+                com.stripe.param.WebhookEndpointCreateParams.EnabledEvent.CHARGE__FAILED)
+            .addEnabledEvent(
+                com.stripe.param.WebhookEndpointCreateParams.EnabledEvent.CHARGE__SUCCEEDED)
+            .build();
+
     com.stripe.model.WebhookEndpoint webhookEndpoint = client.webhookEndpoints().create(params);
     assertNotNull(webhookEndpoint);
     verifyRequest(
@@ -15582,6 +24323,26 @@ class GeneratedExamples extends BaseStripeTest {
 
   @Test
   public void testWebhookEndpointsPost2Services() throws StripeException {
+    StripeClient client = new StripeClient(networkSpy);
+
+    com.stripe.param.WebhookEndpointUpdateParams params =
+        com.stripe.param.WebhookEndpointUpdateParams.builder()
+            .setUrl("https://example.com/new_endpoint")
+            .build();
+
+    com.stripe.model.WebhookEndpoint webhookEndpoint =
+        client.v1().webhookEndpoints().update("we_xxxxxxxxxxxxx", params);
+    assertNotNull(webhookEndpoint);
+    verifyRequest(
+        BaseAddress.API,
+        ApiResource.RequestMethod.POST,
+        "/v1/webhook_endpoints/we_xxxxxxxxxxxxx",
+        params.toMap(),
+        null);
+  }
+
+  @Test
+  public void testWebhookEndpointsPost2ServicesNonNamespaced() throws StripeException {
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.WebhookEndpointUpdateParams params =
@@ -15674,7 +24435,7 @@ class GeneratedExamples extends BaseStripeTest {
                 com.stripe.param.v2.billing.MeterEventStreamCreateParams.Event.builder()
                     .setEventName("event_name")
                     .setIdentifier("identifier")
-                    .putPayload("undefined", "payload")
+                    .putPayload("key", "payload")
                     .setTimestamp(Instant.parse("1970-01-01T15:18:46.294Z"))
                     .build())
             .build();
@@ -15697,13 +24458,13 @@ class GeneratedExamples extends BaseStripeTest {
         null,
         null,
         com.stripe.model.v2.billing.MeterEvent.class,
-        "{\"created\":\"1970-01-12T21:42:34.472Z\",\"event_name\":\"event_name\",\"identifier\":\"identifier\",\"object\":\"v2.billing.meter_event\",\"payload\":{\"undefined\":\"payload\"},\"timestamp\":\"1970-01-01T15:18:46.294Z\",\"livemode\":true}");
+        "{\"created\":\"1970-01-12T21:42:34.472Z\",\"event_name\":\"event_name\",\"identifier\":\"identifier\",\"object\":\"v2.billing.meter_event\",\"payload\":{\"key\":\"payload\"},\"timestamp\":\"1970-01-01T15:18:46.294Z\",\"livemode\":true}");
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.param.v2.billing.MeterEventCreateParams params =
         com.stripe.param.v2.billing.MeterEventCreateParams.builder()
             .setEventName("event_name")
-            .putPayload("undefined", "payload")
+            .putPayload("key", "payload")
             .build();
 
     com.stripe.model.v2.billing.MeterEvent meterEvent =
@@ -15978,7 +24739,7 @@ class GeneratedExamples extends BaseStripeTest {
             .addEvent(
                 com.stripe.param.v2.billing.MeterEventStreamCreateParams.Event.builder()
                     .setEventName("event_name")
-                    .putPayload("undefined", "payload")
+                    .putPayload("key", "payload")
                     .build())
             .build();
 


### PR DESCRIPTION
### What?
We are introducing a V1 namespace to improve code organization in Stripe SDKs.

## Changelog
- Introduced V1 service in StripeClient. All the existing V1 StripeClient services(eg. customers, products) are copied under the new V1 service. Service accessors living directly under StripeClient will be marked as deprecated in the next major release and will be removed in a future release. Eg.
```diff
StripeClient client = new StripeClient("sk_test...")

# Accessing V1 Stripe services on a StripeClient should be through the V1 namespace
- client.customers().list() 
+ client.v1().customers().list()
```
Refer to the [migration guide](https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient) for help upgrading. 
