### PR TITLE
Add new `EventNotificationHandler` class for better thin event management

### DIFF
--- a/src/main/java/com/stripe/EventNotificationCallback.java
+++ b/src/main/java/com/stripe/EventNotificationCallback.java
@@ -1,0 +1,13 @@
+package com.stripe;
+
+import com.stripe.model.v2.core.EventNotification;
+
+/**
+ * Functional interface for callback functions. It describes the signature of the functions you'll
+ * register on a {@link StripeEventNotificationHandler} to process incoming event notifications.
+ */
+@FunctionalInterface
+public interface EventNotificationCallback<E extends EventNotification> {
+  // this is an internal-facing method name that dictates how we call the stored method
+  void process(E event, StripeClient client);
+}

--- a/src/main/java/com/stripe/EventNotificationFallbackCallback.java
+++ b/src/main/java/com/stripe/EventNotificationFallbackCallback.java
@@ -1,0 +1,14 @@
+package com.stripe;
+
+import com.stripe.model.v2.core.EventNotification;
+
+/**
+ * Functional interface for handling otherwise unhandled events. It's similar to {@link
+ * EventNotificationCallback}, but includes additional information about the unhandled event to help
+ * debug it.
+ */
+@FunctionalInterface
+public interface EventNotificationFallbackCallback {
+  // this is an internal-facing method name that dictates how we call the stored method
+  void process(EventNotification event, StripeClient client, UnhandledNotificationDetails details);
+}

--- a/src/main/java/com/stripe/StripeClient.java
+++ b/src/main/java/com/stripe/StripeClient.java
@@ -9,6 +9,7 @@ import com.stripe.net.*;
 import com.stripe.net.Webhook.Signature;
 import java.net.PasswordAuthentication;
 import java.net.Proxy;
+import lombok.Builder;
 import lombok.Getter;
 
 /**
@@ -40,6 +41,62 @@ public class StripeClient {
 
   protected StripeResponseGetter getResponseGetter() {
     return responseGetter;
+  }
+
+  /** Gets the current StripeContext from the client's configuration. Used in unit testing. */
+  protected String getContext() {
+    // TODO(major): add getOptions to the StripeResponseGetter interface? that would simplify this
+    if (!(responseGetter instanceof LiveStripeResponseGetter)) {
+      return null;
+    }
+
+    LiveStripeResponseGetter liveGetter = (LiveStripeResponseGetter) responseGetter;
+    StripeResponseGetterOptions options = liveGetter.getOptions();
+
+    return options.getStripeContext();
+  }
+
+  /**
+   * Creates a new StripeClient with the same configuration as this client but with a custom
+   * StripeContext. This method is useful for creating thread-safe clients with different contexts,
+   * such as when processing webhooks in parallel where each webhook has its own context.
+   *
+   * <p>The new client will share the same configuration (API key, timeouts, proxy settings, etc.)
+   * and HTTP client as this client, but will have the specified context. This allows for efficient
+   * parallel processing without reinitializing HTTP connections.
+   *
+   * @param context the custom stripe_context to use for the new client
+   * @return a new StripeClient with the custom context
+   * @throws IllegalStateException if this client doesn't use a LiveStripeResponseGetter
+   */
+  public StripeClient withStripeContext(StripeContext context) {
+    // Convert StripeContext to String
+    String contextString = (context == null) ? null : context.toString();
+
+    StripeResponseGetter responseGetter = this.getResponseGetter();
+
+    // We can only create a new client for LiveStripeResponseGetter because it's the only class with
+    // `getOptions()`. If we add that method to the interface in a later major, we could remove this
+    // check.
+    if (!(responseGetter instanceof LiveStripeResponseGetter)) {
+      throw new IllegalStateException(
+          "Cannot create a client with custom context for non-Live response getters");
+    }
+
+    LiveStripeResponseGetter liveGetter = (LiveStripeResponseGetter) responseGetter;
+
+    // Create a new LiveStripeResponseGetter with updated context, reusing the HTTP client
+    LiveStripeResponseGetter newResponseGetter =
+        liveGetter.withNewOptions(
+            options -> {
+              ClientStripeResponseGetterOptions existingOptions =
+                  (ClientStripeResponseGetterOptions) options;
+
+              return existingOptions.toBuilder().stripeContext(contextString).build();
+            });
+
+    // Create and return a new StripeClient with the new response getter
+    return new StripeClient(newResponseGetter);
   }
 
   /**
@@ -995,6 +1052,8 @@ public class StripeClient {
   }
 
   // The end of the section generated from our OpenAPI spec
+  @SuppressWarnings("ObjectToString")
+  @Builder(toBuilder = true)
   static class ClientStripeResponseGetterOptions extends StripeResponseGetterOptions {
     // When adding setting here keep them in sync with settings in RequestOptions and
     // in the RequestOptions.merge method
@@ -1399,5 +1458,15 @@ public class StripeClient {
   /** Deserializes StripeResponse returned by rawRequest into a similar class. */
   public StripeObject deserialize(String rawJson, ApiMode apiMode) throws StripeException {
     return StripeObject.deserializeStripeObject(rawJson, this.getResponseGetter(), apiMode);
+  }
+
+  public StripeEventNotificationHandler notificationHandler(
+      String webhookSecret, EventNotificationFallbackCallback fallbackCallback) {
+    return new StripeEventNotificationHandler(webhookSecret, this, fallbackCallback);
+  }
+
+  public StripeEventNotificationHandlerWithoutVerification notificationHandlerWithoutVerification(
+      EventNotificationFallbackCallback fallbackCallback) {
+    return StripeEventNotificationHandler.withoutVerification(this, fallbackCallback);
   }
 }

--- a/src/main/java/com/stripe/StripeEventNotificationHandler.java
+++ b/src/main/java/com/stripe/StripeEventNotificationHandler.java
@@ -1,0 +1,54 @@
+package com.stripe;
+
+import com.stripe.exception.SignatureVerificationException;
+import com.stripe.model.v2.core.EventNotification;
+
+/**
+ * Verifies incoming webhook signatures before routing event notifications to the callbacks
+ * registered on it. This is the handler you want unless events reach you through a channel that has
+ * already authenticated them, in which case see {@link #withoutVerification(StripeClient,
+ * EventNotificationFallbackCallback)}.
+ */
+public class StripeEventNotificationHandler
+    extends StripeEventNotificationHandlerBase<StripeEventNotificationHandler> {
+  private final String webhookSecret;
+
+  public StripeEventNotificationHandler(
+      String webhookSecret,
+      StripeClient client,
+      EventNotificationFallbackCallback fallbackCallback) {
+    super(client, fallbackCallback);
+    if (webhookSecret == null || webhookSecret.isEmpty()) {
+      throw new IllegalArgumentException("webhookSecret must be a non-empty string");
+    }
+    this.webhookSecret = webhookSecret;
+  }
+
+  /**
+   * Creates a handler that processes events without webhook signature verification. Intended for
+   * pre-authenticated channels like AWS EventBridge or Azure Event Grid.
+   */
+  public static StripeEventNotificationHandlerWithoutVerification withoutVerification(
+      StripeClient client, EventNotificationFallbackCallback fallbackCallback) {
+    return new StripeEventNotificationHandlerWithoutVerification(client, fallbackCallback);
+  }
+
+  /**
+   * Handle an incoming webhook event notification.
+   *
+   * @param webhookBody the incoming webhook body
+   * @param sigHeader the incoming webhook signature header
+   * @throws SignatureVerificationException if the validation of the webhook signature fails
+   * @throws IllegalArgumentException if no handler is registered for the event type
+   */
+  public void handle(String webhookBody, String sigHeader) throws SignatureVerificationException {
+    // setting this naiively isn't technically thread-safe, but we expect the all callbacks to be
+    // registered syncronously on startup, so this should be fine
+    hasHandledEvent = true;
+
+    EventNotification eventNotification =
+        this.client.parseEventNotification(webhookBody, sigHeader, this.webhookSecret);
+
+    dispatch(eventNotification);
+  }
+}

--- a/src/main/java/com/stripe/StripeEventNotificationHandlerBase.java
+++ b/src/main/java/com/stripe/StripeEventNotificationHandlerBase.java
@@ -1,0 +1,278 @@
+package com.stripe;
+
+// event-notification-class-imports: The beginning of the section generated from our OpenAPI spec
+// - hack because we can't format java files whose imports aren't a single contiguous block
+// - so _any_ imports in this file have to come from codegen
+// - as do these comments, explaining the whole thing
+import com.stripe.events.V1BillingMeterErrorReportTriggeredEventNotification;
+import com.stripe.events.V1BillingMeterNoMeterFoundEventNotification;
+import com.stripe.events.V2CommerceProductCatalogImportsFailedEventNotification;
+import com.stripe.events.V2CommerceProductCatalogImportsProcessingEventNotification;
+import com.stripe.events.V2CommerceProductCatalogImportsSucceededEventNotification;
+import com.stripe.events.V2CommerceProductCatalogImportsSucceededWithErrorsEventNotification;
+import com.stripe.events.V2CoreAccountClosedEventNotification;
+import com.stripe.events.V2CoreAccountCreatedEventNotification;
+import com.stripe.events.V2CoreAccountIncludingConfigurationCustomerCapabilityStatusUpdatedEventNotification;
+import com.stripe.events.V2CoreAccountIncludingConfigurationCustomerUpdatedEventNotification;
+import com.stripe.events.V2CoreAccountIncludingConfigurationMerchantCapabilityStatusUpdatedEventNotification;
+import com.stripe.events.V2CoreAccountIncludingConfigurationMerchantUpdatedEventNotification;
+import com.stripe.events.V2CoreAccountIncludingConfigurationRecipientCapabilityStatusUpdatedEventNotification;
+import com.stripe.events.V2CoreAccountIncludingConfigurationRecipientUpdatedEventNotification;
+import com.stripe.events.V2CoreAccountIncludingDefaultsUpdatedEventNotification;
+import com.stripe.events.V2CoreAccountIncludingFutureRequirementsUpdatedEventNotification;
+import com.stripe.events.V2CoreAccountIncludingIdentityUpdatedEventNotification;
+import com.stripe.events.V2CoreAccountIncludingRequirementsUpdatedEventNotification;
+import com.stripe.events.V2CoreAccountLinkReturnedEventNotification;
+import com.stripe.events.V2CoreAccountPersonCreatedEventNotification;
+import com.stripe.events.V2CoreAccountPersonDeletedEventNotification;
+import com.stripe.events.V2CoreAccountPersonUpdatedEventNotification;
+import com.stripe.events.V2CoreAccountUpdatedEventNotification;
+import com.stripe.events.V2CoreEventDestinationPingEventNotification;
+import com.stripe.model.v2.core.EventNotification;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+// event-notification-class-imports: The end of the section generated from our OpenAPI spec
+
+/**
+ * Shared registration and dispatch machinery for {@link StripeEventNotificationHandler} and {@link
+ * StripeEventNotificationHandlerWithoutVerification}.
+ *
+ * <p>Package-private, because it's an implementation detail: the user-facing types live at the top
+ * level of this package instead ({@link EventNotificationCallback}, {@link
+ * EventNotificationFallbackCallback}, {@link UnhandledNotificationDetails}).
+ *
+ * <p>The self type {@code T} lets the generated {@code on*} methods return the concrete handler
+ * type. Returning this class instead would break fluent chaining for callers outside {@code
+ * com.stripe}, who cannot access members of a type they can't see.
+ */
+abstract class StripeEventNotificationHandlerBase<T extends StripeEventNotificationHandlerBase<T>> {
+  // this is intentionally naiive to avoid the performance cost of interacting with `volatile`. We
+  // expect that registrations are done synchronously at startup time and handling will happen
+  // async, so thread-safe reads aren't important here.
+  boolean hasHandledEvent = false;
+
+  final StripeClient client;
+  private final EventNotificationFallbackCallback fallbackCallback;
+  private final HashMap<String, EventNotificationCallback<? extends EventNotification>>
+      registeredHandlers = new HashMap<>();
+
+  StripeEventNotificationHandlerBase(
+      StripeClient client, EventNotificationFallbackCallback fallbackCallback) {
+    this.client = client;
+    this.fallbackCallback = fallbackCallback;
+  }
+
+  private <E extends EventNotification> void register(
+      String eventType, EventNotificationCallback<E> handler) {
+    if (hasHandledEvent) {
+      throw new IllegalStateException("Cannot register handlers after handling an event");
+    }
+
+    if (this.registeredHandlers.containsKey(eventType)) {
+      throw new IllegalArgumentException("Handler already registered for event type: " + eventType);
+    }
+    this.registeredHandlers.put(eventType, handler);
+  }
+
+  /** Lets the generated {@code on*} methods return the concrete handler type for chaining. */
+  @SuppressWarnings("unchecked")
+  final T self() {
+    return (T) this;
+  }
+
+  @SuppressWarnings("unchecked")
+  void dispatch(EventNotification eventNotification) {
+    EventNotificationCallback<? extends EventNotification> handler =
+        registeredHandlers.get(eventNotification.getType());
+
+    // Create a new client with the event's context for thread-safe processing
+    StripeClient eventClient = this.client.withStripeContext(eventNotification.context);
+
+    if (handler == null) {
+      boolean isKnownEventType =
+          !(eventNotification instanceof com.stripe.events.UnknownEventNotification);
+      UnhandledNotificationDetails details = new UnhandledNotificationDetails(isKnownEventType);
+
+      this.fallbackCallback.process(eventNotification, eventClient, details);
+    } else {
+      // this is technically unsafe but we control the registration API so should be ok
+      ((EventNotificationCallback<EventNotification>) handler)
+          .process(eventNotification, eventClient);
+    }
+  }
+
+  // notification-handler-methods: The beginning of the section generated from our OpenAPI spec
+  public T onV1BillingMeterErrorReportTriggered(
+      EventNotificationCallback<V1BillingMeterErrorReportTriggeredEventNotification> callback) {
+    this.register("v1.billing.meter.error_report_triggered", callback);
+    return self();
+  }
+
+  public T onV1BillingMeterNoMeterFound(
+      EventNotificationCallback<V1BillingMeterNoMeterFoundEventNotification> callback) {
+    this.register("v1.billing.meter.no_meter_found", callback);
+    return self();
+  }
+
+  public T onV2CommerceProductCatalogImportsFailed(
+      EventNotificationCallback<V2CommerceProductCatalogImportsFailedEventNotification> callback) {
+    this.register("v2.commerce.product_catalog.imports.failed", callback);
+    return self();
+  }
+
+  public T onV2CommerceProductCatalogImportsProcessing(
+      EventNotificationCallback<V2CommerceProductCatalogImportsProcessingEventNotification>
+          callback) {
+    this.register("v2.commerce.product_catalog.imports.processing", callback);
+    return self();
+  }
+
+  public T onV2CommerceProductCatalogImportsSucceeded(
+      EventNotificationCallback<V2CommerceProductCatalogImportsSucceededEventNotification>
+          callback) {
+    this.register("v2.commerce.product_catalog.imports.succeeded", callback);
+    return self();
+  }
+
+  public T onV2CommerceProductCatalogImportsSucceededWithErrors(
+      EventNotificationCallback<V2CommerceProductCatalogImportsSucceededWithErrorsEventNotification>
+          callback) {
+    this.register("v2.commerce.product_catalog.imports.succeeded_with_errors", callback);
+    return self();
+  }
+
+  public T onV2CoreAccountClosed(
+      EventNotificationCallback<V2CoreAccountClosedEventNotification> callback) {
+    this.register("v2.core.account.closed", callback);
+    return self();
+  }
+
+  public T onV2CoreAccountCreated(
+      EventNotificationCallback<V2CoreAccountCreatedEventNotification> callback) {
+    this.register("v2.core.account.created", callback);
+    return self();
+  }
+
+  public T onV2CoreAccountUpdated(
+      EventNotificationCallback<V2CoreAccountUpdatedEventNotification> callback) {
+    this.register("v2.core.account.updated", callback);
+    return self();
+  }
+
+  public T onV2CoreAccountIncludingConfigurationCustomerCapabilityStatusUpdated(
+      EventNotificationCallback<
+              V2CoreAccountIncludingConfigurationCustomerCapabilityStatusUpdatedEventNotification>
+          callback) {
+    this.register("v2.core.account[configuration.customer].capability_status_updated", callback);
+    return self();
+  }
+
+  public T onV2CoreAccountIncludingConfigurationCustomerUpdated(
+      EventNotificationCallback<V2CoreAccountIncludingConfigurationCustomerUpdatedEventNotification>
+          callback) {
+    this.register("v2.core.account[configuration.customer].updated", callback);
+    return self();
+  }
+
+  public T onV2CoreAccountIncludingConfigurationMerchantCapabilityStatusUpdated(
+      EventNotificationCallback<
+              V2CoreAccountIncludingConfigurationMerchantCapabilityStatusUpdatedEventNotification>
+          callback) {
+    this.register("v2.core.account[configuration.merchant].capability_status_updated", callback);
+    return self();
+  }
+
+  public T onV2CoreAccountIncludingConfigurationMerchantUpdated(
+      EventNotificationCallback<V2CoreAccountIncludingConfigurationMerchantUpdatedEventNotification>
+          callback) {
+    this.register("v2.core.account[configuration.merchant].updated", callback);
+    return self();
+  }
+
+  public T onV2CoreAccountIncludingConfigurationRecipientCapabilityStatusUpdated(
+      EventNotificationCallback<
+              V2CoreAccountIncludingConfigurationRecipientCapabilityStatusUpdatedEventNotification>
+          callback) {
+    this.register("v2.core.account[configuration.recipient].capability_status_updated", callback);
+    return self();
+  }
+
+  public T onV2CoreAccountIncludingConfigurationRecipientUpdated(
+      EventNotificationCallback<
+              V2CoreAccountIncludingConfigurationRecipientUpdatedEventNotification>
+          callback) {
+    this.register("v2.core.account[configuration.recipient].updated", callback);
+    return self();
+  }
+
+  public T onV2CoreAccountIncludingDefaultsUpdated(
+      EventNotificationCallback<V2CoreAccountIncludingDefaultsUpdatedEventNotification> callback) {
+    this.register("v2.core.account[defaults].updated", callback);
+    return self();
+  }
+
+  public T onV2CoreAccountIncludingFutureRequirementsUpdated(
+      EventNotificationCallback<V2CoreAccountIncludingFutureRequirementsUpdatedEventNotification>
+          callback) {
+    this.register("v2.core.account[future_requirements].updated", callback);
+    return self();
+  }
+
+  public T onV2CoreAccountIncludingIdentityUpdated(
+      EventNotificationCallback<V2CoreAccountIncludingIdentityUpdatedEventNotification> callback) {
+    this.register("v2.core.account[identity].updated", callback);
+    return self();
+  }
+
+  public T onV2CoreAccountIncludingRequirementsUpdated(
+      EventNotificationCallback<V2CoreAccountIncludingRequirementsUpdatedEventNotification>
+          callback) {
+    this.register("v2.core.account[requirements].updated", callback);
+    return self();
+  }
+
+  public T onV2CoreAccountLinkReturned(
+      EventNotificationCallback<V2CoreAccountLinkReturnedEventNotification> callback) {
+    this.register("v2.core.account_link.returned", callback);
+    return self();
+  }
+
+  public T onV2CoreAccountPersonCreated(
+      EventNotificationCallback<V2CoreAccountPersonCreatedEventNotification> callback) {
+    this.register("v2.core.account_person.created", callback);
+    return self();
+  }
+
+  public T onV2CoreAccountPersonDeleted(
+      EventNotificationCallback<V2CoreAccountPersonDeletedEventNotification> callback) {
+    this.register("v2.core.account_person.deleted", callback);
+    return self();
+  }
+
+  public T onV2CoreAccountPersonUpdated(
+      EventNotificationCallback<V2CoreAccountPersonUpdatedEventNotification> callback) {
+    this.register("v2.core.account_person.updated", callback);
+    return self();
+  }
+
+  public T onV2CoreEventDestinationPing(
+      EventNotificationCallback<V2CoreEventDestinationPingEventNotification> callback) {
+    this.register("v2.core.event_destination.ping", callback);
+    return self();
+  }
+  // notification-handler-methods: The end of the section generated from our OpenAPI spec
+
+  /**
+   * Get a sorted list of all registered event types.
+   *
+   * @return A sorted list of event type strings
+   */
+  public List<String> getRegisteredEventTypes() {
+    List<String> eventTypes = new ArrayList<>(this.registeredHandlers.keySet());
+    Collections.sort(eventTypes);
+    return eventTypes;
+  }
+}

--- a/src/main/java/com/stripe/StripeEventNotificationHandlerWithoutVerification.java
+++ b/src/main/java/com/stripe/StripeEventNotificationHandlerWithoutVerification.java
@@ -1,0 +1,38 @@
+package com.stripe;
+
+import com.stripe.model.v2.core.EventNotification;
+
+/**
+ * A variant of StripeEventNotificationHandler that parses events without verifying webhook
+ * signatures. Intended for pre-authenticated channels like AWS EventBridge or Azure Event Grid.
+ *
+ * <p>Because this is a sibling of {@link StripeEventNotificationHandler} rather than a subclass, it
+ * does not expose that class's two-argument {@code handle} at all — passing a signature header here
+ * is a compile error rather than a runtime one.
+ *
+ * <p>Do not instantiate directly. Use {@link
+ * StripeEventNotificationHandler#withoutVerification(StripeClient,
+ * EventNotificationFallbackCallback)} or {@link
+ * StripeClient#notificationHandlerWithoutVerification(EventNotificationFallbackCallback)} instead.
+ */
+public class StripeEventNotificationHandlerWithoutVerification
+    extends StripeEventNotificationHandlerBase<StripeEventNotificationHandlerWithoutVerification> {
+  StripeEventNotificationHandlerWithoutVerification(
+      StripeClient client, EventNotificationFallbackCallback fallbackCallback) {
+    super(client, fallbackCallback);
+  }
+
+  /**
+   * Handle an incoming webhook event notification without signature verification.
+   *
+   * @param webhookBody the incoming webhook body
+   */
+  public void handle(String webhookBody) {
+    hasHandledEvent = true;
+
+    EventNotification eventNotification =
+        this.client.parseEventNotificationWithoutVerification(webhookBody);
+
+    dispatch(eventNotification);
+  }
+}

--- a/src/main/java/com/stripe/UnhandledNotificationDetails.java
+++ b/src/main/java/com/stripe/UnhandledNotificationDetails.java
@@ -1,0 +1,22 @@
+package com.stripe;
+
+/**
+ * Information about an unhandled event notification to make it easier to respond (and potentially
+ * update your integration).
+ */
+public class UnhandledNotificationDetails {
+  private boolean isKnownEventType;
+
+  // package-private: instances are created by the SDK while dispatching an event
+  UnhandledNotificationDetails(boolean isKnownEventType) {
+    this.isKnownEventType = isKnownEventType;
+  }
+
+  /**
+   * If true, the unhandled event's type is known to the SDK (i.e., it was successfully deserialized
+   * into a specific `EventNotification` subclass).
+   */
+  public boolean isKnownEventType() {
+    return isKnownEventType;
+  }
+}

--- a/src/main/java/com/stripe/examples/EventNotificationHandlerEndpoint.java
+++ b/src/main/java/com/stripe/examples/EventNotificationHandlerEndpoint.java
@@ -1,0 +1,145 @@
+package com.stripe.examples;
+
+import com.stripe.StripeClient;
+import com.stripe.StripeEventNotificationHandler;
+import com.stripe.StripeEventNotificationHandlerWithoutVerification;
+import com.stripe.UnhandledNotificationDetails;
+import com.stripe.events.V1BillingMeterErrorReportTriggeredEventNotification;
+import com.stripe.exception.StripeException;
+import com.stripe.model.billing.Meter;
+import com.stripe.model.v2.core.EventNotification;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Receive and process event notifications (AKA thin events) like
+ * "v1.billing.meter.error_report_triggered" using EventNotificationHandler.
+ *
+ * <p>In this example, we:
+ *
+ * <ul>
+ *   <li>write a fallback callback to handle unrecognized event notifications
+ *   <li>create a StripeClient called client
+ *   <li>Initialize an EventNotificationHandler with the client, webhook secret, and fallback
+ *       callback
+ *   <li>register a specific handler for the "v1.billing.meter.error_report_triggered" event
+ *       notification type
+ *   <li>use handler.handle() to process the received notification webhook body
+ * </ul>
+ *
+ * <p>We also expose a second endpoint for events that arrive through a pre-authenticated channel
+ * (such as AWS EventBridge or Azure Event Grid). Those payloads carry no Stripe-Signature header
+ * because the channel has already authenticated them, so they're routed through a handler created
+ * with notificationHandlerWithoutVerification().
+ */
+public class EventNotificationHandlerEndpoint {
+  private static final String API_KEY = System.getenv("STRIPE_API_KEY");
+  private static final String WEBHOOK_SECRET = System.getenv("WEBHOOK_SECRET");
+
+  private static final StripeClient client = new StripeClient(API_KEY);
+  private static final StripeEventNotificationHandler handler =
+      client.notificationHandler(
+          WEBHOOK_SECRET, EventNotificationHandlerEndpoint::fallbackCallback);
+
+  // Handles events that reach us through a channel which has already authenticated them, so there
+  // is no signature to verify. Callbacks are registered separately from the verifying handler.
+  private static final StripeEventNotificationHandlerWithoutVerification unverifiedHandler =
+      client.notificationHandlerWithoutVerification(
+          EventNotificationHandlerEndpoint::fallbackCallback);
+
+  public static void main(String[] args) throws IOException {
+    handler.onV1BillingMeterErrorReportTriggered(
+        EventNotificationHandlerEndpoint::handleMeterErrors);
+    unverifiedHandler.onV1BillingMeterErrorReportTriggered(
+        EventNotificationHandlerEndpoint::handleMeterErrors);
+
+    HttpServer server = HttpServer.create(new InetSocketAddress(4242), 0);
+    server.createContext("/webhook", new WebhookHandler());
+    server.createContext("/webhook-from-cloud-provider", new UnverifiedWebhookHandler());
+    server.setExecutor(null);
+    server.start();
+  }
+
+  private static void fallbackCallback(
+      EventNotification notif, StripeClient client, UnhandledNotificationDetails details) {
+    System.out.println("Received unhandled event notification type: " + notif.getType());
+  }
+
+  private static void handleMeterErrors(
+      V1BillingMeterErrorReportTriggeredEventNotification notif, StripeClient client) {
+    Meter meter;
+    try {
+      meter = notif.fetchRelatedObject();
+    } catch (StripeException e) {
+      // TODO Auto-generated catch block
+      e.printStackTrace();
+      return;
+    }
+    System.out.println("Handling meter error for meter: " + meter.getDisplayName());
+  }
+
+  static class WebhookHandler implements HttpHandler {
+    // For Java 1.8 compatibility
+    public static byte[] readAllBytes(InputStream inputStream) throws IOException {
+      final int bufLen = 1024;
+      byte[] buf = new byte[bufLen];
+      int readLen;
+
+      ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+      while ((readLen = inputStream.read(buf, 0, bufLen)) != -1)
+        outputStream.write(buf, 0, readLen);
+
+      return outputStream.toByteArray();
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+      if ("POST".equals(exchange.getRequestMethod())) {
+        InputStream requestBody = exchange.getRequestBody();
+        String webhookBody = new String(readAllBytes(requestBody), StandardCharsets.UTF_8);
+        String sigHeader = exchange.getRequestHeaders().getFirst("Stripe-Signature");
+
+        try {
+          handler.handle(webhookBody, sigHeader);
+
+          exchange.sendResponseHeaders(200, -1);
+        } catch (StripeException e) {
+          exchange.sendResponseHeaders(400, -1);
+        }
+      } else {
+        exchange.sendResponseHeaders(405, -1);
+      }
+      exchange.close();
+    }
+  }
+
+  /**
+   * Receives events from a pre-authenticated channel, which deliver no Stripe-Signature header.
+   * Note that handle() takes only the body here, and that it declares no
+   * SignatureVerificationException because no signature is checked.
+   */
+  static class UnverifiedWebhookHandler implements HttpHandler {
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+      if ("POST".equals(exchange.getRequestMethod())) {
+        InputStream requestBody = exchange.getRequestBody();
+        String webhookBody =
+            new String(WebhookHandler.readAllBytes(requestBody), StandardCharsets.UTF_8);
+
+        unverifiedHandler.handle(webhookBody);
+
+        exchange.sendResponseHeaders(200, -1);
+      } else {
+        exchange.sendResponseHeaders(405, -1);
+      }
+      exchange.close();
+    }
+  }
+}

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.logging.Logger;
 
 public class LiveStripeResponseGetter implements StripeResponseGetter {
@@ -77,6 +78,26 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
   public LiveStripeResponseGetter(StripeResponseGetterOptions options, HttpClient httpClient) {
     this.options = options != null ? options : GlobalStripeResponseGetterOptions.INSTANCE;
     this.httpClient = (httpClient != null) ? httpClient : buildDefaultHttpClient();
+  }
+
+  /**
+   * Creates a new LiveStripeResponseGetter with the same configuration and HTTP client as this
+   * instance, but with a different stripe_context. This allows for efficient cloning when you need
+   * to make requests with different contexts (e.g., webhook processing) without reinitializing HTTP
+   * connections.
+   *
+   * @param contextCreator a function that takes the existing options and returns new options with
+   *     the desired context
+   * @return a new LiveStripeResponseGetter with the updated options and the same HTTP client
+   */
+  public LiveStripeResponseGetter withNewOptions(
+      Function<StripeResponseGetterOptions, StripeResponseGetterOptions> contextCreator) {
+    StripeResponseGetterOptions newOptions = contextCreator.apply(this.options);
+    return new LiveStripeResponseGetter(newOptions, this.httpClient);
+  }
+
+  public StripeResponseGetterOptions getOptions() {
+    return this.options;
   }
 
   private StripeRequest toStripeRequest(ApiRequest apiRequest, RequestOptions mergedOptions)

--- a/src/test/java/com/stripe/StripeEventNotificationHandlerTest.java
+++ b/src/test/java/com/stripe/StripeEventNotificationHandlerTest.java
@@ -1,0 +1,633 @@
+package com.stripe;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.stripe.events.UnknownEventNotification;
+import com.stripe.events.V1BillingMeterErrorReportTriggeredEventNotification;
+import com.stripe.events.V2CoreAccountCreatedEventNotification;
+import com.stripe.exception.SignatureVerificationException;
+import com.stripe.model.v2.core.EventNotification;
+import com.stripe.net.Webhook;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class StripeEventNotificationHandlerTest {
+  private static final String DUMMY_WEBHOOK_SECRET = "whsec_test_secret";
+
+  private StripeClient stripeClient;
+  private EventNotificationFallbackCallback fallbackCallback;
+  private StripeEventNotificationHandler eventNotificationHandler;
+
+  private String v1BillingMeterPayload;
+  private String v2AccountCreatedPayload;
+  private String unknownEventPayload;
+
+  @BeforeEach
+  public void setUp() {
+    // Create a StripeClient with context
+    stripeClient =
+        StripeClient.builder()
+            .setApiKey("sk_test_1234")
+            .setStripeContext("original_context_123")
+            .build();
+
+    // Create mock handler for unhandled events
+    fallbackCallback = mock(EventNotificationFallbackCallback.class);
+
+    // Create event router
+    eventNotificationHandler =
+        new StripeEventNotificationHandler(DUMMY_WEBHOOK_SECRET, stripeClient, fallbackCallback);
+
+    // Set up test payloads
+    v1BillingMeterPayload =
+        "{"
+            + "\"id\": \"evt_123\","
+            + "\"object\": \"v2.core.event\","
+            + "\"type\": \"v1.billing.meter.error_report_triggered\","
+            + "\"livemode\": false,"
+            + "\"created\": \"2022-02-15T00:27:45.330Z\","
+            + "\"context\": \"event_context_456\","
+            + "\"related_object\": {"
+            + "\"id\": \"mtr_123\","
+            + "\"type\": \"billing.meter\","
+            + "\"url\": \"/v1/billing/meters/mtr_123\""
+            + "}"
+            + "}";
+
+    v2AccountCreatedPayload =
+        "{"
+            + "\"id\": \"evt_789\","
+            + "\"object\": \"v2.core.event\","
+            + "\"type\": \"v2.core.account.created\","
+            + "\"livemode\": false,"
+            + "\"created\": \"2022-02-15T00:27:45.330Z\","
+            + "\"context\": null,"
+            + "\"related_object\": {"
+            + "\"id\": \"acct_abc\","
+            + "\"type\": \"account\","
+            + "\"url\": \"/v2/core/accounts/acct_abc\""
+            + "}"
+            + "}";
+
+    unknownEventPayload =
+        "{"
+            + "\"id\": \"evt_unknown\","
+            + "\"object\": \"v2.core.event\","
+            + "\"type\": \"llama.created\","
+            + "\"livemode\": false,"
+            + "\"created\": \"2022-02-15T00:27:45.330Z\","
+            + "\"context\": \"event_context_unknown\","
+            + "\"related_object\": {"
+            + "\"id\": \"llama_123\","
+            + "\"type\": \"llama\","
+            + "\"url\": \"/v1/llamas/llama_123\""
+            + "}"
+            + "}";
+  }
+
+  private String generateSigHeader(String payload)
+      throws NoSuchAlgorithmException, InvalidKeyException {
+    Map<String, Object> options = new HashMap<>();
+    options.put("payload", payload);
+    options.put("secret", DUMMY_WEBHOOK_SECRET);
+    return generateSigHeader(options);
+  }
+
+  private String generateSigHeader(Map<String, Object> options)
+      throws NoSuchAlgorithmException, InvalidKeyException {
+    final long timestamp =
+        (options.get("timestamp") != null)
+            ? ((Long) options.get("timestamp")).longValue()
+            : Webhook.Util.getTimeNow();
+    final String payload = (String) options.get("payload");
+    final String secret = (String) options.get("secret");
+    final String scheme =
+        (options.get("scheme") != null)
+            ? (String) options.get("scheme")
+            : Webhook.Signature.EXPECTED_SCHEME;
+    String signature = (String) options.get("signature");
+
+    if (signature == null) {
+      final String payloadToSign = String.format("%d.%s", timestamp, payload);
+      signature = Webhook.Util.computeHmacSha256(secret, payloadToSign);
+    }
+
+    return String.format("t=%d,%s=%s", timestamp, scheme, signature);
+  }
+
+  @Test
+  public void testRoutesEventToRegisteredHandler()
+      throws SignatureVerificationException, NoSuchAlgorithmException, InvalidKeyException {
+    // Test that a registered event type is routed to the correct handler
+    @SuppressWarnings("unchecked")
+    EventNotificationCallback<V1BillingMeterErrorReportTriggeredEventNotification> handler =
+        mock(EventNotificationCallback.class);
+    eventNotificationHandler.onV1BillingMeterErrorReportTriggered(handler);
+
+    String sigHeader = generateSigHeader(v1BillingMeterPayload);
+    eventNotificationHandler.handle(v1BillingMeterPayload, sigHeader);
+
+    verify(handler, times(1))
+        .process(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+    verify(fallbackCallback, never())
+        .process(
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any());
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testRoutesDifferentEventsToCorrectHandlers()
+      throws SignatureVerificationException, NoSuchAlgorithmException, InvalidKeyException {
+    // Test that different event types route to their respective handlers
+    EventNotificationCallback<V1BillingMeterErrorReportTriggeredEventNotification> billingHandler =
+        mock(EventNotificationCallback.class);
+    EventNotificationCallback<V2CoreAccountCreatedEventNotification> accountHandler =
+        mock(EventNotificationCallback.class);
+
+    eventNotificationHandler.onV1BillingMeterErrorReportTriggered(billingHandler);
+    eventNotificationHandler.onV2CoreAccountCreated(accountHandler);
+
+    String sigHeader1 = generateSigHeader(v1BillingMeterPayload);
+    eventNotificationHandler.handle(v1BillingMeterPayload, sigHeader1);
+
+    String sigHeader2 = generateSigHeader(v2AccountCreatedPayload);
+    eventNotificationHandler.handle(v2AccountCreatedPayload, sigHeader2);
+
+    eventNotificationHandler.handle(v1BillingMeterPayload, sigHeader1);
+
+    verify(billingHandler, times(2))
+        .process(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+    verify(accountHandler, times(1))
+        .process(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+    verify(fallbackCallback, never())
+        .process(
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  public void testHandlerReceivesCorrectRuntimeType()
+      throws SignatureVerificationException, NoSuchAlgorithmException, InvalidKeyException {
+    // Test that handlers receive the correctly typed event notification
+    AtomicReference<EventNotification> receivedEvent = new AtomicReference<>();
+    AtomicReference<StripeClient> receivedClient = new AtomicReference<>();
+
+    EventNotificationCallback<V1BillingMeterErrorReportTriggeredEventNotification> handler =
+        (event, client) -> {
+          receivedEvent.set(event);
+          receivedClient.set(client);
+        };
+
+    eventNotificationHandler.onV1BillingMeterErrorReportTriggered(handler);
+
+    String sigHeader = generateSigHeader(v1BillingMeterPayload);
+    eventNotificationHandler.handle(v1BillingMeterPayload, sigHeader);
+
+    assertInstanceOf(
+        V1BillingMeterErrorReportTriggeredEventNotification.class, receivedEvent.get());
+    V1BillingMeterErrorReportTriggeredEventNotification notification =
+        (V1BillingMeterErrorReportTriggeredEventNotification) receivedEvent.get();
+    assertEquals("v1.billing.meter.error_report_triggered", notification.getType());
+    assertEquals("evt_123", notification.getId());
+    assertEquals("mtr_123", notification.getRelatedObject().getId());
+    assertNotNull(receivedClient.get());
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testCannotRegisterHandlerAfterHandling()
+      throws SignatureVerificationException, NoSuchAlgorithmException, InvalidKeyException {
+    // Test that registering handlers after handle() raises IllegalStateException
+    EventNotificationCallback<V1BillingMeterErrorReportTriggeredEventNotification> handler =
+        mock(EventNotificationCallback.class);
+    eventNotificationHandler.onV1BillingMeterErrorReportTriggered(handler);
+
+    String sigHeader = generateSigHeader(v1BillingMeterPayload);
+    eventNotificationHandler.handle(v1BillingMeterPayload, sigHeader);
+
+    IllegalStateException exception =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                eventNotificationHandler.onV2CoreAccountCreated(
+                    mock(EventNotificationCallback.class)));
+
+    assertTrue(exception.getMessage().contains("Cannot register handlers after handling an event"));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testCannotRegisterDuplicateHandler() {
+    // Test that registering the same event type twice raises IllegalArgumentException
+    EventNotificationCallback<V1BillingMeterErrorReportTriggeredEventNotification> handler1 =
+        mock(EventNotificationCallback.class);
+    EventNotificationCallback<V1BillingMeterErrorReportTriggeredEventNotification> handler2 =
+        mock(EventNotificationCallback.class);
+
+    eventNotificationHandler.onV1BillingMeterErrorReportTriggered(handler1);
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> eventNotificationHandler.onV1BillingMeterErrorReportTriggered(handler2));
+
+    assertTrue(
+        exception
+            .getMessage()
+            .contains(
+                "Handler already registered for event type: v1.billing.meter.error_report_triggered"));
+  }
+
+  @Test
+  public void testHandlerUsesEventStripeContext()
+      throws SignatureVerificationException, NoSuchAlgorithmException, InvalidKeyException {
+    // Test that the handler receives a client with stripe_context from the event
+    AtomicReference<String> receivedContext = new AtomicReference<>();
+
+    EventNotificationCallback<V1BillingMeterErrorReportTriggeredEventNotification> handler =
+        (event, client) -> {
+          receivedContext.set(client.getContext());
+        };
+
+    eventNotificationHandler.onV1BillingMeterErrorReportTriggered(handler);
+
+    assertEquals("original_context_123", stripeClient.getContext());
+
+    String sigHeader = generateSigHeader(v1BillingMeterPayload);
+    eventNotificationHandler.handle(v1BillingMeterPayload, sigHeader);
+
+    assertEquals("event_context_456", receivedContext.get());
+  }
+
+  @Test
+  public void testStripeContextRestoredAfterHandlerSuccess()
+      throws SignatureVerificationException, NoSuchAlgorithmException, InvalidKeyException {
+    // Test that the original stripe_context is restored after successful handler execution
+    EventNotificationCallback<V1BillingMeterErrorReportTriggeredEventNotification> handler =
+        (event, client) -> {
+          assertEquals("event_context_456", client.getContext());
+        };
+
+    eventNotificationHandler.onV1BillingMeterErrorReportTriggered(handler);
+
+    assertEquals("original_context_123", stripeClient.getContext());
+
+    String sigHeader = generateSigHeader(v1BillingMeterPayload);
+    eventNotificationHandler.handle(v1BillingMeterPayload, sigHeader);
+
+    assertEquals("original_context_123", stripeClient.getContext());
+  }
+
+  @Test
+  public void testStripeContextRestoredAfterHandlerError()
+      throws NoSuchAlgorithmException, InvalidKeyException {
+    // Test that the original stripe_context is restored even when handler raises an exception
+    EventNotificationCallback<V1BillingMeterErrorReportTriggeredEventNotification> handler =
+        (event, client) -> {
+          assertEquals("event_context_456", client.getContext());
+          throw new RuntimeException("Handler error!");
+        };
+
+    eventNotificationHandler.onV1BillingMeterErrorReportTriggered(handler);
+
+    assertEquals("original_context_123", stripeClient.getContext());
+
+    String sigHeader = generateSigHeader(v1BillingMeterPayload);
+
+    RuntimeException exception =
+        assertThrows(
+            RuntimeException.class,
+            () -> eventNotificationHandler.handle(v1BillingMeterPayload, sigHeader));
+    assertEquals("Handler error!", exception.getMessage());
+
+    assertEquals("original_context_123", stripeClient.getContext());
+  }
+
+  @Test
+  public void testStripeContextSetToNullWhenEventHasNoContext()
+      throws SignatureVerificationException, NoSuchAlgorithmException, InvalidKeyException {
+    // Test that stripe_context is set to null when event context is null
+    AtomicReference<String> receivedContext = new AtomicReference<>();
+
+    EventNotificationCallback<V2CoreAccountCreatedEventNotification> handler =
+        (event, client) -> {
+          receivedContext.set(client.getContext());
+        };
+
+    eventNotificationHandler.onV2CoreAccountCreated(handler);
+
+    assertEquals("original_context_123", stripeClient.getContext());
+
+    String sigHeader = generateSigHeader(v2AccountCreatedPayload);
+    eventNotificationHandler.handle(v2AccountCreatedPayload, sigHeader);
+
+    assertNull(receivedContext.get());
+    assertEquals("original_context_123", stripeClient.getContext());
+  }
+
+  @Test
+  public void testUnknownEventRoutesToOnUnhandled()
+      throws SignatureVerificationException, NoSuchAlgorithmException, InvalidKeyException {
+    // Test that events without SDK types rout handler
+    String sigHeader = generateSigHeader(unknownEventPayload);
+    eventNotificationHandler.handle(unknownEventPayload, sigHeader);
+
+    verify(fallbackCallback, times(1))
+        .process(
+            org.mockito.ArgumentMatchers.argThat(
+                event ->
+                    event instanceof UnknownEventNotification
+                        && event.getType().equals("llama.created")),
+            org.mockito.ArgumentMatchers.any(StripeClient.class),
+            org.mockito.ArgumentMatchers.argThat(info -> info.isKnownEventType() == false));
+  }
+
+  @Test
+  public void testKnownUnregisteredEventRoutesToOnUnhandled()
+      throws SignatureVerificationException, NoSuchAlgorithmException, InvalidKeyException {
+    // Test that known event types without a registered handler rout
+    String sigHeader = generateSigHeader(v1BillingMeterPayload);
+    eventNotificationHandler.handle(v1BillingMeterPayload, sigHeader);
+
+    verify(fallbackCallback, times(1))
+        .process(
+            org.mockito.ArgumentMatchers.argThat(
+                event ->
+                    event instanceof V1BillingMeterErrorReportTriggeredEventNotification
+                        && event.getType().equals("v1.billing.meter.error_report_triggered")),
+            org.mockito.ArgumentMatchers.any(StripeClient.class),
+            org.mockito.ArgumentMatchers.argThat(info -> info.isKnownEventType() == true));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testRegisteredEventDoesNotCallOnUnhandled()
+      throws SignatureVerificationException, NoSuchAlgorithmException, InvalidKeyException {
+    // Test that registered events don't tri
+    EventNotificationCallback<V1BillingMeterErrorReportTriggeredEventNotification> handler =
+        mock(EventNotificationCallback.class);
+    eventNotificationHandler.onV1BillingMeterErrorReportTriggered(handler);
+
+    String sigHeader = generateSigHeader(v1BillingMeterPayload);
+    eventNotificationHandler.handle(v1BillingMeterPayload, sigHeader);
+
+    verify(handler, times(1))
+        .process(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+    verify(fallbackCallback, never())
+        .process(
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  public void testHandlerClientRetainsConfiguration()
+      throws SignatureVerificationException, NoSuchAlgorithmException, InvalidKeyException {
+    // Test that the client passed to handlers retains all configuration except stripe_context
+    String originalContext = "original_context_xyz";
+
+    StripeClient customClient =
+        StripeClient.builder()
+            .setApiKey("sk_test_custom_key")
+            .setStripeContext(originalContext)
+            .build();
+
+    StripeEventNotificationHandler customRouter =
+        new StripeEventNotificationHandler(DUMMY_WEBHOOK_SECRET, customClient, fallbackCallback);
+
+    AtomicReference<String> receivedContext = new AtomicReference<>();
+
+    EventNotificationCallback<V1BillingMeterErrorReportTriggeredEventNotification> handler =
+        (event, client) -> {
+          receivedContext.set(client.getContext());
+        };
+
+    customRouter.onV1BillingMeterErrorReportTriggered(handler);
+
+    String sigHeader = generateSigHeader(v1BillingMeterPayload);
+    customRouter.handle(v1BillingMeterPayload, sigHeader);
+
+    assertEquals("event_context_456", receivedContext.get());
+    assertEquals(originalContext, customClient.getContext());
+  }
+
+  @Test
+  public void testOnUnhandledReceivesCorrectInfoForUnknown()
+      throws SignatureVerificationException, NoSuchAlgorithmException, InvalidKeyException {
+    // Test  receives correct UnhandledNotificationDetails for unknown events
+    String sigHeader = generateSigHeader(unknownEventPayload);
+    eventNotificationHandler.handle(unknownEventPayload, sigHeader);
+
+    verify(fallbackCallback, times(1))
+        .process(
+            org.mockito.ArgumentMatchers.any(EventNotification.class),
+            org.mockito.ArgumentMatchers.any(StripeClient.class),
+            org.mockito.ArgumentMatchers.argThat(info -> info.isKnownEventType() == false));
+  }
+
+  @Test
+  public void testOnUnhandledReceivesCorrectInfoForKnownUnregistered()
+      throws SignatureVerificationException, NoSuchAlgorithmException, InvalidKeyException {
+    // Test  receives correct UnhandledNotificationDetails for known unregistered
+    // events
+    String sigHeader = generateSigHeader(v1BillingMeterPayload);
+    eventNotificationHandler.handle(v1BillingMeterPayload, sigHeader);
+
+    verify(fallbackCallback, times(1))
+        .process(
+            org.mockito.ArgumentMatchers.any(EventNotification.class),
+            org.mockito.ArgumentMatchers.any(StripeClient.class),
+            org.mockito.ArgumentMatchers.argThat(info -> info.isKnownEventType() == true));
+  }
+
+  @Test
+  public void testValidatesWebhookSignature() {
+    // Test that invalid webhook signatures are rejected
+    assertThrows(
+        SignatureVerificationException.class,
+        () -> eventNotificationHandler.handle(v1BillingMeterPayload, "invalid_signature"));
+  }
+
+  @Test
+  public void testConstructor_rejectsNullSecret() {
+    // Test that constructing with a null secret throws IllegalArgumentException
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new StripeEventNotificationHandler(null, stripeClient, fallbackCallback));
+  }
+
+  @Test
+  public void testConstructor_rejectsEmptySecret() {
+    // Test that constructing with an empty secret throws IllegalArgumentException
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new StripeEventNotificationHandler("", stripeClient, fallbackCallback));
+  }
+
+  @Test
+  public void testWithoutVerification_staticFactory() {
+    // Test that StripeEventNotificationHandler.withoutVerification(...) returns the correct type.
+    // Declared as the concrete type: the handlers are siblings, so this is deliberately NOT
+    // assignable to StripeEventNotificationHandler.
+    StripeEventNotificationHandlerWithoutVerification handler =
+        StripeEventNotificationHandler.withoutVerification(stripeClient, fallbackCallback);
+
+    assertInstanceOf(StripeEventNotificationHandlerWithoutVerification.class, handler);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testWithoutVerification_routesEventToHandler() {
+    // Test that a registered event type is routed to the correct handler without sig verification
+    StripeEventNotificationHandlerWithoutVerification handler =
+        StripeEventNotificationHandler.withoutVerification(stripeClient, fallbackCallback);
+
+    EventNotificationCallback<V1BillingMeterErrorReportTriggeredEventNotification> callback =
+        mock(EventNotificationCallback.class);
+    handler.onV1BillingMeterErrorReportTriggered(callback);
+
+    handler.handle(v1BillingMeterPayload);
+
+    verify(callback, times(1))
+        .process(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+    verify(fallbackCallback, never())
+        .process(
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  public void testWithoutVerification_fallbackForUnregisteredEvent() {
+    // Test that a known event type without a registered handler calls fallback with
+    // isKnownEventType true
+    StripeEventNotificationHandlerWithoutVerification handler =
+        StripeEventNotificationHandler.withoutVerification(stripeClient, fallbackCallback);
+
+    handler.handle(v1BillingMeterPayload);
+
+    verify(fallbackCallback, times(1))
+        .process(
+            org.mockito.ArgumentMatchers.argThat(
+                event ->
+                    event instanceof V1BillingMeterErrorReportTriggeredEventNotification
+                        && event.getType().equals("v1.billing.meter.error_report_triggered")),
+            org.mockito.ArgumentMatchers.any(StripeClient.class),
+            org.mockito.ArgumentMatchers.argThat(info -> info.isKnownEventType() == true));
+  }
+
+  @Test
+  public void testWithoutVerification_unknownEventType() {
+    // Test that an unknown event type calls fallback with isKnownEventType false
+    StripeEventNotificationHandlerWithoutVerification handler =
+        StripeEventNotificationHandler.withoutVerification(stripeClient, fallbackCallback);
+
+    handler.handle(unknownEventPayload);
+
+    verify(fallbackCallback, times(1))
+        .process(
+            org.mockito.ArgumentMatchers.argThat(
+                event ->
+                    event instanceof UnknownEventNotification
+                        && event.getType().equals("llama.created")),
+            org.mockito.ArgumentMatchers.any(StripeClient.class),
+            org.mockito.ArgumentMatchers.argThat(info -> info.isKnownEventType() == false));
+  }
+
+  @Test
+  public void testWithoutVerification_contextPropagation() {
+    // Test that the client passed to callbacks has the event's stripe_context
+    AtomicReference<String> receivedContext = new AtomicReference<>();
+
+    StripeEventNotificationHandlerWithoutVerification handler =
+        StripeEventNotificationHandler.withoutVerification(stripeClient, fallbackCallback);
+
+    EventNotificationCallback<V1BillingMeterErrorReportTriggeredEventNotification> callback =
+        (event, client) -> {
+          receivedContext.set(client.getContext());
+        };
+
+    handler.onV1BillingMeterErrorReportTriggered(callback);
+    handler.handle(v1BillingMeterPayload);
+
+    assertEquals("event_context_456", receivedContext.get());
+  }
+
+  @Test
+  public void testWithoutVerification_doesNotExposeVerifyingHandle() {
+    // The two handlers are siblings, so the signature-verifying handle(body, sig) isn't
+    // inherited here at all -- passing a signature header is a compile error rather than a
+    // runtime one. Assert on the declared methods so a refactor can't quietly reintroduce it.
+    int handleMethods = 0;
+    for (java.lang.reflect.Method method :
+        StripeEventNotificationHandlerWithoutVerification.class.getMethods()) {
+      if (method.getName().equals("handle")) {
+        handleMethods += 1;
+        assertEquals(1, method.getParameterCount());
+      }
+    }
+
+    assertEquals(1, handleMethods);
+  }
+
+  @Test
+  public void testRegisteredEventTypesEmpty() {
+    // Test that registered_event_types returns empty list when no handlers are registered
+    List<String> eventTypes = eventNotificationHandler.getRegisteredEventTypes();
+    assertNotNull(eventTypes);
+    assertTrue(eventTypes.isEmpty());
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testRegisteredEventTypesSingle() {
+    // Test that registered_event_types returns a single event type
+    EventNotificationCallback<V1BillingMeterErrorReportTriggeredEventNotification> handler =
+        mock(EventNotificationCallback.class);
+    eventNotificationHandler.onV1BillingMeterErrorReportTriggered(handler);
+
+    List<String> eventTypes = eventNotificationHandler.getRegisteredEventTypes();
+    assertEquals(1, eventTypes.size());
+    assertEquals("v1.billing.meter.error_report_triggered", eventTypes.get(0));
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  @Test
+  public void testRegisteredEventTypesMultipleAlphabetized() {
+    // Test that registered_event_types returns multiple event types in alphabetical order
+    EventNotificationCallback handler = mock(EventNotificationCallback.class);
+
+    // Register in non-alphabetical order
+    eventNotificationHandler.onV2CoreAccountUpdated(handler);
+    eventNotificationHandler.onV1BillingMeterErrorReportTriggered(handler);
+    eventNotificationHandler.onV2CoreAccountCreated(handler);
+
+    List<String> expected =
+        Arrays.asList(
+            "v1.billing.meter.error_report_triggered",
+            "v2.core.account.created",
+            "v2.core.account.updated");
+
+    List<String> eventTypes = eventNotificationHandler.getRegisteredEventTypes();
+    assertEquals(expected, eventTypes);
+  }
+}


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

The event notification handler code has been in the `beta` and `private-preview` branches since last year, but it's time to take it to GA!

This PR is entirely pre-approved code from previous PRs. It takes the static files from codegen, plus all the manual changes I made directly in `beta` to get everything working. It's stacked on top of the non-verified work from this week, too. Once this lands, the managed handler code should be in sync across all channels.

Notably, the static files that we used to share functionality are no longer sourced from codegen. Instead, they're now true manual files in `master` whose changes will flow into preview branches like normal.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- add `EventNotificationHandler` class & supporting infrastructure (ability to copy a `StripeClient`, etc)
- add `stripeClient` methods for creating a handler bound to that client
- add example
- add tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- https://stripe.dev/blog/event-notification-handlers-thin-events
- [internal doc](https://docs.google.com/document/d/1hRpQLMLGfOHhZwXrYt5tvsKT-oIya11M4atunvTOih0/edit?tab=t.w21fiib3jsl3#heading=h.p5iqpr8dzdsz)
- Initial PR: https://github.com/stripe/stripe-java/pull/2104
- Update PR (adds non-verified handlers): https://github.com/stripe/stripe-java/pull/2267

## Changelog

- We've been putting a lot of time into rethinking the event handling experience in the SDKs. This new class is the culmination [of that effort](https://stripe.dev/blog/event-notification-handlers-thin-events).
- They're designed for a tight coupling with both `StripeClient` and the fully-typed nature of [thin events](https://docs.stripe.com/event-destinations#thin-events). This delivers painless event destination upgrades, in-editor checks for common mistakes, and better code modularity.
- Now that we've released [thin event notifications for v1 objects](https://docs.stripe.com/changelog#2026-08-26.dahlia), these new handlers are our recommended path for all integrations using thin event notifications.
- See more detailed docs here: https://docs.stripe.com/webhooks/event-notification-handlers
