### PR TITLE
Deprecate and move V1 services living directly under StripeClient

### DIFF
--- a/src/main/java/com/stripe/StripeClient.java
+++ b/src/main/java/com/stripe/StripeClient.java
@@ -126,8 +126,9 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.accountLinks() is deprecated. All functionality under it has been
-   *     copied over to StripeClient.v1().accountLinks(). See <a
+   * @deprecated StripeClient.accountLinks() is deprecated, use StripeClient.v1().accountLinks()
+   *     instead. All functionality under it has been copied over to
+   *     StripeClient.v1().accountLinks(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -137,8 +138,9 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.accountSessions() is deprecated. All functionality under it has been
-   *     copied over to StripeClient.v1().accountSessions(). See <a
+   * @deprecated StripeClient.accountSessions() is deprecated, use
+   *     StripeClient.v1().accountSessions() instead. All functionality under it has been copied
+   *     over to StripeClient.v1().accountSessions(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -148,8 +150,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.accounts() is deprecated. All functionality under it has been copied
-   *     over to StripeClient.v1().accounts(). See <a
+   * @deprecated StripeClient.accounts() is deprecated, use StripeClient.v1().accounts() instead.
+   *     All functionality under it has been copied over to StripeClient.v1().accounts(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -159,8 +161,9 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.applePayDomains() is deprecated. All functionality under it has been
-   *     copied over to StripeClient.v1().applePayDomains(). See <a
+   * @deprecated StripeClient.applePayDomains() is deprecated, use
+   *     StripeClient.v1().applePayDomains() instead. All functionality under it has been copied
+   *     over to StripeClient.v1().applePayDomains(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -170,8 +173,9 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.applicationFees() is deprecated. All functionality under it has been
-   *     copied over to StripeClient.v1().applicationFees(). See <a
+   * @deprecated StripeClient.applicationFees() is deprecated, use
+   *     StripeClient.v1().applicationFees() instead. All functionality under it has been copied
+   *     over to StripeClient.v1().applicationFees(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -181,8 +185,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.apps() is deprecated. All functionality under it has been copied over
-   *     to StripeClient.v1().apps(). See <a
+   * @deprecated StripeClient.apps() is deprecated, use StripeClient.v1().apps() instead. All
+   *     functionality under it has been copied over to StripeClient.v1().apps(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -192,8 +196,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.balance() is deprecated. All functionality under it has been copied
-   *     over to StripeClient.v1().balance(). See <a
+   * @deprecated StripeClient.balance() is deprecated, use StripeClient.v1().balance() instead. All
+   *     functionality under it has been copied over to StripeClient.v1().balance(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -203,8 +207,9 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.balanceTransactions() is deprecated. All functionality under it has
-   *     been copied over to StripeClient.v1().balanceTransactions(). See <a
+   * @deprecated StripeClient.balanceTransactions() is deprecated, use
+   *     StripeClient.v1().balanceTransactions() instead. All functionality under it has been copied
+   *     over to StripeClient.v1().balanceTransactions(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -214,8 +219,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.billing() is deprecated. All functionality under it has been copied
-   *     over to StripeClient.v1().billing(). See <a
+   * @deprecated StripeClient.billing() is deprecated, use StripeClient.v1().billing() instead. All
+   *     functionality under it has been copied over to StripeClient.v1().billing(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -225,8 +230,9 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.billingPortal() is deprecated. All functionality under it has been
-   *     copied over to StripeClient.v1().billingPortal(). See <a
+   * @deprecated StripeClient.billingPortal() is deprecated, use StripeClient.v1().billingPortal()
+   *     instead. All functionality under it has been copied over to
+   *     StripeClient.v1().billingPortal(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -236,8 +242,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.charges() is deprecated. All functionality under it has been copied
-   *     over to StripeClient.v1().charges(). See <a
+   * @deprecated StripeClient.charges() is deprecated, use StripeClient.v1().charges() instead. All
+   *     functionality under it has been copied over to StripeClient.v1().charges(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -247,8 +253,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.checkout() is deprecated. All functionality under it has been copied
-   *     over to StripeClient.v1().checkout(). See <a
+   * @deprecated StripeClient.checkout() is deprecated, use StripeClient.v1().checkout() instead.
+   *     All functionality under it has been copied over to StripeClient.v1().checkout(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -258,8 +264,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.climate() is deprecated. All functionality under it has been copied
-   *     over to StripeClient.v1().climate(). See <a
+   * @deprecated StripeClient.climate() is deprecated, use StripeClient.v1().climate() instead. All
+   *     functionality under it has been copied over to StripeClient.v1().climate(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -269,8 +275,9 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.confirmationTokens() is deprecated. All functionality under it has
-   *     been copied over to StripeClient.v1().confirmationTokens(). See <a
+   * @deprecated StripeClient.confirmationTokens() is deprecated, use
+   *     StripeClient.v1().confirmationTokens() instead. All functionality under it has been copied
+   *     over to StripeClient.v1().confirmationTokens(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -280,8 +287,9 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.countrySpecs() is deprecated. All functionality under it has been
-   *     copied over to StripeClient.v1().countrySpecs(). See <a
+   * @deprecated StripeClient.countrySpecs() is deprecated, use StripeClient.v1().countrySpecs()
+   *     instead. All functionality under it has been copied over to
+   *     StripeClient.v1().countrySpecs(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -291,8 +299,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.coupons() is deprecated. All functionality under it has been copied
-   *     over to StripeClient.v1().coupons(). See <a
+   * @deprecated StripeClient.coupons() is deprecated, use StripeClient.v1().coupons() instead. All
+   *     functionality under it has been copied over to StripeClient.v1().coupons(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -302,8 +310,9 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.creditNotes() is deprecated. All functionality under it has been
-   *     copied over to StripeClient.v1().creditNotes(). See <a
+   * @deprecated StripeClient.creditNotes() is deprecated, use StripeClient.v1().creditNotes()
+   *     instead. All functionality under it has been copied over to
+   *     StripeClient.v1().creditNotes(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -313,8 +322,9 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.customerSessions() is deprecated. All functionality under it has been
-   *     copied over to StripeClient.v1().customerSessions(). See <a
+   * @deprecated StripeClient.customerSessions() is deprecated, use
+   *     StripeClient.v1().customerSessions() instead. All functionality under it has been copied
+   *     over to StripeClient.v1().customerSessions(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -324,8 +334,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.customers() is deprecated. All functionality under it has been copied
-   *     over to StripeClient.v1().customers(). See <a
+   * @deprecated StripeClient.customers() is deprecated, use StripeClient.v1().customers() instead.
+   *     All functionality under it has been copied over to StripeClient.v1().customers(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -335,8 +345,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.disputes() is deprecated. All functionality under it has been copied
-   *     over to StripeClient.v1().disputes(). See <a
+   * @deprecated StripeClient.disputes() is deprecated, use StripeClient.v1().disputes() instead.
+   *     All functionality under it has been copied over to StripeClient.v1().disputes(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -346,8 +356,9 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.entitlements() is deprecated. All functionality under it has been
-   *     copied over to StripeClient.v1().entitlements(). See <a
+   * @deprecated StripeClient.entitlements() is deprecated, use StripeClient.v1().entitlements()
+   *     instead. All functionality under it has been copied over to
+   *     StripeClient.v1().entitlements(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -357,8 +368,9 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.ephemeralKeys() is deprecated. All functionality under it has been
-   *     copied over to StripeClient.v1().ephemeralKeys(). See <a
+   * @deprecated StripeClient.ephemeralKeys() is deprecated, use StripeClient.v1().ephemeralKeys()
+   *     instead. All functionality under it has been copied over to
+   *     StripeClient.v1().ephemeralKeys(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -368,8 +380,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.events() is deprecated. All functionality under it has been copied
-   *     over to StripeClient.v1().events(). See <a
+   * @deprecated StripeClient.events() is deprecated, use StripeClient.v1().events() instead. All
+   *     functionality under it has been copied over to StripeClient.v1().events(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -379,8 +391,9 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.exchangeRates() is deprecated. All functionality under it has been
-   *     copied over to StripeClient.v1().exchangeRates(). See <a
+   * @deprecated StripeClient.exchangeRates() is deprecated, use StripeClient.v1().exchangeRates()
+   *     instead. All functionality under it has been copied over to
+   *     StripeClient.v1().exchangeRates(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -390,8 +403,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.fileLinks() is deprecated. All functionality under it has been copied
-   *     over to StripeClient.v1().fileLinks(). See <a
+   * @deprecated StripeClient.fileLinks() is deprecated, use StripeClient.v1().fileLinks() instead.
+   *     All functionality under it has been copied over to StripeClient.v1().fileLinks(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -401,8 +414,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.files() is deprecated. All functionality under it has been copied over
-   *     to StripeClient.v1().files(). See <a
+   * @deprecated StripeClient.files() is deprecated, use StripeClient.v1().files() instead. All
+   *     functionality under it has been copied over to StripeClient.v1().files(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -412,8 +425,9 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.financialConnections() is deprecated. All functionality under it has
-   *     been copied over to StripeClient.v1().financialConnections(). See <a
+   * @deprecated StripeClient.financialConnections() is deprecated, use
+   *     StripeClient.v1().financialConnections() instead. All functionality under it has been
+   *     copied over to StripeClient.v1().financialConnections(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -423,8 +437,9 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.forwarding() is deprecated. All functionality under it has been copied
-   *     over to StripeClient.v1().forwarding(). See <a
+   * @deprecated StripeClient.forwarding() is deprecated, use StripeClient.v1().forwarding()
+   *     instead. All functionality under it has been copied over to StripeClient.v1().forwarding().
+   *     See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -434,8 +449,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.identity() is deprecated. All functionality under it has been copied
-   *     over to StripeClient.v1().identity(). See <a
+   * @deprecated StripeClient.identity() is deprecated, use StripeClient.v1().identity() instead.
+   *     All functionality under it has been copied over to StripeClient.v1().identity(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -445,8 +460,9 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.invoiceItems() is deprecated. All functionality under it has been
-   *     copied over to StripeClient.v1().invoiceItems(). See <a
+   * @deprecated StripeClient.invoiceItems() is deprecated, use StripeClient.v1().invoiceItems()
+   *     instead. All functionality under it has been copied over to
+   *     StripeClient.v1().invoiceItems(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -456,8 +472,9 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.invoicePayments() is deprecated. All functionality under it has been
-   *     copied over to StripeClient.v1().invoicePayments(). See <a
+   * @deprecated StripeClient.invoicePayments() is deprecated, use
+   *     StripeClient.v1().invoicePayments() instead. All functionality under it has been copied
+   *     over to StripeClient.v1().invoicePayments(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -467,8 +484,9 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.invoiceRenderingTemplates() is deprecated. All functionality under it
-   *     has been copied over to StripeClient.v1().invoiceRenderingTemplates(). See <a
+   * @deprecated StripeClient.invoiceRenderingTemplates() is deprecated, use
+   *     StripeClient.v1().invoiceRenderingTemplates() instead. All functionality under it has been
+   *     copied over to StripeClient.v1().invoiceRenderingTemplates(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -478,8 +496,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.invoices() is deprecated. All functionality under it has been copied
-   *     over to StripeClient.v1().invoices(). See <a
+   * @deprecated StripeClient.invoices() is deprecated, use StripeClient.v1().invoices() instead.
+   *     All functionality under it has been copied over to StripeClient.v1().invoices(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -489,8 +507,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.issuing() is deprecated. All functionality under it has been copied
-   *     over to StripeClient.v1().issuing(). See <a
+   * @deprecated StripeClient.issuing() is deprecated, use StripeClient.v1().issuing() instead. All
+   *     functionality under it has been copied over to StripeClient.v1().issuing(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -500,8 +518,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.mandates() is deprecated. All functionality under it has been copied
-   *     over to StripeClient.v1().mandates(). See <a
+   * @deprecated StripeClient.mandates() is deprecated, use StripeClient.v1().mandates() instead.
+   *     All functionality under it has been copied over to StripeClient.v1().mandates(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -511,8 +529,9 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.paymentIntents() is deprecated. All functionality under it has been
-   *     copied over to StripeClient.v1().paymentIntents(). See <a
+   * @deprecated StripeClient.paymentIntents() is deprecated, use StripeClient.v1().paymentIntents()
+   *     instead. All functionality under it has been copied over to
+   *     StripeClient.v1().paymentIntents(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -522,8 +541,9 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.paymentLinks() is deprecated. All functionality under it has been
-   *     copied over to StripeClient.v1().paymentLinks(). See <a
+   * @deprecated StripeClient.paymentLinks() is deprecated, use StripeClient.v1().paymentLinks()
+   *     instead. All functionality under it has been copied over to
+   *     StripeClient.v1().paymentLinks(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -533,8 +553,9 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.paymentMethodConfigurations() is deprecated. All functionality under
-   *     it has been copied over to StripeClient.v1().paymentMethodConfigurations(). See <a
+   * @deprecated StripeClient.paymentMethodConfigurations() is deprecated, use
+   *     StripeClient.v1().paymentMethodConfigurations() instead. All functionality under it has
+   *     been copied over to StripeClient.v1().paymentMethodConfigurations(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -544,8 +565,9 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.paymentMethodDomains() is deprecated. All functionality under it has
-   *     been copied over to StripeClient.v1().paymentMethodDomains(). See <a
+   * @deprecated StripeClient.paymentMethodDomains() is deprecated, use
+   *     StripeClient.v1().paymentMethodDomains() instead. All functionality under it has been
+   *     copied over to StripeClient.v1().paymentMethodDomains(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -555,8 +577,9 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.paymentMethods() is deprecated. All functionality under it has been
-   *     copied over to StripeClient.v1().paymentMethods(). See <a
+   * @deprecated StripeClient.paymentMethods() is deprecated, use StripeClient.v1().paymentMethods()
+   *     instead. All functionality under it has been copied over to
+   *     StripeClient.v1().paymentMethods(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -566,8 +589,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.payouts() is deprecated. All functionality under it has been copied
-   *     over to StripeClient.v1().payouts(). See <a
+   * @deprecated StripeClient.payouts() is deprecated, use StripeClient.v1().payouts() instead. All
+   *     functionality under it has been copied over to StripeClient.v1().payouts(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -577,8 +600,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.plans() is deprecated. All functionality under it has been copied over
-   *     to StripeClient.v1().plans(). See <a
+   * @deprecated StripeClient.plans() is deprecated, use StripeClient.v1().plans() instead. All
+   *     functionality under it has been copied over to StripeClient.v1().plans(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -588,8 +611,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.prices() is deprecated. All functionality under it has been copied
-   *     over to StripeClient.v1().prices(). See <a
+   * @deprecated StripeClient.prices() is deprecated, use StripeClient.v1().prices() instead. All
+   *     functionality under it has been copied over to StripeClient.v1().prices(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -599,8 +622,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.products() is deprecated. All functionality under it has been copied
-   *     over to StripeClient.v1().products(). See <a
+   * @deprecated StripeClient.products() is deprecated, use StripeClient.v1().products() instead.
+   *     All functionality under it has been copied over to StripeClient.v1().products(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -610,8 +633,9 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.promotionCodes() is deprecated. All functionality under it has been
-   *     copied over to StripeClient.v1().promotionCodes(). See <a
+   * @deprecated StripeClient.promotionCodes() is deprecated, use StripeClient.v1().promotionCodes()
+   *     instead. All functionality under it has been copied over to
+   *     StripeClient.v1().promotionCodes(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -621,8 +645,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.quotes() is deprecated. All functionality under it has been copied
-   *     over to StripeClient.v1().quotes(). See <a
+   * @deprecated StripeClient.quotes() is deprecated, use StripeClient.v1().quotes() instead. All
+   *     functionality under it has been copied over to StripeClient.v1().quotes(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -632,8 +656,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.radar() is deprecated. All functionality under it has been copied over
-   *     to StripeClient.v1().radar(). See <a
+   * @deprecated StripeClient.radar() is deprecated, use StripeClient.v1().radar() instead. All
+   *     functionality under it has been copied over to StripeClient.v1().radar(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -643,8 +667,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.refunds() is deprecated. All functionality under it has been copied
-   *     over to StripeClient.v1().refunds(). See <a
+   * @deprecated StripeClient.refunds() is deprecated, use StripeClient.v1().refunds() instead. All
+   *     functionality under it has been copied over to StripeClient.v1().refunds(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -654,8 +678,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.reporting() is deprecated. All functionality under it has been copied
-   *     over to StripeClient.v1().reporting(). See <a
+   * @deprecated StripeClient.reporting() is deprecated, use StripeClient.v1().reporting() instead.
+   *     All functionality under it has been copied over to StripeClient.v1().reporting(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -665,8 +689,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.reviews() is deprecated. All functionality under it has been copied
-   *     over to StripeClient.v1().reviews(). See <a
+   * @deprecated StripeClient.reviews() is deprecated, use StripeClient.v1().reviews() instead. All
+   *     functionality under it has been copied over to StripeClient.v1().reviews(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -676,8 +700,9 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.setupAttempts() is deprecated. All functionality under it has been
-   *     copied over to StripeClient.v1().setupAttempts(). See <a
+   * @deprecated StripeClient.setupAttempts() is deprecated, use StripeClient.v1().setupAttempts()
+   *     instead. All functionality under it has been copied over to
+   *     StripeClient.v1().setupAttempts(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -687,8 +712,9 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.setupIntents() is deprecated. All functionality under it has been
-   *     copied over to StripeClient.v1().setupIntents(). See <a
+   * @deprecated StripeClient.setupIntents() is deprecated, use StripeClient.v1().setupIntents()
+   *     instead. All functionality under it has been copied over to
+   *     StripeClient.v1().setupIntents(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -698,8 +724,9 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.shippingRates() is deprecated. All functionality under it has been
-   *     copied over to StripeClient.v1().shippingRates(). See <a
+   * @deprecated StripeClient.shippingRates() is deprecated, use StripeClient.v1().shippingRates()
+   *     instead. All functionality under it has been copied over to
+   *     StripeClient.v1().shippingRates(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -709,8 +736,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.sigma() is deprecated. All functionality under it has been copied over
-   *     to StripeClient.v1().sigma(). See <a
+   * @deprecated StripeClient.sigma() is deprecated, use StripeClient.v1().sigma() instead. All
+   *     functionality under it has been copied over to StripeClient.v1().sigma(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -720,8 +747,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.sources() is deprecated. All functionality under it has been copied
-   *     over to StripeClient.v1().sources(). See <a
+   * @deprecated StripeClient.sources() is deprecated, use StripeClient.v1().sources() instead. All
+   *     functionality under it has been copied over to StripeClient.v1().sources(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -731,8 +758,9 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.subscriptionItems() is deprecated. All functionality under it has been
-   *     copied over to StripeClient.v1().subscriptionItems(). See <a
+   * @deprecated StripeClient.subscriptionItems() is deprecated, use
+   *     StripeClient.v1().subscriptionItems() instead. All functionality under it has been copied
+   *     over to StripeClient.v1().subscriptionItems(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -742,8 +770,9 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.subscriptionSchedules() is deprecated. All functionality under it has
-   *     been copied over to StripeClient.v1().subscriptionSchedules(). See <a
+   * @deprecated StripeClient.subscriptionSchedules() is deprecated, use
+   *     StripeClient.v1().subscriptionSchedules() instead. All functionality under it has been
+   *     copied over to StripeClient.v1().subscriptionSchedules(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -753,8 +782,9 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.subscriptions() is deprecated. All functionality under it has been
-   *     copied over to StripeClient.v1().subscriptions(). See <a
+   * @deprecated StripeClient.subscriptions() is deprecated, use StripeClient.v1().subscriptions()
+   *     instead. All functionality under it has been copied over to
+   *     StripeClient.v1().subscriptions(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -764,8 +794,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.tax() is deprecated. All functionality under it has been copied over
-   *     to StripeClient.v1().tax(). See <a
+   * @deprecated StripeClient.tax() is deprecated, use StripeClient.v1().tax() instead. All
+   *     functionality under it has been copied over to StripeClient.v1().tax(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -775,8 +805,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.taxCodes() is deprecated. All functionality under it has been copied
-   *     over to StripeClient.v1().taxCodes(). See <a
+   * @deprecated StripeClient.taxCodes() is deprecated, use StripeClient.v1().taxCodes() instead.
+   *     All functionality under it has been copied over to StripeClient.v1().taxCodes(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -786,8 +816,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.taxIds() is deprecated. All functionality under it has been copied
-   *     over to StripeClient.v1().taxIds(). See <a
+   * @deprecated StripeClient.taxIds() is deprecated, use StripeClient.v1().taxIds() instead. All
+   *     functionality under it has been copied over to StripeClient.v1().taxIds(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -797,8 +827,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.taxRates() is deprecated. All functionality under it has been copied
-   *     over to StripeClient.v1().taxRates(). See <a
+   * @deprecated StripeClient.taxRates() is deprecated, use StripeClient.v1().taxRates() instead.
+   *     All functionality under it has been copied over to StripeClient.v1().taxRates(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -808,8 +838,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.terminal() is deprecated. All functionality under it has been copied
-   *     over to StripeClient.v1().terminal(). See <a
+   * @deprecated StripeClient.terminal() is deprecated, use StripeClient.v1().terminal() instead.
+   *     All functionality under it has been copied over to StripeClient.v1().terminal(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -819,8 +849,9 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.testHelpers() is deprecated. All functionality under it has been
-   *     copied over to StripeClient.v1().testHelpers(). See <a
+   * @deprecated StripeClient.testHelpers() is deprecated, use StripeClient.v1().testHelpers()
+   *     instead. All functionality under it has been copied over to
+   *     StripeClient.v1().testHelpers(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -830,8 +861,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.tokens() is deprecated. All functionality under it has been copied
-   *     over to StripeClient.v1().tokens(). See <a
+   * @deprecated StripeClient.tokens() is deprecated, use StripeClient.v1().tokens() instead. All
+   *     functionality under it has been copied over to StripeClient.v1().tokens(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -841,8 +872,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.topups() is deprecated. All functionality under it has been copied
-   *     over to StripeClient.v1().topups(). See <a
+   * @deprecated StripeClient.topups() is deprecated, use StripeClient.v1().topups() instead. All
+   *     functionality under it has been copied over to StripeClient.v1().topups(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -852,8 +883,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.transfers() is deprecated. All functionality under it has been copied
-   *     over to StripeClient.v1().transfers(). See <a
+   * @deprecated StripeClient.transfers() is deprecated, use StripeClient.v1().transfers() instead.
+   *     All functionality under it has been copied over to StripeClient.v1().transfers(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -863,8 +894,8 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.treasury() is deprecated. All functionality under it has been copied
-   *     over to StripeClient.v1().treasury(). See <a
+   * @deprecated StripeClient.treasury() is deprecated, use StripeClient.v1().treasury() instead.
+   *     All functionality under it has been copied over to StripeClient.v1().treasury(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
@@ -874,8 +905,9 @@ public class StripeClient {
   }
 
   /**
-   * @deprecated StripeClient.webhookEndpoints() is deprecated. All functionality under it has been
-   *     copied over to StripeClient.v1().webhookEndpoints(). See <a
+   * @deprecated StripeClient.webhookEndpoints() is deprecated, use
+   *     StripeClient.v1().webhookEndpoints() instead. All functionality under it has been copied
+   *     over to StripeClient.v1().webhookEndpoints(). See <a
    *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
    *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */

--- a/src/main/java/com/stripe/StripeClient.java
+++ b/src/main/java/com/stripe/StripeClient.java
@@ -126,705 +126,760 @@ public class StripeClient {
   }
 
   /**
-   * Deprecation Warning: StripeClient.accountLinks() will be deprecated in the next major release.
-   * All functionality under it has been copied over to StripeClient.v1().accountLinks(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.accountLinks() is deprecated. All functionality under it has been
+   *     copied over to StripeClient.v1().accountLinks(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.AccountLinkService accountLinks() {
     return new com.stripe.service.AccountLinkService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.accountSessions() will be deprecated in the next major
-   * release. All functionality under it has been copied over to
-   * StripeClient.v1().accountSessions(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.accountSessions() is deprecated. All functionality under it has been
+   *     copied over to StripeClient.v1().accountSessions(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.AccountSessionService accountSessions() {
     return new com.stripe.service.AccountSessionService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.accounts() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().accounts(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.accounts() is deprecated. All functionality under it has been copied
+   *     over to StripeClient.v1().accounts(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.AccountService accounts() {
     return new com.stripe.service.AccountService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.applePayDomains() will be deprecated in the next major
-   * release. All functionality under it has been copied over to
-   * StripeClient.v1().applePayDomains(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.applePayDomains() is deprecated. All functionality under it has been
+   *     copied over to StripeClient.v1().applePayDomains(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.ApplePayDomainService applePayDomains() {
     return new com.stripe.service.ApplePayDomainService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.applicationFees() will be deprecated in the next major
-   * release. All functionality under it has been copied over to
-   * StripeClient.v1().applicationFees(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.applicationFees() is deprecated. All functionality under it has been
+   *     copied over to StripeClient.v1().applicationFees(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.ApplicationFeeService applicationFees() {
     return new com.stripe.service.ApplicationFeeService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.apps() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().apps(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.apps() is deprecated. All functionality under it has been copied over
+   *     to StripeClient.v1().apps(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.AppsService apps() {
     return new com.stripe.service.AppsService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.balance() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().balance(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.balance() is deprecated. All functionality under it has been copied
+   *     over to StripeClient.v1().balance(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.BalanceService balance() {
     return new com.stripe.service.BalanceService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.balanceTransactions() will be deprecated in the next major
-   * release. All functionality under it has been copied over to
-   * StripeClient.v1().balanceTransactions(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.balanceTransactions() is deprecated. All functionality under it has
+   *     been copied over to StripeClient.v1().balanceTransactions(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.BalanceTransactionService balanceTransactions() {
     return new com.stripe.service.BalanceTransactionService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.billing() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().billing(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.billing() is deprecated. All functionality under it has been copied
+   *     over to StripeClient.v1().billing(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.BillingService billing() {
     return new com.stripe.service.BillingService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.billingPortal() will be deprecated in the next major release.
-   * All functionality under it has been copied over to StripeClient.v1().billingPortal(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.billingPortal() is deprecated. All functionality under it has been
+   *     copied over to StripeClient.v1().billingPortal(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.BillingPortalService billingPortal() {
     return new com.stripe.service.BillingPortalService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.charges() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().charges(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.charges() is deprecated. All functionality under it has been copied
+   *     over to StripeClient.v1().charges(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.ChargeService charges() {
     return new com.stripe.service.ChargeService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.checkout() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().checkout(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.checkout() is deprecated. All functionality under it has been copied
+   *     over to StripeClient.v1().checkout(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.CheckoutService checkout() {
     return new com.stripe.service.CheckoutService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.climate() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().climate(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.climate() is deprecated. All functionality under it has been copied
+   *     over to StripeClient.v1().climate(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.ClimateService climate() {
     return new com.stripe.service.ClimateService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.confirmationTokens() will be deprecated in the next major
-   * release. All functionality under it has been copied over to
-   * StripeClient.v1().confirmationTokens(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.confirmationTokens() is deprecated. All functionality under it has
+   *     been copied over to StripeClient.v1().confirmationTokens(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.ConfirmationTokenService confirmationTokens() {
     return new com.stripe.service.ConfirmationTokenService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.countrySpecs() will be deprecated in the next major release.
-   * All functionality under it has been copied over to StripeClient.v1().countrySpecs(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.countrySpecs() is deprecated. All functionality under it has been
+   *     copied over to StripeClient.v1().countrySpecs(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.CountrySpecService countrySpecs() {
     return new com.stripe.service.CountrySpecService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.coupons() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().coupons(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.coupons() is deprecated. All functionality under it has been copied
+   *     over to StripeClient.v1().coupons(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.CouponService coupons() {
     return new com.stripe.service.CouponService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.creditNotes() will be deprecated in the next major release.
-   * All functionality under it has been copied over to StripeClient.v1().creditNotes(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.creditNotes() is deprecated. All functionality under it has been
+   *     copied over to StripeClient.v1().creditNotes(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.CreditNoteService creditNotes() {
     return new com.stripe.service.CreditNoteService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.customerSessions() will be deprecated in the next major
-   * release. All functionality under it has been copied over to
-   * StripeClient.v1().customerSessions(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.customerSessions() is deprecated. All functionality under it has been
+   *     copied over to StripeClient.v1().customerSessions(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.CustomerSessionService customerSessions() {
     return new com.stripe.service.CustomerSessionService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.customers() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().customers(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.customers() is deprecated. All functionality under it has been copied
+   *     over to StripeClient.v1().customers(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.CustomerService customers() {
     return new com.stripe.service.CustomerService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.disputes() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().disputes(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.disputes() is deprecated. All functionality under it has been copied
+   *     over to StripeClient.v1().disputes(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.DisputeService disputes() {
     return new com.stripe.service.DisputeService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.entitlements() will be deprecated in the next major release.
-   * All functionality under it has been copied over to StripeClient.v1().entitlements(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.entitlements() is deprecated. All functionality under it has been
+   *     copied over to StripeClient.v1().entitlements(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.EntitlementsService entitlements() {
     return new com.stripe.service.EntitlementsService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.ephemeralKeys() will be deprecated in the next major release.
-   * All functionality under it has been copied over to StripeClient.v1().ephemeralKeys(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.ephemeralKeys() is deprecated. All functionality under it has been
+   *     copied over to StripeClient.v1().ephemeralKeys(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.EphemeralKeyService ephemeralKeys() {
     return new com.stripe.service.EphemeralKeyService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.events() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().events(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.events() is deprecated. All functionality under it has been copied
+   *     over to StripeClient.v1().events(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.EventService events() {
     return new com.stripe.service.EventService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.exchangeRates() will be deprecated in the next major release.
-   * All functionality under it has been copied over to StripeClient.v1().exchangeRates(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.exchangeRates() is deprecated. All functionality under it has been
+   *     copied over to StripeClient.v1().exchangeRates(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.ExchangeRateService exchangeRates() {
     return new com.stripe.service.ExchangeRateService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.fileLinks() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().fileLinks(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.fileLinks() is deprecated. All functionality under it has been copied
+   *     over to StripeClient.v1().fileLinks(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.FileLinkService fileLinks() {
     return new com.stripe.service.FileLinkService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.files() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().files(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.files() is deprecated. All functionality under it has been copied over
+   *     to StripeClient.v1().files(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.FileService files() {
     return new com.stripe.service.FileService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.financialConnections() will be deprecated in the next major
-   * release. All functionality under it has been copied over to
-   * StripeClient.v1().financialConnections(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.financialConnections() is deprecated. All functionality under it has
+   *     been copied over to StripeClient.v1().financialConnections(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.FinancialConnectionsService financialConnections() {
     return new com.stripe.service.FinancialConnectionsService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.forwarding() will be deprecated in the next major release.
-   * All functionality under it has been copied over to StripeClient.v1().forwarding(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.forwarding() is deprecated. All functionality under it has been copied
+   *     over to StripeClient.v1().forwarding(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.ForwardingService forwarding() {
     return new com.stripe.service.ForwardingService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.identity() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().identity(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.identity() is deprecated. All functionality under it has been copied
+   *     over to StripeClient.v1().identity(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.IdentityService identity() {
     return new com.stripe.service.IdentityService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.invoiceItems() will be deprecated in the next major release.
-   * All functionality under it has been copied over to StripeClient.v1().invoiceItems(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.invoiceItems() is deprecated. All functionality under it has been
+   *     copied over to StripeClient.v1().invoiceItems(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.InvoiceItemService invoiceItems() {
     return new com.stripe.service.InvoiceItemService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.invoicePayments() will be deprecated in the next major
-   * release. All functionality under it has been copied over to
-   * StripeClient.v1().invoicePayments(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.invoicePayments() is deprecated. All functionality under it has been
+   *     copied over to StripeClient.v1().invoicePayments(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.InvoicePaymentService invoicePayments() {
     return new com.stripe.service.InvoicePaymentService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.invoiceRenderingTemplates() will be deprecated in the next
-   * major release. All functionality under it has been copied over to
-   * StripeClient.v1().invoiceRenderingTemplates(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.invoiceRenderingTemplates() is deprecated. All functionality under it
+   *     has been copied over to StripeClient.v1().invoiceRenderingTemplates(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.InvoiceRenderingTemplateService invoiceRenderingTemplates() {
     return new com.stripe.service.InvoiceRenderingTemplateService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.invoices() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().invoices(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.invoices() is deprecated. All functionality under it has been copied
+   *     over to StripeClient.v1().invoices(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.InvoiceService invoices() {
     return new com.stripe.service.InvoiceService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.issuing() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().issuing(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.issuing() is deprecated. All functionality under it has been copied
+   *     over to StripeClient.v1().issuing(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.IssuingService issuing() {
     return new com.stripe.service.IssuingService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.mandates() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().mandates(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.mandates() is deprecated. All functionality under it has been copied
+   *     over to StripeClient.v1().mandates(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.MandateService mandates() {
     return new com.stripe.service.MandateService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.paymentIntents() will be deprecated in the next major
-   * release. All functionality under it has been copied over to StripeClient.v1().paymentIntents().
-   * See <a href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.paymentIntents() is deprecated. All functionality under it has been
+   *     copied over to StripeClient.v1().paymentIntents(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.PaymentIntentService paymentIntents() {
     return new com.stripe.service.PaymentIntentService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.paymentLinks() will be deprecated in the next major release.
-   * All functionality under it has been copied over to StripeClient.v1().paymentLinks(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.paymentLinks() is deprecated. All functionality under it has been
+   *     copied over to StripeClient.v1().paymentLinks(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.PaymentLinkService paymentLinks() {
     return new com.stripe.service.PaymentLinkService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.paymentMethodConfigurations() will be deprecated in the next
-   * major release. All functionality under it has been copied over to
-   * StripeClient.v1().paymentMethodConfigurations(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.paymentMethodConfigurations() is deprecated. All functionality under
+   *     it has been copied over to StripeClient.v1().paymentMethodConfigurations(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.PaymentMethodConfigurationService paymentMethodConfigurations() {
     return new com.stripe.service.PaymentMethodConfigurationService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.paymentMethodDomains() will be deprecated in the next major
-   * release. All functionality under it has been copied over to
-   * StripeClient.v1().paymentMethodDomains(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.paymentMethodDomains() is deprecated. All functionality under it has
+   *     been copied over to StripeClient.v1().paymentMethodDomains(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.PaymentMethodDomainService paymentMethodDomains() {
     return new com.stripe.service.PaymentMethodDomainService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.paymentMethods() will be deprecated in the next major
-   * release. All functionality under it has been copied over to StripeClient.v1().paymentMethods().
-   * See <a href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.paymentMethods() is deprecated. All functionality under it has been
+   *     copied over to StripeClient.v1().paymentMethods(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.PaymentMethodService paymentMethods() {
     return new com.stripe.service.PaymentMethodService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.payouts() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().payouts(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.payouts() is deprecated. All functionality under it has been copied
+   *     over to StripeClient.v1().payouts(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.PayoutService payouts() {
     return new com.stripe.service.PayoutService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.plans() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().plans(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.plans() is deprecated. All functionality under it has been copied over
+   *     to StripeClient.v1().plans(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.PlanService plans() {
     return new com.stripe.service.PlanService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.prices() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().prices(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.prices() is deprecated. All functionality under it has been copied
+   *     over to StripeClient.v1().prices(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.PriceService prices() {
     return new com.stripe.service.PriceService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.products() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().products(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.products() is deprecated. All functionality under it has been copied
+   *     over to StripeClient.v1().products(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.ProductService products() {
     return new com.stripe.service.ProductService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.promotionCodes() will be deprecated in the next major
-   * release. All functionality under it has been copied over to StripeClient.v1().promotionCodes().
-   * See <a href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.promotionCodes() is deprecated. All functionality under it has been
+   *     copied over to StripeClient.v1().promotionCodes(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.PromotionCodeService promotionCodes() {
     return new com.stripe.service.PromotionCodeService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.quotes() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().quotes(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.quotes() is deprecated. All functionality under it has been copied
+   *     over to StripeClient.v1().quotes(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.QuoteService quotes() {
     return new com.stripe.service.QuoteService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.radar() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().radar(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.radar() is deprecated. All functionality under it has been copied over
+   *     to StripeClient.v1().radar(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.RadarService radar() {
     return new com.stripe.service.RadarService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.refunds() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().refunds(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.refunds() is deprecated. All functionality under it has been copied
+   *     over to StripeClient.v1().refunds(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.RefundService refunds() {
     return new com.stripe.service.RefundService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.reporting() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().reporting(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.reporting() is deprecated. All functionality under it has been copied
+   *     over to StripeClient.v1().reporting(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.ReportingService reporting() {
     return new com.stripe.service.ReportingService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.reviews() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().reviews(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.reviews() is deprecated. All functionality under it has been copied
+   *     over to StripeClient.v1().reviews(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.ReviewService reviews() {
     return new com.stripe.service.ReviewService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.setupAttempts() will be deprecated in the next major release.
-   * All functionality under it has been copied over to StripeClient.v1().setupAttempts(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.setupAttempts() is deprecated. All functionality under it has been
+   *     copied over to StripeClient.v1().setupAttempts(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.SetupAttemptService setupAttempts() {
     return new com.stripe.service.SetupAttemptService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.setupIntents() will be deprecated in the next major release.
-   * All functionality under it has been copied over to StripeClient.v1().setupIntents(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.setupIntents() is deprecated. All functionality under it has been
+   *     copied over to StripeClient.v1().setupIntents(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.SetupIntentService setupIntents() {
     return new com.stripe.service.SetupIntentService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.shippingRates() will be deprecated in the next major release.
-   * All functionality under it has been copied over to StripeClient.v1().shippingRates(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.shippingRates() is deprecated. All functionality under it has been
+   *     copied over to StripeClient.v1().shippingRates(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.ShippingRateService shippingRates() {
     return new com.stripe.service.ShippingRateService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.sigma() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().sigma(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.sigma() is deprecated. All functionality under it has been copied over
+   *     to StripeClient.v1().sigma(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.SigmaService sigma() {
     return new com.stripe.service.SigmaService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.sources() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().sources(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.sources() is deprecated. All functionality under it has been copied
+   *     over to StripeClient.v1().sources(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.SourceService sources() {
     return new com.stripe.service.SourceService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.subscriptionItems() will be deprecated in the next major
-   * release. All functionality under it has been copied over to
-   * StripeClient.v1().subscriptionItems(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.subscriptionItems() is deprecated. All functionality under it has been
+   *     copied over to StripeClient.v1().subscriptionItems(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.SubscriptionItemService subscriptionItems() {
     return new com.stripe.service.SubscriptionItemService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.subscriptionSchedules() will be deprecated in the next major
-   * release. All functionality under it has been copied over to
-   * StripeClient.v1().subscriptionSchedules(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.subscriptionSchedules() is deprecated. All functionality under it has
+   *     been copied over to StripeClient.v1().subscriptionSchedules(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.SubscriptionScheduleService subscriptionSchedules() {
     return new com.stripe.service.SubscriptionScheduleService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.subscriptions() will be deprecated in the next major release.
-   * All functionality under it has been copied over to StripeClient.v1().subscriptions(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.subscriptions() is deprecated. All functionality under it has been
+   *     copied over to StripeClient.v1().subscriptions(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.SubscriptionService subscriptions() {
     return new com.stripe.service.SubscriptionService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.tax() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().tax(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.tax() is deprecated. All functionality under it has been copied over
+   *     to StripeClient.v1().tax(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.TaxService tax() {
     return new com.stripe.service.TaxService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.taxCodes() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().taxCodes(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.taxCodes() is deprecated. All functionality under it has been copied
+   *     over to StripeClient.v1().taxCodes(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.TaxCodeService taxCodes() {
     return new com.stripe.service.TaxCodeService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.taxIds() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().taxIds(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.taxIds() is deprecated. All functionality under it has been copied
+   *     over to StripeClient.v1().taxIds(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.TaxIdService taxIds() {
     return new com.stripe.service.TaxIdService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.taxRates() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().taxRates(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.taxRates() is deprecated. All functionality under it has been copied
+   *     over to StripeClient.v1().taxRates(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.TaxRateService taxRates() {
     return new com.stripe.service.TaxRateService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.terminal() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().terminal(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.terminal() is deprecated. All functionality under it has been copied
+   *     over to StripeClient.v1().terminal(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.TerminalService terminal() {
     return new com.stripe.service.TerminalService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.testHelpers() will be deprecated in the next major release.
-   * All functionality under it has been copied over to StripeClient.v1().testHelpers(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.testHelpers() is deprecated. All functionality under it has been
+   *     copied over to StripeClient.v1().testHelpers(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.TestHelpersService testHelpers() {
     return new com.stripe.service.TestHelpersService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.tokens() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().tokens(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.tokens() is deprecated. All functionality under it has been copied
+   *     over to StripeClient.v1().tokens(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.TokenService tokens() {
     return new com.stripe.service.TokenService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.topups() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().topups(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.topups() is deprecated. All functionality under it has been copied
+   *     over to StripeClient.v1().topups(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.TopupService topups() {
     return new com.stripe.service.TopupService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.transfers() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().transfers(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.transfers() is deprecated. All functionality under it has been copied
+   *     over to StripeClient.v1().transfers(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.TransferService transfers() {
     return new com.stripe.service.TransferService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.treasury() will be deprecated in the next major release. All
-   * functionality under it has been copied over to StripeClient.v1().treasury(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.treasury() is deprecated. All functionality under it has been copied
+   *     over to StripeClient.v1().treasury(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.TreasuryService treasury() {
     return new com.stripe.service.TreasuryService(this.getResponseGetter());
   }
 
   /**
-   * Deprecation Warning: StripeClient.webhookEndpoints() will be deprecated in the next major
-   * release. All functionality under it has been copied over to
-   * StripeClient.v1().webhookEndpoints(). See <a
-   * href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
-   * guide</a> for more on this and tips on migrating to the new v1 namespace.
+   * @deprecated StripeClient.webhookEndpoints() is deprecated. All functionality under it has been
+   *     copied over to StripeClient.v1().webhookEndpoints(). See <a
+   *     href="https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient">migration
+   *     guide</a> for more on this and tips on migrating to the new v1 namespace.
    */
+  @Deprecated
   public com.stripe.service.WebhookEndpointService webhookEndpoints() {
     return new com.stripe.service.WebhookEndpointService(this.getResponseGetter());
   }

--- a/src/test/java/com/stripe/functional/GeneratedExamples.java
+++ b/src/test/java/com/stripe/functional/GeneratedExamples.java
@@ -16017,7 +16017,6 @@ class GeneratedExamples extends BaseStripeTest {
                             .setPrice("price_xxxxxxxxxxxxx")
                             .setQuantity(1L)
                             .build())
-                    .setIterations(12L)
                     .build())
             .build();
 
@@ -16047,7 +16046,6 @@ class GeneratedExamples extends BaseStripeTest {
                             .setPrice("price_xxxxxxxxxxxxx")
                             .setQuantity(1L)
                             .build())
-                    .setIterations(12L)
                     .build())
             .build();
 
@@ -16078,7 +16076,6 @@ class GeneratedExamples extends BaseStripeTest {
                             .setPrice("price_xxxxxxxxxxxxx")
                             .setQuantity(1L)
                             .build())
-                    .setIterations(12L)
                     .build())
             .build();
 
@@ -24588,7 +24585,7 @@ class GeneratedExamples extends BaseStripeTest {
         null,
         null,
         com.stripe.model.v2.DeletedObject.class,
-        "{\"id\":\"abc_123\",\"object\":\"some.object.tag\",\"deleted\":true}");
+        "{\"id\":\"abc_123\",\"object\":\"some.object.tag\"}");
     StripeClient client = new StripeClient(networkSpy);
 
     com.stripe.model.v2.DeletedObject deletedObject =


### PR DESCRIPTION
### What?
We introduced V1 namespace to improve code organization in Stripe SDKs in our [last release.](https://github.com/stripe/stripe-java/releases/tag/v29.5.0) 

## Changelog
- ⚠️ Deprecated the V1 service accessors living directly under StripeClient(e.g. customers, products) as they were copied under the new V1 service in our [last release](https://github.com/stripe/stripe-java/releases/tag/v29.5.0). Service accessors living directly under StripeClient(e.g. customers, products) will be removed from StripeClient in a future release. E.g.
```diff
StripeClient client = new StripeClient("sk_test...")

# Accessing V1 Stripe services on a StripeClient should be through the V1 namespace
- client.customers().list() 
+ client.v1().customers().list()
```
Refer to the [migration guide](https://github.com/stripe/stripe-java/wiki/v1-namespace-in-StripeClient) for help upgrading. 