### PR TITLE
Fix version mismatch in manual JAR installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Add this dependency to your project's POM:
 If you are not using Gradle or Maven, you will need to manually install the following JARs:
 
 1. The Stripe JAR:
-   - Download the latest release version from [Maven Central](https://repo1.maven.org/maven2/com/stripe/stripe-java/29.0.0/stripe-java-29.0.0.jar)
-   - Current release version: 29.0.0
+   - Download the latest release version from [Maven Central](https://repo1.maven.org/maven2/com/stripe/stripe-java/29.5.0/stripe-java-29.5.0.jar)
+   - Current release version: 29.5.0
 
 2. Google Gson:
    - The Stripe JAR builds and tests with Gson version 2.10.1


### PR DESCRIPTION
### Why?
The README for the Stripe Java library contains a version mismatch in the "Others → manual install" section.  
While Maven and Gradle instructions use version **29.5.0**, the manual JAR download section incorrectly references **29.0.0**.  
This update ensures consistency across all installation instructions, preventing confusion for users manually downloading the JAR.

### What?
- Updated the Stripe JAR version in the manual installation instructions from **29.0.0 → 29.5.0**  
- Updated the corresponding Maven Central JAR download link to match **29.5.0**  
- Verified that Google Gson version (2.10.1) is consistent and compatible  
- No changes to code examples or other sections


### See Also
- [Stripe Java 29.5.0 Maven Central](https://repo1.maven.org/maven2/com/stripe/stripe-java/29.5.0/stripe-java-29.5.0.jar)  
- [Stripe Java repository README](https://github.com/stripe/stripe-java/blob/master/README.md)