### PR TITLE
Replace source hash with Telemetry UUID

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
           architecture: x64
 
       - name: Set Test Java Runtime Environment variable
+        shell: bash
         run: echo "JAVA_TEST_HOME=${{ steps.setup-test-jre.outputs.path }}" >> $GITHUB_ENV
 
       # our gradle version wants java 17, so any other test version needs a separate setup
@@ -107,6 +108,7 @@ jobs:
         run: sed -e '/--add-exports/ s/^#*/#/' -i gradle.properties
 
       - name: Display version
+        shell: bash
         run: |
           ./gradlew --version
           echo "JAVA_TEST_HOME=$JAVA_TEST_HOME"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
           - "26"
         include:
           - os: windows-latest
+            # use any modern-ish version
             java-version: "25"
 
     steps:
@@ -93,9 +94,9 @@ jobs:
       - name: Set Test Java Runtime Environment variable
         run: echo "JAVA_TEST_HOME=${{ steps.setup-test-jre.outputs.path }}" >> $GITHUB_ENV
 
-      # gradle needs java 17+, so older java versions need a bonus setup step to run their tests
-      - name: Setup Modern Java (for old versions)
-        if: ${{ matrix.java-version == '1.8' || matrix.java-version == '11' }}
+      # our gradle version wants java 17, so any other test version needs a separate setup
+      - name: Setup Gradle JDK
+        if: ${{ matrix.java-version != '17' }}
         uses: actions/setup-java@v1
         with:
           java-version: "17"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,9 @@ jobs:
         run: ./gradlew assemble javadoc
 
   test:
-    name: Test
+    name: Test (${{ matrix.java-version }}, ${{ matrix.os }})
 
-    runs-on: "ubuntu-24.04"
+    runs-on: ${{ matrix.os }}
 
     permissions:
       contents: read
@@ -60,7 +60,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # We test Stripe SDK against Java LTS versions(8, 11, 17, 21) and currently supported non-LTS versions.
+        os:
+          - "ubuntu-24.04"
+        # We test Stripe SDK against Java LTS versions(8, 11, 17, 21, 25) and currently supported non-LTS versions.
         # https://www.oracle.com/java/technologies/java-se-support-roadmap.html
         # https://endoflife.date/oracle-jdk
         java-version:
@@ -73,6 +75,9 @@ jobs:
           # non-LTS versions
           # we should periodically add the latest non-LTS version here to test against
           - "26"
+        include:
+          - os: windows-latest
+            java-version: "25"
 
     steps:
       - uses: extractions/setup-just@v2
@@ -88,10 +93,12 @@ jobs:
       - name: Set Test Java Runtime Environment variable
         run: echo "JAVA_TEST_HOME=${{ steps.setup-test-jre.outputs.path }}" >> $GITHUB_ENV
 
-      - name: Setup Java
+      # gradle needs java 17+, so older java versions need a bonus setup step to run their tests
+      - name: Setup Modern Java (for old versions)
+        if: ${{ matrix.java-version == '1.8' || matrix.java-version == '11' }}
         uses: actions/setup-java@v1
         with:
-          java-version: "17" # always use 17 LTS for building
+          java-version: "17"
           architecture: x64
 
       - name: Tweak gradle.properties for Java 1.8

--- a/src/main/java/com/stripe/net/HttpClient.java
+++ b/src/main/java/com/stripe/net/HttpClient.java
@@ -7,7 +7,6 @@ import com.stripe.exception.StripeException;
 import java.io.InputStream;
 import java.net.ConnectException;
 import java.net.SocketTimeoutException;
-import java.security.MessageDigest;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -26,53 +25,6 @@ public abstract class HttpClient {
 
   /** A value indicating whether the client should sleep between automatic request retries. */
   boolean networkRetriesSleep = true;
-
-  static String UNAME_HASH = computeUnameHash();
-
-  private static String computeUnameHash() {
-    String uname = "";
-    try {
-      uname =
-          (System.getProperty("os.name", "")
-                  + " "
-                  + System.getProperty("os.version", "")
-                  + " "
-                  + System.getProperty("os.arch", "")
-                  + " "
-                  + System.getProperty("java.version", "")
-                  + " "
-                  + System.getProperty("java.vendor", "")
-                  + " "
-                  + System.getProperty("java.vm.name", "")
-                  + " "
-                  + getHostname())
-              .trim();
-    } catch (Exception e) {
-      // fall through with empty string
-    }
-    if (uname.isEmpty()) {
-      return "";
-    }
-    try {
-      MessageDigest md = MessageDigest.getInstance("MD5");
-      byte[] hashBytes = md.digest(uname.getBytes(java.nio.charset.StandardCharsets.UTF_8));
-      StringBuilder sb = new StringBuilder();
-      for (byte b : hashBytes) {
-        sb.append(String.format("%02x", b));
-      }
-      return sb.toString();
-    } catch (Exception e) {
-      return "";
-    }
-  }
-
-  private static String getHostname() {
-    try {
-      return java.net.InetAddress.getLocalHost().getHostName();
-    } catch (Exception e) {
-      return "";
-    }
-  }
 
   /** Initializes a new instance of the {@link HttpClient} class. */
   protected HttpClient() {}
@@ -276,8 +228,11 @@ public abstract class HttpClient {
       propertyMap.put("ai_agent", aiAgent);
     }
 
-    if (!UNAME_HASH.isEmpty()) {
-      propertyMap.put("source", UNAME_HASH);
+    if (Stripe.enableTelemetry) {
+      String telemetryId = TelemetryId.get();
+      if (telemetryId != null && !telemetryId.isEmpty()) {
+        propertyMap.put("telemetry_id", telemetryId);
+      }
     }
 
     return ApiResource.INTERNAL_GSON.toJson(propertyMap);

--- a/src/main/java/com/stripe/net/TelemetryId.java
+++ b/src/main/java/com/stripe/net/TelemetryId.java
@@ -10,6 +10,9 @@ final class TelemetryId {
   private static volatile String cachedId;
   private static volatile boolean loaded = false;
 
+  // Visible for testing: when non-null, overrides getConfigDir() result.
+  static volatile Path configDirOverride;
+
   private TelemetryId() {}
 
   static String get() {
@@ -46,8 +49,12 @@ final class TelemetryId {
     return Paths.get(home, ".config", "stripe");
   }
 
+  /**
+   * Returns the telemetry ID unless something goes wrong with the file I/O (can't read/write
+   * directory, for example)
+   */
   private static String resolve() {
-    Path configDir = getConfigDir();
+    Path configDir = configDirOverride != null ? configDirOverride : getConfigDir();
     if (configDir == null) {
       return null;
     }
@@ -80,6 +87,7 @@ final class TelemetryId {
     synchronized (TelemetryId.class) {
       cachedId = null;
       loaded = false;
+      configDirOverride = null;
     }
   }
 }

--- a/src/main/java/com/stripe/net/TelemetryId.java
+++ b/src/main/java/com/stripe/net/TelemetryId.java
@@ -1,0 +1,85 @@
+package com.stripe.net;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+final class TelemetryId {
+  private static volatile String cachedId;
+  private static volatile boolean loaded = false;
+
+  private TelemetryId() {}
+
+  static String get() {
+    if (loaded) {
+      return cachedId;
+    }
+    synchronized (TelemetryId.class) {
+      if (loaded) {
+        return cachedId;
+      }
+      cachedId = resolve();
+      loaded = true;
+    }
+    return cachedId;
+  }
+
+  static Path getConfigDir() {
+    String os = System.getProperty("os.name", "").toLowerCase();
+    if (os.contains("win")) {
+      String appData = System.getenv("APPDATA");
+      if (appData == null || appData.isEmpty()) {
+        return null;
+      }
+      return Paths.get(appData, "Stripe");
+    }
+    String xdg = System.getenv("XDG_CONFIG_HOME");
+    if (xdg != null && !xdg.isEmpty()) {
+      return Paths.get(xdg, "stripe");
+    }
+    String home = System.getProperty("user.home");
+    if (home == null || home.isEmpty()) {
+      return null;
+    }
+    return Paths.get(home, ".config", "stripe");
+  }
+
+  private static String resolve() {
+    Path configDir = getConfigDir();
+    if (configDir == null) {
+      return null;
+    }
+
+    Path filePath = configDir.resolve("telemetry_id");
+
+    try {
+      String content = new String(Files.readAllBytes(filePath), "UTF-8").trim();
+      if (!content.isEmpty()) {
+        return content;
+      }
+    } catch (IOException e) {
+      // File doesn't exist or can't be read
+    }
+
+    String newId = UUID.randomUUID().toString().replace("-", "");
+
+    try {
+      Files.createDirectories(configDir);
+      Files.write(filePath, newId.getBytes("UTF-8"));
+    } catch (IOException e) {
+      return null;
+    }
+
+    return newId;
+  }
+
+  // Visible for testing
+  static void reset() {
+    synchronized (TelemetryId.class) {
+      cachedId = null;
+      loaded = false;
+    }
+  }
+}

--- a/src/main/java/com/stripe/net/TelemetryId.java
+++ b/src/main/java/com/stripe/net/TelemetryId.java
@@ -13,6 +13,9 @@ final class TelemetryId {
   // Visible for testing: when non-null, overrides getConfigDir() result.
   static volatile Path configDirOverride;
 
+  // Visible for testing: overrides System.getenv("XDG_CONFIG_HOME") when non-null.
+  static volatile String xdgConfigHomeOverride;
+
   private TelemetryId() {}
 
   static String get() {
@@ -38,7 +41,7 @@ final class TelemetryId {
       }
       return Paths.get(appData, "Stripe");
     }
-    String xdg = System.getenv("XDG_CONFIG_HOME");
+    String xdg = xdgConfigHomeOverride != null ? xdgConfigHomeOverride : System.getenv("XDG_CONFIG_HOME");
     if (xdg != null && !xdg.isEmpty()) {
       return Paths.get(xdg, "stripe");
     }
@@ -88,6 +91,7 @@ final class TelemetryId {
       cachedId = null;
       loaded = false;
       configDirOverride = null;
+      xdgConfigHomeOverride = null;
     }
   }
 }

--- a/src/main/java/com/stripe/net/TelemetryId.java
+++ b/src/main/java/com/stripe/net/TelemetryId.java
@@ -41,7 +41,8 @@ final class TelemetryId {
       }
       return Paths.get(appData, "Stripe");
     }
-    String xdg = xdgConfigHomeOverride != null ? xdgConfigHomeOverride : System.getenv("XDG_CONFIG_HOME");
+    String xdg =
+        xdgConfigHomeOverride != null ? xdgConfigHomeOverride : System.getenv("XDG_CONFIG_HOME");
     if (xdg != null && !xdg.isEmpty()) {
       return Paths.get(xdg, "stripe");
     }

--- a/src/test/java/com/stripe/net/HttpClientTest.java
+++ b/src/test/java/com/stripe/net/HttpClientTest.java
@@ -15,12 +15,16 @@ import com.stripe.exception.ApiConnectionException;
 import com.stripe.exception.StripeException;
 import java.net.ConnectException;
 import java.net.SocketTimeoutException;
+import java.nio.file.Path;
 import java.util.Collections;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 public class HttpClientTest extends BaseStripeTest {
+  @TempDir Path tempDir;
+
   private HttpClient client;
 
   private StripeRequest request;
@@ -303,6 +307,7 @@ public class HttpClientTest extends BaseStripeTest {
     try {
       Stripe.enableTelemetry = true;
       TelemetryId.reset();
+      TelemetryId.configDirOverride = tempDir;
       String json = HttpClient.buildXStripeClientUserAgentString("");
       com.google.gson.JsonObject parsed =
           com.google.gson.JsonParser.parseString(json).getAsJsonObject();

--- a/src/test/java/com/stripe/net/HttpClientTest.java
+++ b/src/test/java/com/stripe/net/HttpClientTest.java
@@ -298,29 +298,38 @@ public class HttpClientTest extends BaseStripeTest {
   }
 
   @Test
-  public void testBuildXStripeClientUserAgentStringIncludesSource() {
-    String json = HttpClient.buildXStripeClientUserAgentString("");
-    com.google.gson.JsonObject parsed =
-        com.google.gson.JsonParser.parseString(json).getAsJsonObject();
-    // "source" should be present and be a 32-character lowercase MD5 hex digest
-    assertTrue(parsed.has("source"), "Expected 'source' field in X-Stripe-Client-User-Agent");
-    String source = parsed.get("source").getAsString();
-    assertTrue(
-        source.matches("[0-9a-f]{32}"),
-        "Expected 'source' to be a 32-character lowercase hex string, got: " + source);
+  public void testBuildXStripeClientUserAgentStringIncludesTelemetryId() {
+    boolean originalTelemetry = Stripe.enableTelemetry;
+    try {
+      Stripe.enableTelemetry = true;
+      TelemetryId.reset();
+      String json = HttpClient.buildXStripeClientUserAgentString("");
+      com.google.gson.JsonObject parsed =
+          com.google.gson.JsonParser.parseString(json).getAsJsonObject();
+      assertTrue(
+          parsed.has("telemetry_id"),
+          "Expected 'telemetry_id' field in X-Stripe-Client-User-Agent");
+      String telemetryId = parsed.get("telemetry_id").getAsString();
+      assertTrue(
+          telemetryId.matches("[0-9a-f]{32}"),
+          "Expected 'telemetry_id' to be a 32-character lowercase hex string, got: " + telemetryId);
+    } finally {
+      Stripe.enableTelemetry = originalTelemetry;
+      TelemetryId.reset();
+    }
   }
 
   @Test
-  public void testBuildXStripeClientUserAgentStringOmitsSourceWhenEmpty() throws Exception {
-    String savedHash = HttpClient.UNAME_HASH;
+  public void testBuildXStripeClientUserAgentStringOmitsTelemetryIdWhenDisabled() {
+    boolean originalTelemetry = Stripe.enableTelemetry;
     try {
-      HttpClient.UNAME_HASH = "";
+      Stripe.enableTelemetry = false;
       String userAgentString = HttpClient.buildXStripeClientUserAgentString("");
       com.google.gson.JsonObject userAgent =
           com.google.gson.JsonParser.parseString(userAgentString).getAsJsonObject();
-      assertFalse(userAgent.has("source"));
+      assertFalse(userAgent.has("telemetry_id"));
     } finally {
-      HttpClient.UNAME_HASH = savedHash;
+      Stripe.enableTelemetry = originalTelemetry;
     }
   }
 }

--- a/src/test/java/com/stripe/net/TelemetryIdTest.java
+++ b/src/test/java/com/stripe/net/TelemetryIdTest.java
@@ -1,0 +1,118 @@
+package com.stripe.net;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.stripe.BaseStripeTest;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class TelemetryIdTest extends BaseStripeTest {
+  @TempDir Path tempDir;
+
+  @BeforeEach
+  public void setUp() {
+    TelemetryId.reset();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    TelemetryId.reset();
+  }
+
+  @Test
+  public void testGetReturnsValidHexString() {
+    String id = TelemetryId.get();
+    assertNotNull(id);
+    assertTrue(
+        id.matches("[0-9a-f]{32}"),
+        "Expected telemetry_id to be a 32-character lowercase hex string, got: " + id);
+  }
+
+  @Test
+  public void testGetReturnsCachedValue() {
+    String id1 = TelemetryId.get();
+    String id2 = TelemetryId.get();
+    assertEquals(id1, id2, "Expected TelemetryId.get() to return the same value on repeated calls");
+  }
+
+  @Test
+  public void testGetReturnsNewValueAfterReset() {
+    // Because get() generates a file, we need to control the config dir to ensure
+    // a fresh UUID is generated. We reset the cache to force re-read from disk (or re-generate).
+    String id1 = TelemetryId.get();
+    assertNotNull(id1);
+    // After reset, calling get() again reads from the same file on disk, so it returns same value
+    TelemetryId.reset();
+    String id2 = TelemetryId.get();
+    assertEquals(id1, id2, "Expected same ID after reset (reads from persisted file)");
+  }
+
+  @Test
+  public void testReadsExistingIdFromFile() throws IOException {
+    String existingId = "abcdef1234567890abcdef1234567890";
+    Path filePath = tempDir.resolve("telemetry_id");
+    Files.write(filePath, existingId.getBytes("UTF-8"));
+
+    String content = new String(Files.readAllBytes(filePath), "UTF-8").trim();
+    assertEquals(existingId, content);
+  }
+
+  @Test
+  public void testGetConfigDirWindows() {
+    // Simulate Windows by checking the logic path; we test the non-Windows path here
+    // since we can't reliably set os.name system property in a running JVM without hacks.
+    // Instead, verify the returned path is non-null on the current platform.
+    Path configDir = TelemetryId.getConfigDir();
+    // On any supported platform with a home dir, configDir should be non-null
+    // (unless APPDATA is missing on Windows or home is missing on Unix)
+    // Just verify the method doesn't throw
+    // configDir may be null only if home/APPDATA is missing
+    assertTrue(
+        configDir == null || configDir.toString().contains("stripe"),
+        "Config dir should be null or contain 'stripe' (or 'Stripe' on Windows)");
+  }
+
+  @Test
+  public void testGetConfigDirWithXdgConfigHome() {
+    // We can't easily override env vars, but we can verify getConfigDir() returns a valid path
+    Path configDir = TelemetryId.getConfigDir();
+    assertNotNull(configDir, "getConfigDir() should return non-null when home dir is available");
+  }
+
+  @Test
+  public void testCreatesFileAndDirectoryIfMissing() throws IOException {
+    // Create a subdirectory under tempDir to use as a config dir
+    Path configDir = tempDir.resolve("stripe-config");
+    Path filePath = configDir.resolve("telemetry_id");
+
+    // Ensure directory doesn't exist yet
+    assertTrue(!Files.exists(configDir));
+
+    // Manually simulate what resolve() does
+    Files.createDirectories(configDir);
+    String newId = "aabbccddeeff00112233445566778899";
+    Files.write(filePath, newId.getBytes("UTF-8"));
+
+    assertTrue(Files.exists(filePath));
+    String content = new String(Files.readAllBytes(filePath), "UTF-8").trim();
+    assertEquals(newId, content);
+  }
+
+  @Test
+  public void testGetReturnsNullSafely() {
+    // When called after reset with a valid environment, should not throw
+    TelemetryId.reset();
+    String id = TelemetryId.get();
+    // id may be null (if file I/O fails) or a valid hex string
+    assertTrue(
+        id == null || id.matches("[0-9a-f]{32}"),
+        "Expected null or a valid 32-char hex string, got: " + id);
+  }
+}

--- a/src/test/java/com/stripe/net/TelemetryIdTest.java
+++ b/src/test/java/com/stripe/net/TelemetryIdTest.java
@@ -19,6 +19,7 @@ public class TelemetryIdTest extends BaseStripeTest {
   @BeforeEach
   public void setUp() {
     TelemetryId.reset();
+    TelemetryId.configDirOverride = tempDir;
   }
 
   @AfterEach
@@ -43,76 +44,63 @@ public class TelemetryIdTest extends BaseStripeTest {
   }
 
   @Test
-  public void testGetReturnsNewValueAfterReset() {
-    // Because get() generates a file, we need to control the config dir to ensure
-    // a fresh UUID is generated. We reset the cache to force re-read from disk (or re-generate).
+  public void testGetPersistsToFile() throws IOException {
+    String id = TelemetryId.get();
+    assertNotNull(id);
+
+    // Verify the ID was written to the expected file path
+    Path filePath = tempDir.resolve("telemetry_id");
+    assertTrue(Files.exists(filePath), "Expected telemetry_id file to be created");
+    String content = new String(Files.readAllBytes(filePath), "UTF-8").trim();
+    assertEquals(id, content);
+  }
+
+  @Test
+  public void testGetReturnsPersistedValueAfterReset() throws IOException {
+    // After reset, calling get() again reads from the same file on disk, so it returns same value
     String id1 = TelemetryId.get();
     assertNotNull(id1);
-    // After reset, calling get() again reads from the same file on disk, so it returns same value
     TelemetryId.reset();
+    TelemetryId.configDirOverride = tempDir;
     String id2 = TelemetryId.get();
     assertEquals(id1, id2, "Expected same ID after reset (reads from persisted file)");
   }
 
   @Test
   public void testReadsExistingIdFromFile() throws IOException {
+    // Pre-populate the file to simulate a previous run having written an ID
     String existingId = "abcdef1234567890abcdef1234567890";
     Path filePath = tempDir.resolve("telemetry_id");
     Files.write(filePath, existingId.getBytes("UTF-8"));
 
-    String content = new String(Files.readAllBytes(filePath), "UTF-8").trim();
-    assertEquals(existingId, content);
+    String id = TelemetryId.get();
+    assertEquals(existingId, id);
   }
 
   @Test
-  public void testGetConfigDirWindows() {
-    // Simulate Windows by checking the logic path; we test the non-Windows path here
-    // since we can't reliably set os.name system property in a running JVM without hacks.
-    // Instead, verify the returned path is non-null on the current platform.
+  public void testGetConfigDirReturnsPathContainingStripe() {
+    // On any supported platform, the config dir should contain "stripe" (or "Stripe" on Windows)
     Path configDir = TelemetryId.getConfigDir();
-    // On any supported platform with a home dir, configDir should be non-null
-    // (unless APPDATA is missing on Windows or home is missing on Unix)
-    // Just verify the method doesn't throw
-    // configDir may be null only if home/APPDATA is missing
     assertTrue(
-        configDir == null || configDir.toString().contains("stripe"),
-        "Config dir should be null or contain 'stripe' (or 'Stripe' on Windows)");
+        configDir == null || configDir.toString().toLowerCase().contains("stripe"),
+        "Config dir should be null or contain 'stripe'");
   }
 
   @Test
-  public void testGetConfigDirWithXdgConfigHome() {
-    // We can't easily override env vars, but we can verify getConfigDir() returns a valid path
+  public void testGetConfigDirReturnsNonNull() {
+    // On a normal dev machine with a home dir, this should always be non-null
     Path configDir = TelemetryId.getConfigDir();
     assertNotNull(configDir, "getConfigDir() should return non-null when home dir is available");
   }
 
   @Test
-  public void testCreatesFileAndDirectoryIfMissing() throws IOException {
-    // Create a subdirectory under tempDir to use as a config dir
-    Path configDir = tempDir.resolve("stripe-config");
-    Path filePath = configDir.resolve("telemetry_id");
+  public void testCreatesDirectoryIfMissing() {
+    // Verify that get() creates intermediate directories when the config dir doesn't exist yet
+    Path nestedDir = tempDir.resolve("nested").resolve("config");
+    TelemetryId.configDirOverride = nestedDir;
 
-    // Ensure directory doesn't exist yet
-    assertTrue(!Files.exists(configDir));
-
-    // Manually simulate what resolve() does
-    Files.createDirectories(configDir);
-    String newId = "aabbccddeeff00112233445566778899";
-    Files.write(filePath, newId.getBytes("UTF-8"));
-
-    assertTrue(Files.exists(filePath));
-    String content = new String(Files.readAllBytes(filePath), "UTF-8").trim();
-    assertEquals(newId, content);
-  }
-
-  @Test
-  public void testGetReturnsNullSafely() {
-    // When called after reset with a valid environment, should not throw
-    TelemetryId.reset();
     String id = TelemetryId.get();
-    // id may be null (if file I/O fails) or a valid hex string
-    assertTrue(
-        id == null || id.matches("[0-9a-f]{32}"),
-        "Expected null or a valid 32-char hex string, got: " + id);
+    assertNotNull(id);
+    assertTrue(Files.exists(nestedDir.resolve("telemetry_id")));
   }
 }

--- a/src/test/java/com/stripe/net/TelemetryIdTest.java
+++ b/src/test/java/com/stripe/net/TelemetryIdTest.java
@@ -2,15 +2,19 @@ package com.stripe.net;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.stripe.BaseStripeTest;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
 public class TelemetryIdTest extends BaseStripeTest {
@@ -102,5 +106,52 @@ public class TelemetryIdTest extends BaseStripeTest {
     String id = TelemetryId.get();
     assertNotNull(id);
     assertTrue(Files.exists(nestedDir.resolve("telemetry_id")));
+  }
+
+  @Test
+  public void testGetReturnsNullWhenWriteFails() throws IOException {
+    // Place a regular file at the path where the config directory should be.
+    // Files.createDirectories will fail because a file already occupies that path,
+    // causing resolve() to catch the IOException and return null.
+    Path blockerFile = tempDir.resolve("blocker");
+    Files.write(blockerFile, new byte[0]);
+    // Set the override to a subdirectory of the blocker file — impossible to create
+    TelemetryId.configDirOverride = blockerFile.resolve("stripe");
+
+    String id = TelemetryId.get();
+    assertNull(id, "Expected get() to return null when the config directory cannot be created");
+  }
+
+  @Test
+  @DisabledOnOs(OS.WINDOWS)
+  public void testGetConfigDirFallsBackToHomeConfig() {
+    // Force the XDG override to empty so the fallback branch is always exercised,
+    // even if the real XDG_CONFIG_HOME is set in the environment.
+    TelemetryId.xdgConfigHomeOverride = "";
+
+    Path configDir = TelemetryId.getConfigDir();
+    assertNotNull(configDir, "getConfigDir() should return non-null on a system with a home dir");
+
+    String home = System.getProperty("user.home");
+    assertTrue(
+        configDir.startsWith(home),
+        "Config dir should be rooted under user.home when XDG_CONFIG_HOME is not set");
+    assertTrue(
+        configDir.toString().endsWith(".config/stripe"),
+        "Config dir should end with .config/stripe when XDG_CONFIG_HOME is not set, got: "
+            + configDir);
+  }
+
+  @Test
+  @DisabledOnOs(OS.WINDOWS)
+  public void testGetConfigDirRespectsXdgConfigHome() {
+    TelemetryId.xdgConfigHomeOverride = "/custom/config";
+
+    Path configDir = TelemetryId.getConfigDir();
+    assertNotNull(configDir);
+    assertEquals(
+        Paths.get("/custom/config", "stripe"),
+        configDir,
+        "getConfigDir() should use XDG_CONFIG_HOME when set");
   }
 }


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Recently, we introduced the `source` hash in the user-agent header to help our support team track down exactly where incoming requests originated from.

They've reported back to us that this hasn't been as useful as we wanted, so we're going a different direction.

Instead, we're adopting an industry-standard method of persisting a small UUID on disk that we include with subsequent requests. It's easy for users to read this file and it contains no PII. It also honors our existing telemetry opt outs.

It's meant to be lightweight and failure tolerant.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- remove `source` key from user-agent header
- add `telemetry_id` to the user-agent header
- adjust tests accordingly

### See Also

<!-- Include any links or additional information that help explain this change. -->

- original request: [DEVSDK-3131](https://go/j/DEVSDK-3131)
- update request: [RUN_DEVSDK-2563](https://go/j/RUN_DEVSDK-2563)
