### PR TITLE
Add better example for accessing non-documented properties in a list response

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ If you are not using Gradle or Maven, you will need to manually install the foll
    - We recommend using the same version of Gson if possible to guarantee compatibility, but you should be able to use any stable version of Gson that is 2.10.1 or newer
 
 To use these JARs:
+
 1. Download the JARs from the links provided above
 2. Add the JARs to your project's classpath
 
@@ -241,6 +242,32 @@ String secondaryValue =
     .getAsString();
 ```
 
+> [!NOTE]
+> `.getRawJsonObject()` is only available on the top-level object returned by an API call. For most requests (like `.retrieve()` or `.create()`) you'll get the object itself. But for `.list()` calls, the top level object is a `List<T>`, so you can only access the raw json of an individual object by going through the list itself.
+>
+> ```java
+> var cards = stripeClient
+>   .v1()
+>   .issuing()
+>   .cards()
+>   .list(params);
+>
+> // doesn't work:
+> cards
+>   .getData()
+>   .get(0)
+>   .getRawJsonObject(); // null
+>
+> // instead, go through the list:
+> cards
+>  .getRawJsonObject()
+>  .getAsJsonArray("data")
+>  .get(0)
+>  .getAsJsonObject()
+>  .getAsJsonPrimitive("undocumented-val")
+>  .getAsString(); // "some-val"
+> ```
+
 ### Writing a plugin
 
 If you're writing a plugin that uses the library, we'd appreciate it if you
@@ -269,7 +296,7 @@ Stripe.enableTelemetry = false;
 Stripe has features in the [public preview phase](https://docs.stripe.com/release-phases) that can be accessed via versions of this package that have the `-beta.X` suffix like `25.2.0-beta.2`.
 We would love for you to try these as we incrementally release new features and improve them based on your feedback.
 
- To install, pick the latest version with the `beta` suffix by reviewing the [releases page](https://github.com/stripe/stripe-java/releases/) and then use it [installation steps above](#installation).
+To install, pick the latest version with the `beta` suffix by reviewing the [releases page](https://github.com/stripe/stripe-java/releases/) and then use it [installation steps above](#installation).
 
 > **Note**
 > There can be breaking changes between two versions of the public preview SDKs without a bump in the major version. Therefore we recommend pinning the package version to a specific version. This way you can install the same version each time without breaking changes unless you are intentionally looking for the latest public preview SDK.
@@ -279,6 +306,7 @@ Some preview features require a name and version to be set in the `Stripe-Versio
 ```java
 Stripe.addBetaVersion("feature_beta", "v3");
 ```
+
 ### Private Preview SDKs
 
 Stripe has features in the [private preview phase](https://docs.stripe.com/release-phases) that can be accessed via versions of this package that have the `-alpha.X` suffix like `25.2.0-alpha.2`. These are invite-only features. Once invited, you can install the private preview SDKs by following the same instructions as for the [public preview SDKs](https://github.com/stripe/stripe-java?tab=readme-ov-file#public-preview-sdks) above and replacing the term `beta` with `alpha`.


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

There was some confusion in https://github.com/stripe/stripe-java/issues/2209 around how to access the raw json of list items. While we're still looking into ways to improve this experience, we can at least document the behavior better

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- add `getRawJsonObject` example for list responses to README

### See Also
<!-- Include any links or additional information that help explain this change. -->

- [RUN_DEVSDK-2364](https://go/j/RUN_DEVSDK-2364)
- https://github.com/stripe/stripe-java/issues/2209