### PR TITLE
Carry private-preview's CI workflow hunks on master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - master
       - beta
+      - private-preview
       - sdk-release/**
       - feature/**
     tags:
@@ -125,6 +126,9 @@ jobs:
           echo "JAVA_TEST_HOME=$JAVA_TEST_HOME"
 
       - uses: stripe/openapi/actions/stripe-mock@master
+        with:
+          # Used to determine if stripe-mock runs in beta mode
+          base: ${{ github.base_ref == 'private-preview' && 'beta' || github.ref_name == 'private-preview' && 'beta' || contains(github.ref_name, '-alpha.') && 'beta' || github.base_ref || github.ref_name }}
       - name: Run test suite
         run: just test
 


### PR DESCRIPTION
### Why?

The codegen job's push to `latest-codegen-private-preview` is rejected by GitHub: the master→private-preview merge produces a `ci.yml` that exists nowhere in the repository, and the App performing the push has no `workflows` permission. Holding private-preview's two workflow hunks on master turns that merge into a carry-forward of an already-committed file. The commit message carries the mechanism and the argument that both hunks are inert on master.

### What?

- adds `private-preview` to `on.push.branches`
- adds the `base:` input to the `stripe-mock` step, copied verbatim from `private-preview`

The resulting `ci.yml` blob is `2ae769f0e56`, byte-identical to what a master→private-preview merge produces today.

### See Also

- Failing codegen run: https://github.com/stripe/sdk-codegen/actions/runs/33121897095