### PR TITLE
don't publish private-preview javadocs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,7 @@ jobs:
       ((github.event_name == 'workflow_dispatch') || (github.event_name == 'push')) &&
       startsWith(github.ref, 'refs/tags/v') &&
       !contains(github.ref, 'beta') &&
+      !contains(github.ref, 'alpha') &&
       endsWith(github.actor, '-stripe')
     needs: [build, test]
     runs-on: "ubuntu-24.04"


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

We have a workflow that publishes javadocs to https://stripe.dev/stripe-java/index.html. For a long time we've ignored the beta branch when running the docs publish job. Since we introduced private-preview, they've been overwriting the GA docs every time they publish:

<img width="505" height="278" alt="image" src="https://github.com/user-attachments/assets/50678b0c-feb2-4783-bf68-fbcd847271f7" />

So, we ignore that release train too, in the hopes that only GA docs are published.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- ignore release names with `alpha` when publishing javadocs

### See Also
<!-- Include any links or additional information that help explain this change. -->

[RUN_DEVSDK-2179](https://go/j/RUN_DEVSDK-2179)