### PR TITLE
Support `EventNotification`s with singleton related objects

### DIFF
--- a/src/main/java/com/stripe/model/v2/core/Event.java
+++ b/src/main/java/com/stripe/model/v2/core/Event.java
@@ -90,12 +90,25 @@ public class Event extends StripeObject implements HasId, StripeActiveObject {
     if (relatedObject == null) {
       return null;
     }
-    if (relatedObject.getUrl() == null) {
+    return fetchRelatedObjectByTypeAndUrl(relatedObject.getType(), relatedObject.getUrl());
+  }
+
+  /** Retrieves the object associated with the event. */
+  protected StripeObject fetchRelatedObject(RelatedSingletonObject relatedObject)
+      throws StripeException {
+    if (relatedObject == null) {
+      return null;
+    }
+    return fetchRelatedObjectByTypeAndUrl(relatedObject.getType(), relatedObject.getUrl());
+  }
+
+  private StripeObject fetchRelatedObjectByTypeAndUrl(String type, String url)
+      throws StripeException {
+    if (url == null) {
       return null;
     }
 
-    Class<? extends StripeObject> objectClass =
-        EventDataClassLookup.classLookup.get(relatedObject.getType());
+    Class<? extends StripeObject> objectClass = EventDataClassLookup.classLookup.get(type);
     if (objectClass == null) {
       objectClass = StripeRawJsonObject.class;
     }
@@ -110,8 +123,7 @@ public class Event extends StripeObject implements HasId, StripeActiveObject {
     RequestOptions opts = optsBuilder.build();
 
     return this.responseGetter.request(
-        new ApiRequest(
-            BaseAddress.API, ApiResource.RequestMethod.GET, relatedObject.getUrl(), null, opts),
+        new ApiRequest(BaseAddress.API, ApiResource.RequestMethod.GET, url, null, opts),
         objectClass);
   }
 
@@ -139,7 +151,21 @@ public class Event extends StripeObject implements HasId, StripeActiveObject {
     @SerializedName("type")
     String type;
 
+    /** URL to retrieve the resource. */
+    @SerializedName("url")
+    String url;
+  }
+
+  /** The related object map for a singleton object who has no {@code id}. */
+  @Getter
+  @Setter
+  @EqualsAndHashCode(callSuper = false)
+  public static class RelatedSingletonObject extends StripeObject {
     /** Type of the object relevant to the event. */
+    @SerializedName("type")
+    String type;
+
+    /** URL to retrieve the resource. */
     @SerializedName("url")
     String url;
   }

--- a/src/main/java/com/stripe/model/v2/core/EventNotification.java
+++ b/src/main/java/com/stripe/model/v2/core/EventNotification.java
@@ -9,6 +9,7 @@ import com.stripe.exception.StripeException;
 import com.stripe.model.StripeObject;
 import com.stripe.model.v2.EventNotificationClassLookup;
 import com.stripe.model.v2.core.Event.RelatedObject;
+import com.stripe.model.v2.core.Event.RelatedSingletonObject;
 import com.stripe.net.ApiMode;
 import com.stripe.net.ApiResource;
 import com.stripe.net.ApiResource.RequestMethod;
@@ -162,8 +163,19 @@ public abstract class EventNotification {
       return null;
     }
 
-    String relativeUrl = relatedObject.getUrl();
+    return fetchRelatedObjectByUrl(relatedObject.getUrl());
+  }
 
+  protected StripeObject fetchRelatedObject(RelatedSingletonObject relatedObject)
+      throws StripeException {
+    if (relatedObject == null) {
+      return null;
+    }
+
+    return fetchRelatedObjectByUrl(relatedObject.getUrl());
+  }
+
+  private StripeObject fetchRelatedObjectByUrl(String relativeUrl) throws StripeException {
     StripeResponse response =
         client.rawRequest(RequestMethod.GET, relativeUrl, null, getRequestOptions());
 

--- a/src/test/java/com/stripe/model/v2/EventTests.java
+++ b/src/test/java/com/stripe/model/v2/EventTests.java
@@ -5,8 +5,11 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.stripe.BaseStripeTest;
 import com.stripe.events.V1BillingMeterErrorReportTriggeredEvent;
 import com.stripe.exception.StripeException;
+import com.stripe.model.StripeObject;
 import com.stripe.model.billing.Meter;
 import com.stripe.model.v2.core.Event;
+import com.stripe.model.v2.core.Event.RelatedSingletonObject;
+import com.stripe.model.v2.core.EventNotification;
 import com.stripe.net.ApiResource;
 import com.stripe.net.HttpHeaders;
 import com.stripe.net.StripeResponse;
@@ -152,6 +155,46 @@ public class EventTests extends BaseStripeTest {
         req ->
             assertEquals(
                 "event=evt_234", req.headers().firstValue("Stripe-Request-Trigger").orElse(null)));
+  }
+
+  /**
+   * The type singleton events point at instead of {@link Event.RelatedObject}. There's no generated
+   * singleton event yet, so exercise the type directly.
+   */
+  @Test
+  public void deserializesRelatedSingletonObject() {
+    String json = "{\n" + "  \"type\": \"balance\",\n" + "  \"url\": \"/v1/balance\"\n" + "}";
+
+    RelatedSingletonObject relatedObject =
+        ApiResource.GSON.fromJson(json, RelatedSingletonObject.class);
+
+    assertEquals("balance", relatedObject.getType());
+    assertEquals("/v1/balance", relatedObject.getUrl());
+
+    // the whole point of the type: no `id` field, and so no accessor for one either
+    assertThrows(
+        NoSuchFieldException.class, () -> RelatedSingletonObject.class.getDeclaredField("id"));
+    assertThrows(
+        NoSuchMethodException.class, () -> RelatedSingletonObject.class.getMethod("getId"));
+  }
+
+  /**
+   * Generated singleton event classes call {@code super.fetchRelatedObject(this.relatedObject)}, so
+   * both base classes need an overload that takes the singleton type. Asserted reflectively because
+   * no generated singleton event exists to exercise it yet.
+   */
+  @Test
+  public void baseClassesAcceptRelatedSingletonObject() throws NoSuchMethodException {
+    assertEquals(
+        StripeObject.class,
+        Event.class
+            .getDeclaredMethod("fetchRelatedObject", RelatedSingletonObject.class)
+            .getReturnType());
+    assertEquals(
+        StripeObject.class,
+        EventNotification.class
+            .getDeclaredMethod("fetchRelatedObject", RelatedSingletonObject.class)
+            .getReturnType());
   }
 
   // FIXME (jar) this should no longer be possible; confirm this and remove before merge


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

There are a few event notification types whose related object is a singleton. As a result, its `id` field will always be `null`. Rather than mark the root `RelatedObject` class as having a nullable string for its id (causing every user to have to do null checks even when we _know_ it'll be there), we're adding a second class and generating accordingly. There'll never be any ambiguity as ot whether a id field will be present in the response.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- add `RelatedSingletonObject` class, which is a copy of `RelatedObject`, but without an `id`. I didn't do inheritance (when relevant) because it's such a tiny, colocated class. If the repetition bothers us, we can reassess.
- add related methods, as needed
- tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- [RUN_DEVSDK-2825](https://go/j/RUN_DEVSDK-2825)
