### PR TITLE
Add "source" field to user-agent header

### DIFF
--- a/src/main/java/com/stripe/net/HttpClient.java
+++ b/src/main/java/com/stripe/net/HttpClient.java
@@ -7,6 +7,7 @@ import com.stripe.exception.StripeException;
 import java.io.InputStream;
 import java.net.ConnectException;
 import java.net.SocketTimeoutException;
+import java.security.MessageDigest;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -25,6 +26,53 @@ public abstract class HttpClient {
 
   /** A value indicating whether the client should sleep between automatic request retries. */
   boolean networkRetriesSleep = true;
+
+  static String UNAME_HASH = computeUnameHash();
+
+  private static String computeUnameHash() {
+    String uname = "";
+    try {
+      uname =
+          (System.getProperty("os.name", "")
+                  + " "
+                  + System.getProperty("os.version", "")
+                  + " "
+                  + System.getProperty("os.arch", "")
+                  + " "
+                  + System.getProperty("java.version", "")
+                  + " "
+                  + System.getProperty("java.vendor", "")
+                  + " "
+                  + System.getProperty("java.vm.name", "")
+                  + " "
+                  + getHostname())
+              .trim();
+    } catch (Exception e) {
+      // fall through with empty string
+    }
+    if (uname.isEmpty()) {
+      return "";
+    }
+    try {
+      MessageDigest md = MessageDigest.getInstance("MD5");
+      byte[] hashBytes = md.digest(uname.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+      StringBuilder sb = new StringBuilder();
+      for (byte b : hashBytes) {
+        sb.append(String.format("%02x", b));
+      }
+      return sb.toString();
+    } catch (Exception e) {
+      return "";
+    }
+  }
+
+  private static String getHostname() {
+    try {
+      return java.net.InetAddress.getLocalHost().getHostName();
+    } catch (Exception e) {
+      return "";
+    }
+  }
 
   /** Initializes a new instance of the {@link HttpClient} class. */
   protected HttpClient() {}
@@ -226,6 +274,10 @@ public abstract class HttpClient {
 
     if (!aiAgent.isEmpty()) {
       propertyMap.put("ai_agent", aiAgent);
+    }
+
+    if (!UNAME_HASH.isEmpty()) {
+      propertyMap.put("source", UNAME_HASH);
     }
 
     return ApiResource.INTERNAL_GSON.toJson(propertyMap);

--- a/src/test/java/com/stripe/net/HttpClientTest.java
+++ b/src/test/java/com/stripe/net/HttpClientTest.java
@@ -1,6 +1,7 @@
 package com.stripe.net;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -293,6 +294,33 @@ public class HttpClientTest extends BaseStripeTest {
       assertTrue(!parsed.has("platform"));
     } finally {
       Stripe.enableTelemetry = originalTelemetry;
+    }
+  }
+
+  @Test
+  public void testBuildXStripeClientUserAgentStringIncludesSource() {
+    String json = HttpClient.buildXStripeClientUserAgentString("");
+    com.google.gson.JsonObject parsed =
+        com.google.gson.JsonParser.parseString(json).getAsJsonObject();
+    // "source" should be present and be a 32-character lowercase MD5 hex digest
+    assertTrue(parsed.has("source"), "Expected 'source' field in X-Stripe-Client-User-Agent");
+    String source = parsed.get("source").getAsString();
+    assertTrue(
+        source.matches("[0-9a-f]{32}"),
+        "Expected 'source' to be a 32-character lowercase hex string, got: " + source);
+  }
+
+  @Test
+  public void testBuildXStripeClientUserAgentStringOmitsSourceWhenEmpty() throws Exception {
+    String savedHash = HttpClient.UNAME_HASH;
+    try {
+      HttpClient.UNAME_HASH = "";
+      String userAgentString = HttpClient.buildXStripeClientUserAgentString("");
+      com.google.gson.JsonObject userAgent =
+          com.google.gson.JsonParser.parseString(userAgentString).getAsJsonObject();
+      assertFalse(userAgent.has("source"));
+    } finally {
+      HttpClient.UNAME_HASH = savedHash;
     }
   }
 }


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Earlier this year, we removed the output of `uname` from the user-agent header for privacy reasons. It over-collected data we usually didn't need.

Since then, our tech support team has reached out asking us to re-add some of the information to help with complex debugging tasks: sometimes they need to help users identify exactly which machine produced an API call.

Rather than just revert the previous change and reintroduce the same privacy issues that caused its removal in the first place, we're taking a more privacy-focused approach. Rather than send all the PII in plaintext, we hash it first. This way it can still be used to confirm the source of an API call if a user generates the hashes themselves, but isn't sensitive in and of itself.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- add `source` key to user-agent hash. It's contents are an md5 hash of `uname -a`
- add tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- [DEVSDK-3131](https://go/j/DEVSDK-3131)
