### PR TITLE
Add Automatic-Module-Name to manifest entry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ jar {
                    "Implementation-Vendor": VENDOR_NAME,
                    "Bundle-SymbolicName": POM_ARTIFACT_ID,
                    "Export-Package": "com.stripe.*",
-                   "Automatic-Module-Name": "com.stripe")
+                   "Automatic-Module-Name": "stripe.java")
 
         archiveVersion = VERSION_NAME
     }


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
It was brought up in https://github.com/stripe/stripe-java/issues/1220 (4.5 years ago!) that our `stripe-java` jar is missing an `Automatic-Module-Name` manifest entry. For Java 9+, that means that consumers must use an inferred name of the module based on the compiled jar name, which is brittle. By adding `Automatic-Module-Name: stripe.java`, consumers and their tooling can confidently depend on that module name.

In the future, we can consider using a more conventional name like `com.stripe`, but that could technically break some users that have an explicit `requires stripe.java;` in their `manifest-info.java`.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- Adds `Automatic-Module-Name: stripe.java` to the jar's manifest entry

