### PR TITLE
Remove `payment_method_types` from manual tests

### DIFF
--- a/src/test/java/com/stripe/functional/PaymentIntentTest.java
+++ b/src/test/java/com/stripe/functional/PaymentIntentTest.java
@@ -39,7 +39,7 @@ public class PaymentIntentTest extends BaseStripeTest {
     final Map<String, Object> params = new HashMap<>();
     params.put("amount", 1234);
     params.put("currency", "usd");
-    params.put("payment_method_types", paymentMethodTypes);
+    params.put("allowed_payment_method_types", paymentMethodTypes);
 
     final PaymentIntent paymentIntent = PaymentIntent.create(params);
 


### PR DESCRIPTION
### Why?

We have a few manual tests that send `payment_method_types` in a `payment_intent`-related test. That field has already been removed from beta, so preview tests are failing. It's also being removed from GA in the next release, so fixing it in master saves us hassle later.

### What?

- swap `payment_method_types` to `allowed_payment_method_types` in manual tests
