### PR TITLE
Validate that webhook secrets are non-empty

### DIFF
--- a/src/main/java/com/stripe/net/Webhook.java
+++ b/src/main/java/com/stripe/net/Webhook.java
@@ -204,6 +204,11 @@ public final class Webhook {
             "No signatures found with expected scheme", sigHeader);
       }
 
+      if (secret == null || secret.isEmpty()) {
+        throw new SignatureVerificationException(
+            "No webhook secret value was provided. It should start with `whsec_`", sigHeader);
+      }
+
       // Compute expected signature
       String signedPayload = String.format("%d.%s", timestamp, payload);
       String expectedSignature;

--- a/src/test/java/com/stripe/net/WebhookTest.java
+++ b/src/test/java/com/stripe/net/WebhookTest.java
@@ -171,6 +171,38 @@ public class WebhookTest extends BaseStripeTest {
   }
 
   @Test
+  public void testEmptySecret()
+      throws SignatureVerificationException, NoSuchAlgorithmException, InvalidKeyException {
+    final String sigHeader = generateSigHeader();
+
+    Throwable exception =
+        assertThrows(
+            SignatureVerificationException.class,
+            () -> {
+              Webhook.Signature.verifyHeader(payload, sigHeader, "", 0, null);
+            });
+    assertEquals(
+        "No webhook secret value was provided. It should start with `whsec_`",
+        exception.getMessage());
+  }
+
+  @Test
+  public void testNullSecret()
+      throws SignatureVerificationException, NoSuchAlgorithmException, InvalidKeyException {
+    final String sigHeader = generateSigHeader();
+
+    Throwable exception =
+        assertThrows(
+            SignatureVerificationException.class,
+            () -> {
+              Webhook.Signature.verifyHeader(payload, sigHeader, null, 0, null);
+            });
+    assertEquals(
+        "No webhook secret value was provided. It should start with `whsec_`",
+        exception.getMessage());
+  }
+
+  @Test
   public void testNoValidSignatureForPayload()
       throws SignatureVerificationException, NoSuchAlgorithmException, InvalidKeyException {
     final Map<String, Object> options = new HashMap<>();


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Fixes a potential security issue where, if the user passes an empty string into the event validation functions, the SDK would still generate a signature. If an attacker knew that a victim was inadvertently using an empty webhook secret, the attacker could send signed webhooks (using the empty secret) that a victim's integration would treat as valid.

The solution is to throw an error if the webhook secret is empty. This ensures all payloads are validated against an actual secret.

We also updated our examples to have better defaults, helping users to avoid this issue.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- verify that a webhook secret is non-empty & non-null when verifying a webhook
- update examples
- add tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- [RUN_DEVSDK-2953](https://go/j/RUN_DEVSDK-2953)
