### PR TITLE
Fix missing stripeContext in RequestOptions.toBuilderFullCopy()

### DIFF
--- a/src/main/java/com/stripe/net/RequestOptions.java
+++ b/src/main/java/com/stripe/net/RequestOptions.java
@@ -168,6 +168,7 @@ public class RequestOptions {
             .setClientId(this.clientId)
             .setIdempotencyKey(this.idempotencyKey)
             .setStripeAccount(this.stripeAccount)
+            .setStripeContext(this.stripeContext)
             .setStripeRequestTrigger(this.stripeRequestTrigger)
             .setConnectTimeout(this.connectTimeout)
             .setReadTimeout(this.readTimeout)

--- a/src/test/java/com/stripe/net/RequestOptionsTest.java
+++ b/src/test/java/com/stripe/net/RequestOptionsTest.java
@@ -47,25 +47,25 @@ public class RequestOptionsTest {
     assertNull(optsRebuilt.getBaseUrl());
   }
 
-    @Test
-    public void testToBuilderFullCopy() {
+  @Test
+  public void testToBuilderFullCopy() {
     RequestOptions opts =
         RequestOptionsBuilder.unsafeSetStripeVersionOverride(
-            RequestOptions.builder()
-                .setApiKey("sk_foo")
-                .setBaseUrl("http://example.com")
-                .setClientId("123")
-                .setIdempotencyKey("123")
-                .setStripeAccount("acct_bar")
-                .setStripeContext("acct_context_123")
-                .setStripeRequestTrigger("some_trigger")
-                .setConnectTimeout(100)
-                .setReadTimeout(100)
-                .setConnectionProxy(
-                    new Proxy(Proxy.Type.HTTP, new InetSocketAddress("localhost", 1234)))
-                .setProxyCredential(
-                    new PasswordAuthentication("username", "password".toCharArray())),
-            "2015-05-05")
+                RequestOptions.builder()
+                    .setApiKey("sk_foo")
+                    .setBaseUrl("http://example.com")
+                    .setClientId("123")
+                    .setIdempotencyKey("123")
+                    .setStripeAccount("acct_bar")
+                    .setStripeContext("acct_context_123")
+                    .setStripeRequestTrigger("some_trigger")
+                    .setConnectTimeout(100)
+                    .setReadTimeout(100)
+                    .setConnectionProxy(
+                        new Proxy(Proxy.Type.HTTP, new InetSocketAddress("localhost", 1234)))
+                    .setProxyCredential(
+                        new PasswordAuthentication("username", "password".toCharArray())),
+                "2015-05-05")
             .build();
 
     RequestOptions optsRebuilt = opts.toBuilderFullCopy().build();
@@ -73,22 +73,7 @@ public class RequestOptionsTest {
     assertEquals(opts, optsRebuilt);
     assertEquals("acct_context_123", optsRebuilt.getStripeContext());
     assertEquals("some_trigger", optsRebuilt.getStripeRequestTrigger());
-    }
-
-    @Test
-    public void testToBuilderFullCopy_preservesStripeContext() {
-    RequestOptions opts =
-        RequestOptions.builder()
-            .setApiKey("sk_test")
-            .setStripeContext("ctx_123")
-            .setStripeRequestTrigger("trigger_123")
-            .build();
-
-    RequestOptions rebuilt = opts.toBuilderFullCopy().build();
-
-    assertEquals("ctx_123", rebuilt.getStripeContext());
-    assertEquals("trigger_123", rebuilt.getStripeRequestTrigger());
-    }
+  }
 
   @Test
   public void testStripeVersionOverride() {

--- a/src/test/java/com/stripe/net/RequestOptionsTest.java
+++ b/src/test/java/com/stripe/net/RequestOptionsTest.java
@@ -47,29 +47,48 @@ public class RequestOptionsTest {
     assertNull(optsRebuilt.getBaseUrl());
   }
 
-  @Test
-  public void testToBuilderFullCopy() {
+    @Test
+    public void testToBuilderFullCopy() {
     RequestOptions opts =
         RequestOptionsBuilder.unsafeSetStripeVersionOverride(
-                RequestOptions.builder()
-                    .setApiKey("sk_foo")
-                    .setBaseUrl("http://example.com")
-                    .setClientId("123")
-                    .setIdempotencyKey("123")
-                    .setStripeAccount("acct_bar")
-                    .setConnectTimeout(100)
-                    .setReadTimeout(100)
-                    .setConnectionProxy(
-                        new Proxy(Proxy.Type.HTTP, new InetSocketAddress("localhost", 1234)))
-                    .setProxyCredential(
-                        new PasswordAuthentication("username", "password".toCharArray())),
-                "2015-05-05")
+            RequestOptions.builder()
+                .setApiKey("sk_foo")
+                .setBaseUrl("http://example.com")
+                .setClientId("123")
+                .setIdempotencyKey("123")
+                .setStripeAccount("acct_bar")
+                .setStripeContext("acct_context_123")
+                .setStripeRequestTrigger("some_trigger")
+                .setConnectTimeout(100)
+                .setReadTimeout(100)
+                .setConnectionProxy(
+                    new Proxy(Proxy.Type.HTTP, new InetSocketAddress("localhost", 1234)))
+                .setProxyCredential(
+                    new PasswordAuthentication("username", "password".toCharArray())),
+            "2015-05-05")
             .build();
 
     RequestOptions optsRebuilt = opts.toBuilderFullCopy().build();
 
     assertEquals(opts, optsRebuilt);
-  }
+    assertEquals("acct_context_123", optsRebuilt.getStripeContext());
+    assertEquals("some_trigger", optsRebuilt.getStripeRequestTrigger());
+    }
+
+    @Test
+    public void testToBuilderFullCopy_preservesStripeContext() {
+    RequestOptions opts =
+        RequestOptions.builder()
+            .setApiKey("sk_test")
+            .setStripeContext("ctx_123")
+            .setStripeRequestTrigger("trigger_123")
+            .build();
+
+    RequestOptions rebuilt = opts.toBuilderFullCopy().build();
+
+    assertEquals("ctx_123", rebuilt.getStripeContext());
+    assertEquals("trigger_123", rebuilt.getStripeRequestTrigger());
+    }
 
   @Test
   public void testStripeVersionOverride() {


### PR DESCRIPTION
### Why?

`RequestOptions.toBuilderFullCopy()` does not copy the `stripeContext` field,
causing it to be lost when rebuilding a `RequestOptions` instance.

This leads to unexpected behavior where request context metadata is silently dropped.

Before this change:
opts.toBuilderFullCopy().build().getStripeContext() == null

After this change:
opts.toBuilderFullCopy().build().getStripeContext() == original value

---

### What?

- Added `.setStripeContext(this.stripeContext)` in `toBuilderFullCopy()`
- Added a regression test to ensure `stripeContext` is preserved during copy

---

### See Also

- https://github.com/stripe/stripe-java/issues/2205

## Changelog
- Fixes a bug where an existing `stripeContext` was being reset to `null` when calling `RequestOptions#toBuilderFullCopy()`