### PR TITLE
Fix type bounds on request

### DIFF
--- a/src/main/java/com/stripe/net/ApiService.java
+++ b/src/main/java/com/stripe/net/ApiService.java
@@ -1,7 +1,7 @@
 package com.stripe.net;
 
 import com.stripe.exception.StripeException;
-import com.stripe.model.StripeObjectInterface;
+import com.stripe.model.StripeObject;
 import java.io.InputStream;
 import java.lang.reflect.Type;
 import lombok.AccessLevel;
@@ -17,7 +17,7 @@ public abstract class ApiService {
   }
 
   @SuppressWarnings("TypeParameterUnusedInFormals")
-  protected <T extends StripeObjectInterface> T request(ApiRequest request, Type typeToken)
+  protected <T extends StripeObject> T request(ApiRequest request, Type typeToken)
       throws StripeException {
     return this.getResponseGetter().request(request.addUsage("stripe_client"), typeToken);
   }

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -118,7 +118,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 
   @Override
   @SuppressWarnings({"TypeParameterUnusedInFormals", "unchecked"})
-  public <T extends StripeObjectInterface> T request(ApiRequest apiRequest, Type typeToken)
+  public <T extends StripeObject> T request(ApiRequest apiRequest, Type typeToken)
       throws StripeException {
 
     RequestOptions mergedOptions = RequestOptions.merge(this.options, apiRequest.getOptions());
@@ -230,7 +230,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
 
   @Override
   @SuppressWarnings({"TypeParameterUnusedInFormals", "deprecation"})
-  public <T extends StripeObjectInterface> T request(
+  public <T extends StripeObject> T request(
       BaseAddress baseAddress,
       ApiResource.RequestMethod method,
       String path,

--- a/src/main/java/com/stripe/net/StripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/StripeResponseGetter.java
@@ -1,7 +1,7 @@
 package com.stripe.net;
 
 import com.stripe.exception.StripeException;
-import com.stripe.model.StripeObjectInterface;
+import com.stripe.model.StripeObject;
 import java.io.InputStream;
 import java.lang.reflect.Type;
 import java.util.Map;
@@ -10,7 +10,7 @@ public interface StripeResponseGetter {
   /** @deprecated Use {@link #request(ApiRequest, Type)} instead. */
   @SuppressWarnings("TypeParameterUnusedInFormals")
   @Deprecated
-  <T extends StripeObjectInterface> T request(
+  <T extends StripeObject> T request(
       BaseAddress baseAddress,
       ApiResource.RequestMethod method,
       String path,
@@ -21,7 +21,7 @@ public interface StripeResponseGetter {
       throws StripeException;
 
   @SuppressWarnings("TypeParameterUnusedInFormals")
-  default <T extends StripeObjectInterface> T request(ApiRequest request, Type typeToken)
+  default <T extends StripeObject> T request(ApiRequest request, Type typeToken)
       throws StripeException {
     return request(
         request.getBaseAddress(),

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -216,8 +216,8 @@ public class BaseStripeTest {
   }
 
   @SuppressWarnings("AssertionFailureIgnored")
-  public static <T extends StripeObject> void verifyRequest(
-      Consumer<ApiRequest> assertOnApiRequest) throws StripeException {
+  public static <T extends StripeObject> void verifyRequest(Consumer<ApiRequest> assertOnApiRequest)
+      throws StripeException {
 
     ArgumentCaptor<ApiRequest> requestCaptor = ArgumentCaptor.forClass(ApiRequest.class);
     List<AssertionError> exceptions = new ArrayList<AssertionError>();
@@ -380,8 +380,8 @@ public class BaseStripeTest {
   }
 
   /** Stubs an OAuth API request. stripe-mock does not supported OAuth endpoints at this time. */
-  public static <T extends StripeObject> void stubOAuthRequest(
-      Class<T> clazz, String response) throws StripeException {
+  public static <T extends StripeObject> void stubOAuthRequest(Class<T> clazz, String response)
+      throws StripeException {
     Mockito.doReturn(ApiResource.GSON.fromJson(response, clazz))
         .when(networkSpy)
         .request(Mockito.any(ApiRequest.class), Mockito.<Type>any());

--- a/src/test/java/com/stripe/BaseStripeTest.java
+++ b/src/test/java/com/stripe/BaseStripeTest.java
@@ -7,7 +7,7 @@ import static org.mockito.Mockito.reset;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.stripe.exception.StripeException;
-import com.stripe.model.StripeObjectInterface;
+import com.stripe.model.StripeObject;
 import com.stripe.net.*;
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
@@ -173,7 +173,7 @@ public class BaseStripeTest {
     verifyRequest(method, path, params, null);
   }
 
-  public static <T extends StripeObjectInterface> void verifyRequest(
+  public static <T extends StripeObject> void verifyRequest(
       ApiResource.RequestMethod method,
       String path,
       Map<String, Object> params,
@@ -190,7 +190,7 @@ public class BaseStripeTest {
    * @param options request options. If null, the options are not checked.
    */
   @SuppressWarnings("AssertionFailureIgnored")
-  public static <T extends StripeObjectInterface> void verifyRequest(
+  public static <T extends StripeObject> void verifyRequest(
       BaseAddress baseAddress,
       ApiResource.RequestMethod method,
       String path,
@@ -216,7 +216,7 @@ public class BaseStripeTest {
   }
 
   @SuppressWarnings("AssertionFailureIgnored")
-  public static <T extends StripeObjectInterface> void verifyRequest(
+  public static <T extends StripeObject> void verifyRequest(
       Consumer<ApiRequest> assertOnApiRequest) throws StripeException {
 
     ArgumentCaptor<ApiRequest> requestCaptor = ArgumentCaptor.forClass(ApiRequest.class);
@@ -249,7 +249,7 @@ public class BaseStripeTest {
   }
 
   @SuppressWarnings("AssertionFailureIgnored")
-  public static <T extends StripeObjectInterface> void verifyStripeRequest(
+  public static <T extends StripeObject> void verifyStripeRequest(
       Consumer<StripeRequest> assertOnStripeRequest) throws StripeException {
 
     ArgumentCaptor<StripeRequest> requestCaptor = ArgumentCaptor.forClass(StripeRequest.class);
@@ -292,7 +292,7 @@ public class BaseStripeTest {
    * @see BaseStripeTest#stubRequest(ApiResource.RequestMethod, String, Map, RequestOptions, Class,
    *     String)
    */
-  public static <T extends StripeObjectInterface> void stubRequest(
+  public static <T extends StripeObject> void stubRequest(
       ApiResource.RequestMethod method, String path, Type typeToken, String response)
       throws StripeException {
     stubRequest(BaseAddress.API, method, path, null, null, typeToken, response);
@@ -304,7 +304,7 @@ public class BaseStripeTest {
    * @see BaseStripeTest#stubRequest(ApiResource.RequestMethod, String, Map, RequestOptions, Class,
    *     String)
    */
-  public static <T extends StripeObjectInterface> void stubRequest(
+  public static <T extends StripeObject> void stubRequest(
       ApiResource.RequestMethod method,
       String path,
       Map<String, Object> params,
@@ -325,7 +325,7 @@ public class BaseStripeTest {
    * @param typeToken Class of the API resource that will be returned for the stubbed request.
    * @param response JSON payload of the API resource that will be returned for the stubbed request.
    */
-  public static <T extends StripeObjectInterface> void stubRequest(
+  public static <T extends StripeObject> void stubRequest(
       BaseAddress baseAddress,
       ApiResource.RequestMethod method,
       String path,
@@ -361,7 +361,7 @@ public class BaseStripeTest {
    * @param typeToken Class of the API resource that will be returned for the stubbed request.
    * @param response JSON payload of the API resource that will be returned for the stubbed request.
    */
-  public static <T extends StripeObjectInterface> void stubRequestReturnError(
+  public static <T extends StripeObject> void stubRequestReturnError(
       BaseAddress baseAddress,
       ApiResource.RequestMethod method,
       String path,
@@ -380,7 +380,7 @@ public class BaseStripeTest {
   }
 
   /** Stubs an OAuth API request. stripe-mock does not supported OAuth endpoints at this time. */
-  public static <T extends StripeObjectInterface> void stubOAuthRequest(
+  public static <T extends StripeObject> void stubOAuthRequest(
       Class<T> clazz, String response) throws StripeException {
     Mockito.doReturn(ApiResource.GSON.fromJson(response, clazz))
         .when(networkSpy)


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
A bug was found internally where a user extended  `StripeObjectInterface` and tried to deserialize a response from Stripe with their class. This caused a `ClassCastException` since we try to cast a response from `StripeObject` on line 144
```
resource = (T) ApiResource.deserializeStripeObject(responseBody, typeToken, this);
```
The method `ApiResource.deserializeStripeObject` returns a `StripeObject`, but previously, `T` was only guaranteed to extend a `StripeObjectInterface`. Our own resources all extend `StripeObject`, so this wasn't a problem, but a user can create their own types that extend `StripeObjectInterface`.


### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- Changes the signature of `LiveResponseGetter#request`, `ApiService#request`, and `StripeResponseGetter#request` to return `<T extends StripeObject>` instead of `<T extends StripeObjectInterface>`.

## Changelog
* ⚠️ Changes the signature of `LiveResponseGetter#request`, `ApiService#request`, and `StripeResponseGetter#request` to return `<T extends StripeObject>` instead of `<T extends StripeObjectInterface>`. This only affects advanced use cases where users are extending `StripeObjectInterface` with their own objects to deserialize Stripe responses. Those objects will now need to extend `StripeObject`.