### PR TITLE
Tweak telemetry collection

### DIFF
--- a/src/main/java/com/stripe/net/HttpClient.java
+++ b/src/main/java/com/stripe/net/HttpClient.java
@@ -201,15 +201,7 @@ public abstract class HttpClient {
   }
 
   static String buildXStripeClientUserAgentString(String aiAgent) {
-    String[] propertyNames = {
-      "os.name",
-      "os.version",
-      "os.arch",
-      "java.version",
-      "java.vendor",
-      "java.vm.version",
-      "java.vm.vendor"
-    };
+    String[] propertyNames = {"java.version", "java.vendor", "java.vm.version", "java.vm.vendor"};
 
     Map<String, String> propertyMap = new HashMap<>();
     for (String propertyName : propertyNames) {
@@ -217,7 +209,15 @@ public abstract class HttpClient {
     }
     propertyMap.put("bindings.version", Stripe.VERSION);
     propertyMap.put("lang", "Java");
-    propertyMap.put("publisher", "Stripe");
+    if (Stripe.enableTelemetry) {
+      propertyMap.put(
+          "platform",
+          System.getProperty("os.name")
+              + " "
+              + System.getProperty("os.version")
+              + " "
+              + System.getProperty("os.arch"));
+    }
     if (Stripe.getAppInfo() != null) {
       propertyMap.put("application", ApiResource.INTERNAL_GSON.toJson(Stripe.getAppInfo()));
     }

--- a/src/test/java/com/stripe/net/HttpClientTest.java
+++ b/src/test/java/com/stripe/net/HttpClientTest.java
@@ -254,4 +254,45 @@ public class HttpClientTest extends BaseStripeTest {
         com.google.gson.JsonParser.parseString(json).getAsJsonObject();
     assertEquals("cursor", parsed.get("ai_agent").getAsString());
   }
+
+  @Test
+  public void testBuildXStripeClientUserAgentStringOmitsPublisherAndOsKeys() {
+    String json = HttpClient.buildXStripeClientUserAgentString("");
+    com.google.gson.JsonObject parsed =
+        com.google.gson.JsonParser.parseString(json).getAsJsonObject();
+    assertTrue(!parsed.has("publisher"));
+    assertTrue(!parsed.has("os.name"));
+    assertTrue(!parsed.has("os.version"));
+    assertTrue(!parsed.has("os.arch"));
+  }
+
+  @Test
+  public void testBuildXStripeClientUserAgentStringPlatformWithTelemetry() {
+    boolean originalTelemetry = Stripe.enableTelemetry;
+    try {
+      Stripe.enableTelemetry = true;
+      String json = HttpClient.buildXStripeClientUserAgentString("");
+      com.google.gson.JsonObject parsed =
+          com.google.gson.JsonParser.parseString(json).getAsJsonObject();
+      assertTrue(parsed.has("platform"));
+      String platform = parsed.get("platform").getAsString();
+      assertTrue(platform.contains(System.getProperty("os.name")));
+    } finally {
+      Stripe.enableTelemetry = originalTelemetry;
+    }
+  }
+
+  @Test
+  public void testBuildXStripeClientUserAgentStringNoPlatformWithoutTelemetry() {
+    boolean originalTelemetry = Stripe.enableTelemetry;
+    try {
+      Stripe.enableTelemetry = false;
+      String json = HttpClient.buildXStripeClientUserAgentString("");
+      com.google.gson.JsonObject parsed =
+          com.google.gson.JsonParser.parseString(json).getAsJsonObject();
+      assertTrue(!parsed.has("platform"));
+    } finally {
+      Stripe.enableTelemetry = originalTelemetry;
+    }
+  }
 }


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

We've long collected detailed platform information about calls made using the SDK. But a user brought to our attention that we're probably collecting more than we need. To fix, we're no longer sending the full `uname` output and only collecting data we actually care about. Additionally, users can opt out of sending platform information using the existing telemetry opt-out methods.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- remove unused `publisher` User-Agent key
- condense important data from `uname` into the `platform` key
- tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- [stripe/stripe-php#2015](https://github.com/stripe/stripe-php/issues/2015)
- [doc](https://docs.google.com/document/d/13fq-DtC_6WTfMyyI8b-Gq6jensyECa5K0X3WPL9fZJU/edit?tab=t.0)
- [RUN_DEVSDK-2244](https://go/j/RUN_DEVSDK-2244)
