### PR TITLE
Update CHANGELOG.md to include note on pinned API version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## 30.1.0 - 2025-10-29
+
+This release changes the pinned API version to `2025-10-29.clover`.
+
 * [#2093](https://github.com/stripe/stripe-java/pull/2093) Update generated code
   * Improve docs for PaymentIntent related endpoints
 * [#2086](https://github.com/stripe/stripe-java/pull/2086) Update generated code


### PR DESCRIPTION
### Why?
Missed adding this line when releasing the latest version

### What?
Added `This release changes the pinned API version to 2025-10-29.clover.`

### See Also
<!-- Include any links or additional information that help explain this change. -->
