### PR TITLE
Add `stripe.major_api_version` constant

### DIFF
--- a/src/main/java/com/stripe/Stripe.java
+++ b/src/main/java/com/stripe/Stripe.java
@@ -10,6 +10,7 @@ public abstract class Stripe {
   public static final int DEFAULT_READ_TIMEOUT = 80 * 1000;
 
   public static final String API_VERSION = ApiVersion.CURRENT;
+  public static final String MAJOR_API_VERSION = ApiVersion.CURRENT_MAJOR;
   public static final String CONNECT_API_BASE = "https://connect.stripe.com";
   public static final String LIVE_API_BASE = "https://api.stripe.com";
   public static final String UPLOAD_API_BASE = "https://files.stripe.com";

--- a/src/main/java/com/stripe/Stripe.java
+++ b/src/main/java/com/stripe/Stripe.java
@@ -15,6 +15,7 @@ public abstract class Stripe {
    * compatible. Is an empty string in preview versions of the SDK.
    */
   public static final String MAJOR_API_VERSION = ApiVersion.CURRENT_MAJOR;
+
   public static final String CONNECT_API_BASE = "https://connect.stripe.com";
   public static final String LIVE_API_BASE = "https://api.stripe.com";
   public static final String UPLOAD_API_BASE = "https://files.stripe.com";

--- a/src/main/java/com/stripe/Stripe.java
+++ b/src/main/java/com/stripe/Stripe.java
@@ -10,6 +10,10 @@ public abstract class Stripe {
   public static final int DEFAULT_READ_TIMEOUT = 80 * 1000;
 
   public static final String API_VERSION = ApiVersion.CURRENT;
+  /**
+   * The major API version that this SDK uses. Objects retrieved using the same major version are
+   * compatible. Is an empty string in preview versions of the SDK.
+   */
   public static final String MAJOR_API_VERSION = ApiVersion.CURRENT_MAJOR;
   public static final String CONNECT_API_BASE = "https://connect.stripe.com";
   public static final String LIVE_API_BASE = "https://api.stripe.com";


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

We've been generating information about the current API version into the SDKs for a while (codegen PR `2555`), but accidentally didn't make those constants user-facing.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- adds a user-facing `major_api_version` constant set to the generated value (currently `"dahlia"`)

### See Also

<!-- Include any links or additional information that help explain this change. -->

- (originally from https://github.com/stripe/stripe-java/issues/2001)
