### PR TITLE
add stripeobject deserialization helper for JsonObject

### DIFF
--- a/src/main/java/com/stripe/exception/RateLimitException.java
+++ b/src/main/java/com/stripe/exception/RateLimitException.java
@@ -26,9 +26,8 @@ public class RateLimitException extends StripeException {
   static RateLimitException parse(
       JsonObject body, int statusCode, String requestId, StripeResponseGetter responseGetter) {
     RateLimitException.RateLimitError error =
-        (RateLimitException.RateLimitError)
-            StripeObject.deserializeStripeObject(
-                body, RateLimitException.RateLimitError.class, responseGetter);
+        StripeObject.deserializeStripeObject(
+            body, RateLimitException.RateLimitError.class, responseGetter);
     RateLimitException exception =
         new RateLimitException(
             error.getMessage(), error.getParam(), requestId, error.getCode(), statusCode, null);

--- a/src/main/java/com/stripe/exception/TemporarySessionExpiredException.java
+++ b/src/main/java/com/stripe/exception/TemporarySessionExpiredException.java
@@ -18,11 +18,10 @@ public final class TemporarySessionExpiredException extends ApiException {
   static TemporarySessionExpiredException parse(
       JsonObject body, int statusCode, String requestId, StripeResponseGetter responseGetter) {
     TemporarySessionExpiredException.TemporarySessionExpiredError error =
-        (TemporarySessionExpiredException.TemporarySessionExpiredError)
-            StripeObject.deserializeStripeObject(
-                body,
-                TemporarySessionExpiredException.TemporarySessionExpiredError.class,
-                responseGetter);
+        StripeObject.deserializeStripeObject(
+            body,
+            TemporarySessionExpiredException.TemporarySessionExpiredError.class,
+            responseGetter);
     TemporarySessionExpiredException exception =
         new TemporarySessionExpiredException(
             error.getMessage(), requestId, error.getCode(), statusCode, null);

--- a/src/main/java/com/stripe/model/StripeObject.java
+++ b/src/main/java/com/stripe/model/StripeObject.java
@@ -133,6 +133,12 @@ public abstract class StripeObject implements StripeObjectInterface {
     return (T) deserializeStripeObject(payload, (Type) type, responseGetter);
   }
 
+  @SuppressWarnings("unchecked")
+  public static <T> T deserializeStripeObject(
+      JsonObject payload, Class<T> type, StripeResponseGetter responseGetter) {
+    return (T) deserializeStripeObject(payload, (Type) type, responseGetter);
+  }
+
   public static StripeObject deserializeStripeObject(
       String payload, Type type, StripeResponseGetter responseGetter) {
     StripeObject object = ApiResource.INTERNAL_GSON.fromJson(payload, type);


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Extracts a small fix out of https://github.com/stripe/stripe-java/pull/2256 so we can merge it into master before the rest of that PR lands. 

We need to do this now because the codegen portion of this change has merged already, so private preview CI is failing (since the generated code expects this fix to be present)

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- add a method for deserializing a `JsonObject` into a `StripeObject`, meaning we don't need to cast inside our exception classes anymore
- update affected exceptions
