### PR TITLE
Add table of contents to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,30 @@
 
 The official [Stripe][stripe] Java client library.
 
+## Table of Contents
+
+- [Installation](#installation)
+  - [Requirements](#requirements)
+  - [Gradle users](#gradle-users)
+  - [Maven users](#maven-users)
+  - [Others](#others)
+  - [ProGuard](#proguard)
+- [Documentation](#documentation)
+- [Usage](#usage)
+  - [StripeClient vs legacy pattern](#stripeclient-vs-legacy-pattern)
+  - [Per-request Configuration](#per-request-configuration)
+  - [Configuring automatic retries](#configuring-automatic-retries)
+  - [Configuring Timeouts](#configuring-timeouts)
+  - [Configuring DNS Cache TTL](#configuring-dns-cache-ttl)
+  - [How to use undocumented parameters and properties](#how-to-use-undocumented-parameters-and-properties)
+  - [Writing a plugin](#writing-a-plugin)
+  - [Request latency telemetry](#request-latency-telemetry)
+  - [Public Preview SDKs](#public-preview-sdks)
+  - [Private Preview SDKs](#private-preview-sdks)
+  - [Custom requests](#custom-requests)
+- [Support](#support)
+- [Development](#development)
+
 ## Installation
 
 ### Requirements


### PR DESCRIPTION
### Why?
Improves README navigation and discoverability by adding a comprehensive table of contents. This makes it easier for developers to quickly find the documentation section they need.

### What?
- Adds a table of contents section to README.md with links to all major sections
- Organizes sections hierarchically to reflect the document structure

### See Also
N/A