### PR TITLE
Add Gson version to Stripe header

### DIFF
--- a/src/main/java/com/stripe/net/HttpClient.java
+++ b/src/main/java/com/stripe/net/HttpClient.java
@@ -4,7 +4,6 @@ import com.google.gson.Gson;
 import com.stripe.Stripe;
 import com.stripe.exception.ApiConnectionException;
 import com.stripe.exception.StripeException;
-
 import java.io.InputStream;
 import java.net.ConnectException;
 import java.net.SocketTimeoutException;
@@ -192,7 +191,8 @@ public abstract class HttpClient {
    * @return the Gson version string, or Optional.empty() if it cannot be determined
    */
   private static Optional<String> getGsonVersion() {
-    try (InputStream in = Gson.class.getResourceAsStream(
+    try (InputStream in =
+        Gson.class.getResourceAsStream(
             "/META-INF/maven/com.google.code.gson/gson/pom.properties")) {
       if (in != null) {
         Properties props = new Properties();


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
In investigating issues like https://github.com/stripe/stripe-java/issues/1213, it helps us if we can see the Gson version used in a request in the Stripe headers. We usually ask the user, but since Java dependency management is tricky, we sometimes get the wrong answer.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- Adds the Gson version included at runtime to the `X-STRIPE-CLIENT-USER-AGENT` header hash
