### PR TITLE
Emit warning when `stripe-notify` header is present in response

### DIFF
--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -21,8 +21,11 @@ import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.logging.Logger;
 
 public class LiveStripeResponseGetter implements StripeResponseGetter {
+  private static final Logger logger = Logger.getLogger("Stripe");
+
   private final HttpClient httpClient;
   private final StripeResponseGetterOptions options;
 
@@ -131,6 +134,8 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
     StripeResponse response =
         sendWithTelemetry(request, apiRequest.getUsage(), r -> httpClient.requestWithRetries(r));
 
+    maybeEmitStripeNotice(response.headers());
+
     int responseCode = response.code();
     String responseBody = response.body();
     String requestId = response.requestId();
@@ -173,6 +178,8 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
     StripeResponseStream responseStream =
         sendWithTelemetry(
             request, apiRequest.getUsage(), r -> httpClient.requestStreamWithRetries(r));
+
+    maybeEmitStripeNotice(responseStream.headers());
 
     int responseCode = responseStream.code();
 
@@ -253,6 +260,10 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
       ApiMode apiMode)
       throws StripeException {
     return this.requestStream(new ApiRequest(baseAddress, method, path, params, options));
+  }
+
+  private static void maybeEmitStripeNotice(HttpHeaders headers) {
+    headers.firstValue("Stripe-Notice").ifPresent(logger::warning);
   }
 
   private static HttpClient buildDefaultHttpClient() {

--- a/src/test/java/com/stripe/functional/LiveStripeResponseGetterTest.java
+++ b/src/test/java/com/stripe/functional/LiveStripeResponseGetterTest.java
@@ -1,9 +1,13 @@
 package com.stripe.functional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonSyntaxException;
 import com.stripe.BaseStripeTest;
 import com.stripe.exception.ApiException;
@@ -18,12 +22,92 @@ import com.stripe.net.LiveStripeResponseGetter;
 import com.stripe.net.StripeRequest;
 import com.stripe.net.StripeResponse;
 import com.stripe.net.StripeResponseGetter;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class LiveStripeResponseGetterTest extends BaseStripeTest {
+  private Logger stripeLogger;
+  private CapturingHandler logHandler;
+
+  private static class CapturingHandler extends Handler {
+    final List<LogRecord> records = new ArrayList<>();
+
+    @Override
+    public void publish(LogRecord record) {
+      records.add(record);
+    }
+
+    @Override
+    public void flush() {}
+
+    @Override
+    public void close() {}
+  }
+
+  @BeforeEach
+  public void setUpLogger() {
+    stripeLogger = Logger.getLogger("Stripe");
+    logHandler = new CapturingHandler();
+    logHandler.setLevel(Level.ALL);
+    stripeLogger.addHandler(logHandler);
+    stripeLogger.setLevel(Level.ALL);
+    stripeLogger.setUseParentHandlers(false);
+  }
+
+  @AfterEach
+  public void tearDownLogger() {
+    stripeLogger.removeHandler(logHandler);
+    stripeLogger.setUseParentHandlers(true);
+  }
+
+  @Test
+  public void testStripeNoticeHeaderEmitsWarning() throws StripeException {
+    HttpClient spy = Mockito.spy(new HttpURLConnectionClient());
+    StripeResponseGetter srg = new LiveStripeResponseGetter(spy);
+    ApiResource.setGlobalResponseGetter(srg);
+    StripeResponse response =
+        new StripeResponse(
+            200,
+            HttpHeaders.of(
+                ImmutableMap.of(
+                    "Stripe-Notice",
+                    ImmutableList.of("This API version will be deprecated soon."))),
+            "{\"id\": \"sub_123\", \"object\": \"subscription\"}");
+    Mockito.doReturn(response).when(spy).requestWithRetries(Mockito.<StripeRequest>any());
+    Subscription.retrieve("sub_123");
+
+    assertEquals(1, logHandler.records.size());
+    assertEquals(Level.WARNING, logHandler.records.get(0).getLevel());
+    assertEquals(
+        "This API version will be deprecated soon.", logHandler.records.get(0).getMessage());
+  }
+
+  @Test
+  public void testNoStripeNoticeHeaderEmitsNoWarning() throws StripeException {
+    HttpClient spy = Mockito.spy(new HttpURLConnectionClient());
+    StripeResponseGetter srg = new LiveStripeResponseGetter(spy);
+    ApiResource.setGlobalResponseGetter(srg);
+    StripeResponse response =
+        new StripeResponse(
+            200,
+            HttpHeaders.of(Collections.emptyMap()),
+            "{\"id\": \"sub_123\", \"object\": \"subscription\"}");
+    Mockito.doReturn(response).when(spy).requestWithRetries(Mockito.<StripeRequest>any());
+    Subscription.retrieve("sub_123");
+
+    assertTrue(logHandler.records.isEmpty());
+  }
+
   @Test
   public void testInvalidJson() throws StripeException {
     HttpClient spy = Mockito.spy(new HttpURLConnectionClient());


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

We've noticed a trend where users (and their agents) will sometimes reach for suboptimal API endpoints/methods because of outdated information. For example, using `/v1/accounts` when `/v2/core/accounts` is available and has a superset of the functionality from v1.

In an effort to help steer users towards best practices, we're introducing a new header to provide feedback during the development process. The SDK is responsible for surfacing this header, if present.

Once enabled internally, the header will be returned by the server for:

- all testmode calls
- livemode calls made by an agent

We may tweak that going forwards. But no matter the conditions, the SDKs will act as a thin pipe.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- Emit warning when we see the `Stripe-Notice` header in a response. **Note** this is the first warning we're emitting in this SDK, so make sure it's the correct way to do that!
- add tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- https://go/agent-steering
- [DEVSDK-2430](https://go/j/browse/DEVSDK-2430)
