### PR TITLE
Fix unhandled NumberFormatException in webhook timestamp parsing

### DIFF
--- a/src/main/java/com/stripe/net/Webhook.java
+++ b/src/main/java/com/stripe/net/Webhook.java
@@ -176,7 +176,11 @@ public final class Webhook {
       for (String item : items) {
         String[] itemParts = item.split("=", 2);
         if (itemParts[0].equals("t")) {
-          return Long.parseLong(itemParts[1]);
+          try {
+            return Long.parseLong(itemParts[1]);
+          } catch (NumberFormatException e) {
+            return -1;
+          }
         }
       }
 

--- a/src/test/java/com/stripe/net/WebhookTest.java
+++ b/src/test/java/com/stripe/net/WebhookTest.java
@@ -161,6 +161,21 @@ public class WebhookTest extends BaseStripeTest {
   }
 
   @Test
+  public void testMalformedTimestampValue() throws SignatureVerificationException {
+    // Test with non-numeric timestamp value - should throw SignatureVerificationException,
+    // not NumberFormatException
+    final String sigHeader = "t=not_a_number,v1=somesignature";
+
+    Throwable exception =
+        assertThrows(
+            SignatureVerificationException.class,
+            () -> {
+              Webhook.Signature.verifyHeader(payload, sigHeader, secret, 0, null);
+            });
+    assertEquals("Unable to extract timestamp and signatures from header", exception.getMessage());
+  }
+
+  @Test
   public void testNoSignaturesWithExpectedScheme()
       throws SignatureVerificationException, NoSuchAlgorithmException, InvalidKeyException {
     final Map<String, Object> options = new HashMap<>();


### PR DESCRIPTION
## Summary

Fixes an unhandled exception in webhook signature verification when the `Stripe-Signature` header contains a non-numeric timestamp value.

## Problem

In `Webhook.Signature.getTimestamp()`, `Long.parseLong()` is called on the timestamp value extracted from the header without exception handling. If a malformed header is received with a non-numeric timestamp (e.g., `t=not_a_number,v1=signature`), a `NumberFormatException` is thrown and propagates up uncaught.

This violates the documented contract of `verifyHeader()` and `constructEvent()`, which state they throw `SignatureVerificationException` when verification fails.

## Solution

Catch `NumberFormatException` in `getTimestamp()` and return `-1`, which causes `verifyHeader()` to throw the expected `SignatureVerificationException` with the message "Unable to extract timestamp and signatures from header".

## Testing

Added a test case `testMalformedTimestampValue()` that verifies the fix by passing a header with a non-numeric timestamp and asserting that `SignatureVerificationException` is thrown (not `NumberFormatException`).