### PR TITLE
Surface `object` property on `EventNotification`

### DIFF
--- a/src/main/java/com/stripe/model/v2/core/EventNotification.java
+++ b/src/main/java/com/stripe/model/v2/core/EventNotification.java
@@ -60,6 +60,10 @@ public abstract class EventNotification {
   @SerializedName("id")
   public String id;
 
+  /** String representing the object's type. Objects of the same type share the same value. */
+  @SerializedName("object")
+  public String object;
+
   /** The type of the event. */
   @SerializedName("type")
   public String type;

--- a/src/test/java/com/stripe/StripeClientTest.java
+++ b/src/test/java/com/stripe/StripeClientTest.java
@@ -246,6 +246,7 @@ public class StripeClientTest extends BaseStripeTest {
         client.parseEventNotification(v2EventNotificationWithRelatedObject, signature, secret);
     assertNotNull(eventNotification);
     assertEquals("evt_234", eventNotification.getId());
+    assertEquals("v2.core.event", eventNotification.getObject());
     assertEquals("v1.billing.meter.error_report_triggered", eventNotification.getType());
     assertEquals(Instant.parse("2022-02-15T00:27:45.330Z"), eventNotification.created);
     assertEquals("org_123", eventNotification.getContext().toString());


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

`object` is present in the original payload, but we didn't surface it on the `EventNotification` class. Because ``v2.core.event"` is the only value that will ever be present, It didn't seem worth adding it to the interface.

I also wanted to better differentiate `EventNotification`s from all other `StripeObject`s (since they _do_ behave differently).

But, that also means interacting with it along with other objects is unnecessarily complicated. From the [original ruby issue](https://github.com/stripe/stripe-ruby/issues/1860):

```rb
def v1?(event)
  (event.try(:object) || event.try(:dig, "object")) == "event"
end

def v2?(event)
  event.is_a?(::Stripe::V2::Core::EventNotification) || # thin event notification
    (event.try(:object) || event.try(:dig, "object")) == "v2.core.event"
end
```

Because the value is present in the original response, it doesn't make sense to eat it.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- add public `object` property to `EventNotification`
- add test

### See Also

<!-- Include any links or additional information that help explain this change. -->

- originally brought up in [stripe/stripe-ruby#1860](https://github.com/stripe/stripe-ruby/issues/1860)
- [DEVSDK-3101](https://go/j/DEVSDK-3101)
