### PR TITLE
chore: upgrade io.github.gradle-nexus.publish-plugin to 2.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 plugins {
     id "java"
     id "maven-publish"
-    id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
+    id "io.github.gradle-nexus.publish-plugin" version "2.0.0"
     id "signing"
     id "jacoco"
     id "io.freefair.lombok" version "6.3.0"


### PR DESCRIPTION
### Why?

This change upgrades the Gradle Nexus Publish Plugin from version 1.1.0 to 2.0.0.  
The previous version is outdated, and the newer version ensures compatibility with Gradle 8.x, includes bug fixes, and improves Maven Central publishing reliability.  
After this change, developers building Stripe locally or in CI will use the latest stable Nexus Publish plugin.

### What?

- Updated `build.gradle` to:
```gradle
id "io.github.gradle-nexus.publish-plugin" version "2.0.0"
```
- Verified that ./gradlew publishToMavenLocal works with the new plugin version.

### See Also

- [Gradle Nexus Publish Plugin Releases](https://github.com/gradle-nexus/publish-plugin/releases)