### PR TITLE
Fix BigDecimal serialization in StripeObject.toJson()

### DIFF
--- a/src/main/java/com/stripe/model/StripeObject.java
+++ b/src/main/java/com/stripe/model/StripeObject.java
@@ -4,15 +4,37 @@ import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import com.stripe.net.ApiMode;
 import com.stripe.net.ApiResource;
 import com.stripe.net.StripeResponse;
 import com.stripe.net.StripeResponseGetter;
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
+import java.math.BigDecimal;
 import java.time.Instant;
 
 public abstract class StripeObject implements StripeObjectInterface {
+  private static final TypeAdapter<BigDecimal> BIG_DECIMAL_STRING_ADAPTER =
+      new TypeAdapter<BigDecimal>() {
+        @Override
+        public void write(JsonWriter out, BigDecimal value) throws IOException {
+          if (value == null) {
+            out.nullValue();
+          } else {
+            out.value(value.toPlainString());
+          }
+        }
+
+        @Override
+        public BigDecimal read(JsonReader in) throws IOException {
+          return new BigDecimal(in.nextString());
+        }
+      };
+
   public static final Gson PRETTY_PRINT_GSON =
       new GsonBuilder()
           .setPrettyPrinting()
@@ -20,6 +42,7 @@ public abstract class StripeObject implements StripeObjectInterface {
           .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
           .registerTypeAdapter(ExpandableField.class, new ExpandableFieldSerializer())
           .registerTypeAdapter(Instant.class, new InstantSerializer())
+          .registerTypeAdapter(BigDecimal.class, BIG_DECIMAL_STRING_ADAPTER)
           .create();
 
   private transient StripeResponse lastResponse;

--- a/src/test/java/com/stripe/model/StripeObjectTest.java
+++ b/src/test/java/com/stripe/model/StripeObjectTest.java
@@ -1,0 +1,29 @@
+package com.stripe.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Test;
+
+public class StripeObjectTest {
+
+  private static final class DecimalStripeObject extends StripeObject {
+    BigDecimal amount;
+  }
+
+  @Test
+  public void toJsonSerializesBigDecimalAsString() {
+    DecimalStripeObject object = new DecimalStripeObject();
+    object.amount = new BigDecimal("25.50");
+
+    String json = object.toJson();
+
+    JsonObject parsed = JsonParser.parseString(json).getAsJsonObject();
+    assertTrue(parsed.get("amount").isJsonPrimitive());
+    assertTrue(parsed.get("amount").getAsJsonPrimitive().isString());
+    assertEquals("25.50", parsed.get("amount").getAsString());
+  }
+}


### PR DESCRIPTION
### Why?

`StripeObject.toJson()` uses a Gson instance that does not serialize `BigDecimal`
values as strings. This leads to inconsistency with Stripe API expectations,
where decimal values are typically represented as strings to preserve precision.

Before this change:
{"amount": 25.50}

After this change:
{"amount": "25.50"}

This fix ensures consistent serialization behavior and avoids potential precision issues.

---

### What?

- Added a custom `TypeAdapter<BigDecimal>` to serialize values using `toPlainString()`
- Registered the adapter in `StripeObject.PRETTY_PRINT_GSON`
- Added a regression test (`StripeObjectTest`) to verify that `BigDecimal` values
  are serialized as JSON strings

---

### See Also

- Related issue: https://github.com/stripe/stripe-java/issues/1845

Note: Full test suite requires `stripe-mock` running locally. Unit tests pass and
this change does not affect API request logic.