### PR TITLE
Add explicit permissions to GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,16 @@ on:
       - sdk-release/**
       - feature/**
 
+permissions: {}
+
 jobs:
   build:
     name: Build
 
     runs-on: "ubuntu-24.04"
+
+    permissions:
+      contents: read
 
     steps:
       - uses: extractions/setup-just@v2
@@ -48,6 +53,9 @@ jobs:
     name: Test
 
     runs-on: "ubuntu-24.04"
+
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false
@@ -106,6 +114,8 @@ jobs:
       endsWith(github.actor, '-stripe')
     needs: [build, test]
     runs-on: "ubuntu-24.04"
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@master
       - name: Setup Java
@@ -168,6 +178,9 @@ jobs:
 
   compat:
     runs-on: "ubuntu-24.04"
+
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -7,6 +7,8 @@ on:
     types:
       - auto_merge_enabled
 
+permissions: {}
+
 jobs:
   require_merge_commit_on_merge_script_pr:
     name: Merge script PRs must create merge commits


### PR DESCRIPTION
### Why?
Fix code scanning alerts about unlimited permissions in GitHub workflows. By default, workflows have read/write access to all scopes, which is a security concern. This change applies the principle of least privilege.

### What?
- Added `permissions: {}` at workflow level to restrict default permissions
- Added `contents: read` permission to each job that needs repository access
- The `publish-docs` job retains `contents: write` as it needs to push to gh-pages
- The `rules` workflow gets empty permissions as it only runs shell scripts

### See Also
- [GitHub docs on workflow permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)