### PR TITLE
Add Ref<T> type for typed v2 object references

### DIFF
--- a/src/main/java/com/stripe/model/v2/Ref.java
+++ b/src/main/java/com/stripe/model/v2/Ref.java
@@ -1,0 +1,52 @@
+package com.stripe.model.v2;
+
+import com.google.gson.annotations.SerializedName;
+import com.stripe.StripeClient;
+import com.stripe.exception.StripeException;
+import com.stripe.model.StripeObject;
+import com.stripe.net.ApiMode;
+import com.stripe.net.ApiResource.RequestMethod;
+import com.stripe.net.StripeResponse;
+import lombok.Getter;
+
+/**
+ * A typed object reference with wire shape {@code {type: string, id: string, url: string}}. Call
+ * {@link #fetch()} to retrieve the full object from the API.
+ *
+ * @param <T> the type of the referenced Stripe object
+ */
+@Getter
+public class Ref<T extends StripeObject> {
+  /** The type of the referenced object (e.g. {@code "v2.billing.meter_event"}). */
+  @SerializedName("type")
+  String type;
+
+  /** The unique identifier of the referenced object. */
+  @SerializedName("id")
+  String id;
+
+  /** The relative URL of the referenced object (e.g. {@code "/v2/billing/meter_events/mtr_123"}). */
+  @SerializedName("url")
+  String url;
+
+  /** The client used to fetch the referenced object. Set externally after deserialization. */
+  transient StripeClient client;
+
+  /**
+   * Fetches the full object from the Stripe API by issuing a GET to {@link #getUrl()}.
+   *
+   * @return the deserialized Stripe object
+   * @throws StripeException if the request fails
+   * @throws IllegalStateException if no client has been set on this reference
+   */
+  @SuppressWarnings("unchecked")
+  public T fetch() throws StripeException {
+    if (client == null) {
+      throw new IllegalStateException(
+          "Cannot fetch Ref without a StripeClient. Set the client field before calling fetch().");
+    }
+
+    StripeResponse response = client.rawRequest(RequestMethod.GET, url, null);
+    return (T) client.deserialize(response.body(), ApiMode.getMode(url));
+  }
+}

--- a/src/main/java/com/stripe/model/v2/Ref.java
+++ b/src/main/java/com/stripe/model/v2/Ref.java
@@ -1,13 +1,16 @@
 package com.stripe.model.v2;
 
 import com.google.gson.annotations.SerializedName;
-import com.stripe.StripeClient;
 import com.stripe.exception.StripeException;
+import com.stripe.model.StripeActiveObject;
 import com.stripe.model.StripeObject;
-import com.stripe.net.ApiMode;
-import com.stripe.net.ApiResource.RequestMethod;
-import com.stripe.net.StripeResponse;
+import com.stripe.net.ApiRequest;
+import com.stripe.net.ApiResource;
+import com.stripe.net.BaseAddress;
+import com.stripe.net.StripeResponseGetter;
+import java.lang.reflect.Type;
 import lombok.Getter;
+import lombok.Setter;
 
 /**
  * A typed object reference with wire shape {@code {type: string, id: string, url: string}}. Call
@@ -16,7 +19,7 @@ import lombok.Getter;
  * @param <T> the type of the referenced Stripe object
  */
 @Getter
-public class Ref<T extends StripeObject> {
+public class Ref<T extends StripeObject> implements StripeActiveObject {
   /** The type of the referenced object (e.g. {@code "v2.billing.meter_event"}). */
   @SerializedName("type")
   String type;
@@ -29,24 +32,33 @@ public class Ref<T extends StripeObject> {
   @SerializedName("url")
   String url;
 
-  /** The client used to fetch the referenced object. Set externally after deserialization. */
-  transient StripeClient client;
+  /** The response getter used to fetch the referenced object. Auto-injected during deserialization. */
+  transient StripeResponseGetter responseGetter;
+
+  /** The concrete type of {@code T}, captured at deserialization time to work around type erasure. */
+  @Setter private transient Type targetType;
+
+  @Override
+  public void setResponseGetter(StripeResponseGetter responseGetter) {
+    this.responseGetter = responseGetter;
+  }
 
   /**
    * Fetches the full object from the Stripe API by issuing a GET to {@link #getUrl()}.
    *
    * @return the deserialized Stripe object
    * @throws StripeException if the request fails
-   * @throws IllegalStateException if no client has been set on this reference
+   * @throws IllegalStateException if no responseGetter has been set on this reference
    */
-  @SuppressWarnings("unchecked")
   public T fetch() throws StripeException {
-    if (client == null) {
+    if (responseGetter == null) {
       throw new IllegalStateException(
-          "Cannot fetch Ref without a StripeClient. Set the client field before calling fetch().");
+          "Cannot fetch Ref without a StripeResponseGetter. Ensure this object was obtained via"
+              + " deserialization.");
     }
 
-    StripeResponse response = client.rawRequest(RequestMethod.GET, url, null);
-    return (T) client.deserialize(response.body(), ApiMode.getMode(url));
+    return responseGetter.request(
+        new ApiRequest(BaseAddress.API, ApiResource.RequestMethod.GET, url, null, null),
+        targetType);
   }
 }

--- a/src/main/java/com/stripe/net/StripeCollectionItemTypeSettingFactory.java
+++ b/src/main/java/com/stripe/net/StripeCollectionItemTypeSettingFactory.java
@@ -8,6 +8,8 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import com.stripe.model.*;
 import java.io.IOException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 
 class StripeCollectionItemTypeSettingFactory implements TypeAdapterFactory {
   @Override
@@ -27,6 +29,13 @@ class StripeCollectionItemTypeSettingFactory implements TypeAdapterFactory {
           ((StripeCollectionInterface<?>) obj).setPageTypeToken(type.getType());
         } else if (obj instanceof com.stripe.model.v2.StripeCollection<?>) {
           ((com.stripe.model.v2.StripeCollection<?>) obj).setPageTypeToken(type.getType());
+        } else if (obj instanceof com.stripe.model.v2.Ref<?>) {
+          // Extract T from Ref<T> so that fetch() can deserialize the referenced object directly.
+          Type refType = type.getType();
+          if (refType instanceof ParameterizedType) {
+            Type itemType = ((ParameterizedType) refType).getActualTypeArguments()[0];
+            ((com.stripe.model.v2.Ref<?>) obj).setTargetType(itemType);
+          }
         }
         return obj;
       }

--- a/src/test/java/com/stripe/model/v2/RefTest.java
+++ b/src/test/java/com/stripe/model/v2/RefTest.java
@@ -1,20 +1,17 @@
 package com.stripe.model.v2;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import com.google.gson.reflect.TypeToken;
-import com.stripe.StripeClient;
 import com.stripe.exception.StripeException;
 import com.stripe.model.v2.billing.MeterEventSession;
-import com.stripe.net.ApiMode;
+import com.stripe.net.ApiRequest;
 import com.stripe.net.ApiResource;
-import com.stripe.net.ApiResource.RequestMethod;
-import com.stripe.net.HttpHeaders;
-import com.stripe.net.RawRequestOptions;
-import com.stripe.net.StripeResponse;
+import com.stripe.net.BaseAddress;
+import com.stripe.net.StripeResponseGetter;
 import java.lang.reflect.Type;
-import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 public class RefTest {
@@ -37,49 +34,60 @@ public class RefTest {
   }
 
   @Test
-  public void clientIsNotDeserializedFromJson() {
+  public void responseGetterIsAutoInjectedOnDeserialization() {
     Type type = new TypeToken<Ref<MeterEventSession>>() {}.getType();
     Ref<MeterEventSession> ref = ApiResource.GSON.fromJson(REF_JSON, type);
 
-    assertNull(ref.client);
+    // StripeResponseGetterSettingTypeAdapterFactory calls setResponseGetter during
+    // deserialization because Ref implements StripeActiveObject.
+    assertNotNull(ref.responseGetter);
   }
 
   @Test
-  public void fetchThrowsWhenClientIsNull() {
+  public void targetTypeIsSetByTypeAdapterFactory() {
     Type type = new TypeToken<Ref<MeterEventSession>>() {}.getType();
     Ref<MeterEventSession> ref = ApiResource.GSON.fromJson(REF_JSON, type);
+
+    // StripeCollectionItemTypeSettingFactory extracts T from Ref<T> and calls setTargetType
+    // so that fetch() can pass the item type directly to responseGetter.request().
+    assertNotNull(ref.getTargetType());
+    assertEquals(MeterEventSession.class, ref.getTargetType());
+  }
+
+  @Test
+  public void fetchThrowsWhenResponseGetterIsNull() {
+    Type type = new TypeToken<Ref<MeterEventSession>>() {}.getType();
+    Ref<MeterEventSession> ref = ApiResource.GSON.fromJson(REF_JSON, type);
+    ref.setResponseGetter(null);
 
     IllegalStateException ex = assertThrows(IllegalStateException.class, ref::fetch);
-    assertTrue(ex.getMessage().contains("StripeClient"));
+    assertTrue(ex.getMessage().contains("StripeResponseGetter"));
   }
 
   @Test
-  public void fetchCallsRawRequestAndDeserializes() throws StripeException {
+  public void fetchCallsResponseGetterRequest() throws StripeException {
     Type type = new TypeToken<Ref<MeterEventSession>>() {}.getType();
     Ref<MeterEventSession> ref = ApiResource.GSON.fromJson(REF_JSON, type);
-
-    String sessionJson =
-        "{"
-            + "\"id\": \"mtes_123\","
-            + "\"object\": \"v2.billing.meter_event_session\","
-            + "\"authentication_token\": \"tok_abc\","
-            + "\"livemode\": false"
-            + "}";
-    StripeResponse mockResponse =
-        new StripeResponse(200, HttpHeaders.of(Collections.emptyMap()), sessionJson);
 
     MeterEventSession expectedSession = new MeterEventSession();
 
-    StripeClient mockClient = mock(StripeClient.class);
-    when(mockClient.rawRequest(RequestMethod.GET, ref.getUrl(), null)).thenReturn(mockResponse);
-    when(mockClient.deserialize(sessionJson, ApiMode.V2)).thenReturn(expectedSession);
+    StripeResponseGetter mockResponseGetter = mock(StripeResponseGetter.class);
+    when(mockResponseGetter.request(
+            any(ApiRequest.class), eq(ref.getTargetType())))
+        .thenReturn(expectedSession);
 
-    ref.client = mockClient;
+    ref.setResponseGetter(mockResponseGetter);
 
     MeterEventSession result = ref.fetch();
 
     assertSame(expectedSession, result);
-    verify(mockClient).rawRequest(RequestMethod.GET, ref.getUrl(), null);
-    verify(mockClient).deserialize(sessionJson, ApiMode.V2);
+    verify(mockResponseGetter)
+        .request(
+            argThat(
+                req ->
+                    req.getBaseAddress() == BaseAddress.API
+                        && req.getMethod() == ApiResource.RequestMethod.GET
+                        && req.getPath().equals(ref.getUrl())),
+            eq(ref.getTargetType()));
   }
 }

--- a/src/test/java/com/stripe/model/v2/RefTest.java
+++ b/src/test/java/com/stripe/model/v2/RefTest.java
@@ -1,0 +1,85 @@
+package com.stripe.model.v2;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.google.gson.reflect.TypeToken;
+import com.stripe.StripeClient;
+import com.stripe.exception.StripeException;
+import com.stripe.model.v2.billing.MeterEventSession;
+import com.stripe.net.ApiMode;
+import com.stripe.net.ApiResource;
+import com.stripe.net.ApiResource.RequestMethod;
+import com.stripe.net.HttpHeaders;
+import com.stripe.net.RawRequestOptions;
+import com.stripe.net.StripeResponse;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+public class RefTest {
+
+  private static final String REF_JSON =
+      "{"
+          + "\"type\": \"v2.billing.meter_event_session\","
+          + "\"id\": \"mtes_123\","
+          + "\"url\": \"/v2/billing/meter_event_sessions/mtes_123\""
+          + "}";
+
+  @Test
+  public void deserializesWireFields() {
+    Type type = new TypeToken<Ref<MeterEventSession>>() {}.getType();
+    Ref<MeterEventSession> ref = ApiResource.GSON.fromJson(REF_JSON, type);
+
+    assertEquals("v2.billing.meter_event_session", ref.getType());
+    assertEquals("mtes_123", ref.getId());
+    assertEquals("/v2/billing/meter_event_sessions/mtes_123", ref.getUrl());
+  }
+
+  @Test
+  public void clientIsNotDeserializedFromJson() {
+    Type type = new TypeToken<Ref<MeterEventSession>>() {}.getType();
+    Ref<MeterEventSession> ref = ApiResource.GSON.fromJson(REF_JSON, type);
+
+    assertNull(ref.client);
+  }
+
+  @Test
+  public void fetchThrowsWhenClientIsNull() {
+    Type type = new TypeToken<Ref<MeterEventSession>>() {}.getType();
+    Ref<MeterEventSession> ref = ApiResource.GSON.fromJson(REF_JSON, type);
+
+    IllegalStateException ex = assertThrows(IllegalStateException.class, ref::fetch);
+    assertTrue(ex.getMessage().contains("StripeClient"));
+  }
+
+  @Test
+  public void fetchCallsRawRequestAndDeserializes() throws StripeException {
+    Type type = new TypeToken<Ref<MeterEventSession>>() {}.getType();
+    Ref<MeterEventSession> ref = ApiResource.GSON.fromJson(REF_JSON, type);
+
+    String sessionJson =
+        "{"
+            + "\"id\": \"mtes_123\","
+            + "\"object\": \"v2.billing.meter_event_session\","
+            + "\"authentication_token\": \"tok_abc\","
+            + "\"livemode\": false"
+            + "}";
+    StripeResponse mockResponse =
+        new StripeResponse(200, HttpHeaders.of(Collections.emptyMap()), sessionJson);
+
+    MeterEventSession expectedSession = new MeterEventSession();
+
+    StripeClient mockClient = mock(StripeClient.class);
+    when(mockClient.rawRequest(RequestMethod.GET, ref.getUrl(), null)).thenReturn(mockResponse);
+    when(mockClient.deserialize(sessionJson, ApiMode.V2)).thenReturn(expectedSession);
+
+    ref.client = mockClient;
+
+    MeterEventSession result = ref.fetch();
+
+    assertSame(expectedSession, result);
+    verify(mockClient).rawRequest(RequestMethod.GET, ref.getUrl(), null);
+    verify(mockClient).deserialize(sessionJson, ApiMode.V2);
+  }
+}


### PR DESCRIPTION
### Why?

Custom objects need typed references to other Stripe objects. A reference has the wire shape `{type, id, url}` and in the SDK becomes `Ref<T>` — a container that knows the target type and can fetch it.

### What?

- `com.stripe.model.v2.Ref<T extends StripeObject>` with `@SerializedName` annotations for `type`, `id`, `url`
- Implements `StripeActiveObject` — `responseGetter` is auto-injected by `StripeResponseGetterSettingTypeAdapterFactory` during GSON deserialization
- Transient `targetType` field set by `StripeCollectionItemTypeSettingFactory` to resolve type erasure
- `fetch()` calls `responseGetter.request(new ApiRequest(GET, url), targetType)` — same pattern as `Event.fetchRelatedObject()`
- Throws `IllegalStateException` when responseGetter is null

### See Also

Generated with [Claude Code](https://claude.com/claude-code)