### PR TITLE
Bump the max heap size to 4gb in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ tasks.withType(JavaCompile) {
     }
 
     options.fork = true
-    options.forkOptions.jvmArgs += ['-Xms512M', '-Xmx1g']
+    options.forkOptions.jvmArgs += ['-Xms512M', '-Xmx4g']
 
     options.release = project.targetCompatibility.majorVersion as Integer
 


### PR DESCRIPTION
### Why?
Builds for private-preview were running into OutOfMemoryError's

### What?
- bumps the max heap used by java processes from gradle to 4g, give us plenty of headroom.

### See Also
<!-- Include any links or additional information that help explain this change. -->
