### PR TITLE
⚠️ Make `tax_rate.tax_details` expandable

### DIFF
--- a/src/main/java/com/stripe/model/CreditNote.java
+++ b/src/main/java/com/stripe/model/CreditNote.java
@@ -949,7 +949,27 @@ public class CreditNote extends ApiResource implements HasId, MetadataStore<Cred
     public static class TaxRateDetails extends StripeObject {
       /** ID of the tax rate. */
       @SerializedName("tax_rate")
-      String taxRate;
+      @Getter(lombok.AccessLevel.NONE)
+      @Setter(lombok.AccessLevel.NONE)
+      ExpandableField<TaxRate> taxRate;
+
+      /** Get ID of expandable {@code taxRate} object. */
+      public String getTaxRate() {
+        return (this.taxRate != null) ? this.taxRate.getId() : null;
+      }
+
+      public void setTaxRate(String id) {
+        this.taxRate = ApiResource.setExpandableFieldId(id, this.taxRate);
+      }
+
+      /** Get expanded {@code taxRate}. */
+      public TaxRate getTaxRateObject() {
+        return (this.taxRate != null) ? this.taxRate.getExpanded() : null;
+      }
+
+      public void setTaxRateObject(TaxRate expandableObject) {
+        this.taxRate = new ExpandableField<TaxRate>(expandableObject.getId(), expandableObject);
+      }
     }
   }
 

--- a/src/main/java/com/stripe/model/CreditNoteLineItem.java
+++ b/src/main/java/com/stripe/model/CreditNoteLineItem.java
@@ -276,7 +276,27 @@ public class CreditNoteLineItem extends StripeObject implements HasId {
     public static class TaxRateDetails extends StripeObject {
       /** ID of the tax rate. */
       @SerializedName("tax_rate")
-      String taxRate;
+      @Getter(lombok.AccessLevel.NONE)
+      @Setter(lombok.AccessLevel.NONE)
+      ExpandableField<TaxRate> taxRate;
+
+      /** Get ID of expandable {@code taxRate} object. */
+      public String getTaxRate() {
+        return (this.taxRate != null) ? this.taxRate.getId() : null;
+      }
+
+      public void setTaxRate(String id) {
+        this.taxRate = ApiResource.setExpandableFieldId(id, this.taxRate);
+      }
+
+      /** Get expanded {@code taxRate}. */
+      public TaxRate getTaxRateObject() {
+        return (this.taxRate != null) ? this.taxRate.getExpanded() : null;
+      }
+
+      public void setTaxRateObject(TaxRate expandableObject) {
+        this.taxRate = new ExpandableField<TaxRate>(expandableObject.getId(), expandableObject);
+      }
     }
   }
 }

--- a/src/main/java/com/stripe/model/Invoice.java
+++ b/src/main/java/com/stripe/model/Invoice.java
@@ -3123,7 +3123,27 @@ public class Invoice extends ApiResource implements HasId, MetadataStore<Invoice
     public static class TaxRateDetails extends StripeObject {
       /** ID of the tax rate. */
       @SerializedName("tax_rate")
-      String taxRate;
+      @Getter(lombok.AccessLevel.NONE)
+      @Setter(lombok.AccessLevel.NONE)
+      ExpandableField<TaxRate> taxRate;
+
+      /** Get ID of expandable {@code taxRate} object. */
+      public String getTaxRate() {
+        return (this.taxRate != null) ? this.taxRate.getId() : null;
+      }
+
+      public void setTaxRate(String id) {
+        this.taxRate = ApiResource.setExpandableFieldId(id, this.taxRate);
+      }
+
+      /** Get expanded {@code taxRate}. */
+      public TaxRate getTaxRateObject() {
+        return (this.taxRate != null) ? this.taxRate.getExpanded() : null;
+      }
+
+      public void setTaxRateObject(TaxRate expandableObject) {
+        this.taxRate = new ExpandableField<TaxRate>(expandableObject.getId(), expandableObject);
+      }
     }
   }
 

--- a/src/main/java/com/stripe/model/InvoiceLineItem.java
+++ b/src/main/java/com/stripe/model/InvoiceLineItem.java
@@ -673,7 +673,27 @@ public class InvoiceLineItem extends ApiResource implements HasId, MetadataStore
     public static class TaxRateDetails extends StripeObject {
       /** ID of the tax rate. */
       @SerializedName("tax_rate")
-      String taxRate;
+      @Getter(lombok.AccessLevel.NONE)
+      @Setter(lombok.AccessLevel.NONE)
+      ExpandableField<TaxRate> taxRate;
+
+      /** Get ID of expandable {@code taxRate} object. */
+      public String getTaxRate() {
+        return (this.taxRate != null) ? this.taxRate.getId() : null;
+      }
+
+      public void setTaxRate(String id) {
+        this.taxRate = ApiResource.setExpandableFieldId(id, this.taxRate);
+      }
+
+      /** Get expanded {@code taxRate}. */
+      public TaxRate getTaxRateObject() {
+        return (this.taxRate != null) ? this.taxRate.getExpanded() : null;
+      }
+
+      public void setTaxRateObject(TaxRate expandableObject) {
+        this.taxRate = new ExpandableField<TaxRate>(expandableObject.getId(), expandableObject);
+      }
     }
   }
 


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

In the recent `2026-04-22.dahlia` API version, we made `tax_details` [expandable wherever they appear](https://docs.stripe.com/changelog/dahlia/2026-04-22/adds-expandable-tax-rate-property-to-tax-rate-details). Changing the type of a field is a breaking change in the SDKs, so the team made the decision to hold that field change out of the SDKs until our next major version in September (which is a fairly common pattern for us).

We figured that by keeping the field as as string, existing users wouldn't have to navigate a breaking change, but users who wanted to could expand and use as needed (after doing some manual type casting). This _is_ true for our interpreted SDKs, but isn't in the compiled ones. In compiled SDKs, expanding `tax_details` fails at runtime because we try to deserialize an object into a string.

The feature needs to work, so we're biting the bullet and doing an out-of-band major in our compiled languages.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- regenerate SDK, which converts 4 usages of `tax_rate.tax_details` into expandable fields

### See Also

<!-- Include any links or additional information that help explain this change. -->
