### PR TITLE
Harden API requestor code against malicious URLs

### DIFF
--- a/src/main/java/com/stripe/model/v2/core/EventNotification.java
+++ b/src/main/java/com/stripe/model/v2/core/EventNotification.java
@@ -143,9 +143,14 @@ public abstract class EventNotification {
 
   /* retrieves the full payload for an event. Protected because individual push classes use it, but type it correctly */
   protected Event fetchEvent() throws StripeException {
+    // `id` comes from the notification body, so encode it the way the generated
+    // services do -- otherwise it can inject extra path or query segments.
     StripeResponse response =
         client.rawRequest(
-            RequestMethod.GET, String.format("/v2/core/events/%s", id), null, getRequestOptions());
+            RequestMethod.GET,
+            String.format("/v2/core/events/%s", ApiResource.urlEncodeId(id)),
+            null,
+            getRequestOptions());
 
     return (Event) client.deserialize(response.body(), ApiMode.V2);
   }

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -476,6 +476,31 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
     }
   }
 
+  /**
+   * Asserts that a request path is origin-relative: that it begins with a single {@code "/"}.
+   *
+   * <p>The absolute URL is built by concatenating a base URL onto this path, and no base URL ends
+   * in a slash. A path like {@code "@evil.example/v1/x"} or {@code ".evil.example/v1/x"} would
+   * therefore land inside the authority component and send the request -- {@code Authorization}
+   * header included -- to a host of the path's choosing. Some request paths originate in remote
+   * data (a webhook body's {@code related_object.url}, a collection's {@code url}, a response's
+   * {@code next_page_url}), so the path cannot be assumed to be well-formed.
+   *
+   * <p>A single leading slash is sufficient: it terminates the authority component, after which
+   * nothing in the path can extend it. Deliberately not using {@link java.net.URI} to parse -- it
+   * enforces RFC 2396 strictly and would reject paths containing characters that callers have
+   * always been able to send.
+   *
+   * <p>Stripe only ever issues plain paths, so anything else is tampering and is rejected rather
+   * than sanitized.
+   */
+  static void validatePath(String path) {
+    if (path == null || !path.startsWith("/") || path.startsWith("//")) {
+      throw new IllegalArgumentException(
+          "Request path must begin with a single \"/\", got: " + path);
+    }
+  }
+
   private String fullUrl(BaseApiRequest apiRequest) {
     BaseAddress baseAddress = apiRequest.getBaseAddress();
     RequestOptions options = apiRequest.getOptions();
@@ -500,6 +525,7 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
     if (options != null && options.getBaseUrl() != null) {
       baseUrl = options.getBaseUrl();
     }
+    validatePath(relativeUrl);
     return String.format("%s%s", baseUrl, relativeUrl);
   }
 }

--- a/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
+++ b/src/main/java/com/stripe/net/LiveStripeResponseGetter.java
@@ -481,18 +481,14 @@ public class LiveStripeResponseGetter implements StripeResponseGetter {
    *
    * <p>The absolute URL is built by concatenating a base URL onto this path, and no base URL ends
    * in a slash. A path like {@code "@evil.example/v1/x"} or {@code ".evil.example/v1/x"} would
-   * therefore land inside the authority component and send the request -- {@code Authorization}
-   * header included -- to a host of the path's choosing. Some request paths originate in remote
-   * data (a webhook body's {@code related_object.url}, a collection's {@code url}, a response's
-   * {@code next_page_url}), so the path cannot be assumed to be well-formed.
+   * modify the resulting host and direct the request (including the API key) to a non-Stripe host.
    *
-   * <p>A single leading slash is sufficient: it terminates the authority component, after which
-   * nothing in the path can extend it. Deliberately not using {@link java.net.URI} to parse -- it
-   * enforces RFC 2396 strictly and would reject paths containing characters that callers have
-   * always been able to send.
+   * <p>Because some relative urls arrive from potentially untrusted sources (like webhook bodies),
+   * we have to be a little defensive.
    *
-   * <p>Stripe only ever issues plain paths, so anything else is tampering and is rejected rather
-   * than sanitized.
+   * <p>So, we require that a path starts with a leading slash. Deliberately not using {@link
+   * java.net.URI} to parse -- it enforces RFC 2396 strictly and would reject paths containing
+   * characters that callers have always been able to send.
    */
   static void validatePath(String path) {
     if (path == null || !path.startsWith("/") || path.startsWith("//")) {

--- a/src/test/java/com/stripe/net/OriginRelativePathTest.java
+++ b/src/test/java/com/stripe/net/OriginRelativePathTest.java
@@ -5,15 +5,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.stripe.BaseStripeTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * The absolute request URL is built by concatenating a base URL onto a relative path, and no base
- * URL ends in a slash. A path that does not begin with a single "/" can therefore land inside the
- * URL's authority component and redirect the request -- Authorization header included -- to a host
- * of the path's choosing.
- *
- * <p>This matters because some request paths originate in remote data: a webhook body's {@code
- * related_object.url}, a collection's {@code url}, a response's {@code next_page_url}.
- */
 public class OriginRelativePathTest extends BaseStripeTest {
 
   private static final String[] ORIGIN_RELATIVE_PATHS = {

--- a/src/test/java/com/stripe/net/OriginRelativePathTest.java
+++ b/src/test/java/com/stripe/net/OriginRelativePathTest.java
@@ -1,0 +1,74 @@
+package com.stripe.net;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.stripe.BaseStripeTest;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The absolute request URL is built by concatenating a base URL onto a relative path, and no base
+ * URL ends in a slash. A path that does not begin with a single "/" can therefore land inside the
+ * URL's authority component and redirect the request -- Authorization header included -- to a host
+ * of the path's choosing.
+ *
+ * <p>This matters because some request paths originate in remote data: a webhook body's {@code
+ * related_object.url}, a collection's {@code url}, a response's {@code next_page_url}.
+ */
+public class OriginRelativePathTest extends BaseStripeTest {
+
+  private static final String[] ORIGIN_RELATIVE_PATHS = {
+    "/v1/customers/cus_123",
+    "/v1/customers",
+    "/v2/core/accounts?page=page_123&limit=2",
+    // '@' is legal inside a path or query string -- it only opens an authority
+    // when it precedes the first '/'.
+    "/v1/customers?email=user%40example.com",
+    "/v1/invoices/in_123@456",
+    // A backslash does not open an authority: the '/' already closed it.
+    "/v1/\\evil.example",
+  };
+
+  private static final String[] HOSTILE_PATHS = {
+    // Concatenated onto a base URL with no trailing slash, each of these moves
+    // the request's authority off api.stripe.com.
+    "@evil.example/v1/leak",
+    ":pw@evil.example/v1/leak",
+    ":80@evil.example/v1/leak",
+    // Extends the host into an attacker-owned subdomain
+    // (api.stripe.com.evil.example), which has a valid certificate.
+    ".evil.example/v1/leak",
+    "-evil.example/v1/leak",
+    "https://evil.example/v1/leak",
+    "//evil.example/v1/leak",
+    "",
+    "v1/customers",
+    null,
+  };
+
+  @Test
+  public void testAcceptsOriginRelativePaths() {
+    for (String path : ORIGIN_RELATIVE_PATHS) {
+      assertDoesNotThrow(
+          () -> LiveStripeResponseGetter.validatePath(path), "expected to accept: " + path);
+    }
+  }
+
+  @Test
+  public void testRejectsHostilePaths() {
+    for (String path : HOSTILE_PATHS) {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> LiveStripeResponseGetter.validatePath(path),
+          "expected to reject: " + path);
+    }
+  }
+
+  @Test
+  public void testRejectionMessageNamesThePath() {
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> LiveStripeResponseGetter.validatePath("@evil.example/v1/leak"));
+    assertTrue(e.getMessage().contains("@evil.example/v1/leak"));
+  }
+}


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

If an attacker got access to a user's webhook secret (or the user wasn't validating incoming webhook signatures) _and_ a user was calling the built-in `event_notification.fetch_related_object()` method, a malicious webhook payload could cause a user integration to make an authenticated request to an attacker-controlled domain (leaking the secret key)

To solve, we're being more careful during url construction to ensure user input can't be used to send requests to non-`stripe.com` domains (on a per-request basis).

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- add path validation method and call it before the final URL is built
- Encode the `event.id` path param in `fetch_event()` to match the sanitation in the rest of the generated endpoints
- add tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- [RUN_DEVSDK-2808](https://go/j/RUN_DEVSDK-2808)
