### PR TITLE
Disable trim_trailing_whitespace for CHANGELOG.md

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,6 @@ indent_size = 2
 [*.json]
 indent_style = space
 indent_size = 2
+
+[CHANGELOG.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Prevents editors from stripping intentional trailing whitespace in changelog entries.

Fixes: https://go/j/DEVSDK-2229